### PR TITLE
fix(migrations): strip ghost entity types and restore search_path

### DIFF
--- a/crates/epigraph-api/src/routes/timeline.rs
+++ b/crates/epigraph-api/src/routes/timeline.rs
@@ -122,7 +122,7 @@ pub async fn get_agent_timeline(
     entries.extend(act_entries);
 
     // --- 5. Sort by timestamp DESC, take top 100 ----------------------------
-    entries.sort_unstable_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    entries.sort_unstable_by_key(|b| std::cmp::Reverse(b.timestamp));
     entries.truncate(100);
 
     Ok(Json(entries))

--- a/crates/epigraph-api/src/state.rs
+++ b/crates/epigraph-api/src/state.rs
@@ -18,9 +18,8 @@ use epigraph_embeddings::EmbeddingService;
 use epigraph_engine::{DatabasePropagator, PropagationConfig, PropagationOrchestrator};
 use epigraph_events::EventBus;
 use epigraph_interfaces::{
-    EncryptionProvider, NoOpEncryptionProvider,
-    OrchestrationBackend, NoOpOrchestrationBackend,
-    PolicyGate, NoOpPolicyGate,
+    EncryptionProvider, NoOpEncryptionProvider, NoOpOrchestrationBackend, NoOpPolicyGate,
+    OrchestrationBackend, PolicyGate,
 };
 use serde::{Deserialize, Serialize};
 
@@ -566,11 +565,9 @@ impl Default for ApiConfig {
 
 #[cfg(test)]
 mod extension_wiring_tests {
-    use epigraph_interfaces::{
-        NoOpEncryptionProvider, NoOpOrchestrationBackend, NoOpPolicyGate,
-    };
-    use std::sync::Arc;
     use super::{SharedEncryptionProvider, SharedOrchestrationBackend, SharedPolicyGate};
+    use epigraph_interfaces::{NoOpEncryptionProvider, NoOpOrchestrationBackend, NoOpPolicyGate};
+    use std::sync::Arc;
 
     #[test]
     fn appstate_accepts_noop_providers() {

--- a/crates/epigraph-cli/src/bin/analyze_graph.rs
+++ b/crates/epigraph-cli/src/bin/analyze_graph.rs
@@ -307,7 +307,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}\n", "=".repeat(60));
 
     let mut clusters_sorted: Vec<_> = result.support_clusters.iter().collect();
-    clusters_sorted.sort_by(|a, b| b.supporters.len().cmp(&a.supporters.len()));
+    clusters_sorted.sort_by_key(|b| std::cmp::Reverse(b.supporters.len()));
 
     println!(
         "  {} target(s) have multiple supporters\n",

--- a/crates/epigraph-core/tests/extensions.rs
+++ b/crates/epigraph-core/tests/extensions.rs
@@ -43,7 +43,10 @@ async fn orchestration_noop_submits_silently() {
         .submit(task_id, serde_json::json!({"type": "test"}))
         .await;
     assert!(result.is_ok(), "no-op orchestration must return Ok(())");
-    assert!(!orch.is_active(), "no-op orchestration must report inactive");
+    assert!(
+        !orch.is_active(),
+        "no-op orchestration must report inactive"
+    );
 }
 
 #[tokio::test]

--- a/crates/epigraph-db/src/repos/lineage.rs
+++ b/crates/epigraph-db/src/repos/lineage.rs
@@ -395,7 +395,7 @@ impl LineageRepository {
         // Build topological order (sorted by depth descending, so ancestors come first)
         let mut topological_order: Vec<(Uuid, i32)> =
             lineage_rows.iter().map(|r| (r.id, r.depth)).collect();
-        topological_order.sort_by(|a, b| b.1.cmp(&a.1)); // Descending depth
+        topological_order.sort_by_key(|b| std::cmp::Reverse(b.1)); // Descending depth
         let topological_order: Vec<Uuid> =
             topological_order.into_iter().map(|(id, _)| id).collect();
 
@@ -557,7 +557,7 @@ impl LineageRepository {
 
         // Sort by depth descending (ancestors first)
         let mut sorted: Vec<(Uuid, i32)> = rows.iter().map(|r| (r.id, r.depth)).collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         Ok(sorted.into_iter().map(|(id, _)| id).collect())
     }
@@ -785,7 +785,7 @@ impl LineageRepository {
         // Build topological order (sorted by depth ascending for descendants)
         let mut topological_order: Vec<(Uuid, i32)> =
             lineage_rows.iter().map(|r| (r.id, r.depth)).collect();
-        topological_order.sort_by(|a, b| a.1.cmp(&b.1)); // Ascending depth for descendants
+        topological_order.sort_by_key(|a| a.1); // Ascending depth for descendants
         let topological_order: Vec<Uuid> =
             topological_order.into_iter().map(|(id, _)| id).collect();
 
@@ -855,7 +855,7 @@ impl LineageRepository {
 
         // Sort by depth ascending (root first)
         let mut sorted: Vec<(Uuid, i32)> = rows.iter().map(|r| (r.id, r.depth)).collect();
-        sorted.sort_by(|a, b| a.1.cmp(&b.1));
+        sorted.sort_by_key(|a| a.1);
 
         Ok(sorted.into_iter().map(|(id, _)| id).collect())
     }

--- a/crates/epigraph-interfaces/src/encryption.rs
+++ b/crates/epigraph-interfaces/src/encryption.rs
@@ -44,21 +44,13 @@ pub trait EncryptionProvider: Send + Sync + 'static {
     ///
     /// Returns the ciphertext. The no-op implementation returns `plaintext`
     /// unchanged.
-    async fn encrypt(
-        &self,
-        plaintext: &[u8],
-        key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError>;
+    async fn encrypt(&self, plaintext: &[u8], key_id: &str) -> Result<Vec<u8>, EncryptionError>;
 
     /// Decrypt `ciphertext` under the key identified by `key_id`.
     ///
     /// Returns the plaintext. The no-op implementation returns `ciphertext`
     /// unchanged.
-    async fn decrypt(
-        &self,
-        ciphertext: &[u8],
-        key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError>;
+    async fn decrypt(&self, ciphertext: &[u8], key_id: &str) -> Result<Vec<u8>, EncryptionError>;
 
     /// Return `true` if this provider performs real encryption.
     ///
@@ -84,19 +76,11 @@ impl NoOpEncryptionProvider {
 
 #[async_trait]
 impl EncryptionProvider for NoOpEncryptionProvider {
-    async fn encrypt(
-        &self,
-        plaintext: &[u8],
-        _key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError> {
+    async fn encrypt(&self, plaintext: &[u8], _key_id: &str) -> Result<Vec<u8>, EncryptionError> {
         Ok(plaintext.to_vec())
     }
 
-    async fn decrypt(
-        &self,
-        ciphertext: &[u8],
-        _key_id: &str,
-    ) -> Result<Vec<u8>, EncryptionError> {
+    async fn decrypt(&self, ciphertext: &[u8], _key_id: &str) -> Result<Vec<u8>, EncryptionError> {
         Ok(ciphertext.to_vec())
     }
 

--- a/crates/epigraph-interfaces/src/orchestration.rs
+++ b/crates/epigraph-interfaces/src/orchestration.rs
@@ -16,8 +16,8 @@
 //!   backend does not need to allocate them.
 
 use async_trait::async_trait;
-use uuid::Uuid;
 use serde_json::Value;
+use uuid::Uuid;
 
 use crate::InterfaceError;
 
@@ -65,11 +65,7 @@ pub trait OrchestrationBackend: Send + Sync + 'static {
     /// the task without waiting for the backend to allocate an ID.
     ///
     /// The no-op silently discards the submission.
-    async fn submit(
-        &self,
-        task_id: Uuid,
-        payload: Value,
-    ) -> Result<(), OrchestrationError>;
+    async fn submit(&self, task_id: Uuid, payload: Value) -> Result<(), OrchestrationError>;
 
     /// Query the current status of a previously submitted task.
     ///
@@ -100,11 +96,7 @@ impl NoOpOrchestrationBackend {
 
 #[async_trait]
 impl OrchestrationBackend for NoOpOrchestrationBackend {
-    async fn submit(
-        &self,
-        _task_id: Uuid,
-        _payload: Value,
-    ) -> Result<(), OrchestrationError> {
+    async fn submit(&self, _task_id: Uuid, _payload: Value) -> Result<(), OrchestrationError> {
         Ok(())
     }
 
@@ -125,7 +117,9 @@ mod tests {
     async fn noop_submit_succeeds_silently() {
         let backend = NoOpOrchestrationBackend::new();
         let id = Uuid::new_v4();
-        let result = backend.submit(id, serde_json::json!({"step": "test"})).await;
+        let result = backend
+            .submit(id, serde_json::json!({"step": "test"}))
+            .await;
         assert!(result.is_ok());
     }
 

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -280,8 +280,6 @@ BEGIN
         WHEN 'analysis'              THEN EXISTS (SELECT 1 FROM analyses WHERE id = entity_id)
         WHEN 'activity'              THEN EXISTS (SELECT 1 FROM activities WHERE id = entity_id)
         WHEN 'source_artifact'       THEN EXISTS (SELECT 1 FROM source_artifacts WHERE id = entity_id)
-        WHEN 'propaganda_technique'  THEN EXISTS (SELECT 1 FROM propaganda_techniques WHERE id = entity_id)
-        WHEN 'coalition'             THEN EXISTS (SELECT 1 FROM coalitions WHERE id = entity_id)
         WHEN 'span'                  THEN EXISTS (SELECT 1 FROM agent_spans WHERE id = entity_id)
         WHEN 'entity'                THEN EXISTS (SELECT 1 FROM entities WHERE id = entity_id)
         WHEN 'task'                  THEN EXISTS (SELECT 1 FROM tasks WHERE id = entity_id)
@@ -309,8 +307,6 @@ BEGIN
         WHEN 'analysis'              THEN EXISTS (SELECT 1 FROM analyses WHERE id = entity_id)
         WHEN 'activity'              THEN EXISTS (SELECT 1 FROM activities WHERE id = entity_id)
         WHEN 'source_artifact'       THEN EXISTS (SELECT 1 FROM source_artifacts WHERE id = entity_id)
-        WHEN 'propaganda_technique'  THEN EXISTS (SELECT 1 FROM propaganda_techniques WHERE id = entity_id)
-        WHEN 'coalition'             THEN EXISTS (SELECT 1 FROM coalitions WHERE id = entity_id)
         WHEN 'span'                  THEN EXISTS (SELECT 1 FROM agent_spans WHERE id = entity_id)
         WHEN 'entity'                THEN EXISTS (SELECT 1 FROM entities WHERE id = entity_id)
         WHEN 'task'                  THEN EXISTS (SELECT 1 FROM tasks WHERE id = entity_id)
@@ -772,7 +768,7 @@ CREATE TABLE public.edges (
     signer_id uuid,
     content_hash bytea,
     CONSTRAINT edges_content_hash_length CHECK (((content_hash IS NULL) OR (octet_length(content_hash) = 32))),
-    CONSTRAINT edges_entity_types_valid CHECK ((((source_type)::text = ANY (ARRAY['claim'::text, 'agent'::text, 'evidence'::text, 'trace'::text, 'node'::text, 'activity'::text, 'paper'::text, 'perspective'::text, 'community'::text, 'context'::text, 'frame'::text, 'analysis'::text, 'experiment'::text, 'experiment_result'::text, 'propaganda_technique'::text, 'coalition'::text, 'source_artifact'::text, 'span'::text, 'entity'::text, 'task'::text, 'event'::text])) AND ((target_type)::text = ANY (ARRAY['claim'::text, 'agent'::text, 'evidence'::text, 'trace'::text, 'node'::text, 'activity'::text, 'paper'::text, 'perspective'::text, 'community'::text, 'context'::text, 'frame'::text, 'analysis'::text, 'experiment'::text, 'experiment_result'::text, 'propaganda_technique'::text, 'coalition'::text, 'source_artifact'::text, 'span'::text, 'entity'::text, 'task'::text, 'event'::text])))),
+    CONSTRAINT edges_entity_types_valid CHECK ((((source_type)::text = ANY (ARRAY['claim'::text, 'agent'::text, 'evidence'::text, 'trace'::text, 'node'::text, 'activity'::text, 'paper'::text, 'perspective'::text, 'community'::text, 'context'::text, 'frame'::text, 'analysis'::text, 'source_artifact'::text, 'span'::text, 'entity'::text, 'task'::text, 'event'::text])) AND ((target_type)::text = ANY (ARRAY['claim'::text, 'agent'::text, 'evidence'::text, 'trace'::text, 'node'::text, 'activity'::text, 'paper'::text, 'perspective'::text, 'community'::text, 'context'::text, 'frame'::text, 'analysis'::text, 'source_artifact'::text, 'span'::text, 'entity'::text, 'task'::text, 'event'::text])))),
     CONSTRAINT edges_no_self_loop CHECK (((source_id <> target_id) OR ((source_type)::text <> (target_type)::text))),
     CONSTRAINT edges_relationship_not_empty CHECK ((length(TRIM(BOTH FROM relationship)) > 0)),
     CONSTRAINT edges_signature_length CHECK (((signature IS NULL) OR (octet_length(signature) = 64))),

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -3908,6 +3908,10 @@ ALTER TABLE ONLY public.triples
 ALTER TABLE ONLY public.workflow_executions
     ADD CONSTRAINT workflow_executions_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.agents(id);
 
+-- Restore search_path so sqlx-cli can resolve _sqlx_migrations (unqualified)
+-- for its post-migration bookkeeping insert. Line 21 cleared it for the dump.
+SELECT pg_catalog.set_config('search_path', 'public', false);
+
 --
 --
 


### PR DESCRIPTION
## Summary

Combines two pg_dump baseline fixes that depend on each other for CI to pass:

1. **Strip ghost entity types** — `001_initial_schema.sql` was a pg_dump with intentional table-filtering for political (`propaganda_techniques`, `coalitions`), experiments (`experiments`, `experiment_results`), privacy/encryption, and host-CLI features. The validator function and `edges_entity_types_valid` CHECK constraint kept entity-type references to those filtered-out features, causing edge inserts to panic with `relation "propaganda_techniques" does not exist`. Strips four ghost types from both validator overloads and both CHECK arrays.

2. **Restore search_path after pg_dump prelude** — line 21 of the dump clears `search_path` and never restores it. `sqlx-cli`'s post-migration `INSERT INTO _sqlx_migrations` then fails with `relation "_sqlx_migrations" does not exist`, breaking local-dev bootstrap. Appends `SELECT pg_catalog.set_config('search_path', 'public', false)` so the unqualified table name resolves.

Both fixes are needed for the `epigraph-db` lineage tests to pass — neither works standalone. Originally tracked as PR #5 (this PR) and PR #1 from @maaku. Combined here so a single PR makes CI green; PR #1's commit is preserved with maaku's authorship.

## Out-of-scope cleanup direction

Per maintainer direction:
- Political features → separate product (not yet defined)
- Experiments → `episcience`
- Privacy/encryption → `epigraph-enterprise`
- Host CLI orchestration → internal-only

Public's `001_initial_schema.sql` should remain scoped to features that ship in the open-source release.

## Test plan
- [x] Migration 001 still applies cleanly to a fresh DB
- [x] `cargo test -p epigraph-db --lib repos::lineage::` — 5/5 passing locally
- [x] sqlx-cli bootstrap (`_sqlx_migrations`) resolves correctly
- [ ] CI green

## Supersedes
Closes #1 (absorbed by this PR's second commit, authored by @maaku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)