### PR TITLE
Port hierarchical extract-claims pipeline (skill + ingest_document MCP tool)

### DIFF
--- a/.claude/skills/extract-claims/SKILL.md
+++ b/.claude/skills/extract-claims/SKILL.md
@@ -1,0 +1,238 @@
+# Extract Claims — Hierarchical Extraction Protocol
+
+Extract epistemic claims from text, documents, or conversations using a 4-stage hierarchical protocol, then ingest the complete DocumentExtraction into the EpiGraph knowledge graph.
+
+## When to use
+
+Use this skill when asked to:
+- Analyze a document or text for epistemic claims
+- Extract and ingest claims from research papers, reports, or discussions
+- Build a knowledge graph from unstructured text using the hierarchical decomposition pipeline
+- Ingest structured claim hierarchies (thesis → section summaries → paragraph compounds → atomic claims)
+
+## The 4-Stage Extraction Cascade
+
+### Stage 1: Document Structure & Section Extraction
+
+Read the entire document and produce:
+- **Document metadata**: Title, authors, publication date, source URL, document type
+- **Section inventory**: Identify logical sections (abstract, introduction, methods, results, discussion, conclusion)
+- **Section titles and summaries**: For each section, write a 1-2 sentence summary capturing the main point
+
+**Output**: Section list with titles and summaries
+
+### Stage 2: Paragraph-Level Compound Extraction
+
+For each section, work through the prose paragraph-by-paragraph:
+- Extract the main **compound claim** — a multi-part assertion that has internal logical structure but is still grounded in one section
+- Provide **supporting_text** — exact or near-exact quote(s) from the document backing the compound
+- Mark **confidence** (0.0–1.0) based on evidence clarity and source reliability
+
+**Apply the Council of Critics here** — this stage has the highest hallucination risk. Each paragraph extraction must pass:
+- **The Skeptic**: Is this really a claim, or noise? Is supporting text present and accurate?
+- **The Logician**: Is the compound extracting actual document content, not inferring unsupported conclusions?
+- **The Architect**: Does this compound relate to others or duplicate an existing claim?
+
+**Output**: List of compound claims per section, each with supporting_text and confidence
+
+### Stage 3: Atomic Decomposition with Generality Scoring
+
+For each compound claim, decompose into **atomic claims** — single subject-predicate-object propositions.
+
+Each atom must:
+- Be a single logical assertion (one fact, one relationship)
+- Resolve all pronouns to explicit entities
+- Preserve specific numbers, names, quantitative details
+- Include only information explicitly stated (no inferences beyond the compound)
+
+Assign each atom a **generality score**:
+- **0 (Foundational)**: Specific facts, measurements, observations (e.g., "Enzyme X has activity 5.2 μmol/min")
+- **1 (Intermediate)**: General principles, methods, relationships (e.g., "Enzymes have optimal pH ranges")
+- **2 (Specialized)**: Domain-specific theoretical frameworks (e.g., "Michaelis-Menten kinetics apply to this system")
+
+Include **cross-atom relationships** when explicitly stated in the source:
+- `supports`: Atom Y directly supports atom X
+- `contradicts`: Atom Y contradicts atom X
+- `refines`: Atom Y adds specificity or conditions to atom X
+
+**Output**: Flat list of atoms with generality scores and inter-atom relationships
+
+### Stage 4 (Optional): Bottom-Up Thesis Derivation
+
+If the document structure is weak or thesis is implicit, perform bottom-up synthesis:
+- Collect section summaries
+- Identify the core hypothesis or research question
+- Infer the document thesis as: "The paper demonstrates/claims that [synthesized claim from section evidence]"
+
+**Only perform if needed**. If the document has explicit thesis/abstract, use that directly.
+
+## The DocumentExtraction JSON Schema
+
+Assemble all stages into a single `DocumentExtraction` JSON structure:
+
+```json
+{
+  "document": {
+    "id": "unique-source-hash",
+    "title": "Paper/Document Title",
+    "authors": ["Author One", "Author Two"],
+    "publication_date": "2025-03-15",
+    "source_url": "https://example.com/paper.pdf",
+    "document_type": "research-paper",
+    "content_hash": "sha256-hash-of-full-text"
+  },
+  "thesis": {
+    "claim": "The core hypothesis or main finding of the document",
+    "confidence": 0.85,
+    "source": "Abstract, conclusion, or derived from sections"
+  },
+  "sections": [
+    {
+      "id": "section-001",
+      "title": "Introduction",
+      "summary": "This section contextualizes the research question within prior work and establishes the motivation.",
+      "paragraphs": [
+        {
+          "id": "para-001",
+          "compound_claim": "Protein folding is a fundamental problem in structural biology, yet current prediction methods have error rates exceeding 5 Å in many cases.",
+          "supporting_text": "\"Protein folding remains challenging. State-of-the-art methods achieve ~7 Å RMSD on test sets (Smith et al. 2024).\"",
+          "confidence": 0.82,
+          "atoms": [
+            {
+              "id": "atom-001",
+              "claim": "Protein folding is a problem in structural biology",
+              "generality": 0,
+              "resolved": true
+            },
+            {
+              "id": "atom-002",
+              "claim": "Current prediction methods have error rates exceeding 5 Å",
+              "generality": 0,
+              "resolved": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "atoms": [
+    {
+      "id": "atom-global-001",
+      "claim": "The protein αβγ adopts a β-barrel structure in solution",
+      "generality": 0,
+      "evidence_type": "empirical",
+      "supporting_text": "\"Crystal structures confirm β-barrel topology (Jones et al. 2024, PDB: 8XYZ)\"",
+      "confidence": 0.91,
+      "resolved": true
+    },
+    {
+      "id": "atom-global-002",
+      "claim": "β-barrel proteins are thermally stable above 60°C",
+      "generality": 1,
+      "evidence_type": "statistical",
+      "supporting_text": "\"Melting temperatures for β-barrels range 65–85°C in thermal shift assays.\"",
+      "confidence": 0.78,
+      "resolved": true
+    }
+  ],
+  "relationships": [
+    {
+      "source_atom": "atom-global-001",
+      "target_atom": "atom-global-002",
+      "relationship": "supports",
+      "explanation": "The β-barrel structure directly contributes to thermal stability"
+    },
+    {
+      "source_atom": "atom-global-003",
+      "target_atom": "atom-global-001",
+      "relationship": "contradicts",
+      "explanation": "Alternative study found α-helical structure; contradicts β-barrel claim"
+    }
+  ]
+}
+```
+
+### Schema Explanation
+
+| Field | Purpose |
+|-------|---------|
+| `document` | Source metadata (title, authors, URL, hash for integrity) |
+| `thesis` | The paper's main claim or hypothesis |
+| `sections` | Organized by document structure; each contains paragraph compounds and atoms |
+| `atoms` | Flat list of ALL atomic claims, including implicit relationships |
+| `relationships` | Inter-atom edges: supports, contradicts, refines |
+| `confidence` | 0.0–1.0; based on evidence quality and source clarity |
+| `generality` | 0 (specific fact), 1 (general principle), 2 (specialized theory) |
+| `resolved` | Boolean; true if all pronouns are explicit, entities named |
+
+## Submission via `ingest_document`
+
+Once the `DocumentExtraction` is assembled:
+
+1. **Write to file**: Save the JSON to `/tmp/extraction_<source_hash>.json`
+2. **Call ingest_document**: Use the MCP tool to submit:
+   ```
+   ingest_document({
+     file_path: "/tmp/extraction_<source_hash>.json",
+     metadata: {
+       extraction_method: "hierarchical",
+       extractor_version: "1.0",
+       timestamp: "2025-03-31T14:23:00Z"
+     }
+   })
+   ```
+
+The API will:
+- Parse and validate the JSON schema
+- Create the document node
+- Ingest all sections, paragraphs, atoms, and relationships
+- Return confirmation with claim IDs for reference
+
+**This replaces the old per-claim `submit_claim` approach** — all claims are now ingested as a single DocumentExtraction transaction, preserving provenance and structure.
+
+## Quality Gate — Council of Critics
+
+Apply at **Stage 2 (Paragraph Extraction)** where hallucination risk is highest:
+
+- **The Skeptic**:
+  - Is the compound claim actually stated in the paragraph, or am I inferring?
+  - Does the supporting_text exactly (or nearly) match the source?
+  - Is the confidence justified by evidence clarity?
+
+- **The Logician**:
+  - Does the compound have falsifiable, testable structure?
+  - Are all propositions atomic or properly decomposed?
+  - Would future claims reference this correctly?
+
+- **The Architect**:
+  - Does this duplicate a prior extraction?
+  - Should it reference or be related to other claims instead?
+  - Is the document structure clear, or is Stage 4 (bottom-up thesis) needed?
+
+**Rejection rule**: If any paragraph fails the Council, flag it explicitly in the report. Do NOT force-fit it into atoms. Reject the compound, note why, and move on.
+
+## Key Rules for All Stages
+
+1. **Atomic claims are single S-P-O propositions**: "Subject + verb + object" with no compound logic. Examples:
+   - ✓ "Protein X binds ligand Y"
+   - ✗ "Protein X binds ligand Y and undergoes conformational change" (two atoms)
+
+2. **Resolve all pronouns**: No "it", "they", "this", "that" in final atoms. Must name the entity explicitly.
+
+3. **Preserve specificity**: Exact numbers, chemical names, gene symbols, measurements. Do NOT round or generalize.
+
+4. **No information beyond the source**: Cross-referencing with prior knowledge is allowed to disambiguate entities ("insulin" = "human insulin, INS gene"), but do NOT infer new facts.
+
+5. **Supporting text must be grounded**: Every compound and atom needs exact or near-exact quotes from the document. Never invent supporting evidence.
+
+6. **Cross-atom relationships are explicit**: Only include relationships (supports, contradicts, refines) when the source explicitly states them. Do NOT infer relationships.
+
+## Report After Ingestion
+
+Summarize:
+- Total compounds extracted
+- Total atoms generated (broken down by generality: 0/1/2)
+- Atoms rejected by Council (with reasons)
+- Relationships identified
+- Confirmation message with assigned claim IDs
+- Any Stage 4 thesis derivation performed and reasoning

--- a/.sqlx/query-19df49e1f777af0645f5af462539f075f8d1f37bd38d8efb755981861076b720.json
+++ b/.sqlx/query-19df49e1f777af0645f5af462539f075f8d1f37bd38d8efb755981861076b720.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, doi, title as \"title?\", journal\n            FROM papers\n            WHERE doi = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "doi",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "journal",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "19df49e1f777af0645f5af462539f075f8d1f37bd38d8efb755981861076b720"
+}

--- a/.sqlx/query-28dc8c422ab4e3c224fdeb6014e620874623d3627b8dff360bf7ec31ad8eed31.json
+++ b/.sqlx/query-28dc8c422ab4e3c224fdeb6014e620874623d3627b8dff360bf7ec31ad8eed31.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT 1 AS exists_marker\n            FROM edges\n            WHERE source_id = $1\n              AND source_type = 'paper'\n              AND relationship = 'processed_by'\n              AND properties ->> 'pipeline' = $2\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists_marker",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "28dc8c422ab4e3c224fdeb6014e620874623d3627b8dff360bf7ec31ad8eed31"
+}

--- a/.sqlx/query-46c820b62afcc6f7e493f9ccf06e5542a912b7f41f9fb020ca5985a1da94f563.json
+++ b/.sqlx/query-46c820b62afcc6f7e493f9ccf06e5542a912b7f41f9fb020ca5985a1da94f563.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id FROM edges\n            WHERE source_id = $1 AND target_id = $2 AND relationship = $3\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "46c820b62afcc6f7e493f9ccf06e5542a912b7f41f9fb020ca5985a1da94f563"
+}

--- a/.sqlx/query-59b418f6d5046976138a4730d1b076481c4b94cb73e400c5efd34abb3005fe6b.json
+++ b/.sqlx/query-59b418f6d5046976138a4730d1b076481c4b94cb73e400c5efd34abb3005fe6b.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT doi, title FROM papers WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "doi",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "59b418f6d5046976138a4730d1b076481c4b94cb73e400c5efd34abb3005fe6b"
+}

--- a/.sqlx/query-85097da8538e4c132e96f0a1adc7069198e526e258c07bc9cf1c14dee1a1ebbd.json
+++ b/.sqlx/query-85097da8538e4c132e96f0a1adc7069198e526e258c07bc9cf1c14dee1a1ebbd.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO papers (doi, title, journal)\n            VALUES ($1, $2, $3)\n            ON CONFLICT (doi) DO UPDATE SET\n                title = COALESCE(EXCLUDED.title, papers.title),\n                journal = COALESCE(EXCLUDED.journal, papers.journal)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "85097da8538e4c132e96f0a1adc7069198e526e258c07bc9cf1c14dee1a1ebbd"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1438,6 +1438,7 @@ dependencies = [
  "epigraph-ds",
  "epigraph-embeddings",
  "epigraph-engine",
+ "epigraph-ingest",
  "hex",
  "openssl",
  "rand 0.8.5",
@@ -1536,9 +1537,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"

--- a/crates/epigraph-db/src/lib.rs
+++ b/crates/epigraph-db/src/lib.rs
@@ -74,7 +74,7 @@ pub use repos::{
     MembershipRow, MentionRow, MethodCapability, MethodEvidenceStrength, MethodFailureModes,
     MethodForCapability, MethodRecord, MethodRepository, MethodSearchResult, MethodSourcePaper,
     MethodUsageExample, OAuthClientRepository, OAuthClientRow, OwnershipRepository,
-    PatternTemplateRepository, PatternTemplateRow, PerspectiveRepository, ProvenanceLogRow,
+    PaperRepository, PaperRow, PatternTemplateRepository, PatternTemplateRow, PerspectiveRepository, ProvenanceLogRow,
     ProvenanceRepository, ReEncryptionKeyRepository, ReEncryptionKeyRow, ReasoningTraceRepository,
     RefreshTokenRepository, RefreshTokenRow, ScopedBeliefRepository, SecurityEventRepository,
     SecurityEventRow, SheafRepository, TaskRepository, TaskRow, TripleRepository, TripleRow,

--- a/crates/epigraph-db/src/lib.rs
+++ b/crates/epigraph-db/src/lib.rs
@@ -74,12 +74,12 @@ pub use repos::{
     MembershipRow, MentionRow, MethodCapability, MethodEvidenceStrength, MethodFailureModes,
     MethodForCapability, MethodRecord, MethodRepository, MethodSearchResult, MethodSourcePaper,
     MethodUsageExample, OAuthClientRepository, OAuthClientRow, OwnershipRepository,
-    PaperRepository, PaperRow, PatternTemplateRepository, PatternTemplateRow, PerspectiveRepository, ProvenanceLogRow,
-    ProvenanceRepository, ReEncryptionKeyRepository, ReEncryptionKeyRow, ReasoningTraceRepository,
-    RefreshTokenRepository, RefreshTokenRow, ScopedBeliefRepository, SecurityEventRepository,
-    SecurityEventRow, SheafRepository, TaskRepository, TaskRow, TripleRepository, TripleRow,
-    WorkflowExecutionRepository, WorkflowExecutionRow, WorkflowListRow, WorkflowRecallResult,
-    WorkflowRepository,
+    PaperRepository, PaperRow, PatternTemplateRepository, PatternTemplateRow,
+    PerspectiveRepository, ProvenanceLogRow, ProvenanceRepository, ReEncryptionKeyRepository,
+    ReEncryptionKeyRow, ReasoningTraceRepository, RefreshTokenRepository, RefreshTokenRow,
+    ScopedBeliefRepository, SecurityEventRepository, SecurityEventRow, SheafRepository,
+    TaskRepository, TaskRow, TripleRepository, TripleRow, WorkflowExecutionRepository,
+    WorkflowExecutionRow, WorkflowListRow, WorkflowRecallResult, WorkflowRepository,
 };
 
 // Re-export sqlx types that users will need

--- a/crates/epigraph-db/src/repos/edge.rs
+++ b/crates/epigraph-db/src/repos/edge.rs
@@ -72,6 +72,73 @@ impl EdgeRepository {
         Ok(row.id)
     }
 
+    /// Like [`create`], but if an edge with the same
+    /// `(source_id, target_id, relationship)` triple already exists, returns
+    /// that edge's id without inserting a duplicate. Idempotent.
+    ///
+    /// Uses check-then-insert in a transaction. The `edges` table has no
+    /// unique index on this triple (multiple parallel edges with different
+    /// `properties` are valid in the general case), so we cannot rely on
+    /// `ON CONFLICT`. Two round-trips are acceptable for the ingestion
+    /// path; the race window is small and edges are idempotent in practice.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if any database operation fails.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip(pool, properties))]
+    pub async fn create_if_not_exists(
+        pool: &PgPool,
+        source_id: Uuid,
+        source_type: &str,
+        target_id: Uuid,
+        target_type: &str,
+        relationship: &str,
+        properties: Option<serde_json::Value>,
+        valid_from: Option<chrono::DateTime<chrono::Utc>>,
+        valid_to: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Uuid, DbError> {
+        let mut tx = pool.begin().await?;
+
+        let existing = sqlx::query!(
+            r#"
+            SELECT id FROM edges
+            WHERE source_id = $1 AND target_id = $2 AND relationship = $3
+            LIMIT 1
+            "#,
+            source_id,
+            target_id,
+            relationship,
+        )
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        if let Some(row) = existing {
+            tx.commit().await?;
+            return Ok(row.id);
+        }
+
+        let properties = properties.unwrap_or(serde_json::json!({}));
+        let row = sqlx::query!(
+            r#"
+            INSERT INTO edges (source_id, source_type, target_id, target_type, relationship, properties, valid_from, valid_to)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING id
+            "#,
+            source_id,
+            source_type,
+            target_id,
+            target_type,
+            relationship,
+            properties,
+            valid_from,
+            valid_to,
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(row.id)
+    }
+
     /// Get edges by source entity
     ///
     /// # Errors

--- a/crates/epigraph-db/src/repos/mod.rs
+++ b/crates/epigraph-db/src/repos/mod.rs
@@ -37,6 +37,7 @@ pub mod mass_function;
 pub mod method;
 pub mod oauth_client;
 pub mod ownership;
+pub mod paper;
 pub mod pattern_template;
 pub mod perspective;
 pub mod political;
@@ -88,6 +89,7 @@ pub use method::{
     MethodRecord, MethodRepository, MethodSearchResult, MethodSourcePaper, MethodUsageExample,
 };
 pub use ownership::OwnershipRepository;
+pub use paper::{PaperRepository, PaperRow};
 pub use perspective::PerspectiveRepository;
 pub use political::{
     AgentClaimProfileRow, CoalitionRow, EvidenceTypeCount, PoliticalRepository,

--- a/crates/epigraph-db/src/repos/paper.rs
+++ b/crates/epigraph-db/src/repos/paper.rs
@@ -1,0 +1,114 @@
+//! Paper entity repository.
+//!
+//! Papers are first-class graph nodes (entity_type = "paper") used by
+//! hierarchical document ingestion. The `papers` table has a UNIQUE
+//! constraint on `doi`, so re-ingestion of the same DOI returns the
+//! existing paper id (get-or-create semantics) rather than creating a
+//! second row. Re-ingestion is gated separately via the `processed_by`
+//! edge with a `pipeline` property.
+
+use sqlx::PgPool;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::errors::DbError;
+
+#[derive(Debug, Clone)]
+pub struct PaperRow {
+    pub id: Uuid,
+    pub doi: String,
+    pub title: Option<String>,
+    pub journal: Option<String>,
+}
+
+pub struct PaperRepository;
+
+impl PaperRepository {
+    /// Insert a paper, or return the existing id if the DOI already exists.
+    ///
+    /// On conflict (UNIQUE doi), updates `title` and `journal` to the
+    /// provided values when non-null. Idempotent for repeat ingestion.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn get_or_create(
+        pool: &PgPool,
+        doi: &str,
+        title: Option<&str>,
+        journal: Option<&str>,
+    ) -> Result<Uuid, DbError> {
+        let row = sqlx::query!(
+            r#"
+            INSERT INTO papers (doi, title, journal)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (doi) DO UPDATE SET
+                title = COALESCE(EXCLUDED.title, papers.title),
+                journal = COALESCE(EXCLUDED.journal, papers.journal)
+            RETURNING id
+            "#,
+            doi,
+            title,
+            journal,
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(row.id)
+    }
+
+    /// Find a paper by DOI. Returns `None` if no paper has this DOI.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn find_by_doi(pool: &PgPool, doi: &str) -> Result<Option<PaperRow>, DbError> {
+        // Use `as "title?"` to override sqlx introspection: the migration
+        // declares `title` nullable; the dev DB has historical NOT NULL drift.
+        let row = sqlx::query!(
+            r#"
+            SELECT id, doi, title as "title?", journal
+            FROM papers
+            WHERE doi = $1
+            "#,
+            doi
+        )
+        .fetch_optional(pool)
+        .await?;
+        Ok(row.map(|r| PaperRow {
+            id: r.id,
+            doi: r.doi,
+            title: r.title,
+            journal: r.journal,
+        }))
+    }
+
+    /// Returns true if the paper has any outgoing `processed_by` edge whose
+    /// `properties.pipeline` matches `pipeline_version`. Used as the
+    /// re-ingestion version gate by hierarchical ingestion.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn has_processed_by_edge(
+        pool: &PgPool,
+        paper_id: Uuid,
+        pipeline_version: &str,
+    ) -> Result<bool, DbError> {
+        let row = sqlx::query!(
+            r#"
+            SELECT 1 AS exists_marker
+            FROM edges
+            WHERE source_id = $1
+              AND source_type = 'paper'
+              AND relationship = 'processed_by'
+              AND properties ->> 'pipeline' = $2
+            LIMIT 1
+            "#,
+            paper_id,
+            pipeline_version,
+        )
+        .fetch_optional(pool)
+        .await?;
+        Ok(row.is_some())
+    }
+}

--- a/crates/epigraph-db/tests/edge_repo_tests.rs
+++ b/crates/epigraph-db/tests/edge_repo_tests.rs
@@ -2,19 +2,16 @@
 
 mod helpers;
 
-use epigraph_db::{
-    AgentRepository, ClaimRepository, EdgeRepository, PaperRepository, PgPool,
-};
+use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, PaperRepository, PgPool};
 use helpers::{make_agent, make_claim};
 
 #[sqlx::test(migrations = "../../migrations")]
 async fn create_if_not_exists_is_idempotent(pool: PgPool) {
     // Set up real source (paper) and target (claim) so the edge-validation
     // trigger doesn't reject the insert.
-    let paper_id =
-        PaperRepository::get_or_create(&pool, "10.1234/idem", Some("Idempotency"), None)
-            .await
-            .expect("create paper");
+    let paper_id = PaperRepository::get_or_create(&pool, "10.1234/idem", Some("Idempotency"), None)
+        .await
+        .expect("create paper");
 
     let agent = make_agent(Some("a"));
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
@@ -23,15 +20,7 @@ async fn create_if_not_exists_is_idempotent(pool: PgPool) {
     let claim_id: uuid::Uuid = claim_row.id.into();
 
     let id1 = EdgeRepository::create_if_not_exists(
-        &pool,
-        paper_id,
-        "paper",
-        claim_id,
-        "claim",
-        "asserts",
-        None,
-        None,
-        None,
+        &pool, paper_id, "paper", claim_id, "claim", "asserts", None, None, None,
     )
     .await
     .expect("first call inserts");
@@ -55,10 +44,9 @@ async fn create_if_not_exists_is_idempotent(pool: PgPool) {
 
 #[sqlx::test(migrations = "../../migrations")]
 async fn create_if_not_exists_distinguishes_by_relationship(pool: PgPool) {
-    let paper_id =
-        PaperRepository::get_or_create(&pool, "10.1234/rel", Some("Relationship"), None)
-            .await
-            .expect("create paper");
+    let paper_id = PaperRepository::get_or_create(&pool, "10.1234/rel", Some("Relationship"), None)
+        .await
+        .expect("create paper");
 
     let agent = make_agent(Some("b"));
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();

--- a/crates/epigraph-db/tests/edge_repo_tests.rs
+++ b/crates/epigraph-db/tests/edge_repo_tests.rs
@@ -1,0 +1,90 @@
+//! `EdgeRepository` integration tests.
+
+mod helpers;
+
+use epigraph_db::{
+    AgentRepository, ClaimRepository, EdgeRepository, PaperRepository, PgPool,
+};
+use helpers::{make_agent, make_claim};
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_if_not_exists_is_idempotent(pool: PgPool) {
+    // Set up real source (paper) and target (claim) so the edge-validation
+    // trigger doesn't reject the insert.
+    let paper_id =
+        PaperRepository::get_or_create(&pool, "10.1234/idem", Some("Idempotency"), None)
+            .await
+            .expect("create paper");
+
+    let agent = make_agent(Some("a"));
+    let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
+    let claim = make_claim(agent_row.id, "the claim", 0.5);
+    let claim_row = ClaimRepository::create(&pool, &claim).await.unwrap();
+    let claim_id: uuid::Uuid = claim_row.id.into();
+
+    let id1 = EdgeRepository::create_if_not_exists(
+        &pool,
+        paper_id,
+        "paper",
+        claim_id,
+        "claim",
+        "asserts",
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("first call inserts");
+
+    let id2 = EdgeRepository::create_if_not_exists(
+        &pool,
+        paper_id,
+        "paper",
+        claim_id,
+        "claim",
+        "asserts",
+        Some(serde_json::json!({"different": "props"})),
+        None,
+        None,
+    )
+    .await
+    .expect("second call returns existing");
+
+    assert_eq!(id1, id2, "second call must return existing edge id");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_if_not_exists_distinguishes_by_relationship(pool: PgPool) {
+    let paper_id =
+        PaperRepository::get_or_create(&pool, "10.1234/rel", Some("Relationship"), None)
+            .await
+            .expect("create paper");
+
+    let agent = make_agent(Some("b"));
+    let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
+    let claim = make_claim(agent_row.id, "another", 0.5);
+    let claim_row = ClaimRepository::create(&pool, &claim).await.unwrap();
+    let claim_id: uuid::Uuid = claim_row.id.into();
+
+    let id_a = EdgeRepository::create_if_not_exists(
+        &pool, paper_id, "paper", claim_id, "claim", "asserts", None, None, None,
+    )
+    .await
+    .unwrap();
+
+    let id_b = EdgeRepository::create_if_not_exists(
+        &pool,
+        paper_id,
+        "paper",
+        claim_id,
+        "claim",
+        "processed_by",
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_ne!(id_a, id_b, "different relationship → different edge");
+}

--- a/crates/epigraph-db/tests/paper_repo_tests.rs
+++ b/crates/epigraph-db/tests/paper_repo_tests.rs
@@ -43,13 +43,11 @@ async fn has_processed_by_edge_reflects_pipeline_property(pool: PgPool) {
             .expect("create paper");
 
     // No edge yet → false.
-    assert!(!PaperRepository::has_processed_by_edge(
-        &pool,
-        paper_id,
-        "hierarchical_extraction_v1"
-    )
-    .await
-    .expect("query has_processed_by_edge"));
+    assert!(
+        !PaperRepository::has_processed_by_edge(&pool, paper_id, "hierarchical_extraction_v1")
+            .await
+            .expect("query has_processed_by_edge")
+    );
 
     // Edges enforce target existence via trigger_validate_edge_refs, so we
     // create a real agent + claim to use as the edge target.
@@ -76,16 +74,16 @@ async fn has_processed_by_edge_reflects_pipeline_property(pool: PgPool) {
     .await
     .expect("create edge");
 
-    assert!(PaperRepository::has_processed_by_edge(
-        &pool,
-        paper_id,
-        "hierarchical_extraction_v1"
-    )
-    .await
-    .expect("query has_processed_by_edge"));
+    assert!(
+        PaperRepository::has_processed_by_edge(&pool, paper_id, "hierarchical_extraction_v1")
+            .await
+            .expect("query has_processed_by_edge")
+    );
 
     // Different pipeline string → still false.
-    assert!(!PaperRepository::has_processed_by_edge(&pool, paper_id, "other_pipeline_v1")
-        .await
-        .expect("query has_processed_by_edge"));
+    assert!(
+        !PaperRepository::has_processed_by_edge(&pool, paper_id, "other_pipeline_v1")
+            .await
+            .expect("query has_processed_by_edge")
+    );
 }

--- a/crates/epigraph-db/tests/paper_repo_tests.rs
+++ b/crates/epigraph-db/tests/paper_repo_tests.rs
@@ -1,0 +1,91 @@
+//! `PaperRepository` integration tests.
+
+mod helpers;
+
+use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, PaperRepository, PgPool};
+use helpers::{make_agent, make_claim};
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_or_create_inserts_then_returns_existing(pool: PgPool) {
+    let doi = "10.1234/test-paper-1";
+    let id1 = PaperRepository::get_or_create(&pool, doi, Some("Title 1"), Some("Journal X"))
+        .await
+        .expect("first insert");
+
+    // Second call with the same DOI should return the same id (UNIQUE on doi).
+    let id2 = PaperRepository::get_or_create(&pool, doi, Some("Title 1 updated"), None)
+        .await
+        .expect("second insert");
+    assert_eq!(id1, id2, "same DOI must return same paper id");
+
+    // The conflict path updated the title.
+    let row = PaperRepository::find_by_doi(&pool, doi)
+        .await
+        .expect("find_by_doi")
+        .expect("paper row");
+    assert_eq!(row.id, id1);
+    assert_eq!(row.title.as_deref(), Some("Title 1 updated"));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn find_by_doi_returns_none_for_unknown(pool: PgPool) {
+    let result = PaperRepository::find_by_doi(&pool, "10.0000/does-not-exist")
+        .await
+        .expect("find_by_doi");
+    assert!(result.is_none());
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn has_processed_by_edge_reflects_pipeline_property(pool: PgPool) {
+    let paper_id =
+        PaperRepository::get_or_create(&pool, "10.1234/has-pbe", Some("Has-PBE Paper"), None)
+            .await
+            .expect("create paper");
+
+    // No edge yet → false.
+    assert!(!PaperRepository::has_processed_by_edge(
+        &pool,
+        paper_id,
+        "hierarchical_extraction_v1"
+    )
+    .await
+    .expect("query has_processed_by_edge"));
+
+    // Edges enforce target existence via trigger_validate_edge_refs, so we
+    // create a real agent + claim to use as the edge target.
+    let agent = make_agent(Some("test-agent"));
+    let agent_row = AgentRepository::create(&pool, &agent)
+        .await
+        .expect("create agent");
+    let claim = make_claim(agent_row.id, "test claim", 0.5);
+    let claim_row = ClaimRepository::create(&pool, &claim)
+        .await
+        .expect("create claim");
+
+    EdgeRepository::create(
+        &pool,
+        paper_id,
+        "paper",
+        claim_row.id.into(),
+        "claim",
+        "processed_by",
+        Some(serde_json::json!({"pipeline": "hierarchical_extraction_v1"})),
+        None,
+        None,
+    )
+    .await
+    .expect("create edge");
+
+    assert!(PaperRepository::has_processed_by_edge(
+        &pool,
+        paper_id,
+        "hierarchical_extraction_v1"
+    )
+    .await
+    .expect("query has_processed_by_edge"));
+
+    // Different pipeline string → still false.
+    assert!(!PaperRepository::has_processed_by_edge(&pool, paper_id, "other_pipeline_v1")
+        .await
+        .expect("query has_processed_by_edge"));
+}

--- a/crates/epigraph-mcp/Cargo.toml
+++ b/crates/epigraph-mcp/Cargo.toml
@@ -15,6 +15,7 @@ epigraph-db = { workspace = true }
 epigraph-ds = { workspace = true }
 epigraph-engine = { workspace = true }
 epigraph-embeddings = { workspace = true }
+epigraph-ingest = { workspace = true }
 
 # MCP protocol (no sqlx dep — coexists with workspace sqlx 0.7)
 rmcp = { workspace = true }

--- a/crates/epigraph-mcp/Cargo.toml
+++ b/crates/epigraph-mcp/Cargo.toml
@@ -59,6 +59,9 @@ openssl = { version = "0.10", features = ["vendored"], optional = true }
 # HTTP transport (axum 0.8 matches rmcp's streamable-http-server dep)
 axum = "0.8"
 
+[dev-dependencies]
+epigraph-ingest = { workspace = true }
+
 [features]
 default = []
 vendored-openssl = ["dep:openssl"]

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -214,6 +214,17 @@ impl EpiGraphMcpFull {
         tools::ingestion::ingest_paper_url(self, params).await
     }
 
+    #[tool(
+        description = "Ingest a hierarchical DocumentExtraction JSON file (thesis -> sections -> paragraphs -> atoms). Creates a paper node, claims at each level, decomposes_to / section_follows / supports / contradicts / refines edges, evidence, traces, embeddings, and CDST mass functions for atoms. Idempotent for re-runs at the same pipeline version."
+    )]
+    async fn ingest_document(
+        &self,
+        Parameters(params): Parameters<IngestDocumentParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::ingestion::ingest_document(self, params).await
+    }
+
     // ── Paper Queries (3 tools) ──
 
     #[tool(description = "Look up a paper by its DOI, returning title, authors, and claims.")]

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -385,20 +385,33 @@ pub async fn do_ingest_document(
     .map_err(internal_error)?;
 
     // ── 3. Ensure author agents + agent --authored--> paper ──
+    // Each author gets a deterministic ed25519 keypair via
+    // `did_key_for_author` — same name (or ORCID, when present in the
+    // extraction) maps to the same agent across papers, which is how
+    // co-authorship lights up in the graph. Affiliations and roles are
+    // not yet first-class on Agent and remain in the extraction JSON
+    // pending an AgentRepository properties surface.
     let mut author_responses = Vec::new();
     let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
     for (idx, author) in extraction.source.authors.iter().enumerate() {
         if author.name.is_empty() {
             continue;
         }
-        // Public's Agent::new doesn't model affiliations/roles structurally;
-        // they remain in the DocumentExtraction JSON for now (TODO: stash in
-        // agent properties JSON when AgentRepository gains that surface).
-        let author_agent = epigraph_core::Agent::new([0u8; 32], Some(author.name.clone()));
-        let created = AgentRepository::create(pool, &author_agent)
-            .await
-            .map_err(internal_error)?;
-        let agent_uuid: Uuid = created.id.into();
+        let (_did, pub_key_bytes) =
+            epigraph_crypto::did_key::did_key_for_author(None, &author.name);
+        let agent_uuid = if let Some(existing) =
+            AgentRepository::get_by_public_key(pool, &pub_key_bytes)
+                .await
+                .map_err(internal_error)?
+        {
+            existing.id.into()
+        } else {
+            let author_agent = epigraph_core::Agent::new(pub_key_bytes, Some(author.name.clone()));
+            let created = AgentRepository::create(pool, &author_agent)
+                .await
+                .map_err(internal_error)?;
+            created.id.into()
+        };
         EdgeRepository::create_if_not_exists(
             pool,
             agent_uuid,
@@ -409,6 +422,7 @@ pub async fn do_ingest_document(
             Some(serde_json::json!({
                 "position": idx,
                 "role": author.roles.first().map_or("author", String::as_str),
+                "affiliations": author.affiliations,
             })),
             None,
             None,
@@ -453,13 +467,22 @@ pub async fn do_ingest_document(
         claim.signature = Some(server.signer.sign(&claim.content_hash));
 
         // ClaimRepository::create dedupes by content_hash and returns the
-        // existing row when the hash matches. A non-equal returned id means
-        // we hit dedup → just link the existing claim to this paper.
+        // existing row when the hash matches. Two dedup paths exist:
+        //   (a) deterministic-id collision: persisted_id != planned.id
+        //       (e.g. content_hash matched some other claim with a different
+        //       UUID — shouldn't happen for atoms or compounds we built,
+        //       but we handle it for safety).
+        //   (b) atom convergence across papers: planned.id is
+        //       uuid_v5(ATOM_NAMESPACE, content_hash), so the existing
+        //       atom has the same id. We detect this via persisted.trace_id
+        //       already being Some (the original ingestion already wrote
+        //       trace + evidence; we must NOT clobber that provenance).
         let persisted = ClaimRepository::create(pool, &claim)
             .await
             .map_err(internal_error)?;
         let persisted_id: Uuid = persisted.id.into();
-        if persisted_id != planned.id {
+        let already_had_trace = persisted.trace_id.is_some();
+        if persisted_id != planned.id || already_had_trace {
             EdgeRepository::create_if_not_exists(
                 pool,
                 paper_id,

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -332,8 +332,11 @@ pub async fn ingest_document(
     do_ingest_document(server, &extraction).await
 }
 
+/// Core ingestion logic factored out so integration tests can drive a parsed
+/// `DocumentExtraction` without round-tripping through the file-path validation
+/// in `ingest_document`.
 #[allow(clippy::too_many_lines)]
-async fn do_ingest_document(
+pub async fn do_ingest_document(
     server: &EpiGraphMcpFull,
     extraction: &DocumentExtraction,
 ) -> Result<CallToolResult, McpError> {
@@ -605,14 +608,16 @@ async fn do_ingest_document(
     };
 
     // ── 7. Mark paper as processed by this pipeline (version gate for re-runs) ──
-    // Use a self-edge on the paper so future runs can short-circuit. Target
-    // type "paper" is valid in the edges check constraint.
+    // Edge target is the server's agent — paper -processed_by-> agent
+    // models "this paper was processed by this agent at this pipeline
+    // version". (Self-loops on paper are blocked by the edges_no_self_loop
+    // check constraint, so we cannot point the edge back at the paper.)
     EdgeRepository::create_if_not_exists(
         pool,
         paper_id,
         "paper",
-        paper_id,
-        "paper",
+        agent_id,
+        "agent",
         "processed_by",
         Some(serde_json::json!({
             "pipeline": PIPELINE_VERSION,

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -573,10 +573,16 @@ pub async fn do_ingest_document(
             };
             (agent_uuid, "agent".to_string())
         } else {
-            let mapped = id_map.get(&edge.source_id).copied().unwrap_or(edge.source_id);
+            let mapped = id_map
+                .get(&edge.source_id)
+                .copied()
+                .unwrap_or(edge.source_id);
             (mapped, edge.source_type.clone())
         };
-        let tgt = id_map.get(&edge.target_id).copied().unwrap_or(edge.target_id);
+        let tgt = id_map
+            .get(&edge.target_id)
+            .copied()
+            .unwrap_or(edge.target_id);
 
         EdgeRepository::create_if_not_exists(
             pool,

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -1,8 +1,10 @@
 #![allow(clippy::wildcard_imports)]
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use rmcp::model::*;
+use uuid::Uuid;
 
 use crate::errors::{internal_error, invalid_params, McpError};
 use crate::server::EpiGraphMcpFull;
@@ -10,12 +12,16 @@ use crate::tools::ds_auto::{self, BatchDsEntry};
 use crate::types::*;
 
 use epigraph_core::{
-    AgentId, Claim, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput, TruthValue,
+    AgentId, Claim, ClaimId, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput,
+    TruthValue,
 };
 use epigraph_crypto::ContentHasher;
 use epigraph_db::{
-    AgentRepository, ClaimRepository, EdgeRepository, EvidenceRepository, ReasoningTraceRepository,
+    AgentRepository, ClaimRepository, EdgeRepository, EvidenceRepository, PaperRepository,
+    ReasoningTraceRepository,
 };
+use epigraph_ingest::builder::{build_ingest_plan, PlannedClaim};
+use epigraph_ingest::schema::DocumentExtraction;
 
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
@@ -296,4 +302,405 @@ async fn do_ingest(
         claims_ds_wired,
         ds_frame_id,
     })
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ingest_document — hierarchical DocumentExtraction → graph
+// ────────────────────────────────────────────────────────────────────────────
+
+const PIPELINE_VERSION: &str = "hierarchical_extraction_v1";
+
+pub async fn ingest_document(
+    server: &EpiGraphMcpFull,
+    params: IngestDocumentParams,
+) -> Result<CallToolResult, McpError> {
+    let canonical = std::fs::canonicalize(&params.file_path)
+        .map_err(|e| invalid_params(format!("invalid file path: {e}")))?;
+    let cwd = std::env::current_dir()
+        .map_err(|e| internal_error(format!("cannot determine CWD: {e}")))?;
+    if !canonical.starts_with(&cwd) {
+        return Err(invalid_params(
+            "file path must be within the working directory",
+        ));
+    }
+    let data = tokio::fs::read_to_string(&canonical)
+        .await
+        .map_err(|e| invalid_params(format!("cannot read {}: {e}", canonical.display())))?;
+    let extraction: DocumentExtraction =
+        serde_json::from_str(&data).map_err(|e| invalid_params(format!("invalid JSON: {e}")))?;
+
+    do_ingest_document(server, &extraction).await
+}
+
+#[allow(clippy::too_many_lines)]
+async fn do_ingest_document(
+    server: &EpiGraphMcpFull,
+    extraction: &DocumentExtraction,
+) -> Result<CallToolResult, McpError> {
+    let plan = build_ingest_plan(extraction);
+    let pool = &server.pool;
+    let agent_id = server.agent_id().await?;
+    let agent_id_typed = AgentId::from_uuid(agent_id);
+    let pub_key = server.signer.public_key();
+
+    let paper_title = extraction.source.title.clone();
+    let doi = resolve_doi(extraction);
+
+    // ── 1. Version gate: skip if already processed by this pipeline ──
+    if let Some(prior) = PaperRepository::find_by_doi(pool, &doi)
+        .await
+        .map_err(internal_error)?
+    {
+        if PaperRepository::has_processed_by_edge(pool, prior.id, PIPELINE_VERSION)
+            .await
+            .map_err(internal_error)?
+        {
+            return success_json(&IngestDocumentResponse {
+                paper_id: prior.id.to_string(),
+                paper_title,
+                doi,
+                authors: vec![],
+                claims_ingested: 0,
+                claims_embedded: 0,
+                claims_skipped_dedup: 0,
+                relationships_created: 0,
+                claims_ds_wired: None,
+                ds_frame_id: None,
+                already_ingested: true,
+            });
+        }
+    }
+
+    // ── 2. Get-or-create paper node ──
+    let paper_id = PaperRepository::get_or_create(
+        pool,
+        &doi,
+        Some(&paper_title),
+        extraction.source.journal.as_deref(),
+    )
+    .await
+    .map_err(internal_error)?;
+
+    // ── 3. Ensure author agents + agent --authored--> paper ──
+    let mut author_responses = Vec::new();
+    let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
+    for (idx, author) in extraction.source.authors.iter().enumerate() {
+        if author.name.is_empty() {
+            continue;
+        }
+        // Public's Agent::new doesn't model affiliations/roles structurally;
+        // they remain in the DocumentExtraction JSON for now (TODO: stash in
+        // agent properties JSON when AgentRepository gains that surface).
+        let author_agent = epigraph_core::Agent::new([0u8; 32], Some(author.name.clone()));
+        let created = AgentRepository::create(pool, &author_agent)
+            .await
+            .map_err(internal_error)?;
+        let agent_uuid: Uuid = created.id.into();
+        EdgeRepository::create_if_not_exists(
+            pool,
+            agent_uuid,
+            "agent",
+            paper_id,
+            "paper",
+            "authored",
+            Some(serde_json::json!({
+                "position": idx,
+                "role": author.roles.first().map_or("author", String::as_str),
+            })),
+            None,
+            None,
+        )
+        .await
+        .map_err(internal_error)?;
+        author_agent_map.insert(idx, agent_uuid);
+        author_responses.push(AuthorResponse {
+            agent_id: agent_uuid.to_string(),
+            name: author.name.clone(),
+        });
+    }
+
+    // ── 4. Walk planned claims: dedup → claim/trace/evidence/embed ──
+    let source_url = if doi.starts_with("10.") {
+        format!("https://doi.org/{doi}")
+    } else {
+        format!("doi:{doi}")
+    };
+
+    let mut claim_ids: Vec<String> = Vec::new();
+    let mut id_map: HashMap<Uuid, Uuid> = HashMap::new();
+    let mut embedded_count = 0_usize;
+    let mut dedup_count = 0_usize;
+    let mut ds_entries: Vec<BatchDsEntry> = Vec::new();
+
+    for planned in &plan.claims {
+        let confidence = planned.confidence.clamp(0.0, 1.0);
+        let methodology = methodology_from_planned(planned);
+        let weight = methodology.weight_modifier();
+        let raw_truth = (confidence * weight).clamp(0.01, 0.99);
+
+        let mut claim = Claim::new(
+            planned.content.clone(),
+            agent_id_typed,
+            pub_key,
+            TruthValue::clamped(raw_truth),
+        );
+        // Override generated id with the planner's deterministic UUID.
+        claim.id = ClaimId::from_uuid(planned.id);
+        claim.content_hash = ContentHasher::hash(planned.content.as_bytes());
+        claim.signature = Some(server.signer.sign(&claim.content_hash));
+
+        // ClaimRepository::create dedupes by content_hash and returns the
+        // existing row when the hash matches. A non-equal returned id means
+        // we hit dedup → just link the existing claim to this paper.
+        let persisted = ClaimRepository::create(pool, &claim)
+            .await
+            .map_err(internal_error)?;
+        let persisted_id: Uuid = persisted.id.into();
+        if persisted_id != planned.id {
+            EdgeRepository::create_if_not_exists(
+                pool,
+                paper_id,
+                "paper",
+                persisted_id,
+                "claim",
+                "asserts",
+                Some(planned.properties.clone()),
+                None,
+                None,
+            )
+            .await
+            .map_err(internal_error)?;
+            id_map.insert(planned.id, persisted_id);
+            claim_ids.push(persisted_id.to_string());
+            dedup_count += 1;
+            continue;
+        }
+
+        // New claim: write the supporting evidence and reasoning trace.
+        let evidence_text = planned
+            .supporting_text
+            .as_deref()
+            .unwrap_or(&planned.content);
+        let formatted_evidence =
+            format!("Source: {paper_title} (DOI: {doi}). Passage: '{evidence_text}'");
+        let evidence_hash = ContentHasher::hash(formatted_evidence.as_bytes());
+        let mut evidence = Evidence::new(
+            agent_id_typed,
+            pub_key,
+            evidence_hash,
+            EvidenceType::Literature {
+                doi: doi.clone(),
+                extraction_target: format!("level_{}", planned.level),
+                page_range: None,
+            },
+            Some(formatted_evidence),
+            claim.id,
+        );
+        evidence.signature = Some(server.signer.sign(&evidence_hash));
+
+        let trace = ReasoningTrace::new(
+            agent_id_typed,
+            pub_key,
+            methodology,
+            vec![TraceInput::Evidence { id: evidence.id }],
+            confidence,
+            format!(
+                "Extracted from '{paper_title}' (DOI: {doi}); level {} ({})",
+                planned.level,
+                level_label(planned.level),
+            ),
+        );
+
+        ReasoningTraceRepository::create(pool, &trace, claim.id)
+            .await
+            .map_err(internal_error)?;
+        EvidenceRepository::create(pool, &evidence)
+            .await
+            .map_err(internal_error)?;
+        ClaimRepository::update_trace_id(pool, claim.id, trace.id)
+            .await
+            .map_err(internal_error)?;
+
+        EdgeRepository::create_if_not_exists(
+            pool,
+            paper_id,
+            "paper",
+            persisted_id,
+            "claim",
+            "asserts",
+            Some(planned.properties.clone()),
+            None,
+            None,
+        )
+        .await
+        .map_err(internal_error)?;
+
+        if server
+            .embedder
+            .embed_and_store(persisted_id, &planned.content)
+            .await
+        {
+            embedded_count += 1;
+        }
+
+        // Atoms (level 3) are the units we trust to carry CDST evidence.
+        if planned.level == 3 {
+            ds_entries.push(BatchDsEntry {
+                claim_id: persisted_id,
+                confidence,
+                weight,
+            });
+        }
+
+        id_map.insert(planned.id, persisted_id);
+        claim_ids.push(persisted_id.to_string());
+
+        // Touch source_url (kept for parity with V2 evidence formatting; the
+        // current EvidenceType::Literature already carries the DOI).
+        let _ = &source_url;
+    }
+
+    // ── 5. Plan edges (decomposes_to / section_follows / supports / authored placeholders) ──
+    let mut relationships_created = 0_usize;
+    for edge in &plan.edges {
+        let (src, src_type) = if edge.source_type == "author_placeholder" {
+            let idx = edge.properties["author_index"].as_u64().unwrap_or(0) as usize;
+            let Some(&agent_uuid) = author_agent_map.get(&idx) else {
+                continue;
+            };
+            (agent_uuid, "agent".to_string())
+        } else {
+            let mapped = id_map.get(&edge.source_id).copied().unwrap_or(edge.source_id);
+            (mapped, edge.source_type.clone())
+        };
+        let tgt = id_map.get(&edge.target_id).copied().unwrap_or(edge.target_id);
+
+        EdgeRepository::create_if_not_exists(
+            pool,
+            src,
+            &src_type,
+            tgt,
+            &edge.target_type,
+            &edge.relationship,
+            Some(edge.properties.clone()),
+            None,
+            None,
+        )
+        .await
+        .map_err(internal_error)?;
+        relationships_created += 1;
+    }
+
+    // ── 6. Auto-CDST batch wire (atoms only) ──
+    let (claims_ds_wired, ds_frame_id) = if ds_entries.is_empty() {
+        (None, None)
+    } else {
+        match ds_auto::auto_wire_ds_batch(pool, &ds_entries, agent_id).await {
+            Ok((fid, count)) => (Some(count), Some(fid.to_string())),
+            Err(e) => {
+                tracing::warn!("ds auto-wire batch failed: {e}");
+                (None, None)
+            }
+        }
+    };
+
+    // ── 7. Mark paper as processed by this pipeline (version gate for re-runs) ──
+    // Use a self-edge on the paper so future runs can short-circuit. Target
+    // type "paper" is valid in the edges check constraint.
+    EdgeRepository::create_if_not_exists(
+        pool,
+        paper_id,
+        "paper",
+        paper_id,
+        "paper",
+        "processed_by",
+        Some(serde_json::json!({
+            "pipeline": PIPELINE_VERSION,
+            "tool": "ingest_document",
+        })),
+        None,
+        None,
+    )
+    .await
+    .map_err(internal_error)?;
+
+    success_json(&IngestDocumentResponse {
+        paper_id: paper_id.to_string(),
+        paper_title,
+        doi,
+        authors: author_responses,
+        claims_ingested: claim_ids.len() - dedup_count,
+        claims_embedded: embedded_count,
+        claims_skipped_dedup: dedup_count,
+        relationships_created,
+        claims_ds_wired,
+        ds_frame_id,
+        already_ingested: false,
+    })
+}
+
+fn resolve_doi(extraction: &DocumentExtraction) -> String {
+    if let Some(d) = &extraction.source.doi {
+        return d.clone();
+    }
+    if let Some(uri) = &extraction.source.uri {
+        // Hand-rolled arXiv pattern: \d{4}\.\d{4,5}
+        if let Some(arxiv) = find_arxiv_id(uri) {
+            return format!("10.48550/arXiv.{arxiv}");
+        }
+        return uri.clone();
+    }
+    "unknown".to_string()
+}
+
+fn find_arxiv_id(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    'outer: for start in 0..bytes.len() {
+        if start + 9 > bytes.len() {
+            return None;
+        }
+        // Need 4 digits, '.', then 4 or 5 digits.
+        for i in 0..4 {
+            if !bytes[start + i].is_ascii_digit() {
+                continue 'outer;
+            }
+        }
+        if bytes[start + 4] != b'.' {
+            continue;
+        }
+        let mut tail = 0;
+        while tail < 5 && start + 5 + tail < bytes.len() && bytes[start + 5 + tail].is_ascii_digit()
+        {
+            tail += 1;
+        }
+        if tail >= 4 {
+            return Some(
+                std::str::from_utf8(&bytes[start..start + 5 + tail])
+                    .ok()?
+                    .to_string(),
+            );
+        }
+    }
+    None
+}
+
+fn methodology_from_planned(planned: &PlannedClaim) -> Methodology {
+    match planned.methodology.as_deref() {
+        Some("statistical" | "instrumental" | "computational") => Methodology::Instrumental,
+        Some("deductive") => Methodology::Deductive,
+        Some("inductive") => Methodology::Inductive,
+        Some("visual_inspection") => Methodology::VisualInspection,
+        Some("expert_elicitation") => Methodology::Heuristic,
+        _ => Methodology::Extraction,
+    }
+}
+
+const fn level_label(level: u8) -> &'static str {
+    match level {
+        0 => "thesis",
+        1 => "section",
+        2 => "paragraph",
+        3 => "atom",
+        _ => "unknown",
+    }
 }

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -577,6 +577,31 @@ pub struct AuthorResponse {
     pub name: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IngestDocumentParams {
+    #[schemars(
+        description = "Absolute or working-directory-relative path to a JSON file containing a hierarchical DocumentExtraction (thesis -> sections -> paragraphs -> atoms)."
+    )]
+    pub file_path: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IngestDocumentResponse {
+    pub paper_id: String,
+    pub paper_title: String,
+    pub doi: String,
+    pub authors: Vec<AuthorResponse>,
+    pub claims_ingested: usize,
+    pub claims_embedded: usize,
+    pub claims_skipped_dedup: usize,
+    pub relationships_created: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claims_ds_wired: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ds_frame_id: Option<String>,
+    pub already_ingested: bool,
+}
+
 #[derive(Debug, Serialize)]
 pub struct PaperResponse {
     pub doi: String,

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -1,0 +1,180 @@
+//! End-to-end smoke test for the hierarchical `ingest_document` tool.
+//!
+//! Drives a tiny synthetic `DocumentExtraction` through `do_ingest_document`
+//! and asserts the expected paper/claim/edge graph shape lands in Postgres.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_ingest::schema::DocumentExtraction;
+use epigraph_mcp::embed::McpEmbedder;
+use epigraph_mcp::server::EpiGraphMcpFull;
+use epigraph_mcp::tools::ingestion::do_ingest_document;
+use sqlx::PgPool;
+
+const FIXTURE: &str = r#"{
+  "source": {
+    "title": "Test Hierarchical Paper",
+    "doi": "10.1234/hierarchy-smoke",
+    "source_type": "Paper",
+    "authors": [
+      {"name": "Alice Author", "affiliations": [], "roles": ["author"]}
+    ]
+  },
+  "thesis": "Hierarchies converge through layered claims",
+  "thesis_derivation": "TopDown",
+  "sections": [{
+    "title": "Intro",
+    "summary": "Background section connecting prior work to this thesis",
+    "paragraphs": [{
+      "compound": "Atomization aids cross-source matching, and explicit decomposition is necessary",
+      "supporting_text": "We argue both points throughout the paper.",
+      "atoms": [
+        "Atomization aids cross-source matching",
+        "Explicit decomposition is necessary for hierarchical reasoning"
+      ],
+      "generality": [3, 3],
+      "confidence": 0.8
+    }]
+  }],
+  "relationships": [
+    {
+      "source_path": "sections/0/paragraphs/0/atoms/0",
+      "target_path": "sections/0/paragraphs/0/atoms/1",
+      "relationship": "supports"
+    }
+  ]
+}"#;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::generate();
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn happy_path_ingests_full_hierarchy(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let extraction: DocumentExtraction = serde_json::from_str(FIXTURE).expect("fixture parses");
+
+    let result = do_ingest_document(&server, &extraction)
+        .await
+        .expect("ingest_document succeeds");
+
+    // Pull the paper_id out of the structured response.
+    let payload = result_text(&result);
+    let json: serde_json::Value = serde_json::from_str(&payload).expect("response JSON");
+    assert_eq!(json["already_ingested"], serde_json::json!(false));
+    assert_eq!(json["doi"], "10.1234/hierarchy-smoke");
+    assert_eq!(
+        json["claims_ingested"].as_u64().unwrap(),
+        5,
+        "thesis + section + paragraph + 2 atoms; all newly inserted, no dedup"
+    );
+    assert_eq!(json["claims_skipped_dedup"].as_u64().unwrap(), 0);
+    assert!(json["relationships_created"].as_u64().unwrap() >= 5);
+
+    let paper_id = uuid::Uuid::parse_str(json["paper_id"].as_str().unwrap()).unwrap();
+
+    // 1. Paper row exists with correct DOI.
+    let row = sqlx::query!("SELECT doi, title FROM papers WHERE id = $1", paper_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.doi, "10.1234/hierarchy-smoke");
+
+    // 2. Each level is represented as a claim node.
+    let claim_count: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*) FROM claims
+        WHERE content IN (
+            'Hierarchies converge through layered claims',
+            'Background section connecting prior work to this thesis',
+            'Atomization aids cross-source matching, and explicit decomposition is necessary',
+            'Atomization aids cross-source matching',
+            'Explicit decomposition is necessary for hierarchical reasoning'
+        )
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(claim_count.0, 5, "all 5 hierarchy levels persisted as claims");
+
+    // 3. Paper -> claim asserts edges exist for every claim.
+    let assert_edges: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*) FROM edges
+        WHERE source_id = $1 AND source_type = 'paper'
+          AND target_type = 'claim' AND relationship = 'asserts'
+        "#,
+    )
+    .bind(paper_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(assert_edges.0, 5, "paper asserts every claim level");
+
+    // 4. agent -authored-> paper edge exists.
+    let authored: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE target_id = $1 AND relationship = 'authored'",
+    )
+    .bind(paper_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(authored.0, 1);
+
+    // 5. supports edge between the two atoms exists.
+    let supports: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE relationship = 'supports' AND source_type = 'claim' AND target_type = 'claim'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(supports.0, 1, "atom -supports-> atom edge persisted");
+
+    // 6. paper -processed_by-> agent edge marks the version gate.
+    let processed: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*) FROM edges
+        WHERE source_id = $1 AND source_type = 'paper'
+          AND target_type = 'agent' AND relationship = 'processed_by'
+          AND properties ->> 'pipeline' = 'hierarchical_extraction_v1'
+        "#,
+    )
+    .bind(paper_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(processed.0, 1);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn re_ingest_hits_version_gate(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let extraction: DocumentExtraction = serde_json::from_str(FIXTURE).expect("fixture parses");
+
+    let _first = do_ingest_document(&server, &extraction)
+        .await
+        .expect("first ingest");
+    let second = do_ingest_document(&server, &extraction)
+        .await
+        .expect("second ingest");
+
+    let payload = result_text(&second);
+    let json: serde_json::Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(json["already_ingested"], serde_json::json!(true));
+    assert_eq!(json["claims_ingested"], serde_json::json!(0));
+    assert_eq!(json["relationships_created"], serde_json::json!(0));
+}
+
+fn result_text(result: &rmcp::model::CallToolResult) -> String {
+    let content = result
+        .content
+        .first()
+        .expect("at least one content block");
+    content
+        .as_text()
+        .expect("text content")
+        .text
+        .clone()
+}

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -97,7 +97,10 @@ async fn happy_path_ingests_full_hierarchy(pool: PgPool) {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(claim_count.0, 5, "all 5 hierarchy levels persisted as claims");
+    assert_eq!(
+        claim_count.0, 5,
+        "all 5 hierarchy levels persisted as claims"
+    );
 
     // 3. Paper -> claim asserts edges exist for every claim.
     let assert_edges: (i64,) = sqlx::query_as(
@@ -168,13 +171,6 @@ async fn re_ingest_hits_version_gate(pool: PgPool) {
 }
 
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
-    let content = result
-        .content
-        .first()
-        .expect("at least one content block");
-    content
-        .as_text()
-        .expect("text content")
-        .text
-        .clone()
+    let content = result.content.first().expect("at least one content block");
+    content.as_text().expect("text content").text.clone()
 }

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -170,6 +170,106 @@ async fn re_ingest_hits_version_gate(pool: PgPool) {
     assert_eq!(json["relationships_created"], serde_json::json!(0));
 }
 
+/// A second fixture sharing one atom and the same author with the primary
+/// fixture. Validates cross-paper atom convergence and author dedup.
+const FIXTURE_OVERLAP: &str = r#"{
+  "source": {
+    "title": "Second Hierarchical Paper",
+    "doi": "10.1234/hierarchy-second",
+    "source_type": "Paper",
+    "authors": [
+      {"name": "Alice Author", "affiliations": [], "roles": ["author"]}
+    ]
+  },
+  "thesis": "Different thesis but shared atom",
+  "thesis_derivation": "TopDown",
+  "sections": [{
+    "title": "Other Intro",
+    "summary": "An entirely different section summary that should not collide",
+    "paragraphs": [{
+      "compound": "A different compound claim that overlaps via one shared atom",
+      "supporting_text": "Different supporting passage.",
+      "atoms": [
+        "Atomization aids cross-source matching",
+        "A genuinely new atom that has never been ingested before"
+      ],
+      "generality": [3, 3],
+      "confidence": 0.7
+    }]
+  }],
+  "relationships": []
+}"#;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn cross_paper_atom_and_author_converge(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let first: DocumentExtraction = serde_json::from_str(FIXTURE).expect("fixture parses");
+    let second: DocumentExtraction = serde_json::from_str(FIXTURE_OVERLAP).expect("fixture parses");
+
+    let _ = do_ingest_document(&server, &first)
+        .await
+        .expect("first ingest");
+    let res = do_ingest_document(&server, &second)
+        .await
+        .expect("second ingest");
+
+    let payload = result_text(&res);
+    let json: serde_json::Value = serde_json::from_str(&payload).unwrap();
+
+    // The shared atom hits cross-paper dedup; the new atom + thesis +
+    // section + paragraph are fresh → 4 newly inserted, 1 deduped.
+    assert_eq!(json["claims_skipped_dedup"].as_u64().unwrap(), 1);
+    assert_eq!(json["claims_ingested"].as_u64().unwrap(), 4);
+
+    // Same shared atom → exactly one atom claim row for that content.
+    let shared_atom_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM claims WHERE content = 'Atomization aids cross-source matching'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        shared_atom_count.0, 1,
+        "shared atom must converge to one row"
+    );
+
+    // The shared atom is asserted by BOTH papers.
+    let asserts_into_shared: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*) FROM edges e
+        JOIN claims c ON c.id = e.target_id
+        WHERE e.relationship = 'asserts'
+          AND e.source_type = 'paper'
+          AND e.target_type = 'claim'
+          AND c.content = 'Atomization aids cross-source matching'
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        asserts_into_shared.0, 2,
+        "both papers assert the shared atom"
+    );
+
+    // Same author across both papers → exactly one author agent row.
+    let alice_agents: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM agents WHERE display_name = 'Alice Author'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(alice_agents.0, 1, "author dedup via deterministic key");
+
+    // ...and Alice authored both papers.
+    let authored_edges: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE relationship = 'authored' AND source_type = 'agent'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(authored_edges.0, 2, "alice authored both papers");
+}
+
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
     let content = result.content.first().expect("at least one content block");
     content.as_text().expect("text content").text.clone()

--- a/docs/superpowers/plans/2026-04-29-extract-claims-mcp-port.md
+++ b/docs/superpowers/plans/2026-04-29-extract-claims-mcp-port.md
@@ -1,0 +1,936 @@
+# Extract-Claims MCP Tool Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the hierarchical document decomposition pipeline (extract-claims SKILL + `ingest_document` MCP tool) from V2 nano into the public `epigraph-io/epigraph` repo.
+
+**Architecture:** The skill (markdown) instructs an LLM to produce a `DocumentExtraction` JSON. `epigraph_ingest::builder::build_ingest_plan` (already in public) converts that JSON into a flat `IngestPlan { claims, edges, path_index }`. The new `ingest_document` MCP tool consumes the plan and writes claims/edges/evidence/embeddings/CDST evidence into Postgres via the public-repo idiom (split repository calls + batch CDST). Paper-as-node pattern is preserved by adding a small `PaperRepository`.
+
+**Tech Stack:** Rust + sqlx + Axum/rmcp; PostgreSQL with pgvector.
+
+**Out of scope (deferred to backlog):**
+- Author affiliations/roles structured fields (V2 had `ensure_author_agent(name, affiliations, roles)`; public's `Agent::new` only takes a name — store extras in agent properties JSON).
+- `find_capability_claim` lookup for processed_by edges to "ingest_paper"/"extract_document" capability nodes — public has no capability registry. Skip with a warning log.
+- The V2 nano `extract.rs` Rust extraction cascade (Rust-side claude-CLI invocation). Not needed; the skill drives the LLM in chat.
+- Per-claim auto-CDST. Use public's existing `auto_wire_ds_batch` instead.
+
+---
+
+## File Structure
+
+**New files:**
+- `.claude/skills/extract-claims/SKILL.md` — the skill (verbatim port from V2)
+- `crates/epigraph-db/src/repos/paper.rs` — minimal PaperRepository: `create`, `find_by_doi`, `has_processed_by_edge`
+- `crates/epigraph-db/tests/paper_repo_tests.rs` — integration tests
+
+**Modified files:**
+- `crates/epigraph-db/src/repos/mod.rs` — register paper module
+- `crates/epigraph-db/src/lib.rs` — re-export PaperRepository
+- `crates/epigraph-db/src/repos/edge.rs` — add `create_if_not_exists`
+- `crates/epigraph-mcp/src/types.rs` — `IngestDocumentParams`, `IngestDocumentResponse`
+- `crates/epigraph-mcp/src/tools/ingestion.rs` — `ingest_document` function (~250 lines)
+- `crates/epigraph-mcp/src/server.rs` — wire `#[tool]` method
+- `crates/epigraph-mcp/Cargo.toml` — add `epigraph-ingest` dependency (if not already there)
+
+---
+
+## Task 1: Port the extract-claims SKILL.md
+
+**Files:**
+- Create: `.claude/skills/extract-claims/SKILL.md`
+
+- [ ] **Step 1.1: Copy SKILL.md from V2**
+
+```bash
+mkdir -p .claude/skills/extract-claims
+cp /home/jeremy/EpigraphV2/EpiGraphV2/.worktrees/textbook-provenance/epigraph-nano/.claude/skills/extract-claims/SKILL.md .claude/skills/extract-claims/SKILL.md
+```
+
+Expected: file exists at `.claude/skills/extract-claims/SKILL.md`.
+
+- [ ] **Step 1.2: Commit**
+
+```bash
+git add .claude/skills/extract-claims/SKILL.md
+git commit -m "feat(skills): add extract-claims hierarchical extraction skill
+
+Verbatim port from V2 nano. The 4-stage protocol (sections → paragraph
+compounds → atomic decomposition → optional bottom-up thesis) drives the
+LLM-side extraction; the resulting DocumentExtraction JSON is consumed by
+the ingest_document MCP tool (separate commit)."
+```
+
+---
+
+## Task 2: Add PaperRepository
+
+V2 models papers as first-class graph nodes (`paper` entity type). The schema in public already supports this (the `papers` table exists in `001_initial_schema.sql:1332` and `paper` is in the edges entity_type CHECK constraint), but no repo wraps it. We need a thin one for ingest_document.
+
+**Files:**
+- Create: `crates/epigraph-db/src/repos/paper.rs`
+- Modify: `crates/epigraph-db/src/repos/mod.rs`
+- Modify: `crates/epigraph-db/src/lib.rs`
+- Test: `crates/epigraph-db/tests/paper_repo_tests.rs` (or extend existing integration tests file)
+
+- [ ] **Step 2.1: Confirm papers table columns**
+
+```bash
+grep -A 8 "CREATE TABLE public.papers" migrations/001_initial_schema.sql | head -15
+```
+
+Expected schema: `id uuid, doi text, title text, journal text, created_at timestamptz`. If extra columns appear (properties jsonb?), extend the repo accordingly.
+
+- [ ] **Step 2.2: Implement PaperRepository**
+
+Create `crates/epigraph-db/src/repos/paper.rs`:
+
+```rust
+//! Paper entity repository — papers are first-class nodes in the graph
+//! (entity_type = "paper") used by hierarchical document ingestion.
+
+use sqlx::PgPool;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::errors::DbError;
+
+/// Row representation of the `papers` table.
+#[derive(Debug, Clone)]
+pub struct PaperRow {
+    pub id: Uuid,
+    pub doi: String,
+    pub title: Option<String>,
+    pub journal: Option<String>,
+}
+
+pub struct PaperRepository;
+
+impl PaperRepository {
+    /// Insert a new paper row. Each ingestion gets a fresh node — re-ingesting
+    /// the same DOI returns a NEW paper row, intentionally; the caller links
+    /// the new paper to prior papers with the same DOI via `same_source` edges
+    /// (matching V2 semantics).
+    #[instrument(skip(pool))]
+    pub async fn create(
+        pool: &PgPool,
+        doi: &str,
+        title: Option<&str>,
+        journal: Option<&str>,
+    ) -> Result<Uuid, DbError> {
+        let row = sqlx::query!(
+            r#"
+            INSERT INTO papers (doi, title, journal)
+            VALUES ($1, $2, $3)
+            RETURNING id
+            "#,
+            doi,
+            title,
+            journal,
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(row.id)
+    }
+
+    /// Find all paper rows with the given DOI, ordered by `created_at DESC`.
+    #[instrument(skip(pool))]
+    pub async fn find_by_doi(pool: &PgPool, doi: &str) -> Result<Vec<PaperRow>, DbError> {
+        let rows = sqlx::query!(
+            r#"
+            SELECT id, doi, title, journal
+            FROM papers
+            WHERE doi = $1
+            ORDER BY created_at DESC
+            "#,
+            doi
+        )
+        .fetch_all(pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| PaperRow {
+                id: r.id,
+                doi: r.doi,
+                title: r.title,
+                journal: r.journal,
+            })
+            .collect())
+    }
+
+    /// Returns true if `paper_id` has any outgoing `processed_by` edge whose
+    /// properties.pipeline matches `pipeline_version`. Used as a re-ingestion
+    /// version gate.
+    #[instrument(skip(pool))]
+    pub async fn has_processed_by_edge(
+        pool: &PgPool,
+        paper_id: Uuid,
+        pipeline_version: &str,
+    ) -> Result<bool, DbError> {
+        let row = sqlx::query!(
+            r#"
+            SELECT 1 AS exists
+            FROM edges
+            WHERE source_id = $1
+              AND source_type = 'paper'
+              AND relationship = 'processed_by'
+              AND properties ->> 'pipeline' = $2
+            LIMIT 1
+            "#,
+            paper_id,
+            pipeline_version
+        )
+        .fetch_optional(pool)
+        .await?;
+        Ok(row.is_some())
+    }
+}
+```
+
+- [ ] **Step 2.3: Wire PaperRepository into mod.rs and lib.rs**
+
+In `crates/epigraph-db/src/repos/mod.rs`, add (alphabetical order):
+
+```rust
+pub mod paper;
+```
+
+In `crates/epigraph-db/src/lib.rs`, find the existing `pub use repos::{...};` block and add `paper::PaperRepository` (alphabetical).
+
+- [ ] **Step 2.4: Build to confirm sqlx queries pass compile-time check**
+
+```bash
+cargo build -p epigraph-db
+```
+
+Expected: clean build. If sqlx complains about `DATABASE_URL`, ensure the dev database is running (`docker ps | grep epigraph-postgres` should show it on `127.0.0.1:5432`) and `DATABASE_URL` is exported per `CLAUDE.md`.
+
+- [ ] **Step 2.5: Add integration test**
+
+Pattern: copy an existing repo test from `crates/epigraph-db/tests/` and follow its setup. Test cases:
+- `create` then `find_by_doi` returns the inserted row.
+- `find_by_doi` returns empty `Vec` for unknown DOI.
+- `has_processed_by_edge` returns false before any edge, true after inserting an edge with matching properties.pipeline, false for a different pipeline string.
+
+- [ ] **Step 2.6: Run the tests**
+
+```bash
+cargo test -p epigraph-db --test paper_repo_tests
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add crates/epigraph-db/src/repos/paper.rs crates/epigraph-db/src/repos/mod.rs crates/epigraph-db/src/lib.rs crates/epigraph-db/tests/paper_repo_tests.rs
+git commit -m "feat(db): add PaperRepository for hierarchical document ingestion
+
+The papers table existed in the 001 schema but had no repo wrapper.
+Hierarchical document ingestion needs paper-as-node semantics (paper
+node, paper -asserts-> claim, agent -authored-> paper edges) so we
+add a thin repository over create/find_by_doi/has_processed_by_edge."
+```
+
+---
+
+## Task 3: Add `EdgeRepository::create_if_not_exists`
+
+V2 uses `insert_edge_if_not_exists(...)` extensively for idempotent re-ingestion (paper→capability_claim processed_by edges, paper→prior_paper same_source edges, claim→atom decomposes_to edges when an atom was deduped to an existing claim). Public's `EdgeRepository::create` always INSERTs — duplicates accumulate.
+
+There is no unique index on `(source_id, target_id, relationship)` in the edges table (verified by reading `001_initial_schema.sql` constraint section). So we implement check-then-insert in a transaction.
+
+**Files:**
+- Modify: `crates/epigraph-db/src/repos/edge.rs`
+
+- [ ] **Step 3.1: Add the helper**
+
+After the existing `create()` method (~line 73), append:
+
+```rust
+    /// Like `create`, but if an edge with the same
+    /// `(source_id, target_id, relationship)` triple already exists, returns the
+    /// existing edge id without inserting. Idempotent.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip(pool, properties))]
+    pub async fn create_if_not_exists(
+        pool: &PgPool,
+        source_id: Uuid,
+        source_type: &str,
+        target_id: Uuid,
+        target_type: &str,
+        relationship: &str,
+        properties: Option<serde_json::Value>,
+        valid_from: Option<chrono::DateTime<chrono::Utc>>,
+        valid_to: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Uuid, DbError> {
+        let mut tx = pool.begin().await?;
+        let existing = sqlx::query!(
+            r#"
+            SELECT id FROM edges
+            WHERE source_id = $1 AND target_id = $2 AND relationship = $3
+            LIMIT 1
+            "#,
+            source_id,
+            target_id,
+            relationship,
+        )
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some(row) = existing {
+            tx.commit().await?;
+            return Ok(row.id);
+        }
+
+        let properties = properties.unwrap_or(serde_json::json!({}));
+        let row = sqlx::query!(
+            r#"
+            INSERT INTO edges (source_id, source_type, target_id, target_type, relationship, properties, valid_from, valid_to)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING id
+            "#,
+            source_id,
+            source_type,
+            target_id,
+            target_type,
+            relationship,
+            properties,
+            valid_from,
+            valid_to,
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(row.id)
+    }
+```
+
+- [ ] **Step 3.2: Add a smoke test**
+
+Append to `crates/epigraph-db/tests/edge_repo_tests.rs` (or create if it doesn't exist; mirror an existing repo test layout):
+
+```rust
+#[sqlx::test]
+async fn create_if_not_exists_is_idempotent(pool: PgPool) {
+    let src = Uuid::new_v4();
+    let tgt = Uuid::new_v4();
+    let id1 = EdgeRepository::create_if_not_exists(
+        &pool, src, "claim", tgt, "claim", "decomposes_to", None, None, None,
+    )
+    .await
+    .unwrap();
+    let id2 = EdgeRepository::create_if_not_exists(
+        &pool, src, "claim", tgt, "claim", "decomposes_to", None, None, None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(id1, id2, "second call must return existing id");
+}
+```
+
+- [ ] **Step 3.3: Run tests**
+
+```bash
+cargo test -p epigraph-db --test edge_repo_tests create_if_not_exists_is_idempotent
+```
+
+Expected: pass.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add crates/epigraph-db/src/repos/edge.rs crates/epigraph-db/tests/edge_repo_tests.rs
+git commit -m "feat(db): add EdgeRepository::create_if_not_exists
+
+Hierarchical ingestion re-runs need idempotent edge insertion (e.g.
+linking deduped atoms to multiple papers via decomposes_to). Uses
+check-then-insert in a transaction since the edges table has no
+unique index on (source, target, relationship)."
+```
+
+---
+
+## Task 4: Add IngestDocumentParams + IngestDocumentResponse
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/types.rs`
+
+- [ ] **Step 4.1: Find where `IngestPaperParams` lives in types.rs**
+
+```bash
+grep -n "IngestPaperParams\|IngestPaperResponse" crates/epigraph-mcp/src/types.rs
+```
+
+- [ ] **Step 4.2: Add new types right after IngestPaperResponse**
+
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IngestDocumentParams {
+    /// Path to a JSON file containing a `DocumentExtraction` (hierarchical).
+    /// Must be inside the current working directory.
+    #[schemars(description = "Absolute or relative path to the DocumentExtraction JSON file")]
+    pub file_path: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct IngestDocumentResponse {
+    pub paper_id: String,
+    pub paper_title: String,
+    pub doi: String,
+    pub authors: Vec<AuthorResponse>,
+    pub claims_ingested: usize,
+    pub claims_embedded: usize,
+    pub claims_skipped_dedup: usize,
+    pub relationships_created: usize,
+    pub claims_ds_wired: Option<usize>,
+    pub ds_frame_id: Option<String>,
+    pub already_ingested: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AuthorResponse {
+    pub agent_id: String,
+    pub name: String,
+}
+```
+
+If `AuthorResponse` already exists (e.g. used by `ingest_paper`), reuse it instead of redefining.
+
+- [ ] **Step 4.3: Build to verify**
+
+```bash
+cargo build -p epigraph-mcp
+```
+
+Expected: clean build (the new types are only defined, not yet used).
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/types.rs
+git commit -m "feat(mcp): add IngestDocument param/response types"
+```
+
+---
+
+## Task 5: Implement `ingest_document` function
+
+This is the heavy task: ~250 lines retargeting V2's nano implementation to public's PgPool+repos pattern.
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/tools/ingestion.rs`
+- Modify: `crates/epigraph-mcp/Cargo.toml` (if `epigraph-ingest` not yet a dep)
+
+Reference V2 source: `/home/jeremy/EpigraphV2/EpiGraphV2/.worktrees/textbook-provenance/epigraph-nano/src/mcp.rs:4515-5310`. Use the existing public `do_ingest` (lines 146-299 of `ingestion.rs`) as the idiom template.
+
+- [ ] **Step 5.1: Confirm Cargo.toml dep**
+
+```bash
+grep epigraph-ingest crates/epigraph-mcp/Cargo.toml
+```
+
+If absent, add under `[dependencies]`: `epigraph-ingest = { path = "../epigraph-ingest" }`.
+
+- [ ] **Step 5.2: Add imports at top of ingestion.rs**
+
+After the existing `use` block:
+
+```rust
+use epigraph_ingest::builder::{build_ingest_plan, PlannedClaim};
+use epigraph_ingest::schema::DocumentExtraction;
+use epigraph_db::PaperRepository;
+use crate::types::{IngestDocumentParams, IngestDocumentResponse, AuthorResponse};
+```
+
+(Adjust `PlannedClaim` import path if the symbol is private — read `crates/epigraph-ingest/src/builder.rs:60-onward` to confirm the correct re-export. If private, walk plan via the public `IngestPlan` accessor only.)
+
+- [ ] **Step 5.3: Add the entry function and helper**
+
+Append to ingestion.rs:
+
+```rust
+const PIPELINE_VERSION: &str = "hierarchical_extraction_v1";
+
+pub async fn ingest_document(
+    server: &EpiGraphMcpFull,
+    params: IngestDocumentParams,
+) -> Result<CallToolResult, McpError> {
+    let canonical = std::fs::canonicalize(&params.file_path)
+        .map_err(|e| invalid_params(format!("invalid file path: {e}")))?;
+    let cwd = std::env::current_dir()
+        .map_err(|e| internal_error(format!("cannot determine CWD: {e}")))?;
+    if !canonical.starts_with(&cwd) {
+        return Err(invalid_params(
+            "file path must be within the working directory",
+        ));
+    }
+    let data = tokio::fs::read_to_string(&canonical)
+        .await
+        .map_err(|e| invalid_params(format!("cannot read {}: {e}", canonical.display())))?;
+    let extraction: DocumentExtraction =
+        serde_json::from_str(&data).map_err(|e| invalid_params(format!("invalid JSON: {e}")))?;
+
+    do_ingest_document(server, &extraction, &params.file_path).await
+}
+
+#[allow(clippy::too_many_lines)]
+async fn do_ingest_document(
+    server: &EpiGraphMcpFull,
+    extraction: &DocumentExtraction,
+    source_path: &str,
+) -> Result<CallToolResult, McpError> {
+    let plan = build_ingest_plan(extraction);
+    let pool = &server.pool;
+    let agent_id = server.agent_id().await?;
+    let agent_id_typed = AgentId::from_uuid(agent_id);
+    let pub_key = server.signer.public_key();
+
+    let paper_title = extraction.source.title.clone();
+    let doi = resolve_doi(extraction);
+
+    // ── 1. Version gate ──
+    let prior_papers = PaperRepository::find_by_doi(pool, &doi)
+        .await
+        .map_err(internal_error)?;
+    for prior in &prior_papers {
+        if PaperRepository::has_processed_by_edge(pool, prior.id, PIPELINE_VERSION)
+            .await
+            .map_err(internal_error)?
+        {
+            return success_json(&IngestDocumentResponse {
+                paper_id: prior.id.to_string(),
+                paper_title,
+                doi,
+                authors: vec![],
+                claims_ingested: 0,
+                claims_embedded: 0,
+                claims_skipped_dedup: 0,
+                relationships_created: 0,
+                claims_ds_wired: None,
+                ds_frame_id: None,
+                already_ingested: true,
+            });
+        }
+    }
+
+    // ── 2. Create fresh paper node + same_source links ──
+    let paper_id = PaperRepository::create(
+        pool,
+        &doi,
+        Some(&paper_title),
+        extraction.source.journal.as_deref(),
+    )
+    .await
+    .map_err(internal_error)?;
+    for prior in &prior_papers {
+        let _ = EdgeRepository::create_if_not_exists(
+            pool, paper_id, "paper", prior.id, "paper", "same_source",
+            Some(serde_json::json!({"doi": &doi})), None, None,
+        )
+        .await;
+    }
+
+    // ── 3. Ensure author agents + agent --authored--> paper ──
+    let mut author_responses = Vec::new();
+    let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
+    for (idx, author) in extraction.source.authors.iter().enumerate() {
+        if author.name.is_empty() { continue; }
+        // Public's Agent::new doesn't model affiliations/roles; store in properties
+        // is a TODO. For now: name only (matches existing ingest_paper pattern).
+        let author_agent = epigraph_core::Agent::new([0u8; 32], Some(author.name.clone()));
+        let created = AgentRepository::create(pool, &author_agent)
+            .await
+            .map_err(internal_error)?;
+        EdgeRepository::create(
+            pool, created.id.into(), "agent", paper_id, "paper", "authored",
+            Some(serde_json::json!({
+                "position": idx,
+                "role": author.roles.first().map(String::as_str).unwrap_or("author"),
+            })),
+            None, None,
+        )
+        .await
+        .map_err(internal_error)?;
+        author_agent_map.insert(idx, created.id.into());
+        author_responses.push(AuthorResponse {
+            agent_id: created.id.as_uuid().to_string(),
+            name: author.name.clone(),
+        });
+    }
+
+    // ── 4. Walk planned claims: dedup → claim/trace/evidence/embed ──
+    let source_url = if doi.starts_with("10.") {
+        format!("https://doi.org/{doi}")
+    } else {
+        format!("doi:{doi}")
+    };
+
+    let mut claim_ids: Vec<String> = Vec::new();
+    let mut id_map: HashMap<Uuid, Uuid> = HashMap::new();
+    let mut embedded_count = 0usize;
+    let mut dedup_count = 0usize;
+    let mut ds_entries: Vec<BatchDsEntry> = Vec::new();
+
+    for planned in plan.iter_claims() { // adjust accessor based on actual API
+        // ClaimRepository::create dedupes by content hash automatically; we
+        // detect dedup by comparing returned id to the one we tried to insert.
+        let confidence = planned.confidence.clamp(0.0, 1.0);
+        let methodology = methodology_from_planned(planned);
+        let weight = methodology.weight_modifier();
+        let raw_truth = (confidence * weight).clamp(0.01, 0.99);
+
+        let mut claim = Claim::new(
+            planned.content.clone(),
+            agent_id_typed,
+            pub_key,
+            TruthValue::clamped(raw_truth),
+        );
+        claim.id = ClaimId::from_uuid(planned.id);
+        claim.content_hash = ContentHasher::hash(planned.content.as_bytes());
+        claim.signature = Some(server.signer.sign(&claim.content_hash));
+
+        let evidence_text = planned
+            .supporting_text
+            .as_deref()
+            .unwrap_or(&planned.content);
+        let formatted_evidence =
+            format!("Source: {paper_title} (DOI: {doi}). Passage: '{evidence_text}'");
+        let evidence_hash = ContentHasher::hash(formatted_evidence.as_bytes());
+        let mut evidence = Evidence::new(
+            agent_id_typed,
+            pub_key,
+            evidence_hash,
+            EvidenceType::Literature {
+                doi: doi.clone(),
+                extraction_target: format!("level_{}", planned.level),
+                page_range: None,
+            },
+            Some(formatted_evidence),
+            claim.id,
+        );
+        evidence.signature = Some(server.signer.sign(&evidence_hash));
+
+        let trace = ReasoningTrace::new(
+            agent_id_typed,
+            pub_key,
+            methodology,
+            vec![TraceInput::Evidence { id: evidence.id }],
+            confidence,
+            format!("Extracted from '{paper_title}' (DOI: {doi}). Level: {}.", planned.level),
+        );
+
+        let persisted = ClaimRepository::create(pool, &claim)
+            .await
+            .map_err(internal_error)?;
+        let persisted_id: Uuid = persisted.id.into();
+        if persisted_id != planned.id {
+            // Deduped to an existing claim — link via paper -asserts-> existing,
+            // skip trace/evidence/embed for this iteration.
+            dedup_count += 1;
+            EdgeRepository::create_if_not_exists(
+                pool, paper_id, "paper", persisted_id, "claim", "asserts",
+                Some(planned.properties.clone()), None, None,
+            )
+            .await
+            .map_err(internal_error)?;
+            id_map.insert(planned.id, persisted_id);
+            claim_ids.push(persisted_id.to_string());
+            continue;
+        }
+
+        ReasoningTraceRepository::create(pool, &trace, claim.id)
+            .await
+            .map_err(internal_error)?;
+        EvidenceRepository::create(pool, &evidence)
+            .await
+            .map_err(internal_error)?;
+        ClaimRepository::update_trace_id(pool, claim.id, trace.id)
+            .await
+            .map_err(internal_error)?;
+
+        // Paper -asserts-> claim
+        EdgeRepository::create(
+            pool, paper_id, "paper", persisted_id, "claim", "asserts",
+            Some(planned.properties.clone()), None, None,
+        )
+        .await
+        .map_err(internal_error)?;
+
+        if server.embedder.embed_and_store(persisted_id, &planned.content).await {
+            embedded_count += 1;
+        }
+
+        // Atoms only → CDST batch
+        if planned.level == 3 {
+            ds_entries.push(BatchDsEntry {
+                claim_id: persisted_id,
+                confidence,
+                weight,
+            });
+        }
+
+        id_map.insert(planned.id, persisted_id);
+        claim_ids.push(persisted_id.to_string());
+    }
+
+    // ── 5. Plan edges (decomposes_to, section_follows, supports/contradicts/refines, author placeholders) ──
+    let mut relationships_created = 0usize;
+    for edge in plan.iter_edges() {
+        let (src, src_type) = if edge.source_type == "author_placeholder" {
+            let idx = edge.properties["author_index"].as_u64().unwrap_or(0) as usize;
+            let Some(&agent_uuid) = author_agent_map.get(&idx) else { continue };
+            (agent_uuid, "agent".to_string())
+        } else {
+            let mapped = id_map.get(&edge.source_id).copied().unwrap_or(edge.source_id);
+            (mapped, edge.source_type.clone())
+        };
+        let tgt = id_map.get(&edge.target_id).copied().unwrap_or(edge.target_id);
+        EdgeRepository::create_if_not_exists(
+            pool, src, &src_type, tgt, &edge.target_type, &edge.relationship,
+            Some(edge.properties.clone()), None, None,
+        )
+        .await
+        .map_err(internal_error)?;
+        relationships_created += 1;
+    }
+
+    // ── 6. Auto-CDST batch wire (atoms only) ──
+    let (claims_ds_wired, ds_frame_id) =
+        match ds_auto::auto_wire_ds_batch(pool, &ds_entries, agent_id).await {
+            Ok((fid, count)) => (Some(count), Some(fid.to_string())),
+            Err(e) => {
+                tracing::warn!("ds auto-wire batch failed: {e}");
+                (None, None)
+            }
+        };
+
+    success_json(&IngestDocumentResponse {
+        paper_id: paper_id.to_string(),
+        paper_title,
+        doi,
+        authors: author_responses,
+        claims_ingested: claim_ids.len() - dedup_count,
+        claims_embedded: embedded_count,
+        claims_skipped_dedup: dedup_count,
+        relationships_created,
+        claims_ds_wired,
+        ds_frame_id,
+        already_ingested: false,
+    })
+}
+
+fn resolve_doi(extraction: &DocumentExtraction) -> String {
+    if let Some(d) = &extraction.source.doi {
+        return d.clone();
+    }
+    if let Some(uri) = &extraction.source.uri {
+        // arXiv ID pattern: \d{4}\.\d{4,5}
+        if let Some(caps) = regex_lite::Regex::new(r"(\d{4}\.\d{4,5})")
+            .ok()
+            .and_then(|re| re.captures(uri).map(|c| c.get(1).map(|m| m.as_str().to_string())))
+            .flatten()
+        {
+            return format!("10.48550/arXiv.{caps}");
+        }
+        return uri.clone();
+    }
+    "unknown".to_string()
+}
+
+fn methodology_from_planned(planned: &PlannedClaim) -> Methodology {
+    match planned.methodology.as_deref() {
+        Some("statistical" | "instrumental" | "computational") => Methodology::StatisticalAnalysis,
+        Some("deductive") => Methodology::DeductiveLogic,
+        Some("inductive" | "visual_inspection") => Methodology::InductiveGeneralization,
+        _ => Methodology::ExpertElicitation,
+    }
+}
+```
+
+> **Note on iteration accessors:** Adjust `plan.iter_claims()` / `plan.iter_edges()` based on the actual `IngestPlan` API in `crates/epigraph-ingest/src/builder.rs`. Read it first; if the fields are `pub claims: Vec<PlannedClaim>` and `pub edges: Vec<PlannedEdge>`, use `&plan.claims` and `&plan.edges` directly.
+
+> **Note on regex_lite:** the dependency may not exist in epigraph-mcp's Cargo.toml. If not, prefer `regex` (already a workspace dep) or hand-roll the arXiv pattern with simple string ops to avoid a new dep.
+
+- [ ] **Step 5.4: Build incrementally and fix import/type errors**
+
+```bash
+cargo build -p epigraph-mcp 2>&1 | head -80
+```
+
+Iterate on import paths and field accessors until clean. Most likely fixups:
+- `Methodology::weight_modifier` may not exist on the public enum — match against existing `lit_methodology` and the way `do_ingest` derives `weight`.
+- `plan.iter_claims()` likely doesn't exist — use `&plan.claims`.
+- `Claim::new` signature may differ slightly.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/ingestion.rs crates/epigraph-mcp/Cargo.toml
+git commit -m "feat(mcp): add ingest_document tool for hierarchical ingestion
+
+Ports the V2 nano ingest_document into public-mcp, retargeting NanoDb
+methods onto PgPool + repos. Paper-as-node pattern preserved; author
+affiliations/roles deferred (stored as TODO). Auto-CDST uses the
+existing batch helper rather than per-claim wiring."
+```
+
+---
+
+## Task 6: Wire `ingest_document` as MCP `#[tool]` method
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/server.rs` (or wherever `#[tool]` methods on `EpiGraphMcpFull` are declared — likely an `impl` block in `tools/mod.rs` or `server.rs`)
+
+- [ ] **Step 6.1: Find existing `#[tool]` on `ingest_paper`**
+
+```bash
+grep -rn "fn ingest_paper" crates/epigraph-mcp/src/
+```
+
+- [ ] **Step 6.2: Mirror the wiring**
+
+Right after `ingest_paper`'s tool method, add:
+
+```rust
+    /// Ingest a hierarchical DocumentExtraction JSON file into the graph.
+    #[tool(description = "Ingest a hierarchical DocumentExtraction JSON file. \
+        Builds paper -> section -> paragraph -> atom claim hierarchy with edges.")]
+    pub async fn ingest_document(
+        &self,
+        Parameters(params): Parameters<IngestDocumentParams>,
+    ) -> Result<CallToolResult, McpError> {
+        if self.read_only {
+            return Err(invalid_params("read-only mode: ingest_document not allowed"));
+        }
+        tools::ingestion::ingest_document(self, params).await
+    }
+```
+
+- [ ] **Step 6.3: Build**
+
+```bash
+cargo build -p epigraph-mcp
+```
+
+Expected: clean.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/server.rs
+git commit -m "feat(mcp): expose ingest_document as #[tool] method"
+```
+
+---
+
+## Task 7: End-to-end smoke test against a real DB
+
+**Files:**
+- Create: `crates/epigraph-mcp/tests/ingest_document_smoke.rs`
+
+The faithful test: parse a tiny synthetic DocumentExtraction (1 thesis, 1 section, 1 paragraph, 2 atoms, 1 supports relationship), run `ingest_document`, then assert claims/edges exist with the right shapes.
+
+- [ ] **Step 7.1: Write the test**
+
+Use `#[sqlx::test]` for an isolated DB. Fixture:
+
+```rust
+const FIXTURE: &str = r#"{
+  "source": {
+    "title": "Test Paper",
+    "doi": "10.1234/test",
+    "source_type": "Paper",
+    "authors": [{"name": "Alice", "affiliations": [], "roles": ["author"]}]
+  },
+  "thesis": "T",
+  "thesis_derivation": "TopDown",
+  "sections": [{
+    "title": "Intro",
+    "summary": "S",
+    "paragraphs": [{
+      "compound": "C",
+      "supporting_text": "ST",
+      "atoms": ["Atom 1", "Atom 2"],
+      "generality": [3, 3],
+      "confidence": 0.8
+    }]
+  }],
+  "relationships": [
+    {"source_path": "atoms[0]", "target_path": "atoms[1]", "relationship": "supports"}
+  ]
+}"#;
+```
+
+Write to a temp file under CWD, call `ingest_document`, then query:
+- `papers` row exists with the doi
+- claims with content "T", "S", "C", "Atom 1", "Atom 2" all exist
+- edges: paper->thesis (asserts), thesis->section (decomposes_to), section->paragraph (decomposes_to), paragraph->atoms (decomposes_to), atom1->atom2 (supports), agent->paper (authored)
+
+- [ ] **Step 7.2: Run**
+
+```bash
+cargo test -p epigraph-mcp --test ingest_document_smoke
+```
+
+Expected: pass. If it fails, fix the implementation, not the test.
+
+- [ ] **Step 7.3: Run idempotency check (re-ingest same fixture)**
+
+Add a second test: call `ingest_document` twice, assert second response has `already_ingested: true` and zero new edges.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add crates/epigraph-mcp/tests/ingest_document_smoke.rs
+git commit -m "test(mcp): smoke-test hierarchical ingest_document end-to-end
+
+Verifies paper node, claim hierarchy, decomposes_to/supports edges,
+author authored edge, and version-gated re-ingest skip."
+```
+
+---
+
+## Task 8: Verification + workflow lint
+
+- [ ] **Step 8.1: Full build**
+
+```bash
+cargo build --workspace
+```
+
+- [ ] **Step 8.2: Full test**
+
+```bash
+cargo test --workspace
+```
+
+Watch for regressions in unrelated crates — none expected, but verify.
+
+- [ ] **Step 8.3: Clippy**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Fix lints before merging. The new `do_ingest_document` is large; `#[allow(clippy::too_many_lines)]` is justified, mirroring `do_ingest`.
+
+- [ ] **Step 8.4: Format check**
+
+```bash
+cargo fmt --check
+```
+
+- [ ] **Step 8.5: Open PR description** (do not push without user's go-ahead)
+
+Draft body covers: skill port, ingest_document MCP tool, PaperRepository, EdgeRepository::create_if_not_exists, deferred items (capability claims, author affiliations, per-claim CDST).
+
+---
+
+## Self-review checklist
+
+- Spec coverage: ✓ skill (T1), ingest_document (T5+T6), prerequisites (T2-T4), tests (T7), CI hygiene (T8).
+- Placeholders: none — every code block is the actual code to write (placeholder hints noted in-line for accessors that depend on the local `IngestPlan` API, which the engineer will resolve at compile time).
+- Type consistency: `IngestDocumentParams`/`IngestDocumentResponse`/`AuthorResponse` introduced in T4 and used unchanged in T5/T6/T7. `PIPELINE_VERSION` constant defined in T5 and queried in T2's `has_processed_by_edge`.
+- Deferred items are explicit, not silent gaps.


### PR DESCRIPTION
## Summary

Ports the hierarchical document decomposition pipeline from EpiGraphV2 into the public repo. Per project memory, the canonical Tier 1 ingestion path is the extract-claims skill plus the `ingest_document` MCP tool; until now the public repo had neither.

- **Skill:** `.claude/skills/extract-claims/SKILL.md` — verbatim port from V2 nano. The 4-stage protocol (thesis → section summaries → paragraph compounds → atomic claims, optional bottom-up thesis) drives LLM-side extraction and produces a `DocumentExtraction` JSON.
- **`ingest_document` MCP tool** — consumes `DocumentExtraction`, retargets V2 nano's `NanoDb` calls onto public's `PgPool` + repos. Builds paper-as-node graph: paper -asserts-> claim at every level, decomposes_to / section_follows / supports / contradicts / refines edges, evidence + reasoning trace per claim, embeddings, and DS auto-wiring for atoms.
- **Supporting plumbing:** `PaperRepository` (the `papers` table existed in `001_initial_schema.sql` but had no repo wrapper), `EdgeRepository::create_if_not_exists` for idempotent re-ingestion, `IngestDocument{Params,Response}` types.

Implementation plan + decisions: `docs/superpowers/plans/2026-04-29-extract-claims-mcp-port.md`.

## Idempotency

- DOI uniqueness: `PaperRepository::get_or_create` uses `INSERT ... ON CONFLICT (doi) DO UPDATE`.
- Pipeline version gate: `paper -processed_by-> agent` edge with `properties.pipeline = "hierarchical_extraction_v1"`. Re-ingest at the same version short-circuits with `already_ingested: true`.
- Edge dedup: `create_if_not_exists` keeps decomposes_to / asserts / authored / processed_by edges duplicate-free.
- Atom convergence: `planned.id = uuid_v5(ATOM_NAMESPACE, content_hash)` is deterministic across documents. Detection via `persisted.trace_id.is_some()` correctly identifies cross-paper dedup and avoids overwriting prior provenance.
- Author convergence: deterministic ed25519 keypair via `epigraph_crypto::did_key_for_author` (name → keypair). Same author across papers maps to the same agent row.

## Tests

All `#[sqlx::test]` integration tests against fresh migrations:

- `epigraph-db`: 3 paper-repo + 2 edge-repo tests (idempotency, relationship distinguishing, processed_by filtering).
- `epigraph-mcp`: 3 end-to-end smoke tests:
  - `happy_path_ingests_full_hierarchy` — thesis + section + paragraph + 2 atoms + 1 supports relationship + 1 author → expected paper / claim / edge graph.
  - `re_ingest_hits_version_gate` — second call returns `already_ingested: true` and no new work.
  - `cross_paper_atom_and_author_converge` — two papers sharing one atom and one author → 1 shared atom row, 2 paper-asserts edges into it, 1 Alice agent, 2 authored edges.

## Out of scope (deferred)

- V2 nano `extract.rs` Rust extraction cascade — not needed; the skill drives the LLM in chat.
- `find_capability_claim` lookup (V2's processed_by → capability claim edges) — public has no capability registry. Replaced with `paper -processed_by-> agent` (semantically: \"paper processed by this agent at this pipeline version\"). The `edges_no_self_loop` check constraint prevents the obvious paper self-loop.
- First-class structured author affiliations on `Agent`. For now, affiliations ride on the `authored` edge's properties JSON.

## Notes for reviewer

- Pre-existing clippy in `crates/epigraph-db/src/repos/claim.rs:1701` (`needless_borrows_for_generic_args`) is on `main` already; not introduced here. If CI's clippy gate trips, that's the cause.
- `cargo sqlx prepare --workspace -- --tests` regenerated the offline cache; only new entries were added (verified via `git diff` — no existing cached queries were modified).
- The `paper.rs` repo uses `as \"title?\"` to override sqlx introspection: the migration declares `title` nullable but the dev DB has historical NOT NULL drift. Fresh-checkout `#[sqlx::test]` builds use the migration, so the override is required.

## Test plan

- [ ] CI green (cargo build / test / clippy / fmt).
- [ ] Reviewer runs `cargo test -p epigraph-db --tests -p epigraph-mcp --tests` against a local epigraph postgres and confirms all 8 new integration tests pass.
- [ ] Manual smoke: drive `ingest_document` from a Claude Code MCP session against a tiny `DocumentExtraction` JSON; verify paper / claims / edges land as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)