### PR TITLE
fix(clippy): unnecessary_sort_by in analyze_graph + timeline

### DIFF
--- a/crates/epigraph-api/src/routes/timeline.rs
+++ b/crates/epigraph-api/src/routes/timeline.rs
@@ -122,7 +122,7 @@ pub async fn get_agent_timeline(
     entries.extend(act_entries);
 
     // --- 5. Sort by timestamp DESC, take top 100 ----------------------------
-    entries.sort_unstable_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    entries.sort_unstable_by_key(|b| std::cmp::Reverse(b.timestamp));
     entries.truncate(100);
 
     Ok(Json(entries))

--- a/crates/epigraph-cli/src/bin/analyze_graph.rs
+++ b/crates/epigraph-cli/src/bin/analyze_graph.rs
@@ -311,7 +311,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}\n", "=".repeat(60));
 
     let mut clusters_sorted: Vec<_> = result.support_clusters.iter().collect();
-    clusters_sorted.sort_by(|a, b| b.supporters.len().cmp(&a.supporters.len()));
+    clusters_sorted.sort_by_key(|b| std::cmp::Reverse(b.supporters.len()));
 
     println!(
         "  {} target(s) have multiple supporters\n",
@@ -439,7 +439,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut influence_ranked: Vec<_> = source_influence.iter().collect();
-    influence_ranked.sort_by(|a, b| b.1.cmp(a.1));
+    influence_ranked.sort_by_key(|a| std::cmp::Reverse(*a.1));
 
     println!("  Top 10 most influential claims (support others transitively):");
     for (i, (id, count)) in influence_ranked.iter().take(10).enumerate() {
@@ -461,7 +461,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\n  Top 10 most dependent claims (supported by others transitively):");
     let mut dep_ranked: Vec<_> = target_dependence.iter().collect();
-    dep_ranked.sort_by(|a, b| b.1.cmp(a.1));
+    dep_ranked.sort_by_key(|a| std::cmp::Reverse(*a.1));
     for (i, (id, count)) in dep_ranked.iter().take(10).enumerate() {
         let truth = claims
             .iter()


### PR DESCRIPTION
Same clippy cleanup as internal's follow-up. Rust 1.95's clippy flags 4 pre-existing `sort_by` / `sort_unstable_by` call sites that earlier versions didn't.

## Changes

- `crates/epigraph-cli/src/bin/analyze_graph.rs` (3 sites): `clusters_sorted`, `influence_ranked`, `dep_ranked` — convert to `sort_by_key` with `std::cmp::Reverse` for descending.
- `crates/epigraph-api/src/routes/timeline.rs` (1 site): `entries.sort_unstable_by` → `sort_unstable_by_key` with `Reverse`.

Pre-existing code; no behavioural change.

## Verification

- `cargo clippy --workspace -- -D warnings` — clean
- `cargo build --workspace` — clean

(The 2 `test_pgvector_*` failures on `dev` CI are pre-existing — see the comment on PR #2.)