### PR TITLE
feat(migrations): forward-port internal 092-103 + revoke_signature route

### DIFF
--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -69,6 +69,7 @@ pub mod political;
 pub mod provenance;
 pub mod rag;
 pub mod reasoning;
+pub mod revoke_signature;
 #[cfg(feature = "db")]
 pub mod search;
 pub mod spans;
@@ -190,6 +191,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/claims/:id/supersede",
             post(versioning::supersede_claim),
+        )
+        .route(
+            "/api/v1/claims/:id/revoke-signature",
+            post(revoke_signature::revoke_claim_signature),
         )
         .route("/api/v1/claims/batch", post(batch::batch_create_claims))
         .route("/api/v1/claims/:id/labels", patch(claims::update_labels))
@@ -758,6 +763,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/claims/:id/supersede",
             post(versioning::supersede_claim),
+        )
+        .route(
+            "/api/v1/claims/:id/revoke-signature",
+            post(revoke_signature::revoke_claim_signature),
         )
         .route("/api/v1/claims/batch", post(batch::batch_create_claims))
         .route("/api/v1/claims/:id/labels", patch(claims::update_labels))

--- a/crates/epigraph-api/src/routes/revoke_signature.rs
+++ b/crates/epigraph-api/src/routes/revoke_signature.rs
@@ -1,0 +1,560 @@
+//! Claim signature revocation endpoint.
+//!
+//! POST /api/v1/claims/:id/revoke-signature
+//!
+//! Sets a claim's `signature` and `signer_id` to NULL, preserving the prior
+//! values in the `claim_signature_revocations` audit table (migration 098).
+//!
+//! # When to use this instead of supersede
+//!
+//! - **Supersede** (POST /api/v1/claims/:id/supersede) when the claim's
+//!   semantic content is still what you want to assert today: creates a new,
+//!   currently-signed claim and forwards graph connectivity to it.
+//! - **Revoke signature** (this endpoint) when the claim's content is of
+//!   unclear provenance, or when revoke-then-supersede is the chosen
+//!   disposition and the caller wants the old claim to clearly verify as
+//!   "unsigned" rather than "tampered."
+//!
+//! Re-signing drifted content would forge the original author's consent and
+//! is NOT supported. The route is intentionally a hole that forces the
+//! caller to either supersede or revoke — never re-sign.
+//!
+//! # Authorization
+//!
+//! Requires OAuth2 Bearer token with the `claims:revoke-signature` scope.
+//! Legacy Ed25519 signature authentication is NOT accepted on this route —
+//! the revoker's identity must be unambiguously extractable from an
+//! AuthContext so the audit row's `revoked_by` column is meaningful.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::ApiError;
+use crate::state::AppState;
+
+/// Maximum length of the revocation reason in bytes.
+/// Mirrors versioning::MAX_REASON_LENGTH to keep audit text bounded.
+const MAX_REASON_LENGTH: usize = 32_768;
+
+/// Request body for revoking a claim's signature.
+#[derive(Debug, Deserialize)]
+pub struct RevokeSignatureRequest {
+    /// Free-text reason recorded in the audit row. Required.
+    /// Examples:
+    ///   - "content_hash_drift_from_uncaptured_content_rewrite"
+    ///   - "superseded_by_<uuid>_content_of_unclear_provenance"
+    ///   - "migration_attestation_<date>_attested_drifted_content"
+    pub reason: String,
+
+    /// If the revocation is part of a supersession workflow, the UUID of the
+    /// superseding claim. The audit row carries this forward link; `None` for
+    /// standalone revocations.
+    #[serde(default)]
+    pub superseded_by: Option<Uuid>,
+
+    /// Optional fat-finger guard: the caller asserts the first N hex chars of
+    /// the current signature it expects to revoke. If set and mismatched, the
+    /// handler returns 409 Conflict without touching the row. Case-insensitive
+    /// hex; length determines how many prefix bytes to compare.
+    #[serde(default)]
+    pub expected_signature_prefix: Option<String>,
+}
+
+/// Response returned after a successful revocation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RevokeSignatureResponse {
+    /// The claim whose signature was revoked.
+    pub claim_id: Uuid,
+    /// UUID of the newly-inserted row in claim_signature_revocations.
+    pub revocation_id: Uuid,
+    /// The signer_id that was cleared (None if the prior signer had been
+    /// deleted and the FK was already NULL).
+    pub previous_signer_id: Option<Uuid>,
+    /// When the revocation was recorded (DB NOW()).
+    pub revoked_at: DateTime<Utc>,
+}
+
+/// Error body returned when a claim is already revoked (409 Conflict).
+/// Names the most recent revocation so the caller can correlate.
+#[derive(Debug, Serialize)]
+struct AlreadyRevokedDetail {
+    revocation_id: Uuid,
+    revoked_by: Uuid,
+    revoked_at: DateTime<Utc>,
+}
+
+/// Parse the optional `expected_signature_prefix` field into raw bytes.
+///
+/// Accepts None, empty, or a hex string optionally prefixed with `0x`.
+/// Rejects odd-length hex, prefixes longer than the 64-byte signature
+/// they would guard, and invalid hex characters.
+///
+/// Pulled out of the handler so it can be unit-tested without a DB.
+fn parse_expected_signature_prefix(input: Option<&str>) -> Result<Option<Vec<u8>>, ApiError> {
+    let Some(s) = input else { return Ok(None) };
+    if s.is_empty() {
+        return Ok(None);
+    }
+    let cleaned = s.trim().trim_start_matches("0x").to_ascii_lowercase();
+    if cleaned.len() % 2 != 0 {
+        return Err(ApiError::ValidationError {
+            field: "expected_signature_prefix".to_string(),
+            reason: "hex prefix must have an even number of characters".to_string(),
+        });
+    }
+    if cleaned.len() > 128 {
+        return Err(ApiError::ValidationError {
+            field: "expected_signature_prefix".to_string(),
+            reason: "hex prefix is longer than the 64-byte signature it would guard".to_string(),
+        });
+    }
+    Ok(Some(hex::decode(&cleaned).map_err(|e| {
+        ApiError::ValidationError {
+            field: "expected_signature_prefix".to_string(),
+            reason: format!("invalid hex: {e}"),
+        }
+    })?))
+}
+
+/// Row type returned by the claim signature lookup query.
+type ClaimSignatureRow = (Option<Vec<u8>>, Option<Uuid>, Option<Vec<u8>>);
+
+/// Revoke the signature on a claim.
+///
+/// POST /api/v1/claims/:id/revoke-signature
+///
+/// # Behavior
+///
+/// 1. Verifies Bearer-token AuthContext has the `claims:revoke-signature` scope.
+/// 2. Validates request: non-empty reason (≤32 KiB), optional prefix guard,
+///    optional superseded_by UUID (must reference an existing claim).
+/// 3. Executes a single DB transaction: SELECTs the current signature state
+///    (404 if missing, 409 if already revoked), checks the optional prefix
+///    guard (409 on mismatch), verifies the optional superseded_by target
+///    (400 if missing), INSERTs an audit row into claim_signature_revocations,
+///    then UPDATEs the claim to NULL both signature and signer_id (satisfies
+///    the migration 073 CHECK constraint).
+///
+/// # Errors
+///
+/// - 401 Unauthorized: no Bearer AuthContext (legacy Ed25519 is rejected here).
+/// - 403 Forbidden: AuthContext present but missing `claims:revoke-signature` scope.
+/// - 400 Bad Request: validation failure, or superseded_by references a missing claim.
+/// - 404 Not Found: claim_id doesn't exist.
+/// - 409 Conflict: claim is already revoked, or expected_signature_prefix mismatch.
+#[cfg(feature = "db")]
+pub async fn revoke_claim_signature(
+    State(state): State<AppState>,
+    auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>,
+    Path(claim_id): Path<Uuid>,
+    Json(request): Json<RevokeSignatureRequest>,
+) -> Result<(StatusCode, Json<RevokeSignatureResponse>), ApiError> {
+    // ---- Auth: bearer-only; legacy Ed25519 is not accepted here. ----
+    let axum::Extension(ref auth) = auth_ctx.ok_or(ApiError::Unauthorized {
+        reason: "claims:revoke-signature requires a Bearer token (AuthContext \
+                 with agent_id); legacy Ed25519 auth is not accepted on this route"
+            .to_string(),
+    })?;
+    crate::middleware::scopes::check_scopes(auth, &["claims:revoke-signature"])?;
+
+    let revoker_agent_id = auth.agent_id.ok_or(ApiError::Forbidden {
+        reason: "revoke-signature requires an AuthContext with a bound agent_id; \
+                 service-only tokens without agent binding cannot be recorded as \
+                 the revoker"
+            .to_string(),
+    })?;
+
+    // ---- Request validation. ----
+    let reason = request.reason.trim();
+    if reason.is_empty() {
+        return Err(ApiError::ValidationError {
+            field: "reason".to_string(),
+            reason: "reason cannot be empty".to_string(),
+        });
+    }
+    if request.reason.len() > MAX_REASON_LENGTH {
+        return Err(ApiError::ValidationError {
+            field: "reason".to_string(),
+            reason: format!(
+                "reason too long: {} bytes, maximum is {}",
+                request.reason.len(),
+                MAX_REASON_LENGTH
+            ),
+        });
+    }
+
+    // Parse expected_signature_prefix early so we don't start a transaction
+    // just to reject malformed hex.
+    let expected_prefix_bytes: Option<Vec<u8>> =
+        parse_expected_signature_prefix(request.expected_signature_prefix.as_deref())?;
+
+    // ---- DB transaction. ----
+    let mut tx = state
+        .db_pool
+        .begin()
+        .await
+        .map_err(|e| ApiError::DatabaseError {
+            message: format!("transaction begin failed: {e}"),
+        })?;
+
+    // Fetch current signature state.
+    let row: Option<ClaimSignatureRow> =
+        sqlx::query_as("SELECT signature, signer_id, content_hash FROM claims WHERE id = $1")
+            .bind(claim_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("claim lookup failed: {e}"),
+            })?;
+
+    let (current_signature, current_signer_id, current_content_hash) =
+        row.ok_or_else(|| ApiError::NotFound {
+            entity: "Claim".to_string(),
+            id: claim_id.to_string(),
+        })?;
+
+    // Already revoked? Surface the prior revocation for correlation.
+    let Some(current_signature) = current_signature else {
+        let prior: Option<(Uuid, Uuid, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT id, revoked_by, revoked_at FROM claim_signature_revocations \
+             WHERE claim_id = $1 ORDER BY revoked_at DESC LIMIT 1",
+        )
+        .bind(claim_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| ApiError::DatabaseError {
+            message: format!("prior revocation lookup failed: {e}"),
+        })?;
+
+        let detail = match prior {
+            Some((id, by, at)) => serde_json::to_value(AlreadyRevokedDetail {
+                revocation_id: id,
+                revoked_by: by,
+                revoked_at: at,
+            })
+            .ok()
+            .map(|v| format!(" (prior: {v})"))
+            .unwrap_or_default(),
+            None => String::new(),
+        };
+        return Err(ApiError::BadRequest {
+            message: format!(
+                "claim {claim_id} has no active signature to revoke (signature IS NULL){detail}"
+            ),
+        });
+    };
+
+    // Signature is NOT NULL, so migration 073's CHECK guarantees signer_id is
+    // NOT NULL and the byte length is 64. Content_hash is also stored. Assert
+    // defensively to surface any future schema drift loudly.
+    let current_signer_id = current_signer_id.ok_or_else(|| ApiError::IntegrityError {
+        field: "signer_id".to_string(),
+        expected: "NOT NULL when signature is NOT NULL (migration 073 CHECK)".to_string(),
+        actual: "NULL".to_string(),
+    })?;
+    let current_content_hash = current_content_hash.ok_or_else(|| ApiError::IntegrityError {
+        field: "content_hash".to_string(),
+        expected: "NOT NULL on any signed claim".to_string(),
+        actual: "NULL".to_string(),
+    })?;
+
+    // Prefix guard (optional): reject fat-finger UUID mistakes.
+    if let Some(expected) = &expected_prefix_bytes {
+        if !current_signature.starts_with(expected) {
+            return Err(ApiError::BadRequest {
+                message: format!(
+                    "expected_signature_prefix mismatch: supplied prefix does not \
+                     match the current signature of claim {claim_id}"
+                ),
+            });
+        }
+    }
+
+    // If superseded_by is set, verify the target claim exists.
+    if let Some(sup_by) = request.superseded_by {
+        let exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM claims WHERE id = $1")
+            .bind(sup_by)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("superseded_by lookup failed: {e}"),
+            })?;
+        if exists.is_none() {
+            return Err(ApiError::BadRequest {
+                message: format!("superseded_by claim {sup_by} does not exist"),
+            });
+        }
+    }
+
+    // Insert the audit row.
+    let revocation_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO claim_signature_revocations \
+            (claim_id, previous_signature, previous_signer_id, previous_content_hash, \
+             revoked_by, reason, superseded_by) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) \
+         RETURNING id",
+    )
+    .bind(claim_id)
+    .bind(&current_signature)
+    .bind(current_signer_id)
+    .bind(&current_content_hash)
+    .bind(revoker_agent_id)
+    .bind(reason)
+    .bind(request.superseded_by)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| ApiError::DatabaseError {
+        message: format!("revocation audit insert failed: {e}"),
+    })?;
+
+    // Null the signature + signer_id. The migration 073 CHECK requires both
+    // change together; doing both in one UPDATE keeps the constraint satisfied.
+    let affected = sqlx::query(
+        "UPDATE claims SET signature = NULL, signer_id = NULL, updated_at = NOW() \
+         WHERE id = $1",
+    )
+    .bind(claim_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| ApiError::DatabaseError {
+        message: format!("claim signature clear failed: {e}"),
+    })?
+    .rows_affected();
+
+    if affected != 1 {
+        return Err(ApiError::DatabaseError {
+            message: format!(
+                "expected to null exactly 1 claim signature, affected {affected} rows"
+            ),
+        });
+    }
+
+    // Fetch revoked_at from the just-inserted row so the response is authoritative.
+    let revoked_at: DateTime<Utc> =
+        sqlx::query_scalar("SELECT revoked_at FROM claim_signature_revocations WHERE id = $1")
+            .bind(revocation_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| ApiError::DatabaseError {
+                message: format!("revoked_at fetch failed: {e}"),
+            })?;
+
+    tx.commit().await.map_err(|e| ApiError::DatabaseError {
+        message: format!("transaction commit failed: {e}"),
+    })?;
+
+    tracing::info!(
+        claim_id = %claim_id,
+        revocation_id = %revocation_id,
+        revoked_by = %revoker_agent_id,
+        previous_signer_id = %current_signer_id,
+        superseded_by = ?request.superseded_by,
+        reason = %reason,
+        "claim signature revoked",
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(RevokeSignatureResponse {
+            claim_id,
+            revocation_id,
+            previous_signer_id: Some(current_signer_id),
+            revoked_at,
+        }),
+    ))
+}
+
+/// Stub for builds without the `db` feature. Always returns 503.
+#[cfg(not(feature = "db"))]
+pub async fn revoke_claim_signature(
+    State(_state): State<AppState>,
+    Path(_claim_id): Path<Uuid>,
+    Json(_request): Json<RevokeSignatureRequest>,
+) -> Result<(StatusCode, Json<RevokeSignatureResponse>), ApiError> {
+    Err(ApiError::ServiceUnavailable {
+        service: "Signature revocation requires database".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- parse_expected_signature_prefix ----
+
+    #[test]
+    fn prefix_none_returns_none() {
+        let out = parse_expected_signature_prefix(None).unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn prefix_empty_string_returns_none() {
+        let out = parse_expected_signature_prefix(Some("")).unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn prefix_accepts_lowercase_hex() {
+        let out = parse_expected_signature_prefix(Some("deadbeef"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_accepts_uppercase_hex() {
+        let out = parse_expected_signature_prefix(Some("DEADBEEF"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_strips_0x_prefix() {
+        let out = parse_expected_signature_prefix(Some("0xdeadbeef"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_trims_whitespace() {
+        let out = parse_expected_signature_prefix(Some("  deadbeef  "))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prefix_rejects_odd_length() {
+        let err = parse_expected_signature_prefix(Some("abc")).unwrap_err();
+        match err {
+            ApiError::ValidationError { field, reason } => {
+                assert_eq!(field, "expected_signature_prefix");
+                assert!(reason.contains("even number"), "got: {reason}");
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prefix_rejects_too_long() {
+        // 130 hex chars = longer than a 64-byte (128-hex-char) signature.
+        // Must be even so we hit the length check rather than the odd-length
+        // check that would otherwise short-circuit.
+        let long = "a".repeat(130);
+        let err = parse_expected_signature_prefix(Some(&long)).unwrap_err();
+        match err {
+            ApiError::ValidationError { field, reason } => {
+                assert_eq!(field, "expected_signature_prefix");
+                assert!(
+                    reason.contains("longer than the 64-byte signature"),
+                    "got: {reason}"
+                );
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prefix_accepts_full_64_byte_signature() {
+        // 128 hex chars = exactly one 64-byte signature, should pass.
+        let full = "a".repeat(128);
+        let out = parse_expected_signature_prefix(Some(&full))
+            .unwrap()
+            .unwrap();
+        assert_eq!(out.len(), 64);
+    }
+
+    #[test]
+    fn prefix_rejects_invalid_hex_chars() {
+        let err = parse_expected_signature_prefix(Some("gggg")).unwrap_err();
+        match err {
+            ApiError::ValidationError { field, reason } => {
+                assert_eq!(field, "expected_signature_prefix");
+                assert!(reason.contains("invalid hex"), "got: {reason}");
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    // ---- DTO serde roundtrip ----
+
+    #[test]
+    fn request_deserializes_minimal() {
+        let req: RevokeSignatureRequest = serde_json::from_value(serde_json::json!({
+            "reason": "hash drift",
+        }))
+        .unwrap();
+        assert_eq!(req.reason, "hash drift");
+        assert!(req.superseded_by.is_none());
+        assert!(req.expected_signature_prefix.is_none());
+    }
+
+    #[test]
+    fn request_deserializes_full() {
+        let sup_by = Uuid::new_v4();
+        let req: RevokeSignatureRequest = serde_json::from_value(serde_json::json!({
+            "reason": "superseded",
+            "superseded_by": sup_by.to_string(),
+            "expected_signature_prefix": "0xdead",
+        }))
+        .unwrap();
+        assert_eq!(req.reason, "superseded");
+        assert_eq!(req.superseded_by, Some(sup_by));
+        assert_eq!(req.expected_signature_prefix.as_deref(), Some("0xdead"));
+    }
+
+    #[test]
+    fn response_serializes_roundtrip() {
+        let resp = RevokeSignatureResponse {
+            claim_id: Uuid::new_v4(),
+            revocation_id: Uuid::new_v4(),
+            previous_signer_id: Some(Uuid::new_v4()),
+            revoked_at: Utc::now(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.get("claim_id").is_some());
+        assert!(json.get("revocation_id").is_some());
+        assert!(json.get("previous_signer_id").is_some());
+        assert!(json.get("revoked_at").is_some());
+        let back: RevokeSignatureResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(back.claim_id, resp.claim_id);
+        assert_eq!(back.revocation_id, resp.revocation_id);
+        assert_eq!(back.previous_signer_id, resp.previous_signer_id);
+    }
+
+    // ---- Non-db stub returns 503 ----
+
+    #[cfg(not(feature = "db"))]
+    mod stub {
+        use super::*;
+        use crate::state::{ApiConfig, AppState};
+
+        #[tokio::test]
+        async fn stub_returns_service_unavailable() {
+            let state = AppState::new(ApiConfig::default());
+            let claim_id = Uuid::new_v4();
+            let req = RevokeSignatureRequest {
+                reason: "test".to_string(),
+                superseded_by: None,
+                expected_signature_prefix: None,
+            };
+            let err = revoke_claim_signature(
+                axum::extract::State(state),
+                axum::extract::Path(claim_id),
+                axum::Json(req),
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(err, ApiError::ServiceUnavailable { .. }));
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-04-26-forward-port-092-103.md
+++ b/docs/superpowers/plans/2026-04-26-forward-port-092-103.md
@@ -1,0 +1,1122 @@
+# Forward-port internal migrations 092–103 to public Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port 11 forward migrations from `epigraph-internal` (renumber from `092–103`, skip non-existent `099`, drop internal-only `104_host_tables_baseline`) into public `epigraph` as new migrations `002–012`, filter ghost entity-type references where the source touches the validator/CHECK, port the matching `revoke_signature.rs` API route for migration `008`, and verify the full `epigraph-db` test suite stays green.
+
+**Architecture:** Each internal migration becomes a renumbered public migration. Two source files (`093`, `095`) re-introduce ghost entity types (`propaganda_technique`, `coalition`, `experiment`, `experiment_result`) in their validator/CHECK updates and must be filtered before commit. After the schema lands, port the `revoke_signature.rs` API route (migration `008` companion) from internal. Each migration commit independently rebuilds the schema from scratch and runs `epigraph-db` tests; the cumulative branch passes the full workspace test suite at the end.
+
+**Tech Stack:** Rust 1.94 (workspace edition 2021), Postgres 16 + pgvector (sqlx 0.7.4 with `#[sqlx::test]` template-DB cloning), cargo
+
+---
+
+## Prerequisites
+
+This plan assumes the following PRs are merged into `main` (or applied locally for testing):
+- **#1** `fix-migration-search-path` (maaku) — restores `search_path` so sqlx-cli bootstrap resolves `_sqlx_migrations`
+- **#5** `chore/strip-ghost-entity-types` — removes `propaganda_technique`, `coalition`, `experiment`, `experiment_result` from `001`'s validator + CHECK
+
+If either is unmerged, applying this branch on top of plain `main` will break. Verify in Task 0.
+
+**Local Postgres assumed available** at `127.0.0.1:5432` with user `epigraph` / password `epigraph` and `CREATEDB` privilege. Verify with:
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "SELECT 1;"
+```
+
+**Worktree:** Already created at `/home/jeremy/epigraph-forward-port` on branch `feat/forward-port-092-103`. All commands run from this directory unless noted.
+
+**Source migrations** are on the renumbered branch `chore/migration-renumber-2026-04-25` of `epigraph-internal`. They've already been pulled to `/tmp/internal-renumber-migrations/migrations/` by the audit step. If that dir is gone, recreate it:
+```bash
+git -C /home/jeremy/epigraph-internal fetch origin chore/migration-renumber-2026-04-25
+rm -rf /tmp/internal-renumber-migrations && mkdir /tmp/internal-renumber-migrations
+git -C /home/jeremy/epigraph-internal archive origin/chore/migration-renumber-2026-04-25 migrations/ \
+  | tar -x -C /tmp/internal-renumber-migrations
+```
+
+---
+
+## Renumbering map
+
+| New (public) | Source (internal) | Filter? | Notes |
+|---|---|---|---|
+| `002_behavioral_executions.sql` | `092_behavioral_executions.sql` | no | new table |
+| `003_business_function_entity_type.sql` | `093_business_function_entity_type.sql` | **yes** | strips ghosts from validator + CHECK |
+| `004_stop_truth_value_overwrite.sql` | `094_stop_truth_value_overwrite.sql` | no | no-op marker (carries note for migration history) |
+| `005_task_event_edge_types.sql` | `095_task_event_edge_types.sql` | **yes** | strips ghosts from validator + CHECK |
+| `006_provenance_patch_payload.sql` | `096_provenance_patch_payload.sql` | no | column add |
+| `007_papers_doi_unique_constraint.sql` | `097_papers_doi_unique_constraint.sql` | no | UNIQUE; reconciliation no-ops on fresh DB |
+| `008_claim_signature_revocations.sql` | `098_claim_signature_revocations.sql` | no | new table |
+| `009_conflict_taxonomy.sql` | `100_conflict_taxonomy.sql` | no | adds `edges.dimension_score`, `evidence.scope` |
+| `010_divergence_cache_validity_constraints.sql` | `101_divergence_cache_validity_constraints.sql` | no | constraints + index |
+| `011_derived_from_uppercase_factor.sql` | `102_derived_from_uppercase_factor.sql` | no | rewrites `edge_to_factor_type()` |
+| `012_cull_low_similarity_corroborates.sql` | `103_cull_low_similarity_corroborates.sql` | no | DELETE statements; no-op on fresh DB |
+
+Skipped: `099` (does not exist in source), `104_host_tables_baseline.sql` (EpiClaw CLI orchestration — internal-only).
+
+---
+
+## Ghost-filter specification
+
+For migrations that update either `validate_edge_reference()` or `edges_entity_types_valid` CHECK, remove **all** lines/array entries containing any of these four entity-type literals:
+- `'propaganda_technique'`
+- `'coalition'`
+- `'experiment'`
+- `'experiment_result'`
+
+Apply via this Python one-liner (used in Tasks 2 and 4 — copy verbatim):
+
+```bash
+python3 - "$src" "$dst" <<'PY'
+import re, sys
+src, dst = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    text = f.read()
+GHOSTS = ["propaganda_technique", "coalition", "experiment_result", "experiment"]
+# Strip whole CASE WHEN lines for ghosts (validator function)
+for g in GHOSTS:
+    text = re.sub(rf"^\s*WHEN '{g}'\s+THEN EXISTS\s*\(SELECT 1 FROM \w+ WHERE id = entity_id\)\n",
+                  "", text, flags=re.MULTILINE)
+# Strip ghost array entries from CHECK constraints. Match `'ghost',` or `, 'ghost'` or `'ghost'` standalone.
+for g in GHOSTS:
+    text = re.sub(rf",\s*'{g}'", "", text)
+    text = re.sub(rf"'{g}'\s*,\s*", "", text)
+    text = re.sub(rf"'{g}'", "", text)
+with open(dst, 'w') as f:
+    f.write(text)
+PY
+```
+
+After running the filter, `grep -c "propaganda_technique\|coalition\|'experiment'\|'experiment_result'" "$dst"` must return `0`.
+
+---
+
+## Verification harness
+
+The harness rebuilds the schema from scratch in a throwaway DB, then runs `epigraph-db`'s lineage tests as a smoke probe. Used after every migration commit.
+
+```bash
+# function definition — paste into shell at start of session
+verify_schema() {
+  local TESTDB="epigraph_fwdport_$$"
+  PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph "$TESTDB" 2>/dev/null
+  PGPASSWORD=epigraph createdb -h 127.0.0.1 -U epigraph "$TESTDB" || return 1
+  for f in migrations/*.sql; do
+    PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d "$TESTDB" \
+      -v ON_ERROR_STOP=1 --single-transaction -f "$f" > /tmp/mig.log 2>&1
+    if [ $? -ne 0 ]; then
+      echo "FAIL on $f:"
+      tail -5 /tmp/mig.log
+      PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph "$TESTDB"
+      return 1
+    fi
+  done
+  echo "schema build: OK"
+  # lineage tests as smoke probe
+  for db in $(PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -tAc \
+    "SELECT datname FROM pg_database WHERE datname LIKE '_sqlx_test%';"); do
+    PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph "$db" 2>&1 > /dev/null
+  done
+  DATABASE_URL="postgres://epigraph:epigraph@127.0.0.1:5432/$TESTDB" SQLX_OFFLINE=true \
+    cargo test -p epigraph-db --lib repos::lineage:: -- --test-threads=1 2>&1 | tail -8
+  PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph "$TESTDB"
+}
+```
+
+Expected output of `verify_schema` after a successful migration:
+```
+schema build: OK
+test result: ok. 5 passed; 0 failed; ...
+```
+
+---
+
+## File Structure
+
+**Create (12 files):**
+- `migrations/002_behavioral_executions.sql` — copy of internal `092`
+- `migrations/003_business_function_entity_type.sql` — filtered copy of internal `093`
+- `migrations/004_stop_truth_value_overwrite.sql` — copy of internal `094` (no-op marker)
+- `migrations/005_task_event_edge_types.sql` — filtered copy of internal `095`
+- `migrations/006_provenance_patch_payload.sql` — copy of internal `096`
+- `migrations/007_papers_doi_unique_constraint.sql` — copy of internal `097`
+- `migrations/008_claim_signature_revocations.sql` — copy of internal `098`
+- `migrations/009_conflict_taxonomy.sql` — copy of internal `100`
+- `migrations/010_divergence_cache_validity_constraints.sql` — copy of internal `101`
+- `migrations/011_derived_from_uppercase_factor.sql` — copy of internal `102`
+- `migrations/012_cull_low_similarity_corroborates.sql` — copy of internal `103`
+- `crates/epigraph-api/src/routes/revoke_signature.rs` — copy from internal `crates/epigraph-api/src/routes/revoke_signature.rs`
+
+**Modify:**
+- `crates/epigraph-api/src/routes/mod.rs` — register `pub mod revoke_signature;` and wire route into the API router (Task 13)
+- `.sqlx/` — regenerate after the schema changes (Task 14)
+
+**Will NOT port (intentional):**
+- `migrations/104_host_tables_baseline.sql` (internal CLI orchestration)
+- `crates/epigraph-api/src/routes/mcp_tools.rs` — this is the *other* file that diffs between repos; not directly tied to migrations 092–103. Investigation step in Task 15 confirms whether it should land here or in a separate PR.
+
+---
+
+## Task 0: Setup and baseline verification
+
+**Files:** none (tooling only)
+
+- [ ] **Step 1: Confirm worktree and branch**
+
+```bash
+cd /home/jeremy/epigraph-forward-port
+git status
+git branch --show-current
+```
+
+Expected: clean working tree on `feat/forward-port-092-103`.
+
+- [ ] **Step 2: Apply prerequisite PRs locally if not yet merged**
+
+Check whether main already has the PR #1 search_path fix and PR #5 strip:
+
+```bash
+grep -c "set_config('search_path'" migrations/001_initial_schema.sql
+grep -c "propaganda_technique\|'coalition'" migrations/001_initial_schema.sql
+```
+
+Expected: `1` and `0` respectively. If either is wrong, the prerequisites aren't merged. Apply them inline:
+
+```bash
+gh pr diff 1 --repo epigraph-io/epigraph | git apply --include='migrations/*'
+# PR #5 is already merged on this branch's base if it was merged before branching;
+# otherwise: git cherry-pick origin/chore/strip-ghost-entity-types
+```
+
+- [ ] **Step 3: Confirm Postgres reachable**
+
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "SELECT version();" | head -3
+```
+
+Expected: a `PostgreSQL 16.x` line.
+
+- [ ] **Step 4: Define `verify_schema` shell function**
+
+Paste the function definition from the [Verification harness](#verification-harness) section into your shell.
+
+- [ ] **Step 5: Run baseline verification**
+
+```bash
+verify_schema
+```
+
+Expected:
+```
+schema build: OK
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 63 filtered out; finished in ~5s
+```
+
+If lineage tests don't pass at baseline, **stop** — the prerequisites aren't right. Do not start porting.
+
+---
+
+## Task 1: Migration 002 — `behavioral_executions`
+
+**Files:**
+- Create: `migrations/002_behavioral_executions.sql` (25 lines, straight copy)
+
+- [ ] **Step 1: Copy migration unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/092_behavioral_executions.sql migrations/002_behavioral_executions.sql
+```
+
+- [ ] **Step 2: Verify file contents look right**
+
+```bash
+head -5 migrations/002_behavioral_executions.sql
+grep "^CREATE TABLE" migrations/002_behavioral_executions.sql
+```
+
+Expected output includes:
+```
+CREATE TABLE IF NOT EXISTS behavioral_executions (
+```
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` followed by `5 passed; 0 failed`.
+
+- [ ] **Step 4: Sanity check the new table exists**
+
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -tAc \
+  "SELECT 'exists' FROM information_schema.tables WHERE table_name='behavioral_executions';" \
+  | head -1 || echo "(test DB already dropped — re-run verify_schema and inspect during the run)"
+```
+
+(The harness drops the test DB at the end; the table-exists check is implicit in `schema build: OK`. Listed here to clarify intent.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/002_behavioral_executions.sql
+git commit -m "feat(migrations): port behavioral_executions table (was 092)
+
+Forward-port from epigraph-internal migration 092. Adds
+behavioral_executions table for task-conditional workflow scoring.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/092_behavioral_executions.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Migration 003 — `business_function_entity_type` (filtered)
+
+**Files:**
+- Create: `migrations/003_business_function_entity_type.sql` (filtered from internal `093`)
+
+- [ ] **Step 1: Apply ghost-filter while copying**
+
+Run the filter script from the [Ghost-filter specification](#ghost-filter-specification) section with:
+```bash
+src=/tmp/internal-renumber-migrations/migrations/093_business_function_entity_type.sql
+dst=migrations/003_business_function_entity_type.sql
+# (paste the python one-liner from the ghost-filter spec)
+```
+
+- [ ] **Step 2: Verify filter removed all four ghosts**
+
+```bash
+grep -c "propaganda_technique\|'coalition'\|'experiment'\|'experiment_result'" migrations/003_business_function_entity_type.sql
+```
+
+Expected: `0`
+
+- [ ] **Step 3: Verify intended additions remain**
+
+```bash
+grep -E "BusinessFunction|'entity'" migrations/003_business_function_entity_type.sql | head -5
+```
+
+Expected: lines mentioning `BusinessFunction` (entities CHECK extension) and `'entity'` in the edges CHECK array.
+
+- [ ] **Step 4: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 5: Sanity-test the new entity edge type works**
+
+Add a one-shot SQL probe (run inside a fresh test DB if the harness has already torn its down):
+
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "CREATE DATABASE _probe_003;"
+for f in migrations/*.sql; do
+  PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d _probe_003 -v ON_ERROR_STOP=1 --single-transaction -f "$f" > /dev/null 2>&1 || { echo "FAIL on $f"; break; }
+done
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d _probe_003 -c \
+  "SELECT validate_edge_reference(NULL::uuid, 'entity'::varchar);"
+PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph _probe_003
+```
+
+Expected: validator returns `f` (false) for nonexistent UUID — but does **not** raise "relation does not exist". Returning `f` is correct (the function executes without error and just reports no match).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add migrations/003_business_function_entity_type.sql
+git commit -m "feat(migrations): port business_function entity type (was 093, filtered)
+
+Forward-port from epigraph-internal migration 093 with ghost entity
+types (propaganda_technique, coalition, experiment, experiment_result)
+filtered out of the validator CASE branches and edges CHECK constraint.
+
+Adds BusinessFunction to entities.type_top and 'entity' to edges
+source_type/target_type lists for GOVERNS edges.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/093_business_function_entity_type.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Migration 004 — `stop_truth_value_overwrite` (no-op marker)
+
+**Files:**
+- Create: `migrations/004_stop_truth_value_overwrite.sql` (7-line comment-only file)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/094_stop_truth_value_overwrite.sql migrations/004_stop_truth_value_overwrite.sql
+```
+
+- [ ] **Step 2: Verify file is just comments (the migration is intentionally a no-op marker)**
+
+```bash
+grep -cE "^[A-Z]" migrations/004_stop_truth_value_overwrite.sql
+```
+
+Expected: `0` (no SQL DDL lines beginning with a capital letter — only `--` comments).
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`. (sqlx will record this migration as applied; the no-op file is safe.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/004_stop_truth_value_overwrite.sql
+git commit -m "chore(migrations): carry truth_value-overwrite no-op marker (was 094)
+
+Forward-port from epigraph-internal migration 094. The migration is a
+comment-only no-op that documents the application-layer fix preventing
+update_claim_belief from overwriting truth_value with BetP. Preserved
+in the migration sequence so internal/public stay aligned.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/094_stop_truth_value_overwrite.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Migration 005 — `task_event_edge_types` (filtered)
+
+**Files:**
+- Create: `migrations/005_task_event_edge_types.sql` (filtered from internal `095`)
+
+- [ ] **Step 1: Apply ghost-filter while copying**
+
+```bash
+src=/tmp/internal-renumber-migrations/migrations/095_task_event_edge_types.sql
+dst=migrations/005_task_event_edge_types.sql
+# (paste the python one-liner from the ghost-filter spec)
+```
+
+- [ ] **Step 2: Verify filter removed all four ghosts**
+
+```bash
+grep -c "propaganda_technique\|'coalition'\|'experiment'\|'experiment_result'" migrations/005_task_event_edge_types.sql
+```
+
+Expected: `0`
+
+- [ ] **Step 3: Verify intended additions remain**
+
+```bash
+grep -E "'task'|'event'" migrations/005_task_event_edge_types.sql | head -5
+```
+
+Expected: lines containing both `'task'` and `'event'` in CHECK arrays / validator branches.
+
+- [ ] **Step 4: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/005_task_event_edge_types.sql
+git commit -m "feat(migrations): port task/event edge types (was 095, filtered)
+
+Forward-port from epigraph-internal migration 095 with ghost entity
+types filtered out. Adds 'task' and 'event' to edges CHECK constraint
+and validate_edge_reference branches for governance bridge edges.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/095_task_event_edge_types.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Migration 006 — `provenance_patch_payload`
+
+**Files:**
+- Create: `migrations/006_provenance_patch_payload.sql` (2 lines)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/096_provenance_patch_payload.sql migrations/006_provenance_patch_payload.sql
+```
+
+- [ ] **Step 2: Verify single ALTER TABLE**
+
+```bash
+grep "^ALTER TABLE" migrations/006_provenance_patch_payload.sql
+```
+
+Expected: exactly one line:
+```
+ALTER TABLE provenance_log ADD COLUMN patch_payload JSONB;
+```
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/006_provenance_patch_payload.sql
+git commit -m "feat(migrations): add provenance_log.patch_payload column (was 096)
+
+Forward-port from epigraph-internal migration 096. Nullable JSONB
+column on provenance_log; existing rows get NULL.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/096_provenance_patch_payload.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Migration 007 — `papers_doi_unique_constraint`
+
+**Files:**
+- Create: `migrations/007_papers_doi_unique_constraint.sql` (~115 lines, includes data reconciliation)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/097_papers_doi_unique_constraint.sql migrations/007_papers_doi_unique_constraint.sql
+```
+
+- [ ] **Step 2: Verify file structure**
+
+```bash
+grep -E "^(CREATE TEMP TABLE|DELETE FROM|UPDATE|DROP INDEX|ALTER TABLE)" migrations/007_papers_doi_unique_constraint.sql
+```
+
+Expected: lines for `CREATE TEMP TABLE paper_dedup_pairs`, several `DELETE/UPDATE` against edges/papers, `DROP INDEX IF EXISTS idx_papers_doi`, and `ALTER TABLE papers ADD CONSTRAINT papers_doi_unique UNIQUE (doi)`.
+
+The reconciliation `DELETE/UPDATE` clauses are no-ops on a fresh DB (no duplicate DOIs to reconcile) and only trigger on data-bearing DBs.
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`. The `--single-transaction` flag in the harness is critical here — the TEMP TABLE `paper_dedup_pairs` uses `ON COMMIT DROP` and would vanish between statements in autocommit mode.
+
+- [ ] **Step 4: Sanity-check UNIQUE constraint exists**
+
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "CREATE DATABASE _probe_007;"
+for f in migrations/*.sql; do
+  PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d _probe_007 -v ON_ERROR_STOP=1 --single-transaction -f "$f" > /dev/null
+done
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d _probe_007 -tAc \
+  "SELECT conname FROM pg_constraint WHERE conname = 'papers_doi_unique';"
+PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph _probe_007
+```
+
+Expected: `papers_doi_unique`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/007_papers_doi_unique_constraint.sql
+git commit -m "feat(migrations): add UNIQUE constraint on papers.doi (was 097)
+
+Forward-port from epigraph-internal migration 097. Replaces the
+non-unique idx_papers_doi index with a UNIQUE constraint. Includes
+duplicate-row reconciliation (no-op on fresh DBs) for safety on
+data-bearing deployments. Required for ON CONFLICT (doi) upsert
+in the API path.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/097_papers_doi_unique_constraint.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Migration 008 — `claim_signature_revocations`
+
+**Files:**
+- Create: `migrations/008_claim_signature_revocations.sql` (53 lines)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/098_claim_signature_revocations.sql migrations/008_claim_signature_revocations.sql
+```
+
+- [ ] **Step 2: Verify table + indexes**
+
+```bash
+grep -E "^(CREATE TABLE|CREATE INDEX)" migrations/008_claim_signature_revocations.sql
+```
+
+Expected:
+```
+CREATE TABLE claim_signature_revocations (
+CREATE INDEX idx_claim_sig_revocations_claim
+CREATE INDEX idx_claim_sig_revocations_revoker
+CREATE INDEX idx_claim_sig_revocations_revoked_at
+```
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/008_claim_signature_revocations.sql
+git commit -m "feat(migrations): port claim_signature_revocations table (was 098)
+
+Forward-port from epigraph-internal migration 098. Adds an audit log
+for revoked claim signatures, preserving original (signature,
+signer_id, content_hash) tuples while the claim row is updated to
+satisfy the migration-073 NULL/NULL invariant.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/098_claim_signature_revocations.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Migration 009 — `conflict_taxonomy`
+
+**Files:**
+- Create: `migrations/009_conflict_taxonomy.sql` (23 lines)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/100_conflict_taxonomy.sql migrations/009_conflict_taxonomy.sql
+```
+
+- [ ] **Step 2: Verify column adds**
+
+```bash
+grep "^ALTER TABLE\|^CREATE INDEX" migrations/009_conflict_taxonomy.sql
+```
+
+Expected:
+```
+ALTER TABLE edges ADD COLUMN dimension_score DOUBLE PRECISION
+ALTER TABLE evidence ADD COLUMN scope JSONB;
+CREATE INDEX IF NOT EXISTS idx_edges_relationship_new
+```
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/009_conflict_taxonomy.sql
+git commit -m "feat(migrations): add multi-dimensional conflict columns (was 100)
+
+Forward-port from epigraph-internal migration 100. Adds
+edges.dimension_score (nullable DOUBLE PRECISION) and evidence.scope
+(JSONB) to support method_diverges, scope_diverges, and temporal_drift
+edge types. Both columns are additive and forward-only; existing rows
+get NULL.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/100_conflict_taxonomy.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Migration 010 — `divergence_cache_validity_constraints`
+
+**Files:**
+- Create: `migrations/010_divergence_cache_validity_constraints.sql` (28 lines)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/101_divergence_cache_validity_constraints.sql migrations/010_divergence_cache_validity_constraints.sql
+```
+
+- [ ] **Step 2: Verify constraints**
+
+```bash
+grep "^ALTER TABLE\|^CREATE INDEX" migrations/010_divergence_cache_validity_constraints.sql
+```
+
+Expected: 3 ALTER TABLE statements on `ds_bayesian_divergence` and one CREATE INDEX `idx_divergence_computed_at`.
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/010_divergence_cache_validity_constraints.sql
+git commit -m "feat(migrations): tighten divergence cache constraints (was 101)
+
+Forward-port from epigraph-internal migration 101. Adds defense-in-depth
+CHECK constraints to ds_bayesian_divergence and a staleness index on
+computed_at. Application-layer clamping is the primary guard against
+the BetP underflow case the constraints catch.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/101_divergence_cache_validity_constraints.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Migration 011 — `derived_from_uppercase_factor`
+
+**Files:**
+- Create: `migrations/011_derived_from_uppercase_factor.sql` (121 lines)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/102_derived_from_uppercase_factor.sql migrations/011_derived_from_uppercase_factor.sql
+```
+
+- [ ] **Step 2: Verify function rewrite**
+
+```bash
+grep -E "^(DROP FUNCTION|CREATE FUNCTION)" migrations/011_derived_from_uppercase_factor.sql
+```
+
+Expected: `DROP FUNCTION IF EXISTS edge_to_factor_type(VARCHAR);` followed by `CREATE FUNCTION edge_to_factor_type(rel VARCHAR)`.
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 4: Sanity-check the function recognizes uppercase DERIVED_FROM**
+
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "CREATE DATABASE _probe_011;"
+for f in migrations/*.sql; do
+  PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d _probe_011 -v ON_ERROR_STOP=1 --single-transaction -f "$f" > /dev/null
+done
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d _probe_011 -tAc \
+  "SELECT edge_to_factor_type('DERIVED_FROM');"
+PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph _probe_011
+```
+
+Expected: a non-NULL string (per migration 102's intent: directional_support).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/011_derived_from_uppercase_factor.sql
+git commit -m "feat(migrations): map DERIVED_FROM (uppercase) to factor type (was 102)
+
+Forward-port from epigraph-internal migration 102. Rewrites
+edge_to_factor_type() to recognize uppercase DERIVED_FROM (used by
+paraphrase_full_sweep.py) as directional_support, fixing BP coupling
+for ~36k paraphrase-probe edges that were silently falling through
+the old lowercase-only mapping.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/102_derived_from_uppercase_factor.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Migration 012 — `cull_low_similarity_corroborates`
+
+**Files:**
+- Create: `migrations/012_cull_low_similarity_corroborates.sql` (43 lines)
+
+- [ ] **Step 1: Copy unchanged**
+
+```bash
+cp /tmp/internal-renumber-migrations/migrations/103_cull_low_similarity_corroborates.sql migrations/012_cull_low_similarity_corroborates.sql
+```
+
+- [ ] **Step 2: Verify it's purely DML (no schema change)**
+
+```bash
+grep -cE "^(DELETE|DROP TABLE)" migrations/012_cull_low_similarity_corroborates.sql
+grep -cE "^(CREATE TABLE|ALTER TABLE)" migrations/012_cull_low_similarity_corroborates.sql
+```
+
+Expected: first count > 0 (DELETE statements + DROP of temp table), second count `0` (no schema change). On a fresh DB the DELETE statements are no-ops.
+
+- [ ] **Step 3: Run verification harness**
+
+```bash
+verify_schema
+```
+
+Expected: `schema build: OK` then `5 passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/012_cull_low_similarity_corroborates.sql
+git commit -m "chore(migrations): cull low-similarity CORROBORATES edges (was 103)
+
+Forward-port from epigraph-internal migration 103. DELETEs CORROBORATES
+edges with similarity < 0.80 and their factor rows. No-op on fresh DBs;
+preserved in sequence so a future production-data migration on a
+public-tracking deployment applies the same cleanup.
+
+Source: epigraph-internal@chore/migration-renumber-2026-04-25
+        migrations/103_cull_low_similarity_corroborates.sql
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Port `revoke_signature.rs` API route
+
+**Files:**
+- Create: `crates/epigraph-api/src/routes/revoke_signature.rs` (copy from internal)
+- Modify: `crates/epigraph-api/src/routes/mod.rs` (add `pub mod revoke_signature;` and route registration)
+
+The new route depends on the `claim_signature_revocations` table created by Task 7's migration `008`. Port the route only after that migration is committed.
+
+- [ ] **Step 1: Copy `revoke_signature.rs` from internal**
+
+```bash
+git -C /home/jeremy/epigraph-internal show origin/main:crates/epigraph-api/src/routes/revoke_signature.rs \
+  > crates/epigraph-api/src/routes/revoke_signature.rs
+wc -l crates/epigraph-api/src/routes/revoke_signature.rs
+```
+
+Expected: a non-empty file (~100–300 lines depending on content).
+
+- [ ] **Step 2: Inspect the internal `mod.rs` to find how revoke_signature is registered**
+
+```bash
+git -C /home/jeremy/epigraph-internal show origin/main:crates/epigraph-api/src/routes/mod.rs \
+  | grep -nE "revoke_signature|pub mod" | head -10
+```
+
+Expected: a `pub mod revoke_signature;` declaration and (likely) a route registration line in the router builder.
+
+- [ ] **Step 3: Add the same `pub mod revoke_signature;` declaration to public's `mod.rs`**
+
+Look at where other route modules are declared (alphabetic ordering — between e.g. `political` and `search` or wherever fits) and insert the new line. Show the diff:
+
+```bash
+grep -n "^pub mod" crates/epigraph-api/src/routes/mod.rs | head
+```
+
+Edit the file to add `pub mod revoke_signature;` in the appropriate alphabetical slot. (Use the `Edit` tool with the surrounding context for uniqueness.)
+
+- [ ] **Step 4: Wire the route into the router builder**
+
+Inspect how internal's `mod.rs` adds the revoke route (likely a `.route("/v1/...", post(revoke_signature::handler))` chain entry). Mirror it in public's `mod.rs`.
+
+```bash
+git -C /home/jeremy/epigraph-internal show origin/main:crates/epigraph-api/src/routes/mod.rs \
+  | grep -nE "revoke_signature::|/v1/.*revoke" | head -5
+```
+
+Add the matching line to public's `mod.rs`.
+
+- [ ] **Step 5: Verify the crate still builds**
+
+```bash
+cargo build -p epigraph-api 2>&1 | tail -10
+```
+
+Expected: `Compiling epigraph-api ...` followed by `Finished` (no errors). If there are missing-import errors, the new route file likely depends on helpers that exist in internal but not public — investigate and resolve before committing.
+
+- [ ] **Step 6: Run epigraph-api tests**
+
+```bash
+DATABASE_URL="postgres://epigraph:epigraph@127.0.0.1:5432/epigraph" SQLX_OFFLINE=true \
+  cargo test -p epigraph-api -- --test-threads=1 2>&1 | tail -10
+```
+
+Expected: tests pass (or, at minimum, no new failures vs. the baseline before this task).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/revoke_signature.rs crates/epigraph-api/src/routes/mod.rs
+git commit -m "feat(api): port revoke_signature route from internal
+
+Companion to migration 008 (claim_signature_revocations table).
+Ports the revoke_signature.rs route from epigraph-internal verbatim
+and wires it into the API router. The handler reads the new
+revocations table and updates claim signatures per the migration-073
+NULL/NULL invariant.
+
+Source: epigraph-internal@main:crates/epigraph-api/src/routes/revoke_signature.rs
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Regenerate `.sqlx/` prepared queries
+
+**Files:**
+- Modify: `.sqlx/*.json` (regenerated)
+
+The new schema columns (`edges.dimension_score`, `evidence.scope`, `provenance_log.patch_payload`) and the new table (`behavioral_executions`, `claim_signature_revocations`) may be referenced in `sqlx::query!` macros that need offline-mode prepared-query JSON. Regenerate.
+
+- [ ] **Step 1: Build and apply schema to a stable test DB**
+
+```bash
+PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph epigraph_sqlx_prep 2>/dev/null
+PGPASSWORD=epigraph createdb -h 127.0.0.1 -U epigraph epigraph_sqlx_prep
+for f in migrations/*.sql; do
+  PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d epigraph_sqlx_prep -v ON_ERROR_STOP=1 --single-transaction -f "$f" > /dev/null
+done
+```
+
+- [ ] **Step 2: Run `cargo sqlx prepare` against the workspace**
+
+```bash
+DATABASE_URL="postgres://epigraph:epigraph@127.0.0.1:5432/epigraph_sqlx_prep" \
+  cargo sqlx prepare --workspace -- --all-targets 2>&1 | tail -10
+```
+
+Expected: `query data written to .sqlx/...` lines, no errors. If `cargo sqlx prepare` is unavailable, install with `cargo install sqlx-cli --no-default-features --features postgres`.
+
+- [ ] **Step 3: Inspect what changed**
+
+```bash
+git status .sqlx/
+git diff --stat .sqlx/ | tail -5
+```
+
+If `.sqlx/` has no changes, no `sqlx::query!` macro depended on the new schema — that's fine, skip Step 4 and Step 5.
+
+- [ ] **Step 4: Run full workspace tests against the prepared queries (offline mode)**
+
+```bash
+SQLX_OFFLINE=true cargo build --workspace 2>&1 | tail -5
+```
+
+Expected: clean build with `SQLX_OFFLINE=true` confirms the prepared queries match the schema.
+
+- [ ] **Step 5: Commit any `.sqlx/` changes**
+
+```bash
+git add .sqlx/
+git commit -m "chore(sqlx): regenerate prepared queries for new schema
+
+Re-runs cargo sqlx prepare against the schema produced by migrations
+001 + 002–012. Updates query JSON for any sqlx::query! macros that
+depend on new columns (edges.dimension_score, evidence.scope,
+provenance_log.patch_payload) or new tables (behavioral_executions,
+claim_signature_revocations).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(If Step 3 showed no diff, skip this commit.)
+
+- [ ] **Step 6: Cleanup test DB**
+
+```bash
+PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph epigraph_sqlx_prep
+```
+
+---
+
+## Task 14: Full workspace test pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Rebuild workspace**
+
+```bash
+cargo build --workspace 2>&1 | tail -5
+```
+
+Expected: `Finished` with no errors.
+
+- [ ] **Step 2: Build a fresh full-schema DB for the test run**
+
+```bash
+PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph epigraph 2>/dev/null
+PGPASSWORD=epigraph createdb -h 127.0.0.1 -U epigraph epigraph
+for f in migrations/*.sql; do
+  PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d epigraph -v ON_ERROR_STOP=1 --single-transaction -f "$f" > /dev/null
+done
+```
+
+- [ ] **Step 3: Run epigraph-db tests (full)**
+
+```bash
+DATABASE_URL="postgres://epigraph:epigraph@127.0.0.1:5432/epigraph" SQLX_OFFLINE=true \
+  cargo test -p epigraph-db -- --test-threads=1 2>&1 | tail -15
+```
+
+Expected: zero failures across the package. Capture the pass count; this is the new baseline.
+
+- [ ] **Step 4: Run epigraph-api tests**
+
+```bash
+DATABASE_URL="postgres://epigraph:epigraph@127.0.0.1:5432/epigraph" SQLX_OFFLINE=true \
+  cargo test -p epigraph-api -- --test-threads=1 2>&1 | tail -15
+```
+
+Expected: zero failures.
+
+- [ ] **Step 5: Run epigraph-engine tests**
+
+```bash
+DATABASE_URL="postgres://epigraph:epigraph@127.0.0.1:5432/epigraph" SQLX_OFFLINE=true \
+  cargo test -p epigraph-engine -- --test-threads=1 2>&1 | tail -15
+```
+
+Expected: zero failures.
+
+- [ ] **Step 6: Run non-DB packages in parallel**
+
+```bash
+SQLX_OFFLINE=true cargo test --workspace --exclude epigraph-db --exclude epigraph-api --exclude epigraph-engine 2>&1 | tail -10
+```
+
+Expected: zero failures.
+
+- [ ] **Step 7: Run cargo fmt --check and clippy**
+
+```bash
+cargo fmt --check 2>&1 | tail -5
+cargo clippy --workspace -- -D warnings 2>&1 | tail -10
+```
+
+Expected: clean for both.
+
+If any step fails, **stop and fix** (likely candidates: a sqlx prepared query needs the schema rebuild, a `mod.rs` line missing from Task 12, or a test that hardcoded an entity-type list and needs updating). Do not proceed to Task 15 with failing tests.
+
+- [ ] **Step 8: Cleanup**
+
+```bash
+PGPASSWORD=epigraph dropdb -h 127.0.0.1 -U epigraph epigraph
+```
+
+---
+
+## Task 15: Investigate `mcp_tools.rs` placement, push, open PR
+
+**Files:** none directly; investigation may add files.
+
+- [ ] **Step 1: Inspect what `mcp_tools.rs` does in internal**
+
+```bash
+git -C /home/jeremy/epigraph-internal show origin/main:crates/epigraph-api/src/routes/mcp_tools.rs | head -40
+git -C /home/jeremy/epigraph-internal grep -n "mcp_tools" origin/main -- "crates/epigraph-api/src/routes/mod.rs"
+```
+
+Decide: does this route depend on internal-only behavior (claude CLI shelling, host_* tables, etc.)? If yes — leave out, file an issue noting it's an internal-only route. If no — add a Task-12-style port commit on this branch.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/forward-port-092-103
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --repo epigraph-io/epigraph --base main --head feat/forward-port-092-103 \
+  --title "feat(migrations): forward-port internal 092–103 (renumbered 002–012)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Forward-ports 11 incremental migrations from \`epigraph-internal\` (renumbered \`092–103\` → \`002–012\` on public's \`001\` baseline). Companion port of \`revoke_signature.rs\` API route for migration \`008\`.
+
+Brings public closer to scope parity with internal:
+- New tables: \`behavioral_executions\`, \`claim_signature_revocations\`
+- Schema: \`edges.dimension_score\`, \`evidence.scope\`, \`provenance_log.patch_payload\`
+- Validator/CHECK extensions: \`entity\`, \`task\`, \`event\` source/target types (with ghost entity types — \`propaganda_technique\`, \`coalition\`, \`experiment\`, \`experiment_result\` — filtered out per #5)
+- Function rewrites: \`edge_to_factor_type()\` recognizes \`DERIVED_FROM\` (uppercase)
+- Defense-in-depth constraints on \`ds_bayesian_divergence\`
+- UNIQUE constraint on \`papers.doi\`
+
+## Out of scope (intentional)
+
+- \`104_host_tables_baseline\` (EpiClaw CLI orchestration — internal-only)
+- \`mcp_tools.rs\` route — pending classification (see issue if filed)
+
+## Test plan
+
+- [x] Schema rebuild from scratch with all 12 migrations applies cleanly
+- [x] \`epigraph-db\` lineage tests pass (smoke probe per migration commit)
+- [x] Full \`epigraph-db\`, \`epigraph-api\`, \`epigraph-engine\` test suites pass
+- [x] \`cargo fmt --check\` and \`cargo clippy --workspace -- -D warnings\` clean
+- [x] \`.sqlx/\` regenerated and committed if any prepared queries depend on new schema
+- [ ] CI green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+If CI fails, capture the failing job log (`gh run view --log-failed`), diagnose, push fix commits onto the same branch, repeat.
+
+---
+
+## Notes for the implementing engineer
+
+- **Do not skip the `--single-transaction` flag** when applying migrations via `psql -f` — migration `007` (papers DOI) uses `CREATE TEMP TABLE ... ON COMMIT DROP` and needs the whole file in a single transaction for the temp table to survive across statements. The verification harness already includes the flag.
+- **Do not rebase commits** before the PR opens. Each per-migration commit is a meaningful unit; reviewer wants to see them individually.
+- **If a migration fails the harness mid-task**, the test DB will be left around; subsequent runs may fail with "database already exists". The harness drops it on entry, so just rerun.
+- **`#[sqlx::test]`-style tests use template DB cloning**, not the harness's static test DB. Stale `_sqlx_test_*` DBs accumulate from killed test runs; the harness sweeps them before running tests.
+- **Ghost-filter is regex-driven**, not parser-driven. It works because all four ghost literals appear in two contexts only: a `WHEN '...'  THEN EXISTS(...)` line in the validator, or a string in a CHECK array. Verify each filtered file with grep (Step 2 of Tasks 2 and 4) — if grep finds any leftovers, the regex didn't catch them and you need to investigate the source migration's structure.
+- **Codebase conventions:** unprefixed table names (`behavioral_executions`, not `public.behavioral_executions`) match the internal style and work because the search_path defaults to public. Do not "normalize" them.
+- **If lineage tests start failing partway**, the most likely cause is that one of the filtered migrations stripped something it shouldn't have (e.g., the regex matched a literal containing `'experiment'` as a substring of a different word). Inspect the diff against the source file to confirm.

--- a/docs/superpowers/plans/2026-04-26-forward-port-092-103.md
+++ b/docs/superpowers/plans/2026-04-26-forward-port-092-103.md
@@ -37,21 +37,29 @@ git -C /home/jeremy/epigraph-internal archive origin/chore/migration-renumber-20
 
 ## Renumbering map
 
-| New (public) | Source (internal) | Filter? | Notes |
+> **Mid-execution correction (2026-04-26):** This plan was originally written assuming `001_initial_schema.sql`'s pg_dump baseline captured internal state at migration `091`. In practice, the dump captured state past `097` for several tables/columns/constraints, so what the plan called "verbatim ports" of `093, 095, 096, 097` are partially or fully redundant against `001`. Tasks 2 and 4 (the two filtered ports for `093` and `095`) ended up being idempotent no-ops because their `DROP IF EXISTS` + `CREATE OR REPLACE` operations simply re-state what `001` already provides. Tasks 5 and 6 (`096`, `097`) were converted to **no-op markers** because verbatim `ALTER TABLE ADD COLUMN` / `ADD CONSTRAINT` would error against an already-applied state. The "no-op marker" pattern preserves sequence parity with internal numbering without re-applying redundant DDL.
+
+| New (public) | Source (internal) | Action | Notes |
 |---|---|---|---|
-| `002_behavioral_executions.sql` | `092_behavioral_executions.sql` | no | new table |
-| `003_business_function_entity_type.sql` | `093_business_function_entity_type.sql` | **yes** | strips ghosts from validator + CHECK |
-| `004_stop_truth_value_overwrite.sql` | `094_stop_truth_value_overwrite.sql` | no | no-op marker (carries note for migration history) |
-| `005_task_event_edge_types.sql` | `095_task_event_edge_types.sql` | **yes** | strips ghosts from validator + CHECK |
-| `006_provenance_patch_payload.sql` | `096_provenance_patch_payload.sql` | no | column add |
-| `007_papers_doi_unique_constraint.sql` | `097_papers_doi_unique_constraint.sql` | no | UNIQUE; reconciliation no-ops on fresh DB |
-| `008_claim_signature_revocations.sql` | `098_claim_signature_revocations.sql` | no | new table |
-| `009_conflict_taxonomy.sql` | `100_conflict_taxonomy.sql` | no | adds `edges.dimension_score`, `evidence.scope` |
-| `010_divergence_cache_validity_constraints.sql` | `101_divergence_cache_validity_constraints.sql` | no | constraints + index |
-| `011_derived_from_uppercase_factor.sql` | `102_derived_from_uppercase_factor.sql` | no | rewrites `edge_to_factor_type()` |
-| `012_cull_low_similarity_corroborates.sql` | `103_cull_low_similarity_corroborates.sql` | no | DELETE statements; no-op on fresh DB |
+| `002_behavioral_executions.sql` | `092_behavioral_executions.sql` | verbatim | new table — needed |
+| `003_business_function_entity_type.sql` | `093_business_function_entity_type.sql` | filtered (idempotent vs 001) | strips ghosts from validator + CHECK; entity branch + BusinessFunction already in 001, but `DROP IF EXISTS` + `CREATE OR REPLACE` make the migration safe |
+| `004_stop_truth_value_overwrite.sql` | `094_stop_truth_value_overwrite.sql` | verbatim | source itself is a no-op marker carrying a note about an application-layer fix |
+| `005_task_event_edge_types.sql` | `095_task_event_edge_types.sql` | filtered (idempotent vs 001) | strips ghosts; task/event already in 001, but DROP IF EXISTS + CREATE OR REPLACE make it safe |
+| `006_provenance_patch_payload.sql` | `096_provenance_patch_payload.sql` | **no-op marker** | `patch_payload` column already in 001; verbatim ALTER ADD COLUMN would error |
+| `007_papers_doi_unique_constraint.sql` | `097_papers_doi_unique_constraint.sql` | **no-op marker** | `papers_doi_unique` constraint already in 001; verbatim ADD CONSTRAINT would error. Source's data-reconciliation logic was a one-time internal-prod cleanup with no public parallel. |
+| `008_claim_signature_revocations.sql` | `098_claim_signature_revocations.sql` | verbatim | new table — needed |
+| `009_conflict_taxonomy.sql` | `100_conflict_taxonomy.sql` | verbatim | adds `edges.dimension_score`, `evidence.scope`, `idx_edges_relationship_new` — all absent in 001 |
+| `010_divergence_cache_validity_constraints.sql` | `101_divergence_cache_validity_constraints.sql` | verbatim | adds 3 CHECK constraints + `idx_divergence_computed_at` — all absent in 001 |
+| `011_derived_from_uppercase_factor.sql` | `102_derived_from_uppercase_factor.sql` | verbatim | function rewrite to add `'DERIVED_FROM'` (uppercase) entry — absent in 001's `edge_to_factor_type()` |
+| `012_cull_low_similarity_corroborates.sql` | `103_cull_low_similarity_corroborates.sql` | verbatim DML | DELETE statements; no-op on fresh DB |
 
 Skipped: `099` (does not exist in source), `104_host_tables_baseline.sql` (EpiClaw CLI orchestration — internal-only).
+
+In-flight infrastructure commits added during execution:
+- `chore(fmt): apply cargo fmt to drifted workspace files` — pre-existing fmt drift on 4 unrelated files (`state.rs`, `extensions.rs`, `encryption.rs`, `orchestration.rs`) cleaned up so Task 14's `cargo fmt --check` passes.
+
+Out of scope, deferred to follow-up PR:
+- `crates/epigraph-api/src/routes/mcp_tools.rs` — internal-only file. Depends on `epigraph_mcp::list_tools()`, which doesn't exist in public's `epigraph-mcp` crate yet. Porting requires also porting the `list_tools()` symbol; not in this PR's scope.
 
 ---
 

--- a/migrations/002_behavioral_executions.sql
+++ b/migrations/002_behavioral_executions.sql
@@ -1,0 +1,25 @@
+-- Behavioral execution tracking for task-conditional workflow scoring.
+-- Stores per-execution data with goal embeddings so the agent can
+-- answer "which workflow works best for goals like THIS one?"
+-- Distinct from workflow_executions (080) which tracks orchestrator state.
+
+CREATE TABLE IF NOT EXISTS behavioral_executions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workflow_id UUID NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    goal_text TEXT NOT NULL,
+    goal_embedding vector(1536),
+    success BOOLEAN NOT NULL,
+    step_beliefs JSONB NOT NULL DEFAULT '{}',
+    tool_pattern TEXT[] NOT NULL DEFAULT '{}',
+    quality DOUBLE PRECISION CHECK (quality IS NULL OR (quality >= 0.0 AND quality <= 1.0)),
+    deviation_count INTEGER NOT NULL DEFAULT 0,
+    total_steps INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_behav_exec_workflow ON behavioral_executions(workflow_id);
+CREATE INDEX IF NOT EXISTS idx_behav_exec_created ON behavioral_executions(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_behav_exec_success ON behavioral_executions(success);
+CREATE INDEX IF NOT EXISTS idx_behav_exec_goal_vec ON behavioral_executions
+    USING hnsw (goal_embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);

--- a/migrations/003_business_function_entity_type.sql
+++ b/migrations/003_business_function_entity_type.sql
@@ -1,0 +1,57 @@
+-- 093_business_function_entity_type.sql
+-- Add BusinessFunction to entity type_top and 'entity' to edges type constraints
+-- for corporate governance GOVERNS edges (claim -> entity).
+
+-- 1. Extend entities type_top to include BusinessFunction
+ALTER TABLE entities DROP CONSTRAINT entities_type_top_valid;
+ALTER TABLE entities ADD CONSTRAINT entities_type_top_valid
+  CHECK (type_top IN (
+    'Material', 'Molecule', 'Method', 'Instrument', 'Property',
+    'Measurement', 'Condition', 'Organism', 'Software',
+    'Person', 'Organization', 'Location', 'Concept',
+    'BusinessFunction'
+  ));
+
+-- 3. Add 'entity' branch to validate_edge_reference trigger function
+--    Required for GOVERNS edges: source_type='claim', target_type='entity'
+CREATE OR REPLACE FUNCTION validate_edge_reference(entity_id uuid, entity_type character varying)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN CASE entity_type
+        WHEN 'claim'                 THEN EXISTS (SELECT 1 FROM claims WHERE id = entity_id)
+        WHEN 'agent'                 THEN EXISTS (SELECT 1 FROM agents WHERE id = entity_id)
+        WHEN 'evidence'              THEN EXISTS (SELECT 1 FROM evidence WHERE id = entity_id)
+        WHEN 'trace'                 THEN EXISTS (SELECT 1 FROM reasoning_traces WHERE id = entity_id)
+        WHEN 'paper'                 THEN EXISTS (SELECT 1 FROM papers WHERE id = entity_id)
+        WHEN 'analysis'              THEN EXISTS (SELECT 1 FROM analyses WHERE id = entity_id)
+        WHEN 'activity'              THEN EXISTS (SELECT 1 FROM activities WHERE id = entity_id)
+        WHEN 'source_artifact'       THEN EXISTS (SELECT 1 FROM source_artifacts WHERE id = entity_id)
+        WHEN 'span'                  THEN EXISTS (SELECT 1 FROM agent_spans WHERE id = entity_id)
+        WHEN 'entity'                THEN EXISTS (SELECT 1 FROM entities WHERE id = entity_id)
+        WHEN 'node'                  THEN TRUE
+        ELSE FALSE
+    END;
+END;
+$$;
+
+-- 2. Extend edges source_type/target_type to include 'entity'
+-- Needed for GOVERNS edges: claim -> entity (BusinessFunction node)
+ALTER TABLE edges DROP CONSTRAINT edges_entity_types_valid;
+ALTER TABLE edges ADD CONSTRAINT edges_entity_types_valid
+  CHECK (
+    source_type = ANY(ARRAY[
+      'claim', 'agent', 'evidence', 'trace', 'node', 'activity',
+      'paper', 'perspective', 'community', 'context', 'frame',
+      'analysis', 'source_artifact', 'span',
+      'entity'
+    ])
+    AND
+    target_type = ANY(ARRAY[
+      'claim', 'agent', 'evidence', 'trace', 'node', 'activity',
+      'paper', 'perspective', 'community', 'context', 'frame',
+      'analysis', 'source_artifact', 'span',
+      'entity'
+    ])
+  );

--- a/migrations/004_stop_truth_value_overwrite.sql
+++ b/migrations/004_stop_truth_value_overwrite.sql
@@ -1,0 +1,7 @@
+-- 091_stop_truth_value_overwrite.sql
+--
+-- truth_value is evidence-derived and should not be overwritten by
+-- belief propagation or DS recomputation. The update_claim_belief
+-- Rust function has been fixed to stop setting truth_value = BetP.
+-- This migration is a no-op marker for tracking purposes.
+SELECT 1;

--- a/migrations/005_task_event_edge_types.sql
+++ b/migrations/005_task_event_edge_types.sql
@@ -1,0 +1,73 @@
+-- Migration 095: add 'task' and 'event' to edges type constraint and referential trigger
+-- Required for governance bridge TRIGGERED_BY (task→event) and PROVENANCE (task→claim) edges
+
+-- Step 1: Drop the existing CHECK constraint
+ALTER TABLE edges DROP CONSTRAINT IF EXISTS edges_entity_types_valid;
+
+-- Step 2: Re-create with 'task' and 'event' added to both source_type and target_type
+ALTER TABLE edges ADD CONSTRAINT edges_entity_types_valid CHECK (
+    (source_type::text = ANY (ARRAY[
+        'claim', 'agent', 'evidence', 'trace', 'node', 'activity', 'paper',
+        'perspective', 'community', 'context', 'frame', 'analysis', 'source_artifact',
+        'span', 'entity', 'task', 'event'
+    ]))
+    AND
+    (target_type::text = ANY (ARRAY[
+        'claim', 'agent', 'evidence', 'trace', 'node', 'activity', 'paper',
+        'perspective', 'community', 'context', 'frame', 'analysis', 'source_artifact',
+        'span', 'entity', 'task', 'event'
+    ]))
+);
+
+-- Step 3: Replace BOTH overloads of validate_edge_reference with task and event branches
+-- The trigger calls (uuid, varchar) overload; there's also a (text, uuid) overload.
+-- Both must be updated.
+
+CREATE OR REPLACE FUNCTION validate_edge_reference(entity_type TEXT, entity_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN CASE entity_type
+        WHEN 'claim'                 THEN EXISTS (SELECT 1 FROM claims WHERE id = entity_id)
+        WHEN 'agent'                 THEN EXISTS (SELECT 1 FROM agents WHERE id = entity_id)
+        WHEN 'evidence'              THEN EXISTS (SELECT 1 FROM evidence WHERE id = entity_id)
+        WHEN 'trace'                 THEN EXISTS (SELECT 1 FROM reasoning_traces WHERE id = entity_id)
+        WHEN 'paper'                 THEN EXISTS (SELECT 1 FROM papers WHERE id = entity_id)
+        WHEN 'analysis'              THEN EXISTS (SELECT 1 FROM analyses WHERE id = entity_id)
+        WHEN 'activity'              THEN EXISTS (SELECT 1 FROM activities WHERE id = entity_id)
+        WHEN 'source_artifact'       THEN EXISTS (SELECT 1 FROM source_artifacts WHERE id = entity_id)
+        WHEN 'span'                  THEN EXISTS (SELECT 1 FROM agent_spans WHERE id = entity_id)
+        WHEN 'entity'                THEN EXISTS (SELECT 1 FROM entities WHERE id = entity_id)
+        WHEN 'task'                  THEN EXISTS (SELECT 1 FROM tasks WHERE id = entity_id)
+        WHEN 'event'                 THEN EXISTS (SELECT 1 FROM events WHERE id = entity_id)
+        WHEN 'node'                  THEN TRUE
+        ELSE FALSE
+    END;
+END;
+$$;
+
+-- The trigger actually calls the (uuid, varchar) overload, so update that too
+CREATE OR REPLACE FUNCTION validate_edge_reference(entity_id UUID, entity_type CHARACTER VARYING)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN CASE entity_type
+        WHEN 'claim'                 THEN EXISTS (SELECT 1 FROM claims WHERE id = entity_id)
+        WHEN 'agent'                 THEN EXISTS (SELECT 1 FROM agents WHERE id = entity_id)
+        WHEN 'evidence'              THEN EXISTS (SELECT 1 FROM evidence WHERE id = entity_id)
+        WHEN 'trace'                 THEN EXISTS (SELECT 1 FROM reasoning_traces WHERE id = entity_id)
+        WHEN 'paper'                 THEN EXISTS (SELECT 1 FROM papers WHERE id = entity_id)
+        WHEN 'analysis'              THEN EXISTS (SELECT 1 FROM analyses WHERE id = entity_id)
+        WHEN 'activity'              THEN EXISTS (SELECT 1 FROM activities WHERE id = entity_id)
+        WHEN 'source_artifact'       THEN EXISTS (SELECT 1 FROM source_artifacts WHERE id = entity_id)
+        WHEN 'span'                  THEN EXISTS (SELECT 1 FROM agent_spans WHERE id = entity_id)
+        WHEN 'entity'                THEN EXISTS (SELECT 1 FROM entities WHERE id = entity_id)
+        WHEN 'task'                  THEN EXISTS (SELECT 1 FROM tasks WHERE id = entity_id)
+        WHEN 'event'                 THEN EXISTS (SELECT 1 FROM events WHERE id = entity_id)
+        WHEN 'node'                  THEN TRUE
+        ELSE FALSE
+    END;
+END;
+$$;

--- a/migrations/006_provenance_patch_payload.sql
+++ b/migrations/006_provenance_patch_payload.sql
@@ -1,0 +1,9 @@
+-- 006_provenance_patch_payload.sql (no-op marker; was internal 096)
+--
+-- The corresponding `ALTER TABLE provenance_log ADD COLUMN patch_payload JSONB`
+-- from internal migration 096 is already absorbed into 001_initial_schema.sql:
+-- the public.provenance_log CREATE TABLE in 001 includes the patch_payload
+-- column directly. Re-applying the ALTER would error ("column already exists"),
+-- so this migration is a no-op marker that preserves migration-sequence parity
+-- with internal/096 without re-adding what 001 already provides.
+SELECT 1;

--- a/migrations/007_papers_doi_unique_constraint.sql
+++ b/migrations/007_papers_doi_unique_constraint.sql
@@ -1,0 +1,16 @@
+-- 007_papers_doi_unique_constraint.sql (no-op marker; was internal 097)
+--
+-- Internal migration 097 reconciles duplicate-DOI papers, drops the
+-- non-unique idx_papers_doi index, and adds a UNIQUE constraint named
+-- papers_doi_unique. The constraint is already present in
+-- 001_initial_schema.sql (the pg_dump baseline captured internal state
+-- past migration 097), so re-running the ALTER TABLE ADD CONSTRAINT
+-- would error with "constraint already exists".
+--
+-- The duplicate-DOI reconciliation logic in 097 was a one-time data
+-- cleanup against internal's production DB; it has no parallel data
+-- to clean in public deployments.
+--
+-- Carries the migration as a no-op marker (SELECT 1;) so the public
+-- sequence stays aligned with internal numbering.
+SELECT 1;

--- a/migrations/008_claim_signature_revocations.sql
+++ b/migrations/008_claim_signature_revocations.sql
@@ -1,0 +1,53 @@
+-- Migration 098: audit log for revoked claim signatures
+--
+-- Evidence: There is no way to express "this claim's signature is no longer
+--   trustworthy" without re-signing. Re-signing drifted content would forge
+--   the original author's consent; deleting the row loses provenance. The
+--   claims_signature_requires_signer CHECK (migration 073) forces either
+--   (signature NULL AND signer_id NULL) or both NOT NULL, so "zero the bytes
+--   but keep signer_id" is not a legal state.
+--
+-- Reasoning: Revocation must (a) null both signature and signer_id on the
+--   claim row to satisfy the 073 constraint, AND (b) preserve the original
+--   (signature, signer_id, content_hash) somewhere so forensic audit is
+--   still possible. A separate table keeps the claims table semantically
+--   clean ("current signature state") while this table answers "what did
+--   the signature chain look like before each revocation?". The optional
+--   superseded_by column links a revocation to a supersession when the
+--   workflow is revoke-as-part-of-supersede; otherwise NULL for standalone
+--   integrity-drift revocations.
+--
+-- FK policy: claim_id is ON DELETE CASCADE. Rationale: revocation rows are
+--   *about* a specific claim — an orphan revocation row referring to a
+--   deleted claim is meaningless. If the claim is deleted deliberately
+--   (rare — most integrity drift resolves via supersede, not delete), the
+--   revocation history is no longer load-bearing. RESTRICT was rejected
+--   because it would retroactively block every existing delete_claim call
+--   path on any revoked claim, which is surprising behavior.
+
+CREATE TABLE claim_signature_revocations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    claim_id UUID NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    previous_signature BYTEA NOT NULL,
+    previous_signer_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    previous_content_hash BYTEA NOT NULL,
+    revoked_by UUID NOT NULL REFERENCES agents(id) ON DELETE RESTRICT,
+    revoked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reason TEXT NOT NULL,
+    superseded_by UUID REFERENCES claims(id) ON DELETE SET NULL,
+    CONSTRAINT revocations_previous_sig_length
+        CHECK (octet_length(previous_signature) = 64),
+    CONSTRAINT revocations_previous_hash_length
+        CHECK (octet_length(previous_content_hash) = 32),
+    CONSTRAINT revocations_reason_nonempty
+        CHECK (length(trim(reason)) > 0)
+);
+
+CREATE INDEX idx_claim_sig_revocations_claim
+    ON claim_signature_revocations(claim_id);
+
+CREATE INDEX idx_claim_sig_revocations_revoker
+    ON claim_signature_revocations(revoked_by);
+
+CREATE INDEX idx_claim_sig_revocations_revoked_at
+    ON claim_signature_revocations(revoked_at DESC);

--- a/migrations/009_conflict_taxonomy.sql
+++ b/migrations/009_conflict_taxonomy.sql
@@ -1,0 +1,23 @@
+-- Migration 100: multi-dimensional conflict surfacing (additive, forward-only).
+--
+-- Evidence:
+-- - docs/superpowers/specs/2026-04-18-multi-dimensional-conflict-surfacing-design.md
+-- - edges.relationship is already VARCHAR(100) (migration 006) so the three
+--   new edge-type strings ('method_diverges', 'scope_diverges', 'temporal_drift')
+--   need no schema change — only new columns land here.
+--
+-- Reasoning:
+-- - dimension_score is nullable because contradicts edges don't require it
+--   (K lives on mass_functions.conflict_k, the source of truth for K).
+-- - evidence.scope is JSONB so new dimension keys can be added without
+--   migration churn; shape: {population?: str, condition?: str,
+--   geography?: str, era?: str}.
+
+ALTER TABLE edges ADD COLUMN dimension_score DOUBLE PRECISION
+  CHECK (dimension_score IS NULL OR (dimension_score >= 0 AND dimension_score <= 1));
+
+ALTER TABLE evidence ADD COLUMN scope JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_edges_relationship_new
+  ON edges(relationship)
+  WHERE relationship IN ('method_diverges', 'scope_diverges', 'temporal_drift');

--- a/migrations/010_divergence_cache_validity_constraints.sql
+++ b/migrations/010_divergence_cache_validity_constraints.sql
@@ -1,0 +1,28 @@
+-- Migration 101: Add validity constraints and staleness index to divergence cache
+--
+-- Rationale: On 2026-03-16, a -0.0 pignistic_prob was written to
+-- ds_bayesian_divergence for claim 70d289c5-7a0c-4e08-98cf-d21d0ea988f3.
+-- This inflated the KL divergence to 1.491 and caused it to appear as the
+-- top divergence outlier.  The root cause (floating-point underflow in BetP
+-- when non_classical_mass ≈ 1.0) is fixed in the application layer; this
+-- migration adds defence-in-depth at the database level.
+--
+-- Note: IEEE 754 -0.0 satisfies BETWEEN 0.0 AND 1.0, so the CHECK constraint
+-- does NOT catch the exact bug — but it blocks obviously-invalid values
+-- (< -1e-9 or > 1 + 1e-9).  Application-layer clamping is the primary guard.
+
+ALTER TABLE ds_bayesian_divergence
+    ADD CONSTRAINT divergence_pignistic_prob_valid
+    CHECK (pignistic_prob >= -1e-9 AND pignistic_prob <= 1.0 + 1e-9);
+
+ALTER TABLE ds_bayesian_divergence
+    ADD CONSTRAINT divergence_bayesian_posterior_valid
+    CHECK (bayesian_posterior >= 0.0 AND bayesian_posterior <= 1.0);
+
+ALTER TABLE ds_bayesian_divergence
+    ADD CONSTRAINT divergence_kl_divergence_non_negative
+    CHECK (kl_divergence >= 0.0);
+
+-- Index to support the 7-day TTL filter in get_latest and top_divergent queries
+CREATE INDEX IF NOT EXISTS idx_divergence_computed_at
+    ON ds_bayesian_divergence (computed_at DESC);

--- a/migrations/011_derived_from_uppercase_factor.sql
+++ b/migrations/011_derived_from_uppercase_factor.sql
@@ -1,0 +1,121 @@
+-- 102_derived_from_uppercase_factor.sql
+--
+-- Add DERIVED_FROM (uppercase) to the factor type mapping.
+--
+-- Problem: paraphrase_full_sweep.py creates edges with relationship='DERIVED_FROM'
+-- (uppercase) but migration 090 only mapped lowercase 'derived_from' and
+-- 'derives_from'. The uppercase variant falls through edge_to_factor_type()
+-- as NULL, so none of the 36,791 DERIVED_FROM edges generate factors — the
+-- paraphrase-probe claims (18,989 created on 2026-04-11) have no BP coupling
+-- to their source atoms.
+--
+-- Semantics for DERIVED_FROM (paraphrase → source atom):
+--   forward_strength = 0.0: the synthetic paraphrase must NOT push belief onto
+--     the source atom — it has no independent evidence. Matches decomposes_to
+--     forward=0 rationale: derived artifact does not validate origin.
+--   reverse_strength = 0.6: the source atom's belief flows strongly into the
+--     paraphrase (the paraphrase is a restatement; if the original is well-
+--     supported, the restatement should inherit that support).
+--
+-- This is intentionally asymmetric and different from lowercase derived_from
+-- (fwd=0.5, rev=0.15), which models general derivative claims where the
+-- derivative's truth IS evidence for the source.
+
+BEGIN;
+
+-- 1. Update edge_to_factor_type to include DERIVED_FROM.
+--    Must drop and recreate: IMMUTABLE function, no ALTER.
+DROP FUNCTION IF EXISTS edge_to_factor_type(VARCHAR);
+CREATE FUNCTION edge_to_factor_type(rel VARCHAR)
+RETURNS TABLE(factor_type VARCHAR, forward_strength DOUBLE PRECISION, reverse_strength DOUBLE PRECISION) AS $$
+BEGIN
+    RETURN QUERY SELECT t.ft, t.fwd::DOUBLE PRECISION, t.rev::DOUBLE PRECISION FROM (VALUES
+        -- Symmetric positive (evidential_support: fwd = rev)
+        ('CORROBORATES'::VARCHAR,       'evidential_support'::VARCHAR, 0.85, 0.85),
+        ('same_as',                     'evidential_support', 0.95, 0.95),
+        ('equivalent_to',              'evidential_support', 0.95, 0.95),
+        ('evidential_support',         'evidential_support', 0.8,  0.8),
+        ('variant_of',                 'evidential_support', 0.65, 0.65),
+        ('definitional_variant_of',    'evidential_support', 0.9,  0.9),
+        ('analogous',                  'evidential_support', 0.2,  0.2),
+
+        -- Negative relationships (mutual_exclusion)
+        ('CONTRADICTS',                'mutual_exclusion', 0.0, 0.0),
+        ('contradicts',                'mutual_exclusion', 0.0, 0.0),
+        ('REFUTES',                    'mutual_exclusion', 0.0, 0.0),
+        ('challenges',                 'mutual_exclusion', 0.0, 0.0),
+
+        -- Directional: parent → child (zero forward: parent truth does NOT push to children)
+        ('decomposes_to',              'directional_support', 0.0, 0.6),
+
+        -- Directional: evidence → conclusion
+        ('supports',                   'directional_support', 0.7,  0.15),
+        ('SUPPORTS',                   'directional_support', 0.7,  0.15),
+        ('provides_evidence',          'directional_support', 0.7,  0.15),
+
+        -- Directional: refined → general
+        ('refines',                    'directional_support', 0.6,  0.2),
+
+        -- Directional: derivative → source (general case)
+        --   Derivative truth implies source validity at 0.5;
+        --   source weakly supports derivative at 0.15.
+        ('derived_from',               'directional_support', 0.5,  0.15),
+        ('derives_from',               'directional_support', 0.5,  0.15),
+
+        -- Directional: synthetic paraphrase → source atom
+        --   Forward=0: paraphrase has no independent evidence, must not
+        --     push onto source truth.
+        --   Reverse=0.6: source atom belief flows strongly into paraphrase
+        --     (a restatement inherits its origin's epistemic state).
+        ('DERIVED_FROM',               'directional_support', 0.0,  0.6),
+
+        -- Directional: specific → general
+        ('specializes',                'directional_support', 0.55, 0.15),
+
+        -- Directional: prerequisite
+        ('enables',                    'directional_support', 0.3,  0.6),
+
+        -- Directional: method → capability
+        ('has_method_capability',      'directional_support', 0.6,  0.4),
+
+        -- Directional: weak informational
+        ('INFORMS',                    'directional_support', 0.4,  0.1)
+    ) AS t(rel_name, ft, fwd, rev)
+    WHERE t.rel_name = rel;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- 2. Backfill factors for all existing DERIVED_FROM edges that lack factors.
+--    ON CONFLICT DO NOTHING: safe to re-run.
+INSERT INTO factors (factor_type, variable_ids, potential, description, properties)
+SELECT DISTINCT ON (var_ids)
+    'directional_support' AS factor_type,
+    CASE WHEN ed.source_id < ed.target_id
+         THEN ARRAY[ed.source_id, ed.target_id]
+         ELSE ARRAY[ed.target_id, ed.source_id]
+    END AS var_ids,
+    jsonb_build_object(
+        'forward_strength', 0.0,
+        'reverse_strength', 0.6,
+        'source_var', ed.source_id::text
+    ) AS potential,
+    format('Backfilled from DERIVED_FROM edge %s', ed.id) AS description,
+    jsonb_build_object(
+        'relationship', 'DERIVED_FROM',
+        'source_edge_id', ed.id,
+        'edge_source_id', ed.source_id,
+        'edge_target_id', ed.target_id
+    ) AS properties
+FROM edges ed
+JOIN claims sc ON sc.id = ed.source_id AND COALESCE(sc.is_current, true) = true
+JOIN claims tc ON tc.id = ed.target_id AND COALESCE(tc.is_current, true) = true
+WHERE ed.source_type = 'claim'
+  AND ed.target_type = 'claim'
+  AND ed.relationship = 'DERIVED_FROM'
+-- ORDER BY var_ids, ed.id makes DISTINCT ON deterministic: for any given
+-- claim pair, the earliest edge (lowest UUID) wins, ensuring a stable
+-- source_var in the stored potential.
+ORDER BY var_ids, ed.id
+ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/migrations/012_cull_low_similarity_corroborates.sql
+++ b/migrations/012_cull_low_similarity_corroborates.sql
@@ -1,0 +1,43 @@
+-- 103_cull_low_similarity_corroborates.sql
+--
+-- Remove CORROBORATES edges with similarity < 0.80 and their factors.
+--
+-- Evidence: sampling 12 edges in the 0.75–0.80 bucket showed ~40–50% false
+-- positive rate — different anatomical structures, opposite binding sites,
+-- different vessel segments — matched on topical vocabulary, not shared facts.
+-- The existing claim in the graph (claim about cross-source threshold needing
+-- raising) noted true corroboration clusters above 0.85; 0.80 is the
+-- conservative cut here pending LLM assessment of the 0.80–0.95 range.
+--
+-- Scope: 24,416 edges, all from paraphrase-probe method (other methods were
+-- already filtered to 0.85+ at ingestion time).
+
+BEGIN;
+
+-- Collect the edge IDs to delete once, reuse in subsequent statements.
+CREATE TEMP TABLE edges_to_cull AS
+SELECT id FROM edges
+WHERE relationship = 'CORROBORATES'
+  AND (properties->>'similarity')::float < 0.80;
+
+-- 1. Remove bp_messages for affected factors (no FK cascade, explicit delete).
+DELETE FROM bp_messages
+WHERE factor_id IN (
+    SELECT f.id FROM factors f
+    WHERE f.properties->>'source_edge_id' IN (
+        SELECT id::text FROM edges_to_cull
+    )
+);
+
+-- 2. Remove the factors themselves.
+DELETE FROM factors
+WHERE properties->>'source_edge_id' IN (
+    SELECT id::text FROM edges_to_cull
+);
+
+-- 3. Delete the edges.
+DELETE FROM edges WHERE id IN (SELECT id FROM edges_to_cull);
+
+DROP TABLE edges_to_cull;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Forward-ports 11 incremental migrations from \`epigraph-internal\` (renumbered \`092-103\` → \`002-012\` on public's \`001\` baseline) plus the matching \`revoke_signature.rs\` API route for migration \`008\`.

Brings public closer to scope parity with internal (kernel features only — no political, experiments, privacy/encryption, or host-CLI orchestration; those belong in their respective downstream products):
- New tables: \`behavioral_executions\` (002), \`claim_signature_revocations\` (008)
- New columns: \`edges.dimension_score\`, \`evidence.scope\`, \`provenance_log.patch_payload\` (some absorbed by 001's pg_dump baseline; see corrected plan)
- Validator/CHECK extensions: \`'entity'\`, \`'task'\`, \`'event'\` source/target types via idempotent rewrites
- Function rewrites: \`edge_to_factor_type()\` recognizes uppercase \`DERIVED_FROM\` (011)
- Defense-in-depth constraints on \`ds_bayesian_divergence\` (010)
- BusinessFunction added to \`entities.type_top\` (003)
- DML cleanup: low-similarity CORROBORATES cull (012, no-op on fresh DBs)
- API: \`POST /api/v1/claims/:id/revoke-signature\` route handler ported verbatim from internal

## Plan correction (mid-execution)

The plan was originally written assuming \`001_initial_schema.sql\`'s pg_dump baseline captured internal state at migration \`091\`. In practice, the dump went past \`097\`, so:
- Migrations 003 and 005 (filtered ports of 093, 095) became idempotent no-ops thanks to \`DROP IF EXISTS\` + \`CREATE OR REPLACE\` — content already in 001 but harmless to re-state.
- Migrations 006 (was 096 patch_payload) and 007 (was 097 papers_doi UNIQUE) **had to become no-op markers** because verbatim \`ALTER TABLE ADD COLUMN\` / \`ADD CONSTRAINT\` would error against an already-applied state.

The corrected renumbering map and discovery details are documented in \`docs/superpowers/plans/2026-04-26-forward-port-092-103.md\` (final commit on this branch).

## Out of scope (intentional, deferred to follow-up)

- \`104_host_tables_baseline\` — EpiClaw CLI orchestration, internal-only
- \`crates/epigraph-api/src/routes/mcp_tools.rs\` — depends on \`epigraph_mcp::list_tools()\` symbol that doesn't exist in public's \`epigraph-mcp\` crate yet

## Test plan
- [x] Schema rebuild from scratch with all 12 migrations applies cleanly (verified locally)
- [x] \`cargo test -p epigraph-db --lib repos::lineage::\` — 5/5 passing locally post-rebase
- [x] Full \`epigraph-db\` (34) / \`epigraph-api\` (49) / \`epigraph-engine\` (38) / non-DB (38) test suites pass
- [x] \`cargo fmt --check\` and \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`.sqlx/\` already in sync (no regeneration needed — new tables use runtime queries, not \`sqlx::query!\` macros)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)