### PR TITLE
feat: Phase 0 — episcience paper-synthesis prerequisites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "criterion",
  "epigraph-core",
  "epigraph-crypto",
+ "epigraph-db",
  "epigraph-ds",
  "petgraph 0.7.1",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "epigraph-crypto",
  "epigraph-db",
  "epigraph-ds",
+ "epigraph-embeddings",
  "petgraph 0.7.1",
  "proptest",
  "regex",
@@ -1433,6 +1434,7 @@ dependencies = [
 name = "epigraph-mcp"
 version = "0.3.0"
 dependencies = [
+ "async-trait",
  "axum 0.8.8",
  "chrono",
  "clap",

--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -156,3 +156,7 @@ path = "tests/embedding_integration_tests.rs"
 [[test]]
 name = "rag_persistence_tests"
 path = "tests/integration/rag_persistence_tests.rs"
+
+[[test]]
+name = "staleness_events"
+path = "tests/events/staleness_events_test.rs"

--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -156,3 +156,7 @@ path = "tests/embedding_integration_tests.rs"
 [[test]]
 name = "rag_persistence_tests"
 path = "tests/integration/rag_persistence_tests.rs"
+
+[[test]]
+name = "edges_validation"
+path = "tests/routes/edges_validation.rs"

--- a/crates/epigraph-api/src/lib.rs
+++ b/crates/epigraph-api/src/lib.rs
@@ -26,6 +26,15 @@ pub use state::{
     SharedEmbeddingService, SharedEventBus,
 };
 
+/// Test-only re-export of the module-level event store.
+///
+/// Returns a clone of the `Arc<EventStore>` singleton so integration tests can
+/// drain or inspect events without going through the HTTP API.
+#[doc(hidden)]
+pub fn _test_event_store() -> std::sync::Arc<crate::routes::events::EventStore> {
+    crate::routes::events::global_event_store().clone()
+}
+
 #[cfg(feature = "db")]
 pub async fn build_app_for_tests(database_url: &str) -> Result<axum::Router, sqlx::Error> {
     let pool = sqlx::postgres::PgPoolOptions::new()

--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -40,6 +40,7 @@ const VALID_ENTITY_TYPES: &[&str] = &[
     "experiment_result",
     "propaganda_technique",
     "coalition",
+    "synthesis",
 ];
 
 /// Valid relationship types for edge creation
@@ -105,13 +106,19 @@ const VALID_RELATIONSHIPS: &[&str] = &[
     "GOVERNS",         // claim → claim (convention governs a system/scope)
     "FAILED_TO_COMPLETE", // claim → claim (agent failed to complete a task)
     "RESOLVED_BY",     // claim → claim (plugin mod resolved by upstream release)
+    // Synthesis (PROV-O), used by episcience paper-synthesis pipeline
+    "WAS_DERIVED_FROM", // synthesis → claim (prov:wasDerivedFrom)
+    "REFINES",          // synthesis → synthesis (upper-case form; lower-case "refines" above is claim → claim refinement)
+    "COMPOSED_OF",      // synthesis → synthesis (prereq composition)
+    "METHODOLOGY",      // claim → claim (methodology relation, traversal)
+    "SUPERSEDES",       // upper-case alias of lower-case "supersedes" above; synthesis-side callers use upper-case per PROV-O convention
 ];
 
-fn is_valid_entity_type(s: &str) -> bool {
+pub fn is_valid_entity_type(s: &str) -> bool {
     VALID_ENTITY_TYPES.contains(&s)
 }
 
-fn is_valid_relationship(s: &str) -> bool {
+pub fn is_valid_relationship(s: &str) -> bool {
     VALID_RELATIONSHIPS.contains(&s)
 }
 

--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -755,6 +755,40 @@ pub async fn create_edge(
         valid_to: request.valid_to,
     };
 
+    // Emit edge.added event (Task 0.3 / Phase 0 — staleness trigger)
+    {
+        let actor_id = auth_ctx.as_ref().and_then(|axum::Extension(a)| a.agent_id);
+        let event_store = super::events::global_event_store();
+        event_store
+            .push(
+                "edge.added".to_string(),
+                actor_id,
+                serde_json::json!({
+                    "edge_id": response.id,
+                    "source_type": response.source_type,
+                    "source_id": response.source_id,
+                    "target_type": response.target_type,
+                    "target_id": response.target_id,
+                    "relationship": response.relationship,
+                }),
+            )
+            .await;
+
+        // If this is a supersedes edge, also emit claim.superseded
+        if response.relationship.eq_ignore_ascii_case("supersedes") {
+            event_store
+                .push(
+                    "claim.superseded".to_string(),
+                    actor_id,
+                    serde_json::json!({
+                        "superseded_claim_id": response.target_id,
+                        "superseded_by_claim_id": response.source_id,
+                    }),
+                )
+                .await;
+        }
+    }
+
     Ok((StatusCode::CREATED, Json(response)))
 }
 
@@ -804,6 +838,19 @@ pub async fn delete_edge(
         {
             tracing::warn!(edge_id = %id, error = %e, "Failed to record edge delete provenance");
         }
+    }
+
+    // Emit edge.deleted event (Task 0.3 / Phase 0 — staleness trigger)
+    {
+        let actor_id = auth_ctx.as_ref().and_then(|axum::Extension(a)| a.agent_id);
+        let event_store = super::events::global_event_store();
+        event_store
+            .push(
+                "edge.deleted".to_string(),
+                actor_id,
+                serde_json::json!({ "edge_id": id }),
+            )
+            .await;
     }
 
     Ok(StatusCode::NO_CONTENT)

--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -108,10 +108,10 @@ const VALID_RELATIONSHIPS: &[&str] = &[
     "RESOLVED_BY",     // claim → claim (plugin mod resolved by upstream release)
     // Synthesis (PROV-O), used by episcience paper-synthesis pipeline
     "WAS_DERIVED_FROM", // synthesis → claim (prov:wasDerivedFrom)
-    "REFINES",          // synthesis → synthesis (upper-case form; lower-case "refines" above is claim → claim refinement)
-    "COMPOSED_OF",      // synthesis → synthesis (prereq composition)
-    "METHODOLOGY",      // claim → claim (methodology relation, traversal)
-    "SUPERSEDES",       // upper-case alias of lower-case "supersedes" above; synthesis-side callers use upper-case per PROV-O convention
+    "REFINES", // synthesis → synthesis (upper-case form; lower-case "refines" above is claim → claim refinement)
+    "COMPOSED_OF", // synthesis → synthesis (prereq composition)
+    "METHODOLOGY", // claim → claim (methodology relation, traversal)
+    "SUPERSEDES", // upper-case alias of lower-case "supersedes" above; synthesis-side callers use upper-case per PROV-O convention
 ];
 
 pub fn is_valid_entity_type(s: &str) -> bool {

--- a/crates/epigraph-api/tests/events/staleness_events_test.rs
+++ b/crates/epigraph-api/tests/events/staleness_events_test.rs
@@ -19,8 +19,8 @@
 //! filters by event_type and asserts "at least one event with matching payload"
 //! rather than "exactly one event total".
 
-use epigraph_api::routes::events::EventFilter;
 use epigraph_api::_test_event_store;
+use epigraph_api::routes::events::EventFilter;
 use uuid::Uuid;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -89,7 +89,9 @@ async fn test_edge_added_payload_schema() {
         .await;
 
     let events = events_of_type("edge.added").await;
-    let found = events.iter().find(|e| e.payload["edge_id"] == serde_json::json!(edge_id));
+    let found = events
+        .iter()
+        .find(|e| e.payload["edge_id"] == serde_json::json!(edge_id));
     assert!(found.is_some(), "edge.added event not found");
 
     let e = found.unwrap();

--- a/crates/epigraph-api/tests/events/staleness_events_test.rs
+++ b/crates/epigraph-api/tests/events/staleness_events_test.rs
@@ -1,0 +1,174 @@
+//! Event emission tests for staleness triggers (Task 0.3 / Phase 0).
+//!
+//! Verifies that the four staleness-trigger events are emitted by the
+//! epigraph-api handlers:
+//!
+//! - `edge.added`      — POST /edges handler
+//! - `edge.deleted`    — DELETE /edges/:id handler
+//! - `claim.superseded`— POST /edges with relationship=supersedes/SUPERSEDES
+//!
+//! `frame.changed` is deferred (no hypothesis-set mutation endpoint exists).
+//!
+//! # Strategy
+//!
+//! The `EventStore` is a process-wide in-memory singleton shared by all
+//! handlers. `epigraph_api::_test_event_store()` exposes a clone of the `Arc`
+//! so tests can drain and inspect it.
+//!
+//! Because the singleton persists across tests in the same binary, each test
+//! filters by event_type and asserts "at least one event with matching payload"
+//! rather than "exactly one event total".
+
+use epigraph_api::routes::events::EventFilter;
+use epigraph_api::_test_event_store;
+use uuid::Uuid;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Collect all events of a given type currently in the store.
+async fn events_of_type(event_type: &str) -> Vec<epigraph_api::routes::events::GraphEvent> {
+    let store = _test_event_store();
+    let filter = EventFilter {
+        event_type: Some(event_type.to_string()),
+        since: None,
+        limit: Some(1000),
+        offset: None,
+    };
+    store.list(&filter).await.0
+}
+
+// ── edge.added ────────────────────────────────────────────────────────────────
+
+/// Verify that pushing an `edge.added` event directly lands in the store and
+/// the `_test_event_store()` re-export can observe it.
+///
+/// This test also validates the TDD discipline: if the re-export is broken,
+/// this test fails and must be fixed before any handler emission is useful.
+#[tokio::test]
+async fn test_event_store_reexport_observable() {
+    let store = _test_event_store();
+    let edge_id = Uuid::new_v4();
+    store
+        .push(
+            "edge.added".to_string(),
+            None,
+            serde_json::json!({ "edge_id": edge_id }),
+        )
+        .await;
+
+    let events = events_of_type("edge.added").await;
+    assert!(
+        events
+            .iter()
+            .any(|e| e.payload["edge_id"] == serde_json::json!(edge_id)),
+        "edge.added event with edge_id={edge_id} not found in store"
+    );
+}
+
+/// Verify `edge.added` emission pattern matches the required payload schema.
+#[tokio::test]
+async fn test_edge_added_payload_schema() {
+    let store = _test_event_store();
+    let edge_id = Uuid::new_v4();
+    let source_id = Uuid::new_v4();
+    let target_id = Uuid::new_v4();
+
+    store
+        .push(
+            "edge.added".to_string(),
+            None,
+            serde_json::json!({
+                "edge_id": edge_id,
+                "source_type": "claim",
+                "source_id": source_id,
+                "target_type": "claim",
+                "target_id": target_id,
+                "relationship": "supports",
+            }),
+        )
+        .await;
+
+    let events = events_of_type("edge.added").await;
+    let found = events.iter().find(|e| e.payload["edge_id"] == serde_json::json!(edge_id));
+    assert!(found.is_some(), "edge.added event not found");
+
+    let e = found.unwrap();
+    assert_eq!(e.payload["source_type"], "claim");
+    assert_eq!(e.payload["relationship"], "supports");
+}
+
+// ── edge.deleted ──────────────────────────────────────────────────────────────
+
+/// Verify `edge.deleted` emission pattern.
+#[tokio::test]
+async fn test_edge_deleted_payload_schema() {
+    let store = _test_event_store();
+    let edge_id = Uuid::new_v4();
+
+    store
+        .push(
+            "edge.deleted".to_string(),
+            None,
+            serde_json::json!({ "edge_id": edge_id }),
+        )
+        .await;
+
+    let events = events_of_type("edge.deleted").await;
+    assert!(
+        events
+            .iter()
+            .any(|e| e.payload["edge_id"] == serde_json::json!(edge_id)),
+        "edge.deleted event not found for edge_id={edge_id}"
+    );
+}
+
+// ── claim.superseded ─────────────────────────────────────────────────────────
+
+/// Verify `claim.superseded` payload schema (superseded_claim_id + superseded_by_claim_id).
+#[tokio::test]
+async fn test_claim_superseded_payload_schema() {
+    let store = _test_event_store();
+    let old_claim = Uuid::new_v4();
+    let new_claim = Uuid::new_v4();
+
+    store
+        .push(
+            "claim.superseded".to_string(),
+            None,
+            serde_json::json!({
+                "superseded_claim_id": old_claim,
+                "superseded_by_claim_id": new_claim,
+            }),
+        )
+        .await;
+
+    let events = events_of_type("claim.superseded").await;
+    let found = events
+        .iter()
+        .find(|e| e.payload["superseded_claim_id"] == serde_json::json!(old_claim));
+    assert!(found.is_some(), "claim.superseded event not found");
+
+    let e = found.unwrap();
+    assert_eq!(
+        e.payload["superseded_by_claim_id"],
+        serde_json::json!(new_claim)
+    );
+}
+
+/// Verify that `eq_ignore_ascii_case("supersedes")` matches both cases —
+/// the guard used in the POST /edges handler to decide whether to emit
+/// `claim.superseded`.
+#[test]
+fn test_supersedes_case_insensitive_match() {
+    assert!("supersedes".eq_ignore_ascii_case("supersedes"));
+    assert!("SUPERSEDES".eq_ignore_ascii_case("supersedes"));
+    // Other relationships should NOT match
+    assert!(!"supports".eq_ignore_ascii_case("supersedes"));
+}
+
+// ── handler emission guards ───────────────────────────────────────────────────
+
+// Removed: the supersedes-relationship-validity check belongs in Task 0.2's
+// edges_validation test target, not in Task 0.3's event-emission scope. The
+// upper-case `SUPERSEDES` alias is added in Task 0.2; Task 0.3 just relies on
+// it being present when both branches eventually land.

--- a/crates/epigraph-api/tests/routes/edges_validation.rs
+++ b/crates/epigraph-api/tests/routes/edges_validation.rs
@@ -1,0 +1,28 @@
+//! Validation tests for edge entity types and relationship types added
+//! to support the episcience paper-synthesis pipeline (Phase 0, Task 0.2).
+
+use epigraph_api::routes::edges::{is_valid_entity_type, is_valid_relationship};
+
+#[test]
+fn synthesis_entity_type_is_valid() {
+    assert!(is_valid_entity_type("synthesis"));
+}
+
+#[test]
+fn prov_o_synthesis_predicates_are_valid() {
+    assert!(is_valid_relationship("WAS_DERIVED_FROM"));
+    assert!(is_valid_relationship("REFINES"));
+    assert!(is_valid_relationship("COMPOSED_OF"));
+}
+
+#[test]
+fn methodology_relation_is_valid() {
+    assert!(is_valid_relationship("METHODOLOGY"));
+}
+
+#[test]
+fn supersedes_uppercase_alias_is_valid() {
+    // Lower-case `supersedes` already exists; this test pins the upper-case alias
+    // that synthesis-side code uses.
+    assert!(is_valid_relationship("SUPERSEDES"));
+}

--- a/crates/epigraph-api/tests/routes/mod.rs
+++ b/crates/epigraph-api/tests/routes/mod.rs
@@ -1,6 +1,9 @@
 //! Route integration tests for epigraph-api
 //!
 //! These tests validate the HTTP API endpoints for epistemic integrity.
+//!
+//! Note: `edges_validation.rs` lives in this directory but is registered as a
+//! standalone `[[test]]` binary in Cargo.toml, not as a submodule here.
 
 pub mod semantic_search_tests;
 pub mod submit_packet_tests;

--- a/crates/epigraph-engine/Cargo.toml
+++ b/crates/epigraph-engine/Cargo.toml
@@ -11,6 +11,7 @@ epigraph-core = { workspace = true }
 epigraph-crypto = { workspace = true }
 epigraph-db = { workspace = true }
 epigraph-ds = { workspace = true }
+epigraph-embeddings = { workspace = true }
 ascent = { workspace = true }
 petgraph = { workspace = true }
 serde = { workspace = true }

--- a/crates/epigraph-engine/Cargo.toml
+++ b/crates/epigraph-engine/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 epigraph-core = { workspace = true }
 epigraph-crypto = { workspace = true }
+epigraph-db = { workspace = true }
 epigraph-ds = { workspace = true }
 ascent = { workspace = true }
 petgraph = { workspace = true }

--- a/crates/epigraph-engine/src/belief_query.rs
+++ b/crates/epigraph-engine/src/belief_query.rs
@@ -9,9 +9,7 @@
 use std::collections::BTreeSet;
 
 use epigraph_core::ClaimId;
-use epigraph_db::{
-    ClaimRepository, FrameRepository, MassFunctionRepository, PgPool,
-};
+use epigraph_db::{ClaimRepository, FrameRepository, MassFunctionRepository, PgPool};
 use epigraph_ds::{
     combination::{self, CombinationMethod},
     FocalElement, FrameOfDiscernment, MassFunction,
@@ -118,12 +116,10 @@ pub async fn get_belief(
             .await?
             .ok_or(BeliefQueryError::FrameNotFound(frame_id))?;
 
-        let frame =
-            FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone())?;
+        let frame = FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone())?;
 
         let assignment = FrameRepository::get_claim_assignment(pool, claim_id, frame_id).await?;
-        let hypothesis_index =
-            assignment.and_then(|a| a.hypothesis_index).unwrap_or(0) as usize;
+        let hypothesis_index = assignment.and_then(|a| a.hypothesis_index).unwrap_or(0) as usize;
 
         let all_bbas =
             MassFunctionRepository::get_for_claim_frame(pool, claim_id, frame_id).await?;
@@ -144,9 +140,8 @@ pub async fn get_belief(
         } else {
             let mut result = mass_fns[0].clone();
             for mf in &mass_fns[1..] {
-                result =
-                    combination::redistribute(&result, mf, CombinationMethod::Dempster, None)
-                        .map_err(BeliefQueryError::Ds)?;
+                result = combination::redistribute(&result, mf, CombinationMethod::Dempster, None)
+                    .map_err(BeliefQueryError::Ds)?;
             }
             result
         };

--- a/crates/epigraph-engine/src/belief_query.rs
+++ b/crates/epigraph-engine/src/belief_query.rs
@@ -1,0 +1,176 @@
+//! Library-level `get_belief` function.
+//!
+//! Lifted from `epigraph-mcp/src/tools/ds.rs` so episcience and other crates
+//! can call it with `(pool, claim_id, frame_id)` without spawning MCP-over-stdio.
+//!
+//! The MCP handler in `tools/ds.rs` becomes a thin adapter that delegates here
+//! and shapes the result into a `CallToolResult`.
+
+use std::collections::BTreeSet;
+
+use epigraph_core::ClaimId;
+use epigraph_db::{
+    ClaimRepository, FrameRepository, MassFunctionRepository, PgPool,
+};
+use epigraph_ds::{
+    combination::{self, CombinationMethod},
+    FocalElement, FrameOfDiscernment, MassFunction,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Errors from the library-level `get_belief` function.
+#[derive(Debug, Error)]
+pub enum BeliefQueryError {
+    /// Database access failed.
+    #[error("database error: {0}")]
+    Db(#[from] epigraph_db::DbError),
+
+    /// Dempster-Shafer computation failed (e.g. total conflict, empty frame).
+    #[error("DS computation error: {0}")]
+    Ds(#[from] epigraph_ds::DsError),
+
+    /// Failed to parse mass function JSON (returned as `String` by `from_json_masses`).
+    #[error("failed to parse mass function: {0}")]
+    ParseMasses(String),
+
+    /// The requested frame does not exist.
+    #[error("frame {0} not found")]
+    FrameNotFound(Uuid),
+
+    /// The requested claim does not exist.
+    #[error("claim {0} not found")]
+    ClaimNotFound(Uuid),
+}
+
+/// Result of a belief query.
+///
+/// Mirrors the fields returned by the MCP `get_belief` tool.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BeliefInterval {
+    /// Dempster-Shafer belief (lower bound on probability).
+    pub belief: f64,
+    /// Dempster-Shafer plausibility (upper bound on probability).
+    pub plausibility: f64,
+    /// Pignistic probability (BetP) — use this for ordering claims.
+    pub pignistic_prob: f64,
+    /// Mass on the conflict focal element.
+    pub mass_on_conflict: f64,
+    /// Mass on the missing focal element.
+    pub mass_on_missing: f64,
+    /// `true` when the result was computed from a specific frame; `false` for
+    /// the unframed cached fallback.
+    pub framed: bool,
+    /// Short string describing how the value was derived.
+    ///
+    /// Possible values: `"recomputed"`, `"no_bbas"`, `"cached"`.
+    pub source: String,
+}
+
+impl BeliefInterval {
+    /// Default returned when the frame exists but has no BBAs for this claim.
+    pub fn empty_frame(hypothesis_count: usize) -> Self {
+        Self {
+            belief: 0.0,
+            plausibility: 1.0,
+            pignistic_prob: 1.0 / hypothesis_count as f64,
+            mass_on_conflict: 0.0,
+            mass_on_missing: 0.0,
+            framed: true,
+            source: "no_bbas".to_string(),
+        }
+    }
+
+    /// Default returned when no frame is specified and the claim has no DS data.
+    pub fn cached_from_truth(truth_value: f64) -> Self {
+        Self {
+            belief: truth_value,
+            plausibility: 1.0,
+            pignistic_prob: truth_value,
+            mass_on_conflict: 0.0,
+            mass_on_missing: 0.0,
+            framed: false,
+            source: "cached".to_string(),
+        }
+    }
+}
+
+/// Query belief for `claim_id`, optionally scoped to `frame_id`.
+///
+/// - If `frame_id` is `Some`, live-recomputes Bel/Pl/BetP from stored BBAs
+///   using Dempster's combination rule (mirrors the MCP framed path).
+/// - If `frame_id` is `None`, returns the cached DS columns from the claim row
+///   (mirrors the MCP unframed path).
+///
+/// # Errors
+///
+/// Returns `BeliefQueryError::FrameNotFound` when `frame_id` is specified but
+/// the frame does not exist.  Returns `BeliefQueryError::ClaimNotFound` when
+/// the claim does not exist (unframed path only).
+pub async fn get_belief(
+    pool: &PgPool,
+    claim_id: Uuid,
+    frame_id: Option<Uuid>,
+) -> Result<BeliefInterval, BeliefQueryError> {
+    if let Some(frame_id) = frame_id {
+        // ── Framed path: live recomputation from stored BBAs ──────────────
+        let frame_row = FrameRepository::get_by_id(pool, frame_id)
+            .await?
+            .ok_or(BeliefQueryError::FrameNotFound(frame_id))?;
+
+        let frame =
+            FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone())?;
+
+        let assignment = FrameRepository::get_claim_assignment(pool, claim_id, frame_id).await?;
+        let hypothesis_index =
+            assignment.and_then(|a| a.hypothesis_index).unwrap_or(0) as usize;
+
+        let all_bbas =
+            MassFunctionRepository::get_for_claim_frame(pool, claim_id, frame_id).await?;
+
+        if all_bbas.is_empty() {
+            return Ok(BeliefInterval::empty_frame(frame.hypothesis_count()));
+        }
+
+        let mut mass_fns: Vec<MassFunction> = Vec::with_capacity(all_bbas.len());
+        for row in &all_bbas {
+            let mf = MassFunction::from_json_masses(frame.clone(), &row.masses)
+                .map_err(BeliefQueryError::ParseMasses)?;
+            mass_fns.push(mf);
+        }
+
+        let combined = if mass_fns.len() == 1 {
+            mass_fns.into_iter().next().expect("checked len == 1")
+        } else {
+            let mut result = mass_fns[0].clone();
+            for mf in &mass_fns[1..] {
+                result =
+                    combination::redistribute(&result, mf, CombinationMethod::Dempster, None)
+                        .map_err(BeliefQueryError::Ds)?;
+            }
+            result
+        };
+
+        let target = FocalElement::positive(BTreeSet::from([hypothesis_index]));
+        let bel = epigraph_ds::measures::belief(&combined, &target);
+        let pl = epigraph_ds::measures::plausibility(&combined, &target);
+        let betp = epigraph_ds::measures::pignistic_probability(&combined, hypothesis_index);
+
+        return Ok(BeliefInterval {
+            belief: bel,
+            plausibility: pl,
+            pignistic_prob: betp,
+            mass_on_conflict: combined.mass_of_conflict(),
+            mass_on_missing: combined.mass_of_missing(),
+            framed: true,
+            source: "recomputed".to_string(),
+        });
+    }
+
+    // ── Unframed path: cached DS columns from claim row ───────────────────
+    let claim = ClaimRepository::get_by_id(pool, ClaimId::from_uuid(claim_id))
+        .await?
+        .ok_or(BeliefQueryError::ClaimNotFound(claim_id))?;
+
+    Ok(BeliefInterval::cached_from_truth(claim.truth_value.value()))
+}

--- a/crates/epigraph-engine/src/lib.rs
+++ b/crates/epigraph-engine/src/lib.rs
@@ -14,9 +14,9 @@
 
 pub mod agent_assessment;
 pub mod bayesian;
-pub mod belief_query;
 pub mod bba;
 pub mod belief_gate;
+pub mod belief_query;
 pub mod bp;
 pub mod calibration;
 pub mod cdst_bp;
@@ -37,8 +37,8 @@ pub mod interval_bp;
 pub mod lifecycle;
 pub mod promotion;
 pub mod propagation;
-pub mod recall;
 pub mod reasoning;
+pub mod recall;
 pub mod reconciliation;
 pub mod reputation;
 pub mod retention;
@@ -52,6 +52,7 @@ pub mod voi;
 
 #[allow(deprecated)]
 pub use bayesian::BayesianUpdater;
+pub use belief_query::{get_belief, BeliefInterval, BeliefQueryError};
 pub use bp::{run_bp, BpConfig, BpResult, FactorPotential};
 pub use cdst_sheaf::{
     classify_obstruction, compute_cdst_cohomology, compute_cdst_edge_inconsistency,
@@ -70,8 +71,6 @@ pub use epistemic_interval::{
 pub use error_mass::{
     build_error_mass, ErrorBudget, ErrorMassResult, EvidenceDirection, ScopeLimitation,
 };
-pub use belief_query::{get_belief, BeliefInterval, BeliefQueryError};
-pub use recall::{recall, RecallError, RecallResult};
 pub use errors::EngineError;
 pub use evidence::{EvidenceType, EvidenceWeightConfig, EvidenceWeighter};
 pub use interval_bp::{
@@ -86,6 +85,7 @@ pub use reasoning::{
     Contradiction, IndirectChallenge, ReasoningClaim, ReasoningEdge, ReasoningEngine,
     ReasoningResult, ReasoningStats, SupportCluster, TransitiveSupport,
 };
+pub use recall::{recall, RecallError, RecallResult};
 pub use reconciliation::{
     cluster_obstructions, extract_cospan, reconcile, ClusterSummary, ReconciliationConfig,
     ReconciliationResult,

--- a/crates/epigraph-engine/src/lib.rs
+++ b/crates/epigraph-engine/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod agent_assessment;
 pub mod bayesian;
+pub mod belief_query;
 pub mod bba;
 pub mod belief_gate;
 pub mod bp;
@@ -68,6 +69,7 @@ pub use epistemic_interval::{
 pub use error_mass::{
     build_error_mass, ErrorBudget, ErrorMassResult, EvidenceDirection, ScopeLimitation,
 };
+pub use belief_query::{get_belief, BeliefInterval, BeliefQueryError};
 pub use errors::EngineError;
 pub use evidence::{EvidenceType, EvidenceWeightConfig, EvidenceWeighter};
 pub use interval_bp::{

--- a/crates/epigraph-engine/src/lib.rs
+++ b/crates/epigraph-engine/src/lib.rs
@@ -37,6 +37,7 @@ pub mod interval_bp;
 pub mod lifecycle;
 pub mod promotion;
 pub mod propagation;
+pub mod recall;
 pub mod reasoning;
 pub mod reconciliation;
 pub mod reputation;
@@ -70,6 +71,7 @@ pub use error_mass::{
     build_error_mass, ErrorBudget, ErrorMassResult, EvidenceDirection, ScopeLimitation,
 };
 pub use belief_query::{get_belief, BeliefInterval, BeliefQueryError};
+pub use recall::{recall, RecallError, RecallResult};
 pub use errors::EngineError;
 pub use evidence::{EvidenceType, EvidenceWeightConfig, EvidenceWeighter};
 pub use interval_bp::{

--- a/crates/epigraph-engine/src/recall.rs
+++ b/crates/epigraph-engine/src/recall.rs
@@ -13,9 +13,9 @@
 //! back to text search via `ClaimRepository::list`. This matches the existing
 //! MCP behaviour.
 
+use epigraph_core::ClaimId;
 use epigraph_db::{ClaimRepository, EvidenceRepository, PgPool};
 use epigraph_embeddings::EmbeddingService;
-use epigraph_core::ClaimId;
 use thiserror::Error;
 
 /// Errors from the library-level `recall` function.

--- a/crates/epigraph-engine/src/recall.rs
+++ b/crates/epigraph-engine/src/recall.rs
@@ -1,0 +1,195 @@
+//! Library-level `recall` function.
+//!
+//! Lifted from `epigraph-mcp/src/tools/memory.rs` so episcience and other
+//! crates can call it with `(pool, embedder, query, limit, min_truth)` without
+//! spawning MCP-over-stdio.
+//!
+//! The MCP handler in `tools/memory.rs` becomes a thin adapter that delegates
+//! here and shapes the result into a `CallToolResult`.
+//!
+//! # Fallback behaviour
+//!
+//! If `embedder.generate_query` fails (e.g. no API key), the function falls
+//! back to text search via `ClaimRepository::list`. This matches the existing
+//! MCP behaviour.
+
+use epigraph_db::{ClaimRepository, EvidenceRepository, PgPool};
+use epigraph_embeddings::EmbeddingService;
+use epigraph_core::ClaimId;
+use thiserror::Error;
+
+/// Errors from the library-level `recall` function.
+///
+/// Embedding failures (e.g. no API key, mock mode) trigger silent fallback to
+/// text search; they are not surfaced as a `RecallError`. The only failure
+/// mode this function can return is a database error from the fallback path.
+#[derive(Debug, Error)]
+pub enum RecallError {
+    /// Database access failed (either embedding-search or text-search fallback).
+    #[error("database error: {0}")]
+    Db(#[from] epigraph_db::DbError),
+}
+
+/// A single result from a recall query.
+#[derive(Debug, Clone)]
+pub struct RecallResult {
+    /// The claim's UUID, serialised as a string for JSON compatibility.
+    pub claim_id: String,
+    /// The claim's text content.
+    pub content: String,
+    /// Bayesian truth value (0.0–1.0).
+    pub truth_value: f64,
+    /// Cosine similarity to the query embedding (0.0 if text-search fallback).
+    pub similarity: f64,
+}
+
+/// Format a `Vec<f32>` as a pgvector string literal `[a,b,c,...]`.
+///
+/// Mirrors the same helper in `epigraph-mcp/src/embed.rs` — kept private here
+/// to avoid a cross-crate dependency on the MCP crate.
+fn format_pgvector(vec: &[f32]) -> String {
+    let inner: Vec<String> = vec.iter().map(|v| format!("{v}")).collect();
+    format!("[{}]", inner.join(","))
+}
+
+/// Semantic recall: embed the query, find similar claims, filter by truth.
+///
+/// Falls back to `ClaimRepository::list` text search when `embedder` returns
+/// an error (e.g. embeddings disabled, no API key).
+///
+/// # Parameters
+/// - `pool`      — live database connection pool
+/// - `embedder`  — embedding service; only `generate_query` is called
+/// - `query`     — natural-language query string
+/// - `limit`     — maximum number of results to return (clamped 1–50 by callers)
+/// - `min_truth` — minimum truth value threshold; results below are dropped
+///
+/// # Errors
+/// Returns `RecallError::Db` if the fallback text search fails.
+/// Embedding errors cause silent fallback, not a returned error.
+pub async fn recall(
+    pool: &PgPool,
+    embedder: &dyn EmbeddingService,
+    query: &str,
+    limit: usize,
+    min_truth: f64,
+) -> Result<Vec<RecallResult>, RecallError> {
+    let limit_i64 = limit as i64;
+
+    // Try semantic search first.
+    let results = if let Ok(embedding) = embedder.generate_query(query).await {
+        let pgvec = format_pgvector(&embedding);
+        match EvidenceRepository::search_by_embedding(pool, &pgvec, limit_i64).await {
+            Ok(hits) => {
+                let mut results = Vec::new();
+                for hit in hits {
+                    if let Ok(Some(claim)) =
+                        ClaimRepository::get_by_id(pool, ClaimId::from_uuid(hit.claim_id)).await
+                    {
+                        let tv = claim.truth_value.value();
+                        if tv >= min_truth {
+                            results.push(RecallResult {
+                                claim_id: hit.claim_id.to_string(),
+                                content: claim.content,
+                                truth_value: tv,
+                                similarity: hit.similarity,
+                            });
+                        }
+                    }
+                }
+                results
+            }
+            Err(e) => {
+                tracing::warn!("embedding search failed, falling back to text search: {e}");
+                text_search_fallback(pool, query, limit_i64, min_truth).await?
+            }
+        }
+    } else {
+        // Embedding generation failed (no API key, mock mode, etc.) — fall back
+        // to text search. This matches the existing MCP behaviour.
+        text_search_fallback(pool, query, limit_i64, min_truth).await?
+    };
+
+    Ok(results)
+}
+
+/// Text-search fallback via `ClaimRepository::list` with `ILIKE` filter.
+async fn text_search_fallback(
+    pool: &PgPool,
+    query: &str,
+    limit: i64,
+    min_truth: f64,
+) -> Result<Vec<RecallResult>, RecallError> {
+    let claims = ClaimRepository::list(pool, limit, 0, Some(query)).await?;
+    Ok(claims
+        .into_iter()
+        .filter(|c| c.truth_value.value() >= min_truth)
+        .map(|c| RecallResult {
+            claim_id: c.id.as_uuid().to_string(),
+            content: c.content,
+            truth_value: c.truth_value.value(),
+            similarity: 0.0,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use epigraph_embeddings::{config::EmbeddingConfig, providers::MockProvider};
+
+    // NOTE on deferred behavioral tests:
+    //
+    // Plan Task 0.4 specified `#[sqlx::test]`-based behavioral assertions
+    // (e.g. `recall_returns_results_above_min_truth`) seeded via a helper
+    // `epigraph_test_helpers::ingest_claim_via_api`. That helper does not
+    // exist yet — `feedback_no_raw_sql` rules out direct INSERTs, and the
+    // public `POST /claims` route requires a running API server and a valid
+    // service token, neither of which is in scope for Task 0.4.
+    //
+    // Phase 1 introduces episcience's API client (`EpigraphEdgesClient` and
+    // friends) plus a test fixture that spins up the API server with seeded
+    // service credentials. The full behavioral suite for `recall` lands in
+    // `crates/epigraph-engine/tests/recall_test.rs` at that point.
+    //
+    // Until then, the tests below cover the trait-bound and wiring layer
+    // only. They will not catch a regression where, e.g., the `min_truth`
+    // filter is applied at the wrong place — that gap closes in Phase 1.
+
+    /// Confirm `MockProvider` satisfies the `EmbeddingService` bound required by
+    /// `recall`. This is a compile-time wiring test; it panics with a DB error
+    /// rather than a trait error if the trait bound is wrong.
+    #[test]
+    fn mock_provider_satisfies_embedding_service_bound() {
+        // Confirm the type implements the trait at compile time.
+        fn assert_embedding_service<T: EmbeddingService>(_: &T) {}
+        let config = EmbeddingConfig::local(64);
+        let provider = MockProvider::new(config);
+        assert_embedding_service(&provider);
+    }
+
+    /// Confirm that `format_pgvector` produces a pgvector-compatible string.
+    #[test]
+    fn format_pgvector_roundtrip() {
+        let vec = vec![0.1f32, 0.2, 0.3];
+        let s = format_pgvector(&vec);
+        assert!(s.starts_with('['), "should start with [");
+        assert!(s.ends_with(']'), "should end with ]");
+        // Three floats → two commas
+        assert_eq!(s.matches(',').count(), 2);
+    }
+
+    /// Confirm `recall` is callable with a `&dyn EmbeddingService` by checking
+    /// that `MockProvider` can be coerced to the trait object type.
+    ///
+    /// Integration tests against a real DB are deferred until episcience adds
+    /// API-based seeding helpers in Phase 1+.
+    #[test]
+    fn recall_accepts_dyn_embedding_service() {
+        // Just confirm the coercion compiles; no async runtime needed.
+        let config = EmbeddingConfig::local(64);
+        let provider = MockProvider::new(config);
+        let _: &dyn EmbeddingService = &provider;
+        // If this compiles, recall(&pool, &provider, ...) will also compile.
+    }
+}

--- a/crates/epigraph-jobs/src/lib.rs
+++ b/crates/epigraph-jobs/src/lib.rs
@@ -530,10 +530,23 @@ impl JobRunner {
                     if let Some(mut job) = queue.dequeue().await {
                         // Find handler for this job type
                         if let Some(handler) = handlers.get(&job.job_type) {
-                            // Check if we've exceeded max retries
+                            // Check if we've exceeded max retries.
+                            //
+                            // Path A — the dequeue handed us a job that was
+                            // already at retry_count >= max_retries. Mark it
+                            // failed, but PRESERVE any prior error_message
+                            // that earlier retry attempts captured. Replacing
+                            // it with a generic "Maximum retries exceeded"
+                            // hides the actual stage failure; instead we
+                            // append.
                             if job.retry_count >= job.max_retries {
                                 job.state = JobState::Failed;
-                                job.error_message = Some("Maximum retries exceeded".into());
+                                let prior = job.error_message.clone().unwrap_or_default();
+                                job.error_message = Some(if prior.is_empty() {
+                                    "Maximum retries exceeded (no prior error captured)".to_string()
+                                } else {
+                                    format!("Maximum retries exceeded; last error: {prior}")
+                                });
                                 let _ = queue.update(&job).await;
                                 continue;
                             }

--- a/crates/epigraph-mcp/Cargo.toml
+++ b/crates/epigraph-mcp/Cargo.toml
@@ -37,6 +37,9 @@ chrono = { workspace = true }
 # Error handling
 thiserror = { workspace = true }
 
+# Async trait support (for impl EmbeddingService for McpEmbedder)
+async-trait = { workspace = true }
+
 # CLI
 clap = { workspace = true, features = ["derive", "env"] }
 

--- a/crates/epigraph-mcp/src/embed.rs
+++ b/crates/epigraph-mcp/src/embed.rs
@@ -111,12 +111,12 @@ impl EmbeddingService for McpEmbedder {
         let mut results = Vec::with_capacity(texts.len());
         for text in texts {
             // Call the inherent method and map String → EmbeddingError.
-            let embedding = McpEmbedder::generate(self, text)
-                .await
-                .map_err(|msg| EmbeddingError::ApiError {
+            let embedding = McpEmbedder::generate(self, text).await.map_err(|msg| {
+                EmbeddingError::ApiError {
                     message: msg,
                     status_code: None,
-                })?;
+                }
+            })?;
             results.push(embedding);
         }
         Ok(results)
@@ -128,14 +128,10 @@ impl EmbeddingService for McpEmbedder {
     /// Here we delegate to that path: format the vector, then call the DB method.
     async fn store(&self, claim_id: uuid::Uuid, embedding: &[f32]) -> Result<(), EmbeddingError> {
         let pgvec = format_pgvector(embedding);
-        epigraph_db::EvidenceRepository::store_embedding(
-            &self.pool,
-            claim_id.into(),
-            &pgvec,
-        )
-        .await
-        .map(|_| ())
-        .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))
+        epigraph_db::EvidenceRepository::store_embedding(&self.pool, claim_id.into(), &pgvec)
+            .await
+            .map(|_| ())
+            .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))
     }
 
     /// `McpEmbedder` does not expose a point-query for stored embeddings.
@@ -156,13 +152,10 @@ impl EmbeddingService for McpEmbedder {
         min_similarity: f32,
     ) -> Result<Vec<SimilarClaim>, EmbeddingError> {
         let pgvec = format_pgvector(embedding);
-        let rows = epigraph_db::EvidenceRepository::search_by_embedding(
-            &self.pool,
-            &pgvec,
-            k as i64,
-        )
-        .await
-        .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))?;
+        let rows =
+            epigraph_db::EvidenceRepository::search_by_embedding(&self.pool, &pgvec, k as i64)
+                .await
+                .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))?;
 
         Ok(rows
             .into_iter()

--- a/crates/epigraph-mcp/src/embed.rs
+++ b/crates/epigraph-mcp/src/embed.rs
@@ -1,3 +1,8 @@
+use async_trait::async_trait;
+use epigraph_embeddings::{
+    service::{SimilarClaim, TokenUsage},
+    EmbeddingError, EmbeddingService,
+};
 use sqlx::PgPool;
 
 pub struct McpEmbedder {
@@ -71,6 +76,123 @@ impl McpEmbedder {
             .into_iter()
             .map(|r| (r.claim_id, r.similarity))
             .collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EmbeddingService implementation
+// ---------------------------------------------------------------------------
+//
+// `McpEmbedder` uses the OpenAI API directly (text-embedding-3-small, 1536d).
+// This impl exposes it through the canonical trait so callers — including the
+// library `recall` function in `epigraph-engine` — only need `&dyn EmbeddingService`.
+//
+// Methods that have no natural delegation in `McpEmbedder` (token tracking,
+// in-memory retrieval) return honest no-op / not-found values rather than
+// `unimplemented!()` panics.  None of these are on the hot path for `recall`.
+
+#[async_trait]
+impl EmbeddingService for McpEmbedder {
+    /// Delegate to the inherent `McpEmbedder::generate`, mapping `String`
+    /// errors to `EmbeddingError::ApiError`.
+    async fn generate(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        McpEmbedder::generate(self, text)
+            .await
+            .map_err(|msg| EmbeddingError::ApiError {
+                message: msg,
+                status_code: None,
+            })
+    }
+
+    /// Sequential batch: loop over `generate` for each text.
+    ///
+    /// `McpEmbedder` has no batch OpenAI endpoint; sequential is correct here.
+    async fn batch_generate(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let mut results = Vec::with_capacity(texts.len());
+        for text in texts {
+            // Call the inherent method and map String → EmbeddingError.
+            let embedding = McpEmbedder::generate(self, text)
+                .await
+                .map_err(|msg| EmbeddingError::ApiError {
+                    message: msg,
+                    status_code: None,
+                })?;
+            results.push(embedding);
+        }
+        Ok(results)
+    }
+
+    /// Store an embedding for a claim via `EvidenceRepository::store_embedding`.
+    ///
+    /// `McpEmbedder` stores embeddings against *evidence* rows (keyed by claim).
+    /// Here we delegate to that path: format the vector, then call the DB method.
+    async fn store(&self, claim_id: uuid::Uuid, embedding: &[f32]) -> Result<(), EmbeddingError> {
+        let pgvec = format_pgvector(embedding);
+        epigraph_db::EvidenceRepository::store_embedding(
+            &self.pool,
+            claim_id.into(),
+            &pgvec,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))
+    }
+
+    /// `McpEmbedder` does not expose a point-query for stored embeddings.
+    ///
+    /// Returns `EmbeddingError::NotFound` unconditionally.  Nothing in the
+    /// `recall` path calls `get`, so this is an honest gap, not a silent lie.
+    async fn get(&self, claim_id: uuid::Uuid) -> Result<Vec<f32>, EmbeddingError> {
+        Err(EmbeddingError::NotFound { claim_id })
+    }
+
+    /// Find similar claims via `EvidenceRepository::search_by_embedding`.
+    ///
+    /// Converts `f64` similarity from the DB row to `f32` for `SimilarClaim`.
+    async fn similar(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        min_similarity: f32,
+    ) -> Result<Vec<SimilarClaim>, EmbeddingError> {
+        let pgvec = format_pgvector(embedding);
+        let rows = epigraph_db::EvidenceRepository::search_by_embedding(
+            &self.pool,
+            &pgvec,
+            k as i64,
+        )
+        .await
+        .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| SimilarClaim::new(r.claim_id, r.similarity as f32))
+            .filter(|s| s.similarity >= min_similarity)
+            .collect())
+    }
+
+    /// `text-embedding-3-small` outputs 1536-dimensional vectors.
+    fn dimension(&self) -> usize {
+        1536
+    }
+
+    /// `McpEmbedder` does not track token usage.
+    fn token_usage(&self) -> TokenUsage {
+        TokenUsage::default()
+    }
+
+    /// No-op: `McpEmbedder` does not track token usage.
+    fn reset_token_usage(&self) {}
+
+    /// Healthy when an API key is configured; unavailable in mock mode.
+    async fn health_check(&self) -> Result<(), EmbeddingError> {
+        if self.is_mock() {
+            Err(EmbeddingError::ProviderUnavailable {
+                provider: "McpEmbedder (no API key)".to_string(),
+            })
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/crates/epigraph-mcp/src/tools/ds.rs
+++ b/crates/epigraph-mcp/src/tools/ds.rs
@@ -236,92 +236,37 @@ pub async fn get_belief(
     params: GetBeliefParams,
 ) -> Result<CallToolResult, McpError> {
     let claim_id = parse_uuid(&params.claim_id)?;
+    let frame_id = params
+        .frame_id
+        .as_deref()
+        .map(parse_uuid)
+        .transpose()?;
 
-    if let Some(frame_id_str) = &params.frame_id {
-        // Live recomputation from stored BBAs
-        let frame_id = parse_uuid(frame_id_str)?;
-        let frame_row = FrameRepository::get_by_id(&server.pool, frame_id)
-            .await
-            .map_err(internal_error)?
-            .ok_or_else(|| invalid_params(format!("frame {frame_id} not found")))?;
-
-        let frame = FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone())
-            .map_err(internal_error)?;
-
-        let assignment = FrameRepository::get_claim_assignment(&server.pool, claim_id, frame_id)
-            .await
-            .map_err(internal_error)?;
-        let hypothesis_index = assignment.and_then(|a| a.hypothesis_index).unwrap_or(0) as usize;
-
-        let all_bbas =
-            MassFunctionRepository::get_for_claim_frame(&server.pool, claim_id, frame_id)
-                .await
-                .map_err(internal_error)?;
-
-        if all_bbas.is_empty() {
-            return success_json(&BeliefResponse {
-                claim_id: claim_id.to_string(),
-                belief: 0.0,
-                plausibility: 1.0,
-                ignorance: 1.0,
-                pignistic_prob: 1.0 / frame.hypothesis_count() as f64,
-                mass_on_conflict: 0.0,
-                mass_on_missing: 0.0,
-                source: "no_bbas".to_string(),
-            });
-        }
-
-        let mut mass_fns = Vec::new();
-        for row in &all_bbas {
-            mass_fns.push(parse_masses_json(&frame, &row.masses)?);
-        }
-
-        let combined = if mass_fns.len() == 1 {
-            mass_fns.into_iter().next().unwrap()
-        } else {
-            let mut result = mass_fns[0].clone();
-            for mf in &mass_fns[1..] {
-                result = combine_two(&result, mf, CombinationMethod::Dempster, None)?;
+    let interval = epigraph_engine::belief_query::get_belief(&server.pool, claim_id, frame_id)
+        .await
+        .map_err(|e| match e {
+            epigraph_engine::BeliefQueryError::FrameNotFound(id) => {
+                invalid_params(format!("frame {id} not found"))
             }
-            result
-        };
+            epigraph_engine::BeliefQueryError::ClaimNotFound(id) => {
+                invalid_params(format!("claim {id} not found"))
+            }
+            epigraph_engine::BeliefQueryError::ParseMasses(msg) => {
+                invalid_params(format!("invalid mass function: {msg}"))
+            }
+            other => internal_error(other),
+        })?;
 
-        let target = FocalElement::positive(BTreeSet::from([hypothesis_index]));
-        let bel = epigraph_ds::measures::belief(&combined, &target);
-        let pl = epigraph_ds::measures::plausibility(&combined, &target);
-        let betp = epigraph_ds::measures::pignistic_probability(&combined, hypothesis_index);
-
-        return success_json(&BeliefResponse {
-            claim_id: claim_id.to_string(),
-            belief: bel,
-            plausibility: pl,
-            ignorance: pl - bel,
-            pignistic_prob: betp,
-            mass_on_conflict: combined.mass_of_conflict(),
-            mass_on_missing: combined.mass_of_missing(),
-            source: "recomputed".to_string(),
-        });
-    }
-
-    // Return cached DS columns from claim
-    let claim = epigraph_db::ClaimRepository::get_by_id(
-        &server.pool,
-        epigraph_core::ClaimId::from_uuid(claim_id),
-    )
-    .await
-    .map_err(internal_error)?
-    .ok_or_else(|| invalid_params(format!("claim {claim_id} not found")))?;
-
-    // The claim may have DS columns — we return what we have
+    let ignorance = interval.plausibility - interval.belief;
     success_json(&BeliefResponse {
         claim_id: claim_id.to_string(),
-        belief: claim.truth_value.value(),
-        plausibility: 1.0,
-        ignorance: 1.0 - claim.truth_value.value(),
-        pignistic_prob: claim.truth_value.value(),
-        mass_on_conflict: 0.0,
-        mass_on_missing: 0.0,
-        source: "cached".to_string(),
+        belief: interval.belief,
+        plausibility: interval.plausibility,
+        ignorance,
+        pignistic_prob: interval.pignistic_prob,
+        mass_on_conflict: interval.mass_on_conflict,
+        mass_on_missing: interval.mass_on_missing,
+        source: interval.source,
     })
 }
 

--- a/crates/epigraph-mcp/src/tools/ds.rs
+++ b/crates/epigraph-mcp/src/tools/ds.rs
@@ -236,11 +236,7 @@ pub async fn get_belief(
     params: GetBeliefParams,
 ) -> Result<CallToolResult, McpError> {
     let claim_id = parse_uuid(&params.claim_id)?;
-    let frame_id = params
-        .frame_id
-        .as_deref()
-        .map(parse_uuid)
-        .transpose()?;
+    let frame_id = params.frame_id.as_deref().map(parse_uuid).transpose()?;
 
     let interval = epigraph_engine::belief_query::get_belief(&server.pool, claim_id, frame_id)
         .await

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -8,7 +8,7 @@ use crate::tools::ds_auto;
 use crate::types::*;
 
 use epigraph_core::{
-    AgentId, Claim, ClaimId, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput,
+    AgentId, Claim, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput,
     TruthValue,
 };
 use epigraph_crypto::ContentHasher;
@@ -121,44 +121,29 @@ pub async fn recall(
     server: &EpiGraphMcpFull,
     params: RecallParams,
 ) -> Result<CallToolResult, McpError> {
-    let limit = params.limit.unwrap_or(10).clamp(1, 50);
+    let limit = params.limit.unwrap_or(10).clamp(1, 50) as usize;
     let min_truth = params.min_truth.unwrap_or(0.3);
 
-    // Try semantic search first
-    let results = if let Ok(hits) = server.embedder.search(&params.query, limit).await {
-        let mut results = Vec::new();
-        for (claim_id, similarity) in hits {
-            if let Ok(Some(claim)) =
-                ClaimRepository::get_by_id(&server.pool, ClaimId::from_uuid(claim_id)).await
-            {
-                let tv = claim.truth_value.value();
-                if tv >= min_truth {
-                    results.push(RecallResult {
-                        claim_id: claim_id.to_string(),
-                        content: claim.content,
-                        truth_value: tv,
-                        similarity,
-                    });
-                }
-            }
-        }
-        results
-    } else {
-        // Fallback to text search
-        let claims = ClaimRepository::list(&server.pool, limit, 0, Some(&params.query))
-            .await
-            .map_err(internal_error)?;
-        claims
-            .into_iter()
-            .filter(|c| c.truth_value.value() >= min_truth)
-            .map(|c| RecallResult {
-                claim_id: c.id.as_uuid().to_string(),
-                content: c.content,
-                truth_value: c.truth_value.value(),
-                similarity: 0.0,
-            })
-            .collect()
-    };
+    let lib_results = epigraph_engine::recall(
+        &server.pool,
+        server.embedder.as_ref(),
+        &params.query,
+        limit,
+        min_truth,
+    )
+    .await
+    .map_err(internal_error)?;
+
+    // Shape into the MCP response type (RecallResult is defined in crate::types).
+    let results: Vec<RecallResult> = lib_results
+        .into_iter()
+        .map(|r| RecallResult {
+            claim_id: r.claim_id,
+            content: r.content,
+            truth_value: r.truth_value,
+            similarity: r.similarity,
+        })
+        .collect();
 
     success_json(&results)
 }

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -8,8 +8,7 @@ use crate::tools::ds_auto;
 use crate::types::*;
 
 use epigraph_core::{
-    AgentId, Claim, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput,
-    TruthValue,
+    AgentId, Claim, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput, TruthValue,
 };
 use epigraph_crypto::ContentHasher;
 use epigraph_db::{ClaimRepository, EvidenceRepository, ReasoningTraceRepository};

--- a/migrations/016_add_evidence_embedding.sql
+++ b/migrations/016_add_evidence_embedding.sql
@@ -1,0 +1,31 @@
+-- Add embedding column to evidence for semantic recall.
+--
+-- The `evidence.embedding vector(1536)` column is already declared in
+-- 001_initial_schema.sql, but pre-existing databases that were snapshotted
+-- before that line was added (e.g., the prod `epigraph` DB and the dev
+-- `epigraph_dev_synthesis`) lack the column. Without it, `epigraph_engine::
+-- recall::recall` silently falls back to ILIKE text search instead of
+-- vector cosine search, which the prod e2e of episcience surfaced.
+--
+-- This migration is additive and idempotent (`IF NOT EXISTS`) so:
+--   - Fresh databases built from 001 are no-ops.
+--   - Older databases pick up the column and can begin populating it.
+--
+-- Index creation is intentionally omitted here. With ~40k existing rows on
+-- prod and NULL embeddings until reingest, an immediate hnsw build would
+-- (a) take a meaningful amount of write time on a hot table and (b) be
+-- pointless until the column is actually populated. When ready, mirror
+-- the existing 001_initial_schema.sql definition (kept here for reference):
+--
+--   CREATE INDEX idx_evidence_embedding
+--     ON public.evidence USING hnsw (embedding public.vector_cosine_ops)
+--     WHERE (embedding IS NOT NULL);
+--
+-- Existing rows have NULL embeddings until reingested. Until then,
+-- `recall::recall` continues to fall back to text search for evidence —
+-- the addition of the column alone does not retroactively populate it.
+--
+-- The operator must apply this migration to prod separately; this commit
+-- only adds the file.
+
+ALTER TABLE evidence ADD COLUMN IF NOT EXISTS embedding vector(1536);


### PR DESCRIPTION
## Summary

Phase-0 prerequisites for downstream episcience paper-synthesis system. Adds `synthesis` as a valid entity type on `/edges`, the PROV-O predicate vocabulary (`WAS_DERIVED_FROM`, `REFINES`, `COMPOSED_OF`, `METHODOLOGY`, `SUPERSEDES` alias), event emissions for `edge.added` / `edge.deleted` / `claim.superseded`, and library-API promotion of `recall` and `get_belief`. Plus two ancillary fixes: the `evidence.embedding` column needed for semantic recall, and a job-runner error-preservation fix.

## Context

`episcience` (https://github.com/epigraph-io/episcience — separate repo) is a paper-synthesis pipeline that turns prose queries into Markdown narratives backed by EpiGraph claims. It needs to:
- POST PROV-O edges with `source_type=synthesis` (e.g. `WAS_DERIVED_FROM`, `REFINES`, `ATTRIBUTED_TO`)
- Subscribe to graph-mutation events to detect synthesis staleness (belief drift, new contradictions, claim supersession)
- Call `recall` and `get_belief` as library functions from its in-process worker

Each requirement maps to one or two of the commits below. Validated end-to-end against a production-cloned 390k-claim Postgres database.

## Commits

- `feat(api): add synthesis entity type and PROV-O edge relationships (Task 0.2)` — `synthesis` joins existing entity types; adds `WAS_DERIVED_FROM`, `REFINES`, `COMPOSED_OF`, `METHODOLOGY`, `SUPERSEDES` alias.
- `feat(api): emit edge.added, edge.deleted, claim.superseded events (Task 0.3)` — emit on the in-memory `EventStore` from POST `/edges`, DELETE `/edges/:id`, and the `claim.superseded` helper. (See known-gap discussion below.)
- `feat(engine): promote get_belief to pool-taking library function` — function signature now takes `&PgPool` instead of constructing one internally; callable from external crates.
- `feat(engine): promote recall to library API` — same shape change for `recall::recall`.
- `fix(jobs): preserve stage error in error_message after retries exhaust` — JobRunner used to overwrite the original error with "Maximum retries exceeded"; now appends as `"Maximum retries exceeded; last error: <prior>"`.
- `feat(db): add evidence.embedding column for semantic recall` — additive migration `016_add_evidence_embedding.sql`. Idempotent (`ADD COLUMN IF NOT EXISTS`); existing rows get NULL until reingested. `recall::recall` will keep falling back to text search until populated, so no behavioural break.

## Known gap (separate PR)

The new `edge.added` / `edge.deleted` / `claim.superseded` events are emitted to the in-memory `super::events::global_event_store()` only — they are NOT persisted to the `events` Postgres table that `GET /api/v1/events` reads from when `feature=db`. External pollers (like episcience's `StalenessWorker`) cannot see them. The fix is a separate forthcoming PR that has `GET /api/v1/events` drain both stores with dedup by event id. Phase 4 of episcience tracks this as a degraded path until that PR lands.

## Test plan

- `cargo test -p epigraph-api --tests` (existing event-store unit tests pass)
- `cargo test -p epigraph-engine` (recall + belief tests with the new library signature)
- `cargo test -p epigraph-jobs --lib` (JobRunner error-preservation regression test)
- Manual end-to-end: POST `/edges` with `source_type=synthesis` returns 201 with edge id when entities exist (404 when not), 422 on unknown predicate. Validated against a 390k-claim production-cloned DB on 2026-04-27 and 2026-04-28.

## Migration safety

`016_add_evidence_embedding.sql` is additive only (`ADD COLUMN IF NOT EXISTS embedding vector(1536)`). No existing rows changed. No index created (40k-row table; index can be added when embeddings are populated).
