### PR TITLE
feat(api): unify GET /events — drain persisted + in-memory stores

### DIFF
--- a/crates/epigraph-api/src/routes/events.rs
+++ b/crates/epigraph-api/src/routes/events.rs
@@ -31,7 +31,13 @@ use uuid::Uuid;
 // ── Event store singleton ────────────────────────────────────────────────────
 
 /// Module-level singleton so all handlers share the same store.
-pub(crate) fn global_event_store() -> &'static Arc<EventStore> {
+///
+/// Exposed as `pub` so integration tests (and any future cross-crate consumer
+/// that needs to drive the in-memory event bus) can push to the same store
+/// the route handlers read from. The store has no externally observable
+/// state beyond what its own methods expose, so widening visibility doesn't
+/// break encapsulation.
+pub fn global_event_store() -> &'static Arc<EventStore> {
     static STORE: OnceLock<Arc<EventStore>> = OnceLock::new();
     STORE.get_or_init(|| Arc::new(EventStore::new()))
 }
@@ -220,18 +226,24 @@ pub async fn list_events(
     #[cfg(feature = "db")]
     {
         let limit = filter.limit.unwrap_or(100).min(1000);
+        let offset = filter.offset.unwrap_or(0);
+
+        // 1. Pull from the persisted events table. Overfetch (limit + offset)
+        //    plus headroom so dedup against the in-memory store doesn't
+        //    starve the page. We still apply the final limit/offset post-merge.
+        let overfetch = (limit.saturating_add(offset)).saturating_mul(2).max(limit);
         let rows = epigraph_db::EventRepository::list(
             &_state.db_pool,
             filter.event_type.as_deref(),
-            None,
-            limit as i64,
+            None, // actor_id — not part of the public filter
+            overfetch as i64,
         )
         .await
         .map_err(|e| ApiError::InternalError {
-            message: format!("Failed to list events: {e}"),
+            message: format!("Failed to list persisted events: {e}"),
         })?;
-        let total = rows.len();
-        let events: Vec<GraphEvent> = rows
+
+        let mut events: Vec<GraphEvent> = rows
             .into_iter()
             .map(|r| GraphEvent {
                 id: r.id,
@@ -242,6 +254,41 @@ pub async fn list_events(
                 created_at: r.created_at,
             })
             .collect();
+
+        // 2. Drain the in-memory event store, filtered by event_type and
+        //    since. EventStore::list also caps at `limit` internally, so we
+        //    pass a large limit here and re-page after merging.
+        let in_mem_filter = EventFilter {
+            since: filter.since,
+            event_type: filter.event_type.clone(),
+            limit: Some(usize::MAX),
+            offset: None,
+        };
+        let (in_mem, _) = global_event_store().list(&in_mem_filter).await;
+        events.extend(in_mem);
+
+        // 3. Defensive since-filter on the merged set. The DB query above
+        //    didn't narrow by `since`, so persisted events older than the
+        //    cutoff need to be dropped here.
+        if let Some(since) = filter.since {
+            events.retain(|e| e.created_at >= since);
+        }
+
+        // 4. Dedup by event id. Persisted rows are first in the vec, so
+        //    `retain` keeps the persisted copy when the same id appears in
+        //    both stores.
+        let mut seen: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+        events.retain(|e| seen.insert(e.id));
+
+        // 5. Sort by `created_at` ascending. ASC matches the natural
+        //    polling semantics of `since`-based subscribers (oldest-first
+        //    so the next `since` cursor is just the last event's `created_at`).
+        events.sort_by_key(|e| e.created_at);
+
+        // 6. Apply offset + limit to the merged, sorted, deduped set.
+        let total = events.len();
+        let events = events.into_iter().skip(offset).take(limit).collect();
+
         Ok(Json(EventListResponse { events, total }))
     }
     #[cfg(not(feature = "db"))]

--- a/crates/epigraph-api/tests/events_unified_test.rs
+++ b/crates/epigraph-api/tests/events_unified_test.rs
@@ -1,0 +1,170 @@
+//! Integration tests for the unified `GET /api/v1/events` endpoint.
+//!
+//! The handler drains both the persisted `events` table and the in-process
+//! `EventStore`, deduplicates by event id, and returns time-ordered results.
+//! These tests exercise the merge logic end-to-end via HTTP, against the
+//! same test server fixture used by other db-feature integration tests.
+
+#![cfg(feature = "db")]
+
+use serde_json::Value;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+mod common;
+
+/// Test 1 — events pushed to the in-memory `EventStore` are visible via
+/// `GET /api/v1/events`. Before this PR, the `feature = "db"` handler read
+/// only from the persisted table, so transient events emitted to the
+/// in-process bus (Task 0.3 emissions, etc.) were invisible to HTTP pollers.
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_returns_in_memory_events_via_http() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let unique_type = format!("test.unified_inmem_{}", Uuid::new_v4().simple());
+
+    // Push directly to the global in-memory store. The handler shares
+    // this same OnceLock-backed singleton at runtime.
+    let pushed = epigraph_api::routes::events::global_event_store()
+        .push(
+            unique_type.clone(),
+            None,
+            serde_json::json!({"source": "in_memory_test"}),
+        )
+        .await;
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "http://{addr}/api/v1/events?event_type={unique_type}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: Value = resp.json().await.unwrap();
+    let events = body["events"].as_array().expect("events array");
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one in-memory event of type {unique_type}, got {body}"
+    );
+    assert_eq!(events[0]["id"], serde_json::json!(pushed.id));
+    assert_eq!(events[0]["event_type"], unique_type);
+    assert_eq!(events[0]["payload"]["source"], "in_memory_test");
+}
+
+/// Test 2 — when the same event id appears in both the persisted table and
+/// the in-memory store, the unified endpoint returns it exactly once.
+/// Persisted-first ordering means the DB row wins (its `graph_version` is
+/// the canonical one), but either way the consumer must not see duplicates.
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_dedupes_by_id_when_event_in_both_stores() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let unique_type = format!("test.unified_dedup_{}", Uuid::new_v4().simple());
+
+    // 1. Push to in-memory first so we capture the auto-generated id.
+    let pushed = epigraph_api::routes::events::global_event_store()
+        .push(
+            unique_type.clone(),
+            None,
+            serde_json::json!({"source": "dedup_test"}),
+        )
+        .await;
+
+    // 2. Insert a row into the DB events table reusing the same id. We
+    //    can't use EventRepository::insert (it generates a fresh uuid), so
+    //    drop to raw SQL — this mirrors how a future shared-id write path
+    //    might land the same event in both stores.
+    sqlx::query(
+        "INSERT INTO events (id, event_type, actor_id, payload, graph_version, created_at) \
+         VALUES ($1, $2, NULL, $3, nextval('events_graph_version_seq'), NOW())",
+    )
+    .bind(pushed.id)
+    .bind(&unique_type)
+    .bind(serde_json::json!({"source": "dedup_test_db_copy"}))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "http://{addr}/api/v1/events?event_type={unique_type}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: Value = resp.json().await.unwrap();
+    let events = body["events"].as_array().expect("events array");
+    let matching: Vec<&Value> = events
+        .iter()
+        .filter(|e| e["id"] == serde_json::json!(pushed.id))
+        .collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one event with id {} after dedup, found {}: {body}",
+        pushed.id,
+        matching.len()
+    );
+    // Persisted row appears first in the merge order, so dedup keeps the
+    // DB copy. Verify by checking the payload reflects the DB-side write.
+    assert_eq!(matching[0]["payload"]["source"], "dedup_test_db_copy");
+}
+
+/// Test 3 — when the in-memory store has no events of a given type but
+/// the DB does, the endpoint returns the persisted rows. This is the
+/// pre-existing behavior; the test guards against regressions in the
+/// merge path that might silently drop persisted-only events.
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_returns_persisted_only_when_in_memory_empty() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let unique_type = format!("test.unified_db_only_{}", Uuid::new_v4().simple());
+    let event_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO events (id, event_type, actor_id, payload, graph_version, created_at) \
+         VALUES ($1, $2, NULL, $3, nextval('events_graph_version_seq'), NOW())",
+    )
+    .bind(event_id)
+    .bind(&unique_type)
+    .bind(serde_json::json!({"source": "db_only_test"}))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "http://{addr}/api/v1/events?event_type={unique_type}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: Value = resp.json().await.unwrap();
+    let events = body["events"].as_array().expect("events array");
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one persisted event of type {unique_type}, got {body}"
+    );
+    assert_eq!(events[0]["id"], serde_json::json!(event_id));
+    assert_eq!(events[0]["payload"]["source"], "db_only_test");
+}


### PR DESCRIPTION
## Summary

Resolves the architectural split where Task 0.3's `edge.added` / `edge.deleted` / `claim.superseded` events landed only in the in-memory `EventStore` and were invisible to external HTTP pollers. `GET /api/v1/events` now drains both stores, deduplicates by event id (persisted wins on conflict), applies `since` filter and time ordering across the merged set.

## Context

A downstream project (`episcience` paper-synthesis pipeline) needs to subscribe to graph-mutation events from a separate process to detect synthesis staleness. The in-process bus isn't reachable cross-process; option (b) — drain at GET time — was chosen over (a) dual-write or (c) Postgres LISTEN/NOTIFY because it preserves the existing emission code path (low blast radius) and the in-memory bus's transient/stateless semantics.

## Implementation

`list_events` (under `feature = "db"`, the production default) now:

1. Reads from `EventRepository::list` (persisted events table), overfetching `(limit + offset) * 2` to give dedup headroom.
2. Drains `global_event_store().list(...)` filtered by `event_type` and `since` (limit set to `usize::MAX`, paged post-merge).
3. Merges both streams (persisted rows first).
4. Re-applies `since` defensively to the merged set, since the DB query doesn't narrow by `since`.
5. Dedupes by event id; because persisted rows are first, `retain` keeps the DB copy when an id appears in both stores.
6. Sorts by `created_at` ascending.
7. Applies `offset` and `limit`.

`global_event_store()` visibility widens from `pub(crate)` to `pub` so the integration test crate can drive the same in-memory singleton the route handler reads.

## Behavior changes worth noting for reviewers

- **Sort order is now ASC by `created_at`** (was DESC). Aligns with `since`-cursor polling where the consumer wants oldest-first so the next cursor is the last event's timestamp. The doc-comment claim about "matching the existing graph_version ordering convention" was wrong — the prior DB path returned newest-first.
- **`total` now reflects the pre-page merged count** (was the post-limit page size, arguably a bug). Consumers using `total` for pagination semantics get more useful information.
- Behavior under `not(feature = "db")` is unchanged (legacy in-memory-only path preserved).

## Tests

Added `crates/epigraph-api/tests/events_unified_test.rs` with three integration tests, all passing against the dev database:

- `list_events_returns_in_memory_events_via_http` — push an event into `global_event_store()`, GET `/api/v1/events?event_type=...`, assert it appears with correct id and payload.
- `list_events_dedupes_by_id_when_event_in_both_stores` — push to in-memory, then INSERT a row into the `events` table reusing the same id; assert exactly one occurrence in the response, and that the DB-side payload wins (persisted-first ordering).
- `list_events_returns_persisted_only_when_in_memory_empty` — INSERT a unique-event-type row directly via SQL; assert the GET returns it. Guards against regressions in the persisted-only path.

Each test uses a UUID-suffixed `event_type` so the shared-OnceLock global store doesn't cross-contaminate.

```
test list_events_returns_in_memory_events_via_http ... ok
test list_events_dedupes_by_id_when_event_in_both_stores ... ok
test list_events_returns_persisted_only_when_in_memory_empty ... ok

test result: ok. 3 passed; 0 failed
```

Full `cargo test -p epigraph-api --tests` passes except for 5 pre-existing failures in `graph_routes_test.rs` that fail identically on a clean `origin/main` (missing `graph_cluster_runs` table in the local dev DB — unrelated to this PR).

## Out of scope

- Bounding the in-memory store (currently an unbounded `Vec`). Acceptable for now since events are short-lived per process; if cross-process polling makes the in-mem path the dominant write target we'll want a ring buffer or LRU cap — separate change.
- Merging the snapshot endpoint similarly. `/api/v1/graph/snapshot/:version` still reads only from the persisted table; the use case (replay from a known DB version) doesn't have the same in-memory invisibility problem.
