### PR TITLE
Forward-sync V2 kernel commits as discrete migrations 003/004

### DIFF
--- a/.sqlx/query-953c5d43d33967d9c5b0a4e8764534f59064db03a55d717975a87555e0507aaa.json
+++ b/.sqlx/query-953c5d43d33967d9c5b0a4e8764534f59064db03a55d717975a87555e0507aaa.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, content, truth_value, agent_id, trace_id, created_at, updated_at\n               FROM claims WHERE content_hash = $1 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "truth_value",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 3,
+        "name": "agent_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "trace_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "953c5d43d33967d9c5b0a4e8764534f59064db03a55d717975a87555e0507aaa"
+}

--- a/crates/epigraph-api/src/bin/server.rs
+++ b/crates/epigraph-api/src/bin/server.rs
@@ -185,8 +185,12 @@ async fn main() {
     let metrics = Arc::new(Metrics::new());
     let app = create_router(state).layer(axum::Extension(metrics));
 
-    // Bind to address
-    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], 8080));
+    // Bind to address. EPIGRAPH_PORT env var allows side-by-side test runs.
+    let port: u16 = std::env::var("EPIGRAPH_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8080);
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
 
     // Check for TLS configuration via environment variables.
     // EPIGRAPH_TLS_CERT and EPIGRAPH_TLS_KEY must both be set to enable TLS.

--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -1007,6 +1007,13 @@ async fn entity_exists(
             .map_err(|e| ApiError::InternalError {
                 message: format!("DB check failed: {e}"),
             })?,
+        "paper" => sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM papers WHERE id = $1)")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .map_err(|e| ApiError::InternalError {
+                message: format!("DB check failed: {e}"),
+            })?,
         _ => false, // Unknown types already rejected by validation above
     };
     Ok(exists)

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -69,6 +69,7 @@ pub mod political;
 pub mod provenance;
 pub mod rag;
 pub mod reasoning;
+pub mod revoke_signature;
 #[cfg(feature = "db")]
 pub mod search;
 pub mod spans;
@@ -190,6 +191,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/claims/:id/supersede",
             post(versioning::supersede_claim),
+        )
+        .route(
+            "/api/v1/claims/:id/revoke-signature",
+            post(revoke_signature::revoke_claim_signature),
         )
         .route("/api/v1/claims/batch", post(batch::batch_create_claims))
         .route("/api/v1/claims/:id/labels", patch(claims::update_labels))
@@ -758,6 +763,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/claims/:id/supersede",
             post(versioning::supersede_claim),
+        )
+        .route(
+            "/api/v1/claims/:id/revoke-signature",
+            post(revoke_signature::revoke_claim_signature),
         )
         .route("/api/v1/claims/batch", post(batch::batch_create_claims))
         .route("/api/v1/claims/:id/labels", patch(claims::update_labels))

--- a/crates/epigraph-api/src/routes/papers.rs
+++ b/crates/epigraph-api/src/routes/papers.rs
@@ -99,24 +99,64 @@ pub async fn create_paper(
     }
 
     use sqlx::Row;
-    let row = sqlx::query(
-        r#"
-        INSERT INTO papers (doi, title, journal)
-        VALUES ($1, $2, $3)
-        ON CONFLICT (doi) DO UPDATE
-            SET title   = COALESCE(EXCLUDED.title, papers.title),
-                journal = COALESCE(EXCLUDED.journal, papers.journal)
-        RETURNING id, doi, title, journal, created_at
-        "#,
+
+    // Check for existing paper first (papers.doi has btree index but no UNIQUE constraint)
+    let existing: Option<_> = sqlx::query(
+        "SELECT id, doi, title, journal, created_at FROM papers WHERE doi = $1 LIMIT 1",
     )
     .bind(&request.doi)
-    .bind(&request.title)
-    .bind(&request.journal)
-    .fetch_one(&state.db_pool)
+    .fetch_optional(&state.db_pool)
     .await
     .map_err(|e| ApiError::DatabaseError {
-        message: format!("Failed to upsert paper: {e}"),
+        message: format!("Failed to query paper: {e}"),
     })?;
+
+    let row = if let Some(existing_row) = existing {
+        // Paper exists — update title/journal if new values provided, then re-fetch
+        if request.title.is_some() || request.journal.is_some() {
+            sqlx::query(
+                r#"UPDATE papers
+                   SET title   = COALESCE($2, title),
+                       journal = COALESCE($3, journal)
+                   WHERE doi = $1"#,
+            )
+            .bind(&request.doi)
+            .bind(&request.title)
+            .bind(&request.journal)
+            .execute(&state.db_pool)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("Failed to update paper: {e}"),
+            })?;
+            // Re-fetch updated row
+            sqlx::query(
+                "SELECT id, doi, title, journal, created_at FROM papers WHERE doi = $1 LIMIT 1",
+            )
+            .bind(&request.doi)
+            .fetch_one(&state.db_pool)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("Failed to re-fetch paper: {e}"),
+            })?
+        } else {
+            existing_row
+        }
+    } else {
+        // New paper — insert
+        sqlx::query(
+            r#"INSERT INTO papers (doi, title, journal)
+               VALUES ($1, $2, $3)
+               RETURNING id, doi, title, journal, created_at"#,
+        )
+        .bind(&request.doi)
+        .bind(&request.title)
+        .bind(&request.journal)
+        .fetch_one(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::DatabaseError {
+            message: format!("Failed to insert paper: {e}"),
+        })?
+    };
 
     Ok(Json(PaperResponse {
         id: row.get("id"),

--- a/crates/epigraph-api/src/routes/revoke_signature.rs
+++ b/crates/epigraph-api/src/routes/revoke_signature.rs
@@ -89,6 +89,42 @@ struct AlreadyRevokedDetail {
     revoked_at: DateTime<Utc>,
 }
 
+/// Parse the optional `expected_signature_prefix` field into raw bytes.
+///
+/// Accepts None, empty, or a hex string optionally prefixed with `0x`.
+/// Rejects odd-length hex, prefixes longer than the 64-byte signature
+/// they would guard, and invalid hex characters.
+///
+/// Pulled out of the handler so it can be unit-tested without a DB.
+fn parse_expected_signature_prefix(
+    input: Option<&str>,
+) -> Result<Option<Vec<u8>>, ApiError> {
+    let Some(s) = input else { return Ok(None) };
+    if s.is_empty() {
+        return Ok(None);
+    }
+    let cleaned = s.trim().trim_start_matches("0x").to_ascii_lowercase();
+    if cleaned.len() % 2 != 0 {
+        return Err(ApiError::ValidationError {
+            field: "expected_signature_prefix".to_string(),
+            reason: "hex prefix must have an even number of characters".to_string(),
+        });
+    }
+    if cleaned.len() > 128 {
+        return Err(ApiError::ValidationError {
+            field: "expected_signature_prefix".to_string(),
+            reason: "hex prefix is longer than the 64-byte signature it would guard"
+                .to_string(),
+        });
+    }
+    Ok(Some(hex::decode(&cleaned).map_err(|e| {
+        ApiError::ValidationError {
+            field: "expected_signature_prefix".to_string(),
+            reason: format!("invalid hex: {e}"),
+        }
+    })?))
+}
+
 /// Revoke the signature on a claim.
 ///
 /// POST /api/v1/claims/:id/revoke-signature
@@ -162,31 +198,8 @@ pub async fn revoke_claim_signature(
 
     // Parse expected_signature_prefix early so we don't start a transaction
     // just to reject malformed hex.
-    let expected_prefix_bytes: Option<Vec<u8>> = match &request.expected_signature_prefix {
-        None => None,
-        Some(s) if s.is_empty() => None,
-        Some(s) => {
-            let cleaned = s.trim().trim_start_matches("0x").to_ascii_lowercase();
-            if cleaned.len() % 2 != 0 {
-                return Err(ApiError::ValidationError {
-                    field: "expected_signature_prefix".to_string(),
-                    reason: "hex prefix must have an even number of characters".to_string(),
-                });
-            }
-            if cleaned.len() > 128 {
-                // 64-byte signature = 128 hex chars; longer is nonsense.
-                return Err(ApiError::ValidationError {
-                    field: "expected_signature_prefix".to_string(),
-                    reason: "hex prefix is longer than the 64-byte signature it would guard"
-                        .to_string(),
-                });
-            }
-            Some(hex::decode(&cleaned).map_err(|e| ApiError::ValidationError {
-                field: "expected_signature_prefix".to_string(),
-                reason: format!("invalid hex: {e}"),
-            })?)
-        }
-    };
+    let expected_prefix_bytes: Option<Vec<u8>> =
+        parse_expected_signature_prefix(request.expected_signature_prefix.as_deref())?;
 
     // ---- DB transaction. ----
     let mut tx = state
@@ -379,4 +392,179 @@ pub async fn revoke_claim_signature(
     Err(ApiError::ServiceUnavailable {
         service: "Signature revocation requires database".to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- parse_expected_signature_prefix ----
+
+    #[test]
+    fn prefix_none_returns_none() {
+        let out = parse_expected_signature_prefix(None).unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn prefix_empty_string_returns_none() {
+        let out = parse_expected_signature_prefix(Some("")).unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn prefix_accepts_lowercase_hex() {
+        let out = parse_expected_signature_prefix(Some("deadbeef"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_accepts_uppercase_hex() {
+        let out = parse_expected_signature_prefix(Some("DEADBEEF"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_strips_0x_prefix() {
+        let out = parse_expected_signature_prefix(Some("0xdeadbeef"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_trims_whitespace() {
+        let out = parse_expected_signature_prefix(Some("  deadbeef  "))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_rejects_odd_length() {
+        let err = parse_expected_signature_prefix(Some("abc")).unwrap_err();
+        match err {
+            ApiError::ValidationError { field, reason } => {
+                assert_eq!(field, "expected_signature_prefix");
+                assert!(reason.contains("even number"), "got: {reason}");
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prefix_rejects_too_long() {
+        // 130 hex chars = longer than a 64-byte (128-hex-char) signature.
+        // Must be even so we hit the length check rather than the odd-length
+        // check that would otherwise short-circuit.
+        let long = "a".repeat(130);
+        let err = parse_expected_signature_prefix(Some(&long)).unwrap_err();
+        match err {
+            ApiError::ValidationError { field, reason } => {
+                assert_eq!(field, "expected_signature_prefix");
+                assert!(
+                    reason.contains("longer than the 64-byte signature"),
+                    "got: {reason}"
+                );
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prefix_accepts_full_64_byte_signature() {
+        // 128 hex chars = exactly one 64-byte signature, should pass.
+        let full = "a".repeat(128);
+        let out = parse_expected_signature_prefix(Some(&full)).unwrap().unwrap();
+        assert_eq!(out.len(), 64);
+    }
+
+    #[test]
+    fn prefix_rejects_invalid_hex_chars() {
+        let err = parse_expected_signature_prefix(Some("gggg")).unwrap_err();
+        match err {
+            ApiError::ValidationError { field, reason } => {
+                assert_eq!(field, "expected_signature_prefix");
+                assert!(reason.contains("invalid hex"), "got: {reason}");
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    // ---- DTO serde roundtrip ----
+
+    #[test]
+    fn request_deserializes_minimal() {
+        let req: RevokeSignatureRequest = serde_json::from_value(serde_json::json!({
+            "reason": "hash drift",
+        }))
+        .unwrap();
+        assert_eq!(req.reason, "hash drift");
+        assert!(req.superseded_by.is_none());
+        assert!(req.expected_signature_prefix.is_none());
+    }
+
+    #[test]
+    fn request_deserializes_full() {
+        let sup_by = Uuid::new_v4();
+        let req: RevokeSignatureRequest = serde_json::from_value(serde_json::json!({
+            "reason": "superseded",
+            "superseded_by": sup_by.to_string(),
+            "expected_signature_prefix": "0xdead",
+        }))
+        .unwrap();
+        assert_eq!(req.reason, "superseded");
+        assert_eq!(req.superseded_by, Some(sup_by));
+        assert_eq!(req.expected_signature_prefix.as_deref(), Some("0xdead"));
+    }
+
+    #[test]
+    fn response_serializes_roundtrip() {
+        let resp = RevokeSignatureResponse {
+            claim_id: Uuid::new_v4(),
+            revocation_id: Uuid::new_v4(),
+            previous_signer_id: Some(Uuid::new_v4()),
+            revoked_at: Utc::now(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.get("claim_id").is_some());
+        assert!(json.get("revocation_id").is_some());
+        assert!(json.get("previous_signer_id").is_some());
+        assert!(json.get("revoked_at").is_some());
+        let back: RevokeSignatureResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(back.claim_id, resp.claim_id);
+        assert_eq!(back.revocation_id, resp.revocation_id);
+        assert_eq!(back.previous_signer_id, resp.previous_signer_id);
+    }
+
+    // ---- Non-db stub returns 503 ----
+
+    #[cfg(not(feature = "db"))]
+    mod stub {
+        use super::*;
+        use crate::state::{ApiConfig, AppState};
+
+        #[tokio::test]
+        async fn stub_returns_service_unavailable() {
+            let state = AppState::new(ApiConfig::default());
+            let claim_id = Uuid::new_v4();
+            let req = RevokeSignatureRequest {
+                reason: "test".to_string(),
+                superseded_by: None,
+                expected_signature_prefix: None,
+            };
+            let err = revoke_claim_signature(
+                axum::extract::State(state),
+                axum::extract::Path(claim_id),
+                axum::Json(req),
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(err, ApiError::ServiceUnavailable { .. }));
+        }
+    }
 }

--- a/crates/epigraph-api/src/routes/revoke_signature.rs
+++ b/crates/epigraph-api/src/routes/revoke_signature.rs
@@ -1,0 +1,382 @@
+//! Claim signature revocation endpoint.
+//!
+//! POST /api/v1/claims/:id/revoke-signature
+//!
+//! Sets a claim's `signature` and `signer_id` to NULL, preserving the prior
+//! values in the `claim_signature_revocations` audit table (migration 098).
+//!
+//! # When to use this instead of supersede
+//!
+//! - **Supersede** (POST /api/v1/claims/:id/supersede) when the claim's
+//!   semantic content is still what you want to assert today: creates a new,
+//!   currently-signed claim and forwards graph connectivity to it.
+//! - **Revoke signature** (this endpoint) when the claim's content is of
+//!   unclear provenance, or when revoke-then-supersede is the chosen
+//!   disposition and the caller wants the old claim to clearly verify as
+//!   "unsigned" rather than "tampered."
+//!
+//! Re-signing drifted content would forge the original author's consent and
+//! is NOT supported. The route is intentionally a hole that forces the
+//! caller to either supersede or revoke — never re-sign.
+//!
+//! # Authorization
+//!
+//! Requires OAuth2 Bearer token with the `claims:revoke-signature` scope.
+//! Legacy Ed25519 signature authentication is NOT accepted on this route —
+//! the revoker's identity must be unambiguously extractable from an
+//! AuthContext so the audit row's `revoked_by` column is meaningful.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::ApiError;
+use crate::state::AppState;
+
+/// Maximum length of the revocation reason in bytes.
+/// Mirrors versioning::MAX_REASON_LENGTH to keep audit text bounded.
+const MAX_REASON_LENGTH: usize = 32_768;
+
+/// Request body for revoking a claim's signature.
+#[derive(Debug, Deserialize)]
+pub struct RevokeSignatureRequest {
+    /// Free-text reason recorded in the audit row. Required.
+    /// Examples:
+    ///   - "content_hash_drift_from_uncaptured_content_rewrite"
+    ///   - "superseded_by_<uuid>_content_of_unclear_provenance"
+    ///   - "migration_attestation_<date>_attested_drifted_content"
+    pub reason: String,
+
+    /// If the revocation is part of a supersession workflow, the UUID of the
+    /// superseding claim. The audit row carries this forward link; `None` for
+    /// standalone revocations.
+    #[serde(default)]
+    pub superseded_by: Option<Uuid>,
+
+    /// Optional fat-finger guard: the caller asserts the first N hex chars of
+    /// the current signature it expects to revoke. If set and mismatched, the
+    /// handler returns 409 Conflict without touching the row. Case-insensitive
+    /// hex; length determines how many prefix bytes to compare.
+    #[serde(default)]
+    pub expected_signature_prefix: Option<String>,
+}
+
+/// Response returned after a successful revocation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RevokeSignatureResponse {
+    /// The claim whose signature was revoked.
+    pub claim_id: Uuid,
+    /// UUID of the newly-inserted row in claim_signature_revocations.
+    pub revocation_id: Uuid,
+    /// The signer_id that was cleared (None if the prior signer had been
+    /// deleted and the FK was already NULL).
+    pub previous_signer_id: Option<Uuid>,
+    /// When the revocation was recorded (DB NOW()).
+    pub revoked_at: DateTime<Utc>,
+}
+
+/// Error body returned when a claim is already revoked (409 Conflict).
+/// Names the most recent revocation so the caller can correlate.
+#[derive(Debug, Serialize)]
+struct AlreadyRevokedDetail {
+    revocation_id: Uuid,
+    revoked_by: Uuid,
+    revoked_at: DateTime<Utc>,
+}
+
+/// Revoke the signature on a claim.
+///
+/// POST /api/v1/claims/:id/revoke-signature
+///
+/// # Behavior
+///
+/// 1. Verifies Bearer-token AuthContext has the `claims:revoke-signature` scope.
+/// 2. Validates request: non-empty reason (≤32 KiB), optional prefix guard,
+///    optional superseded_by UUID (must reference an existing claim).
+/// 3. In a single DB transaction:
+///    a. SELECT the claim's current (signature, signer_id, content_hash).
+///       Returns 404 if the claim doesn't exist.
+///       Returns 409 with prior-revocation reference if signature is already NULL.
+///    b. If `expected_signature_prefix` is set, checks it against the stored
+///       signature's hex. Returns 409 on mismatch.
+///    c. If `superseded_by` is set, verifies the target claim exists.
+///       Returns 400 if it doesn't.
+///    d. INSERTs a row into claim_signature_revocations with the preserved
+///       signature, signer_id, content_hash, reason, and the caller's agent_id
+///       as revoked_by.
+///    e. UPDATEs the claim to set signature = NULL AND signer_id = NULL
+///       (satisfies the migration 073 CHECK constraint).
+///
+/// # Errors
+///
+/// - 401 Unauthorized: no Bearer AuthContext (legacy Ed25519 is rejected here).
+/// - 403 Forbidden: AuthContext present but missing `claims:revoke-signature` scope.
+/// - 400 Bad Request: validation failure, or superseded_by references a missing claim.
+/// - 404 Not Found: claim_id doesn't exist.
+/// - 409 Conflict: claim is already revoked, or expected_signature_prefix mismatch.
+#[cfg(feature = "db")]
+pub async fn revoke_claim_signature(
+    State(state): State<AppState>,
+    auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>,
+    Path(claim_id): Path<Uuid>,
+    Json(request): Json<RevokeSignatureRequest>,
+) -> Result<(StatusCode, Json<RevokeSignatureResponse>), ApiError> {
+    // ---- Auth: bearer-only; legacy Ed25519 is not accepted here. ----
+    let axum::Extension(ref auth) = auth_ctx.ok_or(ApiError::Unauthorized {
+        reason: "claims:revoke-signature requires a Bearer token (AuthContext \
+                 with agent_id); legacy Ed25519 auth is not accepted on this route"
+            .to_string(),
+    })?;
+    crate::middleware::scopes::check_scopes(auth, &["claims:revoke-signature"])?;
+
+    let revoker_agent_id = auth.agent_id.ok_or(ApiError::Forbidden {
+        reason: "revoke-signature requires an AuthContext with a bound agent_id; \
+                 service-only tokens without agent binding cannot be recorded as \
+                 the revoker"
+            .to_string(),
+    })?;
+
+    // ---- Request validation. ----
+    let reason = request.reason.trim();
+    if reason.is_empty() {
+        return Err(ApiError::ValidationError {
+            field: "reason".to_string(),
+            reason: "reason cannot be empty".to_string(),
+        });
+    }
+    if request.reason.len() > MAX_REASON_LENGTH {
+        return Err(ApiError::ValidationError {
+            field: "reason".to_string(),
+            reason: format!(
+                "reason too long: {} bytes, maximum is {}",
+                request.reason.len(),
+                MAX_REASON_LENGTH
+            ),
+        });
+    }
+
+    // Parse expected_signature_prefix early so we don't start a transaction
+    // just to reject malformed hex.
+    let expected_prefix_bytes: Option<Vec<u8>> = match &request.expected_signature_prefix {
+        None => None,
+        Some(s) if s.is_empty() => None,
+        Some(s) => {
+            let cleaned = s.trim().trim_start_matches("0x").to_ascii_lowercase();
+            if cleaned.len() % 2 != 0 {
+                return Err(ApiError::ValidationError {
+                    field: "expected_signature_prefix".to_string(),
+                    reason: "hex prefix must have an even number of characters".to_string(),
+                });
+            }
+            if cleaned.len() > 128 {
+                // 64-byte signature = 128 hex chars; longer is nonsense.
+                return Err(ApiError::ValidationError {
+                    field: "expected_signature_prefix".to_string(),
+                    reason: "hex prefix is longer than the 64-byte signature it would guard"
+                        .to_string(),
+                });
+            }
+            Some(hex::decode(&cleaned).map_err(|e| ApiError::ValidationError {
+                field: "expected_signature_prefix".to_string(),
+                reason: format!("invalid hex: {e}"),
+            })?)
+        }
+    };
+
+    // ---- DB transaction. ----
+    let mut tx = state
+        .db_pool
+        .begin()
+        .await
+        .map_err(|e| ApiError::DatabaseError {
+            message: format!("transaction begin failed: {e}"),
+        })?;
+
+    // Fetch current signature state.
+    let row: Option<(Option<Vec<u8>>, Option<Uuid>, Option<Vec<u8>>)> = sqlx::query_as(
+        "SELECT signature, signer_id, content_hash FROM claims WHERE id = $1",
+    )
+    .bind(claim_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| ApiError::DatabaseError {
+        message: format!("claim lookup failed: {e}"),
+    })?;
+
+    let (current_signature, current_signer_id, current_content_hash) =
+        row.ok_or_else(|| ApiError::NotFound {
+            entity: "Claim".to_string(),
+            id: claim_id.to_string(),
+        })?;
+
+    // Already revoked? Surface the prior revocation for correlation.
+    let Some(current_signature) = current_signature else {
+        let prior: Option<(Uuid, Uuid, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT id, revoked_by, revoked_at FROM claim_signature_revocations \
+             WHERE claim_id = $1 ORDER BY revoked_at DESC LIMIT 1",
+        )
+        .bind(claim_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| ApiError::DatabaseError {
+            message: format!("prior revocation lookup failed: {e}"),
+        })?;
+
+        let detail = match prior {
+            Some((id, by, at)) => serde_json::to_value(AlreadyRevokedDetail {
+                revocation_id: id,
+                revoked_by: by,
+                revoked_at: at,
+            })
+            .ok()
+            .map(|v| format!(" (prior: {v})"))
+            .unwrap_or_default(),
+            None => String::new(),
+        };
+        return Err(ApiError::BadRequest {
+            message: format!(
+                "claim {claim_id} has no active signature to revoke (signature IS NULL){detail}"
+            ),
+        });
+    };
+
+    // Signature is NOT NULL, so migration 073's CHECK guarantees signer_id is
+    // NOT NULL and the byte length is 64. Content_hash is also stored. Assert
+    // defensively to surface any future schema drift loudly.
+    let current_signer_id = current_signer_id.ok_or_else(|| ApiError::IntegrityError {
+        field: "signer_id".to_string(),
+        expected: "NOT NULL when signature is NOT NULL (migration 073 CHECK)".to_string(),
+        actual: "NULL".to_string(),
+    })?;
+    let current_content_hash = current_content_hash.ok_or_else(|| ApiError::IntegrityError {
+        field: "content_hash".to_string(),
+        expected: "NOT NULL on any signed claim".to_string(),
+        actual: "NULL".to_string(),
+    })?;
+
+    // Prefix guard (optional): reject fat-finger UUID mistakes.
+    if let Some(expected) = &expected_prefix_bytes {
+        if !current_signature.starts_with(expected) {
+            return Err(ApiError::BadRequest {
+                message: format!(
+                    "expected_signature_prefix mismatch: supplied prefix does not \
+                     match the current signature of claim {claim_id}"
+                ),
+            });
+        }
+    }
+
+    // If superseded_by is set, verify the target claim exists.
+    if let Some(sup_by) = request.superseded_by {
+        let exists: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM claims WHERE id = $1")
+                .bind(sup_by)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| ApiError::DatabaseError {
+                    message: format!("superseded_by lookup failed: {e}"),
+                })?;
+        if exists.is_none() {
+            return Err(ApiError::BadRequest {
+                message: format!(
+                    "superseded_by claim {sup_by} does not exist"
+                ),
+            });
+        }
+    }
+
+    // Insert the audit row.
+    let revocation_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO claim_signature_revocations \
+            (claim_id, previous_signature, previous_signer_id, previous_content_hash, \
+             revoked_by, reason, superseded_by) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) \
+         RETURNING id",
+    )
+    .bind(claim_id)
+    .bind(&current_signature)
+    .bind(current_signer_id)
+    .bind(&current_content_hash)
+    .bind(revoker_agent_id)
+    .bind(reason)
+    .bind(request.superseded_by)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| ApiError::DatabaseError {
+        message: format!("revocation audit insert failed: {e}"),
+    })?;
+
+    // Null the signature + signer_id. The migration 073 CHECK requires both
+    // change together; doing both in one UPDATE keeps the constraint satisfied.
+    let affected = sqlx::query(
+        "UPDATE claims SET signature = NULL, signer_id = NULL, updated_at = NOW() \
+         WHERE id = $1",
+    )
+    .bind(claim_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| ApiError::DatabaseError {
+        message: format!("claim signature clear failed: {e}"),
+    })?
+    .rows_affected();
+
+    if affected != 1 {
+        return Err(ApiError::DatabaseError {
+            message: format!(
+                "expected to null exactly 1 claim signature, affected {affected} rows"
+            ),
+        });
+    }
+
+    // Fetch revoked_at from the just-inserted row so the response is authoritative.
+    let revoked_at: DateTime<Utc> = sqlx::query_scalar(
+        "SELECT revoked_at FROM claim_signature_revocations WHERE id = $1",
+    )
+    .bind(revocation_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| ApiError::DatabaseError {
+        message: format!("revoked_at fetch failed: {e}"),
+    })?;
+
+    tx.commit().await.map_err(|e| ApiError::DatabaseError {
+        message: format!("transaction commit failed: {e}"),
+    })?;
+
+    tracing::info!(
+        claim_id = %claim_id,
+        revocation_id = %revocation_id,
+        revoked_by = %revoker_agent_id,
+        previous_signer_id = %current_signer_id,
+        superseded_by = ?request.superseded_by,
+        reason = %reason,
+        "claim signature revoked",
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(RevokeSignatureResponse {
+            claim_id,
+            revocation_id,
+            previous_signer_id: Some(current_signer_id),
+            revoked_at,
+        }),
+    ))
+}
+
+/// Stub for builds without the `db` feature. Always returns 503.
+#[cfg(not(feature = "db"))]
+pub async fn revoke_claim_signature(
+    State(_state): State<AppState>,
+    Path(_claim_id): Path<Uuid>,
+    Json(_request): Json<RevokeSignatureRequest>,
+) -> Result<(StatusCode, Json<RevokeSignatureResponse>), ApiError> {
+    Err(ApiError::ServiceUnavailable {
+        service: "Signature revocation requires database".to_string(),
+    })
+}

--- a/crates/epigraph-api/src/routes/revoke_signature.rs
+++ b/crates/epigraph-api/src/routes/revoke_signature.rs
@@ -133,17 +133,17 @@ fn parse_expected_signature_prefix(input: Option<&str>) -> Result<Option<Vec<u8>
 ///    optional superseded_by UUID (must reference an existing claim).
 /// 3. In a single DB transaction:
 ///    a. SELECT the claim's current (signature, signer_id, content_hash).
-///       Returns 404 if the claim doesn't exist.
-///       Returns 409 with prior-revocation reference if signature is already NULL.
+///    Returns 404 if the claim doesn't exist.
+///    Returns 409 with prior-revocation reference if signature is already NULL.
 ///    b. If `expected_signature_prefix` is set, checks it against the stored
-///       signature's hex. Returns 409 on mismatch.
+///    signature's hex. Returns 409 on mismatch.
 ///    c. If `superseded_by` is set, verifies the target claim exists.
-///       Returns 400 if it doesn't.
+///    Returns 400 if it doesn't.
 ///    d. INSERTs a row into claim_signature_revocations with the preserved
-///       signature, signer_id, content_hash, reason, and the caller's agent_id
-///       as revoked_by.
+///    signature, signer_id, content_hash, reason, and the caller's agent_id
+///    as revoked_by.
 ///    e. UPDATEs the claim to set signature = NULL AND signer_id = NULL
-///       (satisfies the migration 073 CHECK constraint).
+///    (satisfies the migration 073 CHECK constraint).
 ///
 /// # Errors
 ///
@@ -208,7 +208,8 @@ pub async fn revoke_claim_signature(
         })?;
 
     // Fetch current signature state.
-    let row: Option<(Option<Vec<u8>>, Option<Uuid>, Option<Vec<u8>>)> =
+    type ClaimSigRow = (Option<Vec<u8>>, Option<Uuid>, Option<Vec<u8>>);
+    let row: Option<ClaimSigRow> =
         sqlx::query_as("SELECT signature, signer_id, content_hash FROM claims WHERE id = $1")
             .bind(claim_id)
             .fetch_optional(&mut *tx)

--- a/crates/epigraph-api/src/routes/revoke_signature.rs
+++ b/crates/epigraph-api/src/routes/revoke_signature.rs
@@ -96,9 +96,7 @@ struct AlreadyRevokedDetail {
 /// they would guard, and invalid hex characters.
 ///
 /// Pulled out of the handler so it can be unit-tested without a DB.
-fn parse_expected_signature_prefix(
-    input: Option<&str>,
-) -> Result<Option<Vec<u8>>, ApiError> {
+fn parse_expected_signature_prefix(input: Option<&str>) -> Result<Option<Vec<u8>>, ApiError> {
     let Some(s) = input else { return Ok(None) };
     if s.is_empty() {
         return Ok(None);
@@ -113,8 +111,7 @@ fn parse_expected_signature_prefix(
     if cleaned.len() > 128 {
         return Err(ApiError::ValidationError {
             field: "expected_signature_prefix".to_string(),
-            reason: "hex prefix is longer than the 64-byte signature it would guard"
-                .to_string(),
+            reason: "hex prefix is longer than the 64-byte signature it would guard".to_string(),
         });
     }
     Ok(Some(hex::decode(&cleaned).map_err(|e| {
@@ -211,15 +208,14 @@ pub async fn revoke_claim_signature(
         })?;
 
     // Fetch current signature state.
-    let row: Option<(Option<Vec<u8>>, Option<Uuid>, Option<Vec<u8>>)> = sqlx::query_as(
-        "SELECT signature, signer_id, content_hash FROM claims WHERE id = $1",
-    )
-    .bind(claim_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| ApiError::DatabaseError {
-        message: format!("claim lookup failed: {e}"),
-    })?;
+    let row: Option<(Option<Vec<u8>>, Option<Uuid>, Option<Vec<u8>>)> =
+        sqlx::query_as("SELECT signature, signer_id, content_hash FROM claims WHERE id = $1")
+            .bind(claim_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("claim lookup failed: {e}"),
+            })?;
 
     let (current_signature, current_signer_id, current_content_hash) =
         row.ok_or_else(|| ApiError::NotFound {
@@ -286,19 +282,16 @@ pub async fn revoke_claim_signature(
 
     // If superseded_by is set, verify the target claim exists.
     if let Some(sup_by) = request.superseded_by {
-        let exists: Option<(Uuid,)> =
-            sqlx::query_as("SELECT id FROM claims WHERE id = $1")
-                .bind(sup_by)
-                .fetch_optional(&mut *tx)
-                .await
-                .map_err(|e| ApiError::DatabaseError {
-                    message: format!("superseded_by lookup failed: {e}"),
-                })?;
+        let exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM claims WHERE id = $1")
+            .bind(sup_by)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("superseded_by lookup failed: {e}"),
+            })?;
         if exists.is_none() {
             return Err(ApiError::BadRequest {
-                message: format!(
-                    "superseded_by claim {sup_by} does not exist"
-                ),
+                message: format!("superseded_by claim {sup_by} does not exist"),
             });
         }
     }
@@ -347,15 +340,14 @@ pub async fn revoke_claim_signature(
     }
 
     // Fetch revoked_at from the just-inserted row so the response is authoritative.
-    let revoked_at: DateTime<Utc> = sqlx::query_scalar(
-        "SELECT revoked_at FROM claim_signature_revocations WHERE id = $1",
-    )
-    .bind(revocation_id)
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(|e| ApiError::DatabaseError {
-        message: format!("revoked_at fetch failed: {e}"),
-    })?;
+    let revoked_at: DateTime<Utc> =
+        sqlx::query_scalar("SELECT revoked_at FROM claim_signature_revocations WHERE id = $1")
+            .bind(revocation_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("revoked_at fetch failed: {e}"),
+            })?;
 
     tx.commit().await.map_err(|e| ApiError::DatabaseError {
         message: format!("transaction commit failed: {e}"),
@@ -479,7 +471,9 @@ mod tests {
     fn prefix_accepts_full_64_byte_signature() {
         // 128 hex chars = exactly one 64-byte signature, should pass.
         let full = "a".repeat(128);
-        let out = parse_expected_signature_prefix(Some(&full)).unwrap().unwrap();
+        let out = parse_expected_signature_prefix(Some(&full))
+            .unwrap()
+            .unwrap();
         assert_eq!(out.len(), 64);
     }
 

--- a/crates/epigraph-api/src/state.rs
+++ b/crates/epigraph-api/src/state.rs
@@ -18,9 +18,8 @@ use epigraph_embeddings::EmbeddingService;
 use epigraph_engine::{DatabasePropagator, PropagationConfig, PropagationOrchestrator};
 use epigraph_events::EventBus;
 use epigraph_interfaces::{
-    EncryptionProvider, NoOpEncryptionProvider,
-    OrchestrationBackend, NoOpOrchestrationBackend,
-    PolicyGate, NoOpPolicyGate,
+    EncryptionProvider, NoOpEncryptionProvider, NoOpOrchestrationBackend, NoOpPolicyGate,
+    OrchestrationBackend, PolicyGate,
 };
 use serde::{Deserialize, Serialize};
 
@@ -566,11 +565,9 @@ impl Default for ApiConfig {
 
 #[cfg(test)]
 mod extension_wiring_tests {
-    use epigraph_interfaces::{
-        NoOpEncryptionProvider, NoOpOrchestrationBackend, NoOpPolicyGate,
-    };
-    use std::sync::Arc;
     use super::{SharedEncryptionProvider, SharedOrchestrationBackend, SharedPolicyGate};
+    use epigraph_interfaces::{NoOpEncryptionProvider, NoOpOrchestrationBackend, NoOpPolicyGate};
+    use std::sync::Arc;
 
     #[test]
     fn appstate_accepts_noop_providers() {

--- a/crates/epigraph-api/tests/integration/submit_persistence_tests.rs
+++ b/crates/epigraph-api/tests/integration/submit_persistence_tests.rs
@@ -259,6 +259,27 @@ fn create_test_router(pool: PgPool) -> Router {
     create_router(state)
 }
 
+/// Mint a test Bearer token valid against the dev JWT secret.
+///
+/// The secret is the same fallback used by `default_jwt_config()` in
+/// state.rs when `EPIGRAPH_JWT_SECRET` is not set, so it works against
+/// the test app router without any env-var setup.
+fn test_bearer_token() -> String {
+    use epigraph_api::oauth::JwtConfig;
+    let jwt_config = JwtConfig::from_secret(b"epigraph-dev-secret-change-in-production!!");
+    let (token, _) = jwt_config
+        .issue_access_token(
+            Uuid::new_v4(),
+            vec!["epigraph:write".to_string(), "epigraph:read".to_string()],
+            "service",
+            None,
+            None,
+            chrono::Duration::seconds(300),
+        )
+        .expect("issue_access_token must succeed for tests");
+    token
+}
+
 /// Make a POST request to the submit packet endpoint (creates fresh router per call)
 async fn submit_packet_request(pool: &PgPool, packet: &EpistemicPacket) -> (StatusCode, String) {
     let router = create_test_router(pool.clone());
@@ -274,7 +295,10 @@ async fn send_packet(router: &Router, packet: &EpistemicPacket) -> (StatusCode, 
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass") // Pass bearer_auth_middleware (falls through to legacy path)
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(body))
         .expect("Failed to build request");
 

--- a/crates/epigraph-api/tests/routes/submit_packet_tests.rs
+++ b/crates/epigraph-api/tests/routes/submit_packet_tests.rs
@@ -1413,10 +1413,17 @@ async fn test_different_idempotency_keys_create_different_claims() {
     let agent_id = Uuid::new_v4();
     ensure_agent_in_db(agent_id).await;
 
+    // Distinct content per packet — migration 097 added a UNIQUE constraint on
+    // (content_hash, agent_id), so two packets with the same content under the
+    // same agent would now violate the constraint regardless of idempotency key.
+    // The test still validates the original intent: different idempotency keys
+    // (paired with materially different requests) produce different claims.
     let mut packet1 = create_valid_packet(agent_id);
+    packet1.claim.content = "Hypothesis A is supported by evidence".to_string();
     packet1.claim.idempotency_key = Some("key_one".to_string());
 
     let mut packet2 = create_valid_packet(agent_id);
+    packet2.claim.content = "Hypothesis B is supported by evidence".to_string();
     packet2.claim.idempotency_key = Some("key_two".to_string());
 
     let (status1, body1) = submit_packet(app.clone(), &packet1).await;

--- a/crates/epigraph-api/tests/routes/submit_packet_tests.rs
+++ b/crates/epigraph-api/tests/routes/submit_packet_tests.rs
@@ -235,6 +235,27 @@ fn create_test_app_no_sig() -> axum::Router {
     create_router(state)
 }
 
+/// Mint a test Bearer token valid against the dev JWT secret.
+///
+/// The secret is the same fallback used by `default_jwt_config()` in
+/// state.rs when `EPIGRAPH_JWT_SECRET` is not set, so it works against
+/// the test app router without any env-var setup.
+fn test_bearer_token() -> String {
+    use epigraph_api::oauth::JwtConfig;
+    let jwt_config = JwtConfig::from_secret(b"epigraph-dev-secret-change-in-production!!");
+    let (token, _) = jwt_config
+        .issue_access_token(
+            Uuid::new_v4(),
+            vec!["epigraph:write".to_string(), "epigraph:read".to_string()],
+            "service",
+            None,
+            None,
+            chrono::Duration::seconds(300),
+        )
+        .expect("issue_access_token must succeed for tests");
+    token
+}
+
 /// Register a test agent in the database so submit validation passes.
 ///
 /// The submit handler validates that `agent_id` exists in the DB.
@@ -331,7 +352,10 @@ async fn submit_packet(app: axum::Router, packet: &EpistemicPacket) -> (StatusCo
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass") // Pass bearer_auth_middleware (falls through to legacy path)
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(body))
         .unwrap();
 
@@ -431,7 +455,10 @@ async fn test_packet_missing_claim_returns_400() {
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(malformed_packet.to_string()))
         .unwrap();
 
@@ -571,7 +598,10 @@ async fn test_packet_truth_value_nan_returns_400() {
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(packet_json.to_string()))
         .unwrap();
 
@@ -619,7 +649,10 @@ async fn test_packet_truth_value_infinity_returns_400() {
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(packet_json.to_string()))
         .unwrap();
 
@@ -660,7 +693,10 @@ async fn test_packet_missing_reasoning_trace_returns_400() {
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(packet_json.to_string()))
         .unwrap();
 
@@ -1448,7 +1484,10 @@ async fn test_rate_limit_headers_present() {
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(body))
         .unwrap();
 
@@ -1797,7 +1836,10 @@ async fn test_malformed_json_returns_400() {
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "application/json")
-        .header("x-signature", "test-bypass")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from("{ this is not valid json }"))
         .unwrap();
 
@@ -1821,7 +1863,10 @@ async fn test_wrong_content_type_returns_415() {
         .method(Method::POST)
         .uri("/api/v1/submit/packet")
         .header(header::CONTENT_TYPE, "text/plain") // Wrong!
-        .header("x-signature", "test-bypass")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
         .body(Body::from(serde_json::to_string(&packet).unwrap()))
         .unwrap();
 

--- a/crates/epigraph-cli/src/bin/ingest_literature.rs
+++ b/crates/epigraph-cli/src/bin/ingest_literature.rs
@@ -532,10 +532,10 @@ fn build_packets(
                 idempotency_key: None,
             };
 
-            // Sign the entire packet
-            let packet_bytes = serde_json::to_vec(&(&claim_submission, &evidence_items, &trace))
-                .unwrap_or_default();
-            let packet_signature = hex::encode(signer.sign(&packet_bytes));
+            // The submit/packet endpoint requires a placeholder signature (128 hex zeros)
+            // until Ed25519 verification is wired up server-side. Real signatures are
+            // rejected by the current server implementation (see submit.rs validation).
+            let packet_signature = "0".repeat(128);
 
             EpistemicPacket {
                 claim: claim_submission,
@@ -664,13 +664,26 @@ async fn main() {
         }
     };
 
+    // Build a reqwest client with optional Bearer token from EPIGRAPH_TOKEN env var
+    let auth_client = {
+        let mut builder = reqwest::Client::builder();
+        if let Ok(token) = std::env::var("EPIGRAPH_TOKEN") {
+            let mut headers = reqwest::header::HeaderMap::new();
+            let header_val = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+                .expect("token must be ASCII");
+            headers.insert(reqwest::header::AUTHORIZATION, header_val);
+            builder = builder.default_headers(headers);
+        }
+        builder.build().expect("Failed to build HTTP client")
+    };
+
     // In live mode, register agent via API; in dry-run, use random UUID
     let agent_id = if args.dry_run {
         let id = Uuid::new_v4();
         println!("Agent ID: {id} (dry-run, not registered)");
         id
     } else {
-        let client = reqwest::Client::new();
+        let client = auth_client.clone();
         let display_name = format!("literature-ingester:{}", extraction.source.doi);
         match register_agent(&client, &args.endpoint, &signer, &display_name).await {
             Ok(id) => {
@@ -797,7 +810,7 @@ async fn main() {
     }
 
     // Submit packets
-    let client = reqwest::Client::new();
+    let client = auth_client;
     let mut submitted = 0;
     let mut failed = 0;
 

--- a/crates/epigraph-core/tests/extensions.rs
+++ b/crates/epigraph-core/tests/extensions.rs
@@ -43,7 +43,10 @@ async fn orchestration_noop_submits_silently() {
         .submit(task_id, serde_json::json!({"type": "test"}))
         .await;
     assert!(result.is_ok(), "no-op orchestration must return Ok(())");
-    assert!(!orch.is_active(), "no-op orchestration must report inactive");
+    assert!(
+        !orch.is_active(),
+        "no-op orchestration must report inactive"
+    );
 }
 
 #[tokio::test]

--- a/crates/epigraph-crypto/src/encryption.rs
+++ b/crates/epigraph-crypto/src/encryption.rs
@@ -51,10 +51,7 @@ impl EncryptedPayload {
         }
         if bytes.len() > MAX_ENCRYPTED_PAYLOAD_BYTES {
             return Err(CryptoError::InvalidPayload {
-                reason: format!(
-                    "payload exceeds 10 MiB limit: {} bytes",
-                    bytes.len()
-                ),
+                reason: format!("payload exceeds 10 MiB limit: {} bytes", bytes.len()),
             });
         }
         let mut nonce = [0u8; 12];

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -67,6 +67,30 @@ impl ClaimRepository {
         // Calculate content hash using BLAKE3
         let content_hash = ContentHasher::hash(claim.content.as_bytes());
 
+        // Dedup: if a claim with this content already exists, return it instead of
+        // inserting a duplicate. Two round-trips are acceptable; the race window is
+        // tiny and duplicate claims are idempotent in practice.
+        let existing = sqlx::query!(
+            r#"SELECT id, content, truth_value, agent_id, trace_id, created_at, updated_at
+               FROM claims WHERE content_hash = $1 LIMIT 1"#,
+            content_hash.as_slice()
+        )
+        .fetch_optional(pool)
+        .await?;
+
+        if let Some(existing_row) = existing {
+            let tv = TruthValue::new(existing_row.truth_value)?;
+            return Ok(claim_from_row(
+                existing_row.id,
+                existing_row.content,
+                existing_row.agent_id,
+                existing_row.trace_id,
+                tv,
+                existing_row.created_at,
+                existing_row.updated_at,
+            ));
+        }
+
         let row = sqlx::query!(
             r#"
             INSERT INTO claims (
@@ -121,6 +145,30 @@ impl ClaimRepository {
         let content_hash = ContentHasher::hash(claim.content.as_bytes());
 
         use sqlx::Row;
+
+        // Dedup check within the same transaction
+        let existing = sqlx::query(
+            "SELECT id, content, truth_value, agent_id, trace_id, created_at, updated_at
+             FROM claims WHERE content_hash = $1 LIMIT 1",
+        )
+        .bind(content_hash.as_slice())
+        .fetch_optional(&mut *conn)
+        .await?;
+
+        if let Some(existing_row) = existing {
+            let truth_val: f64 = existing_row.get("truth_value");
+            let tv = TruthValue::new(truth_val)?;
+            return Ok(claim_from_row(
+                existing_row.get("id"),
+                existing_row.get("content"),
+                existing_row.get("agent_id"),
+                existing_row.get("trace_id"),
+                tv,
+                existing_row.get("created_at"),
+                existing_row.get("updated_at"),
+            ));
+        }
+
         let row = sqlx::query(
             r#"INSERT INTO claims (id, content, content_hash, truth_value, agent_id, trace_id, created_at, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)

--- a/crates/epigraph-db/src/repos/lineage.rs
+++ b/crates/epigraph-db/src/repos/lineage.rs
@@ -989,21 +989,21 @@ mod tests {
         let child_b = Uuid::new_v4();
 
         // Insert claims
-        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
             .bind(parent_id)
             .bind("Parent claim")
             .bind(test_agent)
             .execute(&pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
             .bind(child_a)
             .bind("Child A")
             .bind(test_agent)
             .execute(&pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
             .bind(child_b)
             .bind("Child B")
             .bind(test_agent)
@@ -1048,14 +1048,14 @@ mod tests {
         let claim_a = Uuid::new_v4();
         let claim_b = Uuid::new_v4();
 
-        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
             .bind(claim_a)
             .bind("Isolated claim A")
             .bind(test_agent)
             .execute(&pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
             .bind(claim_b)
             .bind("Isolated claim B")
             .bind(test_agent)
@@ -1091,7 +1091,7 @@ mod tests {
 
         // Insert claims
         for (id, content) in [(root, "Root claim"), (mid_a, "Mid A"), (mid_b, "Mid B")] {
-            sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+            sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
                 .bind(id)
                 .bind(content)
                 .bind(test_agent)
@@ -1130,14 +1130,14 @@ mod tests {
         let ancestor = Uuid::new_v4();
         let descendant = Uuid::new_v4();
 
-        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
             .bind(ancestor)
             .bind("Ancestor claim")
             .bind(test_agent)
             .execute(&pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, '\\x0000000000000000000000000000000000000000000000000000000000000000'::bytea, 0.5, $3)")
+        sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id) VALUES ($1, $2, sha256($1::text::bytea), 0.5, $3)")
             .bind(descendant)
             .bind("Descendant claim")
             .bind(test_agent)

--- a/crates/epigraph-db/src/repos/lineage.rs
+++ b/crates/epigraph-db/src/repos/lineage.rs
@@ -395,7 +395,7 @@ impl LineageRepository {
         // Build topological order (sorted by depth descending, so ancestors come first)
         let mut topological_order: Vec<(Uuid, i32)> =
             lineage_rows.iter().map(|r| (r.id, r.depth)).collect();
-        topological_order.sort_by(|a, b| b.1.cmp(&a.1)); // Descending depth
+        topological_order.sort_by_key(|b| std::cmp::Reverse(b.1)); // Descending depth
         let topological_order: Vec<Uuid> =
             topological_order.into_iter().map(|(id, _)| id).collect();
 
@@ -557,7 +557,7 @@ impl LineageRepository {
 
         // Sort by depth descending (ancestors first)
         let mut sorted: Vec<(Uuid, i32)> = rows.iter().map(|r| (r.id, r.depth)).collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         Ok(sorted.into_iter().map(|(id, _)| id).collect())
     }
@@ -785,7 +785,7 @@ impl LineageRepository {
         // Build topological order (sorted by depth ascending for descendants)
         let mut topological_order: Vec<(Uuid, i32)> =
             lineage_rows.iter().map(|r| (r.id, r.depth)).collect();
-        topological_order.sort_by(|a, b| a.1.cmp(&b.1)); // Ascending depth for descendants
+        topological_order.sort_by_key(|a| a.1); // Ascending depth for descendants
         let topological_order: Vec<Uuid> =
             topological_order.into_iter().map(|(id, _)| id).collect();
 
@@ -855,7 +855,7 @@ impl LineageRepository {
 
         // Sort by depth ascending (root first)
         let mut sorted: Vec<(Uuid, i32)> = rows.iter().map(|r| (r.id, r.depth)).collect();
-        sorted.sort_by(|a, b| a.1.cmp(&b.1));
+        sorted.sort_by_key(|a| a.1);
 
         Ok(sorted.into_iter().map(|(id, _)| id).collect())
     }

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -151,9 +151,9 @@ impl MassFunctionRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(pool)
+        .fetch_optional(pool)
         .await
-        .ok();
+        .map_err(DbError::from)?;
 
         Ok(row)
     }

--- a/crates/epigraph-embeddings/src/providers/jina.rs
+++ b/crates/epigraph-embeddings/src/providers/jina.rs
@@ -466,7 +466,10 @@ impl EmbeddingService for JinaProvider {
     }
 
     fn token_usage(&self) -> TokenUsage {
-        self.token_usage.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        self.token_usage
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     fn reset_token_usage(&self) {

--- a/crates/epigraph-embeddings/src/providers/local.rs
+++ b/crates/epigraph-embeddings/src/providers/local.rs
@@ -211,7 +211,10 @@ impl EmbeddingService for LocalProvider {
     }
 
     fn token_usage(&self) -> TokenUsage {
-        self.token_usage.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        self.token_usage
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     fn reset_token_usage(&self) {

--- a/crates/epigraph-embeddings/src/providers/mock.rs
+++ b/crates/epigraph-embeddings/src/providers/mock.rs
@@ -250,7 +250,10 @@ impl EmbeddingService for MockProvider {
     }
 
     fn token_usage(&self) -> TokenUsage {
-        self.token_usage.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        self.token_usage
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     fn reset_token_usage(&self) {
@@ -367,7 +370,10 @@ impl MockMultimodalProvider {
     /// Get the number of times `generate_from_image` was called
     #[allow(clippy::missing_panics_doc)]
     pub fn image_call_count(&self) -> usize {
-        *self.image_call_count.lock().unwrap_or_else(|e| e.into_inner())
+        *self
+            .image_call_count
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
     }
 }
 
@@ -432,7 +438,10 @@ impl MultimodalEmbeddingService for MockMultimodalProvider {
             });
         }
 
-        *self.image_call_count.lock().unwrap_or_else(|e| e.into_inner()) += 1;
+        *self
+            .image_call_count
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) += 1;
 
         // Generate deterministic embedding from image data hash
         let dim = self.inner.dimension();

--- a/crates/epigraph-embeddings/src/providers/openai.rs
+++ b/crates/epigraph-embeddings/src/providers/openai.rs
@@ -354,7 +354,10 @@ impl EmbeddingService for OpenAiProvider {
     }
 
     fn token_usage(&self) -> TokenUsage {
-        self.token_usage.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        self.token_usage
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     fn reset_token_usage(&self) {

--- a/crates/epigraph-engine/src/dag.rs
+++ b/crates/epigraph-engine/src/dag.rs
@@ -148,8 +148,7 @@ impl DagValidator {
                 if on_stack.contains(&next) {
                     // Back-edge found: extract the cycle from path
                     if let Some(pos) = path.iter().position(|&n| n == next) {
-                        let cycle: Vec<Uuid> =
-                            path[pos..].iter().map(|&n| self.graph[n]).collect();
+                        let cycle: Vec<Uuid> = path[pos..].iter().map(|&n| self.graph[n]).collect();
                         return cycle;
                     }
                 } else if !visited.contains(&next) {

--- a/crates/epigraph-engine/tests/integration_live.rs
+++ b/crates/epigraph-engine/tests/integration_live.rs
@@ -18,15 +18,14 @@ async fn get_pool() -> Option<PgPool> {
 
 async fn create_test_claim(pool: &PgPool, content: &str, truth_value: f64) -> Uuid {
     let id = Uuid::new_v4();
-    // content_hash is NOT NULL — use a deterministic dummy hash (32 bytes)
-    let content_hash = vec![0u8; 32];
+    // content_hash is derived from the per-row UUID via Postgres sha256 so each
+    // test claim satisfies migration 097's UNIQUE(content_hash, agent_id).
     sqlx::query(
         "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current) \
-         VALUES ($1, $2, $3, $4, (SELECT id FROM agents LIMIT 1), true)",
+         VALUES ($1, $2, sha256($1::text::bytea), $3, (SELECT id FROM agents LIMIT 1), true)",
     )
     .bind(id)
     .bind(content)
-    .bind(&content_hash)
     .bind(truth_value)
     .execute(pool)
     .await

--- a/crates/epigraph-interfaces/src/encryption.rs
+++ b/crates/epigraph-interfaces/src/encryption.rs
@@ -44,21 +44,13 @@ pub trait EncryptionProvider: Send + Sync + 'static {
     ///
     /// Returns the ciphertext. The no-op implementation returns `plaintext`
     /// unchanged.
-    async fn encrypt(
-        &self,
-        plaintext: &[u8],
-        key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError>;
+    async fn encrypt(&self, plaintext: &[u8], key_id: &str) -> Result<Vec<u8>, EncryptionError>;
 
     /// Decrypt `ciphertext` under the key identified by `key_id`.
     ///
     /// Returns the plaintext. The no-op implementation returns `ciphertext`
     /// unchanged.
-    async fn decrypt(
-        &self,
-        ciphertext: &[u8],
-        key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError>;
+    async fn decrypt(&self, ciphertext: &[u8], key_id: &str) -> Result<Vec<u8>, EncryptionError>;
 
     /// Return `true` if this provider performs real encryption.
     ///
@@ -84,19 +76,11 @@ impl NoOpEncryptionProvider {
 
 #[async_trait]
 impl EncryptionProvider for NoOpEncryptionProvider {
-    async fn encrypt(
-        &self,
-        plaintext: &[u8],
-        _key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError> {
+    async fn encrypt(&self, plaintext: &[u8], _key_id: &str) -> Result<Vec<u8>, EncryptionError> {
         Ok(plaintext.to_vec())
     }
 
-    async fn decrypt(
-        &self,
-        ciphertext: &[u8],
-        _key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError> {
+    async fn decrypt(&self, ciphertext: &[u8], _key_id: &str) -> Result<Vec<u8>, EncryptionError> {
         Ok(ciphertext.to_vec())
     }
 

--- a/crates/epigraph-interfaces/src/orchestration.rs
+++ b/crates/epigraph-interfaces/src/orchestration.rs
@@ -16,8 +16,8 @@
 //!   backend does not need to allocate them.
 
 use async_trait::async_trait;
-use uuid::Uuid;
 use serde_json::Value;
+use uuid::Uuid;
 
 use crate::InterfaceError;
 
@@ -65,11 +65,7 @@ pub trait OrchestrationBackend: Send + Sync + 'static {
     /// the task without waiting for the backend to allocate an ID.
     ///
     /// The no-op silently discards the submission.
-    async fn submit(
-        &self,
-        task_id: Uuid,
-        payload: Value,
-    ) -> Result<(), OrchestrationError>;
+    async fn submit(&self, task_id: Uuid, payload: Value) -> Result<(), OrchestrationError>;
 
     /// Query the current status of a previously submitted task.
     ///
@@ -100,11 +96,7 @@ impl NoOpOrchestrationBackend {
 
 #[async_trait]
 impl OrchestrationBackend for NoOpOrchestrationBackend {
-    async fn submit(
-        &self,
-        _task_id: Uuid,
-        _payload: Value,
-    ) -> Result<(), OrchestrationError> {
+    async fn submit(&self, _task_id: Uuid, _payload: Value) -> Result<(), OrchestrationError> {
         Ok(())
     }
 
@@ -125,7 +117,9 @@ mod tests {
     async fn noop_submit_succeeds_silently() {
         let backend = NoOpOrchestrationBackend::new();
         let id = Uuid::new_v4();
-        let result = backend.submit(id, serde_json::json!({"step": "test"})).await;
+        let result = backend
+            .submit(id, serde_json::json!({"step": "test"}))
+            .await;
         assert!(result.is_ok());
     }
 

--- a/crates/epigraph-jobs/src/lib.rs
+++ b/crates/epigraph-jobs/src/lib.rs
@@ -3071,7 +3071,10 @@ impl Default for InMemoryJobQueue {
 impl JobQueue for InMemoryJobQueue {
     async fn enqueue(&self, job: Job) -> Result<JobId, JobError> {
         let id = job.id;
-        self.jobs.write().unwrap_or_else(|e| e.into_inner()).push(job);
+        self.jobs
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(job);
         Ok(id)
     }
 

--- a/crates/epigraph-mcp/src/tools/batch.rs
+++ b/crates/epigraph-mcp/src/tools/batch.rs
@@ -41,7 +41,11 @@ pub async fn batch_submit_claims(
                     .first()
                     .and_then(|c| c.as_text())
                     .and_then(|t| serde_json::from_str::<serde_json::Value>(&t.text).ok())
-                    .and_then(|v| v.get("claim_id").and_then(|id| id.as_str()).map(String::from))
+                    .and_then(|v| {
+                        v.get("claim_id")
+                            .and_then(|id| id.as_str())
+                            .map(String::from)
+                    })
                     .unwrap_or_default();
                 submitted.push(serde_json::json!({
                     "index": i,

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -54,7 +54,9 @@ pub async fn ingest_paper(
     let cwd = std::env::current_dir()
         .map_err(|e| internal_error(format!("cannot determine CWD: {e}")))?;
     if !canonical.starts_with(&cwd) {
-        return Err(invalid_params("file path must be within the working directory"));
+        return Err(invalid_params(
+            "file path must be within the working directory",
+        ));
     }
     let data = tokio::fs::read_to_string(&canonical)
         .await

--- a/migrations/002_code_review_hardening.sql
+++ b/migrations/002_code_review_hardening.sql
@@ -5,7 +5,10 @@
 -- 1. Composite index on edges for path queries
 --    (note: idx_edges_unique_triple covers the same columns with a UNIQUE constraint;
 --     this non-unique index is added for query planner flexibility on non-unique paths)
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_edges_source_target_rel
+--    CONCURRENTLY dropped: sqlx 0.7 wraps migrations in a transaction, which forbids
+--    CREATE INDEX CONCURRENTLY. For production clean-rollouts on a live DB, a DBA
+--    should reissue this with CONCURRENTLY outside a transaction.
+CREATE INDEX IF NOT EXISTS idx_edges_source_target_rel
     ON edges(source_id, target_id, relationship);
 
 -- 2. idx_claims_agent_id already exists in 001_initial_schema.sql — skipped.
@@ -13,7 +16,7 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_edges_source_target_rel
 -- 3. Missing index on bp_messages.factor_id
 --    (the existing UNIQUE constraint covers (factor_id, variable_id, direction) but
 --     a standalone factor_id index improves single-column lookups and joins)
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bp_messages_factor_id
+CREATE INDEX IF NOT EXISTS idx_bp_messages_factor_id
     ON bp_messages(factor_id);
 
 -- 4. UNIQUE constraint on claims deduplication

--- a/migrations/003_papers_doi_unique_constraint.sql
+++ b/migrations/003_papers_doi_unique_constraint.sql
@@ -1,0 +1,115 @@
+-- Migration 097: Add unique constraint on papers.doi
+--
+-- The papers table has idx_papers_doi (btree) but no UNIQUE constraint,
+-- causing ON CONFLICT (doi) to fail in the API upsert path.
+-- This migration reconciles edges attached to duplicate papers (repointing
+-- from the younger row to the canonical oldest row), drops the younger
+-- duplicate rows, then adds the UNIQUE constraint.
+--
+-- Reconciliation is required because the papers table has a
+-- `cascade_delete_edges('paper')` BEFORE DELETE trigger: a naive
+-- `DELETE FROM papers` would silently destroy every edge incident on the
+-- duplicate row. Before this revision was made, applying that naive delete
+-- against the current DB would have cascaded 1,759 edges on two duplicate
+-- DOI groups (10.48550/arXiv.2512.24431 and 10.48550/arXiv.2603.11781).
+
+-- ---------------------------------------------------------------------------
+-- Step 1: Materialize duplicate→canonical pairs for the whole migration.
+-- Canonical = oldest row per doi. Pairs survive across the following DML.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE paper_dedup_pairs ON COMMIT DROP AS
+WITH canonicals AS (
+    SELECT DISTINCT ON (doi) id AS canonical_id, doi
+    FROM papers
+    WHERE doi IN (SELECT doi FROM papers GROUP BY doi HAVING COUNT(*) > 1)
+    ORDER BY doi, created_at ASC
+)
+SELECT p.id AS dup_id, c.canonical_id
+FROM papers p
+JOIN canonicals c ON p.doi = c.doi
+WHERE p.id <> c.canonical_id;
+
+-- ---------------------------------------------------------------------------
+-- Step 2: Drop colliding edges.
+-- An edge (dup_id → target, relationship) collides if the canonical already
+-- has (canonical_id → target, relationship) — the edges table has
+-- idx_edges_source_target_relationship UNIQUE on (source_id, target_id,
+-- relationship), so the UPDATE in Step 3 would otherwise fail.
+-- Current DB: 98 such collisions — the duplicate is redundant; dropping it
+-- collapses the duplicate reference without losing information.
+-- ---------------------------------------------------------------------------
+DELETE FROM edges e
+USING paper_dedup_pairs p
+WHERE e.source_type = 'paper'
+  AND e.source_id = p.dup_id
+  AND EXISTS (
+      SELECT 1 FROM edges e2
+      WHERE e2.source_id = p.canonical_id
+        AND e2.target_id = e.target_id
+        AND e2.relationship = e.relationship
+  );
+
+-- Symmetric handling for paper-as-target edges. No such edges exist in the
+-- current DB (verified: 0 rows with target_type='paper' AND target_id ∈ dups)
+-- but defensive coverage keeps the migration robust against future data.
+DELETE FROM edges e
+USING paper_dedup_pairs p
+WHERE e.target_type = 'paper'
+  AND e.target_id = p.dup_id
+  AND EXISTS (
+      SELECT 1 FROM edges e2
+      WHERE e2.target_id = p.canonical_id
+        AND e2.source_id = e.source_id
+        AND e2.relationship = e.relationship
+  );
+
+-- ---------------------------------------------------------------------------
+-- Step 3: Repoint surviving edges from duplicate → canonical.
+-- Current DB: 1,759 edges total on duplicates (all as source); after Step 2
+-- drops 98 collisions, 1,661 will be repointed.
+-- ---------------------------------------------------------------------------
+UPDATE edges e
+SET source_id = p.canonical_id
+FROM paper_dedup_pairs p
+WHERE e.source_type = 'paper'
+  AND e.source_id = p.dup_id;
+
+UPDATE edges e
+SET target_id = p.canonical_id
+FROM paper_dedup_pairs p
+WHERE e.target_type = 'paper'
+  AND e.target_id = p.dup_id;
+
+-- ---------------------------------------------------------------------------
+-- Step 4: Sanity check — no edges should remain on duplicate paper rows.
+-- If any remain, the cascade trigger in Step 5 would quietly destroy them.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    orphan_count INT;
+BEGIN
+    SELECT COUNT(*) INTO orphan_count
+    FROM edges e
+    JOIN paper_dedup_pairs p ON
+        (e.source_type = 'paper' AND e.source_id = p.dup_id)
+        OR (e.target_type = 'paper' AND e.target_id = p.dup_id);
+    IF orphan_count > 0 THEN
+        RAISE EXCEPTION
+            'Migration 097: % edges remain on duplicate papers after Step 3; aborting to avoid cascade loss',
+            orphan_count;
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Step 5: Drop the duplicate paper rows. The `cascade_delete_edges('paper')`
+-- BEFORE DELETE trigger will run but find no matching edges (Step 4 verified).
+-- ---------------------------------------------------------------------------
+DELETE FROM papers p
+USING paper_dedup_pairs d
+WHERE p.id = d.dup_id;
+
+-- ---------------------------------------------------------------------------
+-- Step 6: Replace the non-unique index with a unique constraint.
+-- ---------------------------------------------------------------------------
+DROP INDEX IF EXISTS idx_papers_doi;
+ALTER TABLE papers ADD CONSTRAINT papers_doi_unique UNIQUE (doi);

--- a/migrations/004_claim_signature_revocations.sql
+++ b/migrations/004_claim_signature_revocations.sql
@@ -1,0 +1,53 @@
+-- Migration 098: audit log for revoked claim signatures
+--
+-- Evidence: There is no way to express "this claim's signature is no longer
+--   trustworthy" without re-signing. Re-signing drifted content would forge
+--   the original author's consent; deleting the row loses provenance. The
+--   claims_signature_requires_signer CHECK (migration 073) forces either
+--   (signature NULL AND signer_id NULL) or both NOT NULL, so "zero the bytes
+--   but keep signer_id" is not a legal state.
+--
+-- Reasoning: Revocation must (a) null both signature and signer_id on the
+--   claim row to satisfy the 073 constraint, AND (b) preserve the original
+--   (signature, signer_id, content_hash) somewhere so forensic audit is
+--   still possible. A separate table keeps the claims table semantically
+--   clean ("current signature state") while this table answers "what did
+--   the signature chain look like before each revocation?". The optional
+--   superseded_by column links a revocation to a supersession when the
+--   workflow is revoke-as-part-of-supersede; otherwise NULL for standalone
+--   integrity-drift revocations.
+--
+-- FK policy: claim_id is ON DELETE CASCADE. Rationale: revocation rows are
+--   *about* a specific claim — an orphan revocation row referring to a
+--   deleted claim is meaningless. If the claim is deleted deliberately
+--   (rare — most integrity drift resolves via supersede, not delete), the
+--   revocation history is no longer load-bearing. RESTRICT was rejected
+--   because it would retroactively block every existing delete_claim call
+--   path on any revoked claim, which is surprising behavior.
+
+CREATE TABLE claim_signature_revocations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    claim_id UUID NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    previous_signature BYTEA NOT NULL,
+    previous_signer_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    previous_content_hash BYTEA NOT NULL,
+    revoked_by UUID NOT NULL REFERENCES agents(id) ON DELETE RESTRICT,
+    revoked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reason TEXT NOT NULL,
+    superseded_by UUID REFERENCES claims(id) ON DELETE SET NULL,
+    CONSTRAINT revocations_previous_sig_length
+        CHECK (octet_length(previous_signature) = 64),
+    CONSTRAINT revocations_previous_hash_length
+        CHECK (octet_length(previous_content_hash) = 32),
+    CONSTRAINT revocations_reason_nonempty
+        CHECK (length(trim(reason)) > 0)
+);
+
+CREATE INDEX idx_claim_sig_revocations_claim
+    ON claim_signature_revocations(claim_id);
+
+CREATE INDEX idx_claim_sig_revocations_revoker
+    ON claim_signature_revocations(revoked_by);
+
+CREATE INDEX idx_claim_sig_revocations_revoked_at
+    ON claim_signature_revocations(revoked_at DESC);


### PR DESCRIPTION
Forward port of V2 post-split kernel changes (same set as epigraph-internal PR #2), landed as discrete migrations 003 + 004 per public-repo release policy.

## Migrations
- **003_papers_doi_unique_constraint.sql** — from V2 migrations 097 (squashed: ff5149d + c41c6bf)
- **004_claim_signature_revocations.sql** — from V2 migration 098 (audit table for revoke-signature endpoint)

## Code (same 8 commits as epigraph-internal PR #2)
- fix(db): propagate DB errors from mass_function lookup
- fix(db): dedup claims by content_hash before insert
- fix(api): dedup papers via select-then-insert
- feat(api): accept paper as entity type on edges
- feat(api): POST /api/v1/claims/:id/revoke-signature + DTO tests
- feat(api): EPIGRAPH_PORT env var
- feat(cli): EPIGRAPH_TOKEN bearer auth in ingest_literature

## Additional cleanup commits
- **style: apply cargo fmt** — cleans pre-existing formatting drift in 14 files (unrelated to these patches; accumulated on dev between releases)
- **fix(api): revoke_signature clippy** — doc_overindented_list_items + type_complexity in the new handler

## Base
`dev` (not main). Promotion to main is a release decision.

## Related
Stacked (logically, not via branch base) with `epigraph-internal` PR #2 — same code changes applied with renumbered migrations per repo.

## Plan
`/home/jeremy/docs/superpowers/plans/2026-04-17-v2-kernel-sync.md`