### PR TITLE
fix(migrations): restore search_path after pg_dump prelude

### DIFF
--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -3912,6 +3912,10 @@ ALTER TABLE ONLY public.triples
 ALTER TABLE ONLY public.workflow_executions
     ADD CONSTRAINT workflow_executions_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.agents(id);
 
+-- Restore search_path so sqlx-cli can resolve _sqlx_migrations (unqualified)
+-- for its post-migration bookkeeping insert. Line 21 cleared it for the dump.
+SELECT pg_catalog.set_config('search_path', 'public', false);
+
 --
 --
 


### PR DESCRIPTION
Line 21 clears search_path as part of the pg_dump prelude. The session retains that empty setting after the schema load, which breaks sqlx-cli's post-migration INSERT into _sqlx_migrations (the unqualified table name no longer resolves):

  relation "_sqlx_migrations" does not exist

CI does not exercise this code path. The test suite uses #[sqlx::test] template-DB cloning, not `sqlx migrate run`, so the failure only surfaces on first application against a fresh DB. Affects local dev bootstrap and any deployment that applies migrations via sqlx-cli.