### PR TITLE
feat: port S3a MCP writer migration from epigraph-internal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,13 @@ jobs:
         run: cargo build --workspace
       - name: Test (non-DB packages, parallel)
         # Packages without DB tests can run fully in parallel.
-        # epigraph-engine has live integration tests that touch the DB,
-        # so it is excluded here and run sequentially below.
+        # epigraph-engine and epigraph-mcp have live integration tests
+        # that touch the DB, so they are excluded here and run sequentially below.
         run: cargo test --workspace
           --exclude epigraph-db
           --exclude epigraph-api
           --exclude epigraph-engine
+          --exclude epigraph-mcp
       - name: Test (epigraph-db, serialized)
         # #[sqlx::test] creates a postgres template DB per binary; concurrent
         # binaries race on _sqlx_migrations → "tuple concurrently updated".
@@ -51,6 +52,10 @@ jobs:
         run: cargo test -p epigraph-api -- --test-threads=1
       - name: Test (epigraph-engine, serialized)
         run: cargo test -p epigraph-engine -- --test-threads=1
+      - name: Test (epigraph-mcp, serialized)
+        # claim_helper_tests adds a temporary CHECK constraint on `edges`
+        # that would race with sibling tests under parallel execution.
+        run: cargo test -p epigraph-mcp -- --test-threads=1
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
       - name: Format check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "uuid",
 ]
 
@@ -4931,6 +4932,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/crates/epigraph-mcp/Cargo.toml
+++ b/crates/epigraph-mcp/Cargo.toml
@@ -64,6 +64,10 @@ axum = "0.8"
 
 [dev-dependencies]
 epigraph-ingest = { workspace = true }
+# `no-env-filter` is REQUIRED for integration tests in tests/* to capture
+# events emitted from src/ (different crate target). Without it, the macro's
+# default env filter scopes capture to the test crate only.
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 
 [features]
 default = []

--- a/crates/epigraph-mcp/src/claim_helper.rs
+++ b/crates/epigraph-mcp/src/claim_helper.rs
@@ -1,0 +1,61 @@
+//! Idempotent claim creation + AUTHORED verb-edge emission for MCP-layer
+//! writers. See docs/architecture/noun-claims-and-verb-edges.md and
+//! docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md.
+
+use epigraph_core::Claim;
+use epigraph_db::{ClaimRepository, EdgeRepository};
+use serde_json::json;
+use sqlx::PgPool;
+
+use crate::errors::{internal_error, McpError};
+
+/// Idempotently create a claim by `(content_hash, agent_id)` and emit an
+/// AUTHORED verb-edge marking the submission lifecycle event.
+///
+/// Mirrors the API handler's pattern at routes/claims.rs:444-576: dedup
+/// inside a connection scope via `ClaimRepository::create_or_get`, then
+/// fire-and-forget the AUTHORED edge on the pool after the connection is
+/// released. AUTHORED failure is logged via `tracing::warn!` but never
+/// propagated — orphan claims are tolerated per the architecture doc's
+/// atomicity policy. Each submission emits a distinct AUTHORED edge
+/// regardless of `was_created`, because each submission is an authorship
+/// verb-event.
+///
+/// # Errors
+/// Returns the underlying `McpError::internal_error` if `pool.acquire()`
+/// or `ClaimRepository::create_or_get` fail. AUTHORED edge failure is
+/// not returned (logged + swallowed).
+pub async fn create_claim_idempotent(
+    pool: &PgPool,
+    claim: &Claim,
+    tool_name: &'static str,
+) -> Result<(Claim, bool), McpError> {
+    let mut conn = pool.acquire().await.map_err(internal_error)?;
+    let (claim, was_created) = ClaimRepository::create_or_get(&mut conn, claim)
+        .await
+        .map_err(internal_error)?;
+    drop(conn);
+
+    if let Err(e) = EdgeRepository::create(
+        pool,
+        claim.agent_id.as_uuid(),
+        "agent",
+        claim.id.as_uuid(),
+        "claim",
+        "AUTHORED",
+        Some(json!({"tool": tool_name, "was_created": was_created})),
+        None,
+        None,
+    )
+    .await
+    {
+        tracing::warn!(
+            claim_id = %claim.id.as_uuid(),
+            tool = tool_name,
+            error = %e,
+            "AUTHORED verb-edge emit failed; claim row persisted as orphan"
+        );
+    }
+
+    Ok((claim, was_created))
+}

--- a/crates/epigraph-mcp/src/lib.rs
+++ b/crates/epigraph-mcp/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::doc_markdown)]
 
+pub mod claim_helper;
 pub mod embed;
 pub mod errors;
 pub mod server;

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -12,7 +12,7 @@ use epigraph_core::{
     TruthValue,
 };
 use epigraph_crypto::ContentHasher;
-use epigraph_db::{ClaimRepository, EvidenceRepository, ReasoningTraceRepository};
+use epigraph_db::{ClaimRepository, EdgeRepository, EvidenceRepository, ReasoningTraceRepository};
 
 fn parse_methodology(s: &str) -> Result<Methodology, String> {
     match s.to_lowercase().replace('-', "_").as_str() {
@@ -81,22 +81,22 @@ pub async fn submit_claim(
     let pub_key = server.signer.public_key();
     let confidence = params.confidence.clamp(0.0, 1.0);
 
-    // Compute initial truth: confidence * evidence_type_weight (from calibration.toml)
-    // I-3: use helper that checks CALIBRATION_PATH env var before relative path
     let weight = load_evidence_type_weight(&params.evidence_type);
     let raw_truth = (confidence * weight).clamp(0.01, 0.99);
     let truth_value = TruthValue::clamped(raw_truth);
 
-    // Create claim (trace_id starts as None; linked after trace creation)
     let mut claim = Claim::new(params.content.clone(), agent_id_typed, pub_key, truth_value);
-    let claim_uuid = claim.id.as_uuid();
-
-    // Compute content hash and signature
     let content_hash = ContentHasher::hash(params.content.as_bytes());
     claim.content_hash = content_hash;
     claim.signature = Some(server.signer.sign(&content_hash));
 
-    // Create evidence
+    // Idempotent canonical claim create + AUTHORED verb-edge.
+    let (claim, was_created) =
+        crate::claim_helper::create_claim_idempotent(&server.pool, &claim, "submit_claim").await?;
+    let claim_uuid = claim.id.as_uuid();
+
+    // Build Evidence + Trace from this submission. Both are noun-claims with
+    // their own UUIDs and signatures regardless of was_created.
     let evidence_hash = ContentHasher::hash(params.evidence_data.as_bytes());
     let evidence = Evidence::new(
         agent_id_typed,
@@ -112,7 +112,6 @@ pub async fn submit_claim(
         e
     };
 
-    // Create reasoning trace
     let explanation = params.reasoning.unwrap_or_else(|| {
         format!(
             "Claim submitted via MCP with {} methodology",
@@ -130,63 +129,102 @@ pub async fn submit_claim(
         explanation,
     );
 
-    // Persist: claim (NULL trace_id) → trace → evidence → link trace
-    ClaimRepository::create(&server.pool, &claim)
-        .await
-        .map_err(internal_error)?;
+    // Persist Trace + Evidence on every submission.
     ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
         .await
         .map_err(internal_error)?;
     EvidenceRepository::create(&server.pool, &evidence_with_sig)
         .await
         .map_err(internal_error)?;
-    ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
-        .await
-        .map_err(internal_error)?;
 
-    // DS auto-wire (best-effort — errors logged but do not abort claim creation)
-    let ds_result = ds_auto::auto_wire_ds_for_claim(
+    // Verb-edges: every submission references its own Evidence + Trace.
+    // Emitted on both branches per the architecture doc's "re-occurrence
+    // = new edge" rule. Matches ingest_paper's hoist (S3a Task 6, fix #1).
+    // The was_created marker on properties lets queries distinguish
+    // first-create from resubmit edges.
+    //
+    // Note: the API handler at routes/claims.rs:585-614 still follows the
+    // pre-S3a skip-on-resubmit rule. Aligning the API to MCP's accumulating
+    // semantics is spec backlog item #10.
+    let _ = EdgeRepository::create(
         &server.pool,
         claim_uuid,
-        agent_id,
-        confidence,
-        weight,
-        true,
-        Some(&params.evidence_type),
+        "claim",
+        evidence_with_sig.id.as_uuid(),
+        "evidence",
+        "DERIVED_FROM",
+        Some(serde_json::json!({"was_created": was_created})),
+        None,
+        None,
     )
     .await;
-    if let Err(ref e) = ds_result {
-        tracing::warn!(claim_id = %claim_uuid, "ds auto-wire failed: {e}");
-    }
+    let _ = EdgeRepository::create(
+        &server.pool,
+        claim_uuid,
+        "claim",
+        trace.id.as_uuid(),
+        "trace",
+        "HAS_TRACE",
+        Some(serde_json::json!({"was_created": was_created})),
+        None,
+        None,
+    )
+    .await;
 
-    // Overwrite truth_value with CDST pignistic probability when available
-    if let Ok(ref ds) = ds_result {
-        let ds_truth = TruthValue::clamped(ds.pignistic_prob);
-        // I-4: log rather than silently discard truth update errors
-        if let Err(e) = ClaimRepository::update_truth_value(
+    let (final_truth, ds, embedded) = if was_created {
+        // First-create: full lineage. update_trace_id, DS auto-wire, embed.
+        ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
+            .await
+            .map_err(internal_error)?;
+
+        let ds_result = ds_auto::auto_wire_ds_for_claim(
             &server.pool,
-            ClaimId::from_uuid(claim_uuid),
-            ds_truth,
+            claim_uuid,
+            agent_id,
+            confidence,
+            weight,
+            true,
+            Some(&params.evidence_type),
         )
-        .await
-        {
-            tracing::warn!(claim_id = %claim_uuid, "failed to update truth from DS pignistic: {e}");
-        }
-    }
-    let ds = ds_result.ok();
-
-    // Embed (best-effort)
-    let embedded = server
-        .embedder
-        .embed_and_store(claim_uuid, &params.content)
         .await;
+        if let Err(ref e) = ds_result {
+            tracing::warn!(claim_id = %claim_uuid, "ds auto-wire failed: {e}");
+        }
+        if let Ok(ref ds) = ds_result {
+            let ds_truth = TruthValue::clamped(ds.pignistic_prob);
+            if let Err(e) = ClaimRepository::update_truth_value(
+                &server.pool,
+                ClaimId::from_uuid(claim_uuid),
+                ds_truth,
+            )
+            .await
+            {
+                tracing::warn!(
+                    claim_id = %claim_uuid,
+                    "failed to update truth from DS pignistic: {e}"
+                );
+            }
+        }
+        let ds = ds_result.ok();
 
-    // Report the truth value that was actually stored (pignistic if DS succeeded,
-    // otherwise the initial confidence*weight estimate).
-    let final_truth = ds
-        .as_ref()
-        .map(|d| d.pignistic_prob.clamp(0.01, 0.99))
-        .unwrap_or(raw_truth);
+        let embedded = server
+            .embedder
+            .embed_and_store(claim_uuid, &params.content)
+            .await;
+
+        let final_truth = ds
+            .as_ref()
+            .map(|d| d.pignistic_prob.clamp(0.01, 0.99))
+            .unwrap_or(raw_truth);
+
+        (final_truth, ds, embedded)
+    } else {
+        // Resubmit (Option B): verb-edges already emitted above. Skip
+        // update_trace_id (canonical trace immutable), skip DS auto-wire
+        // (canonical truth set on first create), skip embed (canonical
+        // embedding already exists). Report canonical truth, not raw.
+        (claim.truth_value.value(), None, false)
+    };
 
     success_json(&SubmitClaimResponse {
         claim_id: claim_uuid.to_string(),

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -23,6 +23,7 @@ use epigraph_db::{
 use epigraph_ingest::builder::{build_ingest_plan, PlannedClaim};
 use epigraph_ingest::schema::DocumentExtraction;
 
+
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
         serde_json::to_string_pretty(value).map_err(internal_error)?,
@@ -150,7 +151,7 @@ async fn download_pdf(url: &str, output_dir: &str, name: &str) -> Result<String,
 }
 
 #[allow(clippy::too_many_lines)]
-async fn do_ingest(
+pub async fn do_ingest(
     server: &EpiGraphMcpFull,
     extraction: &LiteratureExtraction,
 ) -> Result<CallToolResult, McpError> {
@@ -161,13 +162,18 @@ async fn do_ingest(
     let doi = &extraction.source.doi;
     let title = &extraction.source.title;
 
-    // Ensure author agents exist
+    // BUG (s3a-followup): every author Agent is constructed with the same
+    // hardcoded public_key=[0u8; 32]. Migration 057's
+    // agents_public_key_unique constraint then rejects the second author of
+    // any paper with 2+ distinct names. Pre-existing bug; not introduced by
+    // S3a. Tier-2 test uses authors=vec![] to sidestep. Backlog item:
+    // "ingest_paper hardcoded author key bug — assign per-author keypairs
+    // or look up agents by name". Filed in EpiGraph with s3a-followup label.
     for author_val in &extraction.source.authors {
         let name = parse_author_entry(author_val);
         if name.is_empty() {
             continue;
         }
-        // Create or get agent for author
         let author_agent = epigraph_core::Agent::new([0u8; 32], Some(name.clone()));
         let _created = AgentRepository::create(&server.pool, &author_agent)
             .await
@@ -194,6 +200,15 @@ async fn do_ingest(
         claim.content_hash = ContentHasher::hash(lit_claim.statement.as_bytes());
         claim.signature = Some(server.signer.sign(&claim.content_hash));
 
+        // Idempotent canonical claim create + AUTHORED verb-edge.
+        let (claim, was_created) =
+            crate::claim_helper::create_claim_idempotent(&server.pool, &claim, "ingest_paper")
+                .await?;
+        let claim_uuid = claim.id.as_uuid();
+
+        // Build per-call Evidence + Trace regardless of was_created. Each
+        // ingest run carries its own (possibly different) supporting passage,
+        // so we preserve them as noun-claims linked via verb-edges.
         let evidence_hash = ContentHasher::hash(lit_claim.supporting_text.as_bytes());
         let mut evidence = Evidence::new(
             agent_id_typed,
@@ -221,50 +236,82 @@ async fn do_ingest(
             format!("Extracted from paper: {title} (DOI: {doi})"),
         );
 
-        ClaimRepository::create(&server.pool, &claim)
-            .await
-            .map_err(internal_error)?;
         ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
             .await
             .map_err(internal_error)?;
         EvidenceRepository::create(&server.pool, &evidence)
             .await
             .map_err(internal_error)?;
-        ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
-            .await
-            .map_err(internal_error)?;
 
-        // Embed
-        if server
-            .embedder
-            .embed_and_store(claim.id.as_uuid(), &lit_claim.statement)
-            .await
-        {
-            claims_embedded += 1;
+        // Verb-edges: every submission references its own Evidence + Trace.
+        // Emitted on both branches per the architecture doc's "re-occurrence
+        // = new edge" rule. Matches submit_claim's hoist (S3a Task 2). The
+        // was_created marker on properties lets queries distinguish
+        // first-create from resubmit edges.
+        let _ = EdgeRepository::create(
+            &server.pool,
+            claim_uuid,
+            "claim",
+            evidence.id.as_uuid(),
+            "evidence",
+            "DERIVED_FROM",
+            Some(serde_json::json!({"was_created": was_created})),
+            None,
+            None,
+        )
+        .await;
+        let _ = EdgeRepository::create(
+            &server.pool,
+            claim_uuid,
+            "claim",
+            trace.id.as_uuid(),
+            "trace",
+            "HAS_TRACE",
+            Some(serde_json::json!({"was_created": was_created})),
+            None,
+            None,
+        )
+        .await;
+
+        if was_created {
+            ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
+                .await
+                .map_err(internal_error)?;
+
+            if server
+                .embedder
+                .embed_and_store(claim_uuid, &lit_claim.statement)
+                .await
+            {
+                claims_embedded += 1;
+            }
+
+            ds_entries.push(BatchDsEntry {
+                claim_id: claim_uuid,
+                confidence,
+                weight,
+            });
         }
 
-        // Collect for DS batch wiring
-        ds_entries.push(BatchDsEntry {
-            claim_id: claim.id.as_uuid(),
-            confidence,
-            weight,
-        });
-
-        claim_ids.push(claim.id.as_uuid().to_string());
-        claim_uuids.push(claim.id.as_uuid());
+        // Always push to claim_ids / claim_uuids — relationship edges below
+        // reference these by index. Multi-emit on resubmit is intentional
+        // per architecture rule 1 ("re-occurrence = new edge").
+        claim_ids.push(claim_uuid.to_string());
+        claim_uuids.push(claim_uuid);
     }
 
-    // DS batch auto-wire (best-effort)
-    let (claims_ds_wired, ds_frame_id) =
+    let (claims_ds_wired, ds_frame_id) = if ds_entries.is_empty() {
+        (None, None)
+    } else {
         match ds_auto::auto_wire_ds_batch(&server.pool, &ds_entries, agent_id).await {
             Ok((fid, count)) => (Some(count), Some(fid.to_string())),
             Err(e) => {
                 tracing::warn!("ds auto-wire batch failed: {e}");
                 (None, None)
             }
-        };
+        }
+    };
 
-    // Create relationship edges
     let mut relationships_created = 0;
     for rel in &extraction.relationships {
         if rel.source_index < claim_uuids.len() && rel.target_index < claim_uuids.len() {
@@ -303,7 +350,6 @@ async fn do_ingest(
         ds_frame_id,
     })
 }
-
 // ────────────────────────────────────────────────────────────────────────────
 // ingest_document — hierarchical DocumentExtraction → graph
 // ────────────────────────────────────────────────────────────────────────────

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -23,7 +23,6 @@ use epigraph_db::{
 use epigraph_ingest::builder::{build_ingest_plan, PlannedClaim};
 use epigraph_ingest::schema::DocumentExtraction;
 
-
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
         serde_json::to_string_pretty(value).map_err(internal_error)?,

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -8,7 +8,8 @@ use crate::tools::ds_auto;
 use crate::types::*;
 
 use epigraph_core::{
-    AgentId, Claim, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput, TruthValue,
+    AgentId, Claim, ClaimId, Evidence, EvidenceType, Methodology, ReasoningTrace, TraceInput,
+    TruthValue,
 };
 use epigraph_crypto::ContentHasher;
 use epigraph_db::{ClaimRepository, EvidenceRepository, ReasoningTraceRepository};
@@ -29,85 +30,91 @@ pub async fn memorize(
     let confidence = params.confidence.unwrap_or(0.7).clamp(0.0, 1.0);
     let tags = params.tags.unwrap_or_default();
 
-    // Testimonial weight = 0.6x
     let raw_truth = (confidence * 0.6).clamp(0.01, 0.99);
     let truth_value = TruthValue::clamped(raw_truth);
 
     let mut claim = Claim::new(params.content.clone(), agent_id_typed, pub_key, truth_value);
-    let claim_uuid = claim.id.as_uuid();
     claim.content_hash = ContentHasher::hash(params.content.as_bytes());
     claim.signature = Some(server.signer.sign(&claim.content_hash));
 
-    // Tag-based evidence content
-    let evidence_text = if tags.is_empty() {
-        "Memory stored via MCP memorize tool".to_string()
+    // Idempotent canonical claim create + AUTHORED verb-edge.
+    let (claim, was_created) =
+        crate::claim_helper::create_claim_idempotent(&server.pool, &claim, "memorize").await?;
+    let claim_uuid = claim.id.as_uuid();
+
+    let (final_truth, ds, embedded) = if was_created {
+        let evidence_text = if tags.is_empty() {
+            "Memory stored via MCP memorize tool".to_string()
+        } else {
+            format!("Memory [{}] stored via MCP memorize tool", tags.join(", "))
+        };
+        let evidence_hash = ContentHasher::hash(evidence_text.as_bytes());
+        let mut evidence = Evidence::new(
+            agent_id_typed,
+            pub_key,
+            evidence_hash,
+            EvidenceType::Testimony {
+                source: "mcp-memorize".to_string(),
+                testified_at: chrono::Utc::now(),
+                verification: None,
+            },
+            Some(evidence_text),
+            claim.id,
+        );
+        evidence.signature = Some(server.signer.sign(&evidence_hash));
+
+        let trace = ReasoningTrace::new(
+            agent_id_typed,
+            pub_key,
+            Methodology::Heuristic,
+            vec![TraceInput::Evidence { id: evidence.id }],
+            confidence,
+            format!("Memory stored via memorize tool. Tags: {}", tags.join(", ")),
+        );
+
+        ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
+            .await
+            .map_err(internal_error)?;
+        EvidenceRepository::create(&server.pool, &evidence)
+            .await
+            .map_err(internal_error)?;
+        ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
+            .await
+            .map_err(internal_error)?;
+
+        let ds = match ds_auto::auto_wire_ds_for_claim(
+            &server.pool,
+            claim_uuid,
+            agent_id,
+            confidence,
+            0.6,
+            true,
+            None,
+        )
+        .await
+        {
+            Ok(r) => Some(r),
+            Err(e) => {
+                tracing::warn!(claim_id = %claim_uuid, "ds auto-wire memorize failed: {e}");
+                None
+            }
+        };
+
+        let embedded = server
+            .embedder
+            .embed_and_store(claim_uuid, &params.content)
+            .await;
+
+        (raw_truth, ds, embedded)
     } else {
-        format!("Memory [{}] stored via MCP memorize tool", tags.join(", "))
+        // Option A: skip Evidence + Trace + update_trace_id + DS + embed.
+        // AUTHORED already fired in the helper. Report canonical truth.
+        (claim.truth_value.value(), None, false)
     };
-    let evidence_hash = ContentHasher::hash(evidence_text.as_bytes());
-    let mut evidence = Evidence::new(
-        agent_id_typed,
-        pub_key,
-        evidence_hash,
-        EvidenceType::Testimony {
-            source: "mcp-memorize".to_string(),
-            testified_at: chrono::Utc::now(),
-            verification: None,
-        },
-        Some(evidence_text),
-        claim.id,
-    );
-    evidence.signature = Some(server.signer.sign(&evidence_hash));
-
-    let trace = ReasoningTrace::new(
-        agent_id_typed,
-        pub_key,
-        Methodology::Heuristic,
-        vec![TraceInput::Evidence { id: evidence.id }],
-        confidence,
-        format!("Memory stored via memorize tool. Tags: {}", tags.join(", ")),
-    );
-
-    ClaimRepository::create(&server.pool, &claim)
-        .await
-        .map_err(internal_error)?;
-    ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
-        .await
-        .map_err(internal_error)?;
-    EvidenceRepository::create(&server.pool, &evidence)
-        .await
-        .map_err(internal_error)?;
-    ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
-        .await
-        .map_err(internal_error)?;
-
-    // DS auto-wire (best-effort, testimonial weight = 0.6)
-    let ds = match ds_auto::auto_wire_ds_for_claim(
-        &server.pool,
-        claim_uuid,
-        agent_id,
-        confidence,
-        0.6,
-        true,
-        None, // evidence_type: Task 4 will populate
-    )
-    .await
-    {
-        Ok(r) => Some(r),
-        Err(e) => {
-            tracing::warn!(claim_id = %claim_uuid, "ds auto-wire memorize failed: {e}");
-            None
-        }
-    };
-
-    let embedded = server
-        .embedder
-        .embed_and_store(claim_uuid, &params.content)
-        .await;
 
     success_json(&MemorizeResponse {
         claim_id: claim_uuid.to_string(),
-        truth_value: raw_truth,
+        truth_value: final_truth,
         embedded,
         tags,
         belief: ds.as_ref().map(|d| d.belief),
@@ -120,29 +127,44 @@ pub async fn recall(
     server: &EpiGraphMcpFull,
     params: RecallParams,
 ) -> Result<CallToolResult, McpError> {
-    let limit = params.limit.unwrap_or(10).clamp(1, 50) as usize;
+    let limit = params.limit.unwrap_or(10).clamp(1, 50);
     let min_truth = params.min_truth.unwrap_or(0.3);
 
-    let lib_results = epigraph_engine::recall(
-        &server.pool,
-        server.embedder.as_ref(),
-        &params.query,
-        limit,
-        min_truth,
-    )
-    .await
-    .map_err(internal_error)?;
-
-    // Shape into the MCP response type (RecallResult is defined in crate::types).
-    let results: Vec<RecallResult> = lib_results
-        .into_iter()
-        .map(|r| RecallResult {
-            claim_id: r.claim_id,
-            content: r.content,
-            truth_value: r.truth_value,
-            similarity: r.similarity,
-        })
-        .collect();
+    // Try semantic search first
+    let results = if let Ok(hits) = server.embedder.search(&params.query, limit).await {
+        let mut results = Vec::new();
+        for (claim_id, similarity) in hits {
+            if let Ok(Some(claim)) =
+                ClaimRepository::get_by_id(&server.pool, ClaimId::from_uuid(claim_id)).await
+            {
+                let tv = claim.truth_value.value();
+                if tv >= min_truth {
+                    results.push(RecallResult {
+                        claim_id: claim_id.to_string(),
+                        content: claim.content,
+                        truth_value: tv,
+                        similarity,
+                    });
+                }
+            }
+        }
+        results
+    } else {
+        // Fallback to text search
+        let claims = ClaimRepository::list(&server.pool, limit, 0, Some(&params.query))
+            .await
+            .map_err(internal_error)?;
+        claims
+            .into_iter()
+            .filter(|c| c.truth_value.value() >= min_truth)
+            .map(|c| RecallResult {
+                claim_id: c.id.as_uuid().to_string(),
+                content: c.content,
+                truth_value: c.truth_value.value(),
+                similarity: 0.0,
+            })
+            .collect()
+    };
 
     success_json(&results)
 }

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -90,7 +90,6 @@ pub async fn store_workflow(
     let tags = params.tags.unwrap_or_default();
     let prereqs = params.prerequisites.unwrap_or_default();
 
-    // Workflow content is stored as JSON
     let content = serde_json::json!({
         "goal": params.goal,
         "steps": params.steps,
@@ -106,7 +105,7 @@ pub async fn store_workflow(
     });
     let content_str = serde_json::to_string(&content).map_err(internal_error)?;
 
-    let raw_truth = (confidence * 0.5).clamp(0.01, 0.99); // Workflows start unproven
+    let raw_truth = (confidence * 0.5).clamp(0.01, 0.99);
     let mut claim = Claim::new(
         content_str.clone(),
         agent_id_typed,
@@ -116,74 +115,81 @@ pub async fn store_workflow(
     claim.content_hash = ContentHasher::hash(content_str.as_bytes());
     claim.signature = Some(server.signer.sign(&claim.content_hash));
 
-    let evidence_text = format!("Workflow hypothesis: {}", params.goal);
-    let evidence_hash = ContentHasher::hash(evidence_text.as_bytes());
-    let mut evidence = Evidence::new(
-        agent_id_typed,
-        pub_key,
-        evidence_hash,
-        EvidenceType::Testimony {
-            source: "mcp-workflow".to_string(),
-            testified_at: chrono::Utc::now(),
-            verification: None,
-        },
-        Some(evidence_text),
-        claim.id,
-    );
-    evidence.signature = Some(server.signer.sign(&evidence_hash));
+    let (claim, was_created) =
+        crate::claim_helper::create_claim_idempotent(&server.pool, &claim, "store_workflow")
+            .await?;
+    let claim_uuid = claim.id.as_uuid();
 
-    let trace = ReasoningTrace::new(
-        agent_id_typed,
-        pub_key,
-        Methodology::Heuristic,
-        vec![TraceInput::Evidence { id: evidence.id }],
-        confidence,
-        format!("Workflow stored: {}", params.goal),
-    );
+    let (final_truth, ds, embedded) = if was_created {
+        let evidence_text = format!("Workflow hypothesis: {}", params.goal);
+        let evidence_hash = ContentHasher::hash(evidence_text.as_bytes());
+        let mut evidence = Evidence::new(
+            agent_id_typed,
+            pub_key,
+            evidence_hash,
+            EvidenceType::Testimony {
+                source: "mcp-workflow".to_string(),
+                testified_at: chrono::Utc::now(),
+                verification: None,
+            },
+            Some(evidence_text),
+            claim.id,
+        );
+        evidence.signature = Some(server.signer.sign(&evidence_hash));
 
-    ClaimRepository::create(&server.pool, &claim)
-        .await
-        .map_err(internal_error)?;
-    ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
-        .await
-        .map_err(internal_error)?;
-    EvidenceRepository::create(&server.pool, &evidence)
-        .await
-        .map_err(internal_error)?;
-    ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
-        .await
-        .map_err(internal_error)?;
+        let trace = ReasoningTrace::new(
+            agent_id_typed,
+            pub_key,
+            Methodology::Heuristic,
+            vec![TraceInput::Evidence { id: evidence.id }],
+            confidence,
+            format!("Workflow stored: {}", params.goal),
+        );
 
-    // DS auto-wire (best-effort, workflow weight = 0.5)
-    let ds = match ds_auto::auto_wire_ds_for_claim(
-        &server.pool,
-        claim.id.as_uuid(),
-        agent_id,
-        confidence,
-        0.5,
-        true,
-        None, // evidence_type: Task 4 will populate
-    )
-    .await
-    {
-        Ok(r) => Some(r),
-        Err(e) => {
-            tracing::warn!(workflow_id = %claim.id.as_uuid(), "ds auto-wire workflow failed: {e}");
-            None
-        }
+        ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
+            .await
+            .map_err(internal_error)?;
+        EvidenceRepository::create(&server.pool, &evidence)
+            .await
+            .map_err(internal_error)?;
+        ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
+            .await
+            .map_err(internal_error)?;
+
+        let ds = match ds_auto::auto_wire_ds_for_claim(
+            &server.pool,
+            claim_uuid,
+            agent_id,
+            confidence,
+            0.5,
+            true,
+            None,
+        )
+        .await
+        {
+            Ok(r) => Some(r),
+            Err(e) => {
+                tracing::warn!(workflow_id = %claim_uuid, "ds auto-wire workflow failed: {e}");
+                None
+            }
+        };
+
+        let embed_text = workflow_embed_text(&params.goal, &params.steps, &prereqs);
+        let embedded = server
+            .embedder
+            .embed_and_store(claim_uuid, &embed_text)
+            .await;
+
+        (raw_truth, ds, embedded)
+    } else {
+        (claim.truth_value.value(), None, false)
     };
 
-    let embed_text = workflow_embed_text(&params.goal, &params.steps, &prereqs);
-    let embedded = server
-        .embedder
-        .embed_and_store(claim.id.as_uuid(), &embed_text)
-        .await;
-
     success_json(&StoreWorkflowResponse {
-        workflow_id: claim.id.as_uuid().to_string(),
+        workflow_id: claim_uuid.to_string(),
         goal: params.goal,
         step_count: params.steps.len(),
-        truth_value: raw_truth,
+        truth_value: final_truth,
         embedded,
         belief: ds.as_ref().map(|d| d.belief),
         plausibility: ds.as_ref().map(|d| d.plausibility),
@@ -546,88 +552,96 @@ pub async fn improve_workflow(
         content_str.clone(),
         agent_id_typed,
         pub_key,
-        TruthValue::clamped(0.5), // Unproven variant
+        TruthValue::clamped(0.5),
     );
     claim.content_hash = ContentHasher::hash(content_str.as_bytes());
     claim.signature = Some(server.signer.sign(&claim.content_hash));
 
-    let evidence_text = format!(
-        "Improved variant of workflow {}. Rationale: {}",
-        parent_id, params.change_rationale
-    );
-    let evidence_hash = ContentHasher::hash(evidence_text.as_bytes());
-    let mut evidence = Evidence::new(
-        agent_id_typed,
-        pub_key,
-        evidence_hash,
-        EvidenceType::Testimony {
-            source: "mcp-workflow-improve".to_string(),
-            testified_at: chrono::Utc::now(),
-            verification: None,
-        },
-        Some(evidence_text),
-        claim.id,
-    );
-    evidence.signature = Some(server.signer.sign(&evidence_hash));
+    let (claim, was_created) =
+        crate::claim_helper::create_claim_idempotent(&server.pool, &claim, "improve_workflow")
+            .await?;
+    let claim_uuid = claim.id.as_uuid();
 
-    let trace = ReasoningTrace::new(
-        agent_id_typed,
-        pub_key,
-        Methodology::Heuristic,
-        vec![
-            TraceInput::Evidence { id: evidence.id },
-            TraceInput::Claim {
-                id: epigraph_core::ClaimId::from_uuid(parent_id),
-            },
-        ],
-        0.5,
-        format!(
-            "Workflow variant of {}. {}",
+    let embedded = if was_created {
+        let evidence_text = format!(
+            "Improved variant of workflow {}. Rationale: {}",
             parent_id, params.change_rationale
-        ),
-    );
+        );
+        let evidence_hash = ContentHasher::hash(evidence_text.as_bytes());
+        let mut evidence = Evidence::new(
+            agent_id_typed,
+            pub_key,
+            evidence_hash,
+            EvidenceType::Testimony {
+                source: "mcp-workflow-improve".to_string(),
+                testified_at: chrono::Utc::now(),
+                verification: None,
+            },
+            Some(evidence_text),
+            claim.id,
+        );
+        evidence.signature = Some(server.signer.sign(&evidence_hash));
 
-    ClaimRepository::create(&server.pool, &claim)
-        .await
-        .map_err(internal_error)?;
-    ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
-        .await
-        .map_err(internal_error)?;
-    EvidenceRepository::create(&server.pool, &evidence)
-        .await
-        .map_err(internal_error)?;
-    ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
+        let trace = ReasoningTrace::new(
+            agent_id_typed,
+            pub_key,
+            Methodology::Heuristic,
+            vec![
+                TraceInput::Evidence { id: evidence.id },
+                TraceInput::Claim {
+                    id: epigraph_core::ClaimId::from_uuid(parent_id),
+                },
+            ],
+            0.5,
+            format!(
+                "Workflow variant of {}. {}",
+                parent_id, params.change_rationale
+            ),
+        );
+
+        ReasoningTraceRepository::create(&server.pool, &trace, claim.id)
+            .await
+            .map_err(internal_error)?;
+        EvidenceRepository::create(&server.pool, &evidence)
+            .await
+            .map_err(internal_error)?;
+        ClaimRepository::update_trace_id(&server.pool, claim.id, trace.id)
+            .await
+            .map_err(internal_error)?;
+
+        // First-create only: the parent → variant relationship.
+        EdgeRepository::create(
+            &server.pool,
+            claim_uuid,
+            "claim",
+            parent_id,
+            "claim",
+            "variant_of",
+            Some(serde_json::json!({"generation": generation})),
+            None,
+            None,
+        )
         .await
         .map_err(internal_error)?;
 
-    // Create variant_of edge
-    EdgeRepository::create(
-        &server.pool,
-        claim.id.as_uuid(),
-        "claim",
-        parent_id,
-        "claim",
-        "variant_of",
-        Some(serde_json::json!({"generation": generation})),
-        None,
-        None,
-    )
-    .await
-    .map_err(internal_error)?;
-
-    let embed_text = workflow_embed_text(&goal, &steps, &prereqs);
-    let embedded = server
-        .embedder
-        .embed_and_store(claim.id.as_uuid(), &embed_text)
-        .await;
+        let embed_text = workflow_embed_text(&goal, &steps, &prereqs);
+        server
+            .embedder
+            .embed_and_store(claim_uuid, &embed_text)
+            .await
+    } else {
+        // Option A + idempotent variant_of: skip everything including the
+        // variant_of edge (already created on first variant insert).
+        false
+    };
 
     success_json(&ImproveWorkflowResponse {
-        variant_id: claim.id.as_uuid().to_string(),
+        variant_id: claim_uuid.to_string(),
         parent_id: parent_id.to_string(),
         goal,
         step_count: steps.len(),
         generation,
-        truth_value: 0.5,
+        truth_value: claim.truth_value.value(),
         embedded,
     })
 }

--- a/crates/epigraph-mcp/tests/claim_helper_tests.rs
+++ b/crates/epigraph-mcp/tests/claim_helper_tests.rs
@@ -1,0 +1,312 @@
+//! Tier-1 unit tests for create_claim_idempotent.
+//! Patterns after crates/epigraph-db/tests/claim_repo_helpers.rs.
+
+#[macro_use]
+mod common;
+
+use common::*;
+use epigraph_crypto::ContentHasher;
+use epigraph_mcp::claim_helper::create_claim_idempotent;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+// ────────────────────────────────────────────────────────────────────────────
+// helper_creates_when_absent — first call inserts and emits AUTHORED
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn helper_creates_when_absent() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let agent_id = Uuid::new_v4();
+    insert_test_agent(&pool, agent_id).await;
+
+    let claim = make_claim(&format!("absent {}", Uuid::new_v4()), agent_id);
+
+    let (returned, was_created) = create_claim_idempotent(&pool, &claim, "test_tool")
+        .await
+        .expect("helper call");
+    assert!(was_created, "first call should be was_created=true");
+
+    let claim_uuid: Uuid = returned.id.into();
+    let claim_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM claims WHERE id = $1")
+        .bind(claim_uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(claim_count.0, 1, "exactly one claim row");
+
+    let edge_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'AUTHORED'
+           AND properties->>'tool' = 'test_tool'
+           AND properties->>'was_created' = 'true'",
+    )
+    .bind(agent_id)
+    .bind(claim_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(edge_count.0, 1, "one AUTHORED edge with was_created=true");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// helper_returns_existing_when_present — second call returns canonical
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn helper_returns_existing_when_present() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let agent_id = Uuid::new_v4();
+    insert_test_agent(&pool, agent_id).await;
+
+    let content = format!("existing {}", Uuid::new_v4());
+    let claim_a = make_claim(&content, agent_id);
+    let claim_b = make_claim(&content, agent_id);
+
+    let (first, first_created) = create_claim_idempotent(&pool, &claim_a, "test_tool")
+        .await
+        .expect("first call");
+    let (second, second_created) = create_claim_idempotent(&pool, &claim_b, "test_tool")
+        .await
+        .expect("second call");
+
+    assert!(first_created);
+    assert!(!second_created, "second call should be was_created=false");
+
+    let first_uuid: Uuid = first.id.into();
+    let second_uuid: Uuid = second.id.into();
+    assert_eq!(
+        first_uuid, second_uuid,
+        "second call returns canonical UUID"
+    );
+
+    let claim_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(ContentHasher::hash(content.as_bytes()).as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(claim_count.0, 1, "still only one claim row");
+
+    let authored_total: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'AUTHORED'",
+    )
+    .bind(agent_id)
+    .bind(first_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(authored_total.0, 2, "two AUTHORED edges (one per call)");
+
+    let resubmit_authored: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'AUTHORED'
+           AND properties->>'was_created' = 'false'",
+    )
+    .bind(agent_id)
+    .bind(first_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        resubmit_authored.0, 1,
+        "second call's AUTHORED has was_created=false"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// helper_emits_authored_on_both_branches — sanity cross-check
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn helper_emits_authored_on_both_branches() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let agent_id = Uuid::new_v4();
+    insert_test_agent(&pool, agent_id).await;
+
+    let content = format!("both-branches {}", Uuid::new_v4());
+    let claim = make_claim(&content, agent_id);
+
+    let _ = create_claim_idempotent(&pool, &claim, "test_tool")
+        .await
+        .expect("first");
+    let _ = create_claim_idempotent(&pool, &claim, "test_tool")
+        .await
+        .expect("second");
+
+    let claim_uuid: (Uuid,) =
+        sqlx::query_as("SELECT id FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(ContentHasher::hash(content.as_bytes()).as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    let true_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE target_id = $1 AND relationship = 'AUTHORED'
+           AND properties->>'was_created' = 'true'",
+    )
+    .bind(claim_uuid.0)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let false_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE target_id = $1 AND relationship = 'AUTHORED'
+           AND properties->>'was_created' = 'false'",
+    )
+    .bind(claim_uuid.0)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(true_count.0, 1, "one was_created=true edge");
+    assert_eq!(false_count.0, 1, "one was_created=false edge");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// helper_post_107_idempotent — second call returns existing post-constraint
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Single-threaded tests cannot deterministically exercise the catch path in
+// create_or_get (the unique-violation recovery from a concurrent INSERT) —
+// the find-by-(content_hash, agent_id) lookup runs first and returns the
+// existing row before the INSERT is attempted. This test instead verifies
+// that post-107 idempotency holds: a second helper call for the same
+// (content_hash, agent_id) returns the canonical row regardless of whether
+// the find-then-return or INSERT-catch-refind branch fired internally.
+// Mirrors the equivalent test in crates/epigraph-db/tests/claim_repo_helpers.rs.
+
+#[tokio::test]
+async fn helper_post_107_idempotent() {
+    let pool = test_pool_or_skip!();
+    add_unique_constraint(&pool).await;
+
+    let agent_id = Uuid::new_v4();
+    insert_test_agent(&pool, agent_id).await;
+
+    let content = format!("post-107 {}", Uuid::new_v4());
+    let claim = make_claim(&content, agent_id);
+
+    let (first, first_created) = create_claim_idempotent(&pool, &claim, "test_tool")
+        .await
+        .expect("first call");
+    let (second, second_created) = create_claim_idempotent(&pool, &claim, "test_tool")
+        .await
+        .expect("second call");
+
+    assert!(first_created);
+    assert!(!second_created);
+    let first_uuid: Uuid = first.id.into();
+    let second_uuid: Uuid = second.id.into();
+    assert_eq!(first_uuid, second_uuid);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// helper_pre_107_no_constraint — find-then-return path under pre-107 fixture
+// ────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn helper_pre_107_no_constraint() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let agent_id = Uuid::new_v4();
+    insert_test_agent(&pool, agent_id).await;
+
+    let content = format!("pre-107 {}", Uuid::new_v4());
+    let claim = make_claim(&content, agent_id);
+
+    let (_first, first_created) = create_claim_idempotent(&pool, &claim, "test_tool")
+        .await
+        .expect("first call");
+    let (_second, second_created) = create_claim_idempotent(&pool, &claim, "test_tool")
+        .await
+        .expect("second call");
+
+    assert!(first_created);
+    assert!(
+        !second_created,
+        "find-then-return path returns existing row"
+    );
+
+    let claim_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(ContentHasher::hash(content.as_bytes()).as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(claim_count.0, 1, "exactly one row, no pre-107 dup created");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// helper_authored_failure_does_not_propagate — log warn, return Ok
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Forces an AUTHORED INSERT failure by adding a temporary CHECK constraint
+// that rejects AUTHORED edges, runs the helper, asserts Ok with a warn-level
+// log, then drops the constraint. Earlier versions tried renaming `edges`
+// away — that doesn't work because sqlx prepared statements bind to table
+// OIDs (RENAME preserves OID, so the INSERT still hits the renamed table).
+// `--test-threads=1` makes this safe (no other test sees the constraint).
+
+#[traced_test]
+#[tokio::test]
+async fn helper_authored_failure_does_not_propagate() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let agent_id = Uuid::new_v4();
+    insert_test_agent(&pool, agent_id).await;
+
+    let claim = make_claim(&format!("authored-fail {}", Uuid::new_v4()), agent_id);
+
+    // NOT VALID skips the existing-row scan — earlier tests in this file
+    // legitimately created AUTHORED edges that would otherwise fail validation.
+    // The constraint still rejects new INSERTs.
+    sqlx::query(
+        "ALTER TABLE edges ADD CONSTRAINT no_authored_edges_for_test \
+         CHECK (relationship != 'AUTHORED') NOT VALID",
+    )
+    .execute(&pool)
+    .await
+    .expect("add no-AUTHORED constraint");
+
+    let result = create_claim_idempotent(&pool, &claim, "test_tool").await;
+
+    sqlx::query("ALTER TABLE edges DROP CONSTRAINT no_authored_edges_for_test")
+        .execute(&pool)
+        .await
+        .expect("drop no-AUTHORED constraint");
+
+    let (returned, was_created) = result.expect("helper must not propagate AUTHORED failure");
+    assert!(
+        was_created,
+        "claim insert succeeded even though edge insert failed"
+    );
+    let claim_uuid: Uuid = returned.id.into();
+
+    // Claim row exists despite AUTHORED edge missing
+    let claim_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM claims WHERE id = $1")
+        .bind(claim_uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(claim_count.0, 1, "orphan claim row persisted");
+
+    // Confirm the warn fired
+    assert!(
+        logs_contain("AUTHORED verb-edge emit failed"),
+        "tracing::warn! must fire on AUTHORED failure"
+    );
+}

--- a/crates/epigraph-mcp/tests/common/mod.rs
+++ b/crates/epigraph-mcp/tests/common/mod.rs
@@ -1,0 +1,90 @@
+//! Shared test helpers for epigraph-mcp integration tests. Mirrors
+//! crates/epigraph-db/tests/claim_repo_helpers.rs — same try_test_pool,
+//! pre-107/post-107 fixture toggling, agent insert, claim builder.
+
+#![allow(dead_code)]
+
+use epigraph_core::{AgentId, Claim, TruthValue};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub async fn try_test_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&url)
+        .await
+        .ok()?;
+    sqlx::migrate!("../../migrations").run(&pool).await.ok()?;
+    Some(pool)
+}
+
+#[macro_export]
+macro_rules! test_pool_or_skip {
+    () => {{
+        match $crate::common::try_test_pool().await {
+            Some(p) => p,
+            None => {
+                eprintln!("Skipping DB test: DATABASE_URL not set or unreachable");
+                return;
+            }
+        }
+    }};
+}
+
+/// Drop the (content_hash, agent_id) UNIQUE constraint to exercise the
+/// pre-107 fixture path.
+pub async fn drop_unique_constraint(pool: &PgPool) {
+    sqlx::query("ALTER TABLE claims DROP CONSTRAINT IF EXISTS uq_claims_content_hash_agent")
+        .execute(pool)
+        .await
+        .expect("drop constraint");
+}
+
+/// Add the (content_hash, agent_id) UNIQUE constraint, deduping any
+/// existing duplicate rows first. Postgres has no `ADD CONSTRAINT IF NOT
+/// EXISTS`, so the DO block swallows duplicate_object.
+pub async fn add_unique_constraint(pool: &PgPool) {
+    sqlx::query(
+        "DELETE FROM claims a USING claims b
+         WHERE a.ctid > b.ctid
+           AND a.content_hash = b.content_hash
+           AND a.agent_id = b.agent_id",
+    )
+    .execute(pool)
+    .await
+    .expect("dedup before constraint");
+
+    sqlx::query(
+        r#"DO $$ BEGIN
+              ALTER TABLE claims ADD CONSTRAINT uq_claims_content_hash_agent
+                  UNIQUE (content_hash, agent_id);
+           EXCEPTION WHEN duplicate_object THEN NULL;
+           END $$"#,
+    )
+    .execute(pool)
+    .await
+    .expect("add constraint");
+}
+
+pub async fn insert_test_agent(pool: &PgPool, agent_id: Uuid) {
+    sqlx::query(
+        r#"INSERT INTO agents (id, public_key, created_at, updated_at)
+           VALUES ($1, sha256($1::text::bytea), NOW(), NOW())
+           ON CONFLICT (id) DO NOTHING"#,
+    )
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("upsert agent");
+}
+
+pub fn make_claim(content: &str, agent_id: Uuid) -> Claim {
+    Claim::new(
+        content.to_string(),
+        AgentId::from_uuid(agent_id),
+        [0u8; 32],
+        TruthValue::new(0.5).unwrap(),
+    )
+}

--- a/crates/epigraph-mcp/tests/tool_resubmit_tests.rs
+++ b/crates/epigraph-mcp/tests/tool_resubmit_tests.rs
@@ -1,0 +1,694 @@
+//! Tier-2 integration tests for the trickiest two MCP tools post-S3a.
+
+#[macro_use]
+mod common;
+
+use common::*;
+use epigraph_crypto::{AgentSigner, ContentHasher};
+use epigraph_mcp::types::SubmitClaimParams;
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn build_test_server(pool: PgPool, signer_seed: [u8; 32]) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&signer_seed).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None); // mock — no API key
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+async fn server_agent_uuid(pool: &PgPool, signer_seed: [u8; 32]) -> Uuid {
+    let signer = AgentSigner::from_bytes(&signer_seed).expect("signer");
+    let pub_key = signer.public_key();
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM agents WHERE public_key = $1")
+        .bind(pub_key.as_slice())
+        .fetch_one(pool)
+        .await
+        .expect("server agent must exist (set by submit_claim's agent_id())")
+}
+
+#[tokio::test]
+async fn submit_claim_resubmit_creates_evidence_trace_via_edges() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0x42u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    let content = format!("submit-claim test {}", Uuid::new_v4());
+    let params1 = SubmitClaimParams {
+        content: content.clone(),
+        evidence_data: "evidence-1".to_string(),
+        evidence_type: "empirical".to_string(),
+        methodology: "bayesian".to_string(),
+        confidence: 0.8,
+        source_url: None,
+        reasoning: None,
+    };
+    let params2 = SubmitClaimParams {
+        content: content.clone(),
+        evidence_data: "evidence-2-different-text".to_string(),
+        evidence_type: "empirical".to_string(),
+        methodology: "bayesian".to_string(),
+        confidence: 0.9,
+        source_url: None,
+        reasoning: None,
+    };
+
+    tools::claims::submit_claim(&server, params1)
+        .await
+        .expect("first submit_claim");
+    tools::claims::submit_claim(&server, params2)
+        .await
+        .expect("second submit_claim");
+
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let content_hash = ContentHasher::hash(content.as_bytes());
+
+    // Exactly one canonical claims row for this (content_hash, agent_id)
+    let claim_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(content_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(claim_count.0, 1, "exactly one canonical claims row");
+
+    let canonical: (Uuid, Option<Uuid>, f64) = sqlx::query_as(
+        "SELECT id, trace_id, truth_value FROM claims
+         WHERE content_hash = $1 AND agent_id = $2",
+    )
+    .bind(content_hash.as_slice())
+    .bind(agent_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let (claim_id, canonical_trace_id, canonical_truth) = canonical;
+
+    // Two evidence rows (one per call)
+    let evidence_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM evidence WHERE claim_id = $1")
+            .bind(claim_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(evidence_count.0, 2, "two evidence rows");
+
+    // Two reasoning_traces rows (one per call)
+    let trace_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM reasoning_traces WHERE claim_id = $1")
+            .bind(claim_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(trace_count.0, 2, "two reasoning_traces rows");
+
+    // Canonical claim's trace_id is the FIRST trace (immutable post-creation)
+    let first_trace_id: (Uuid,) = sqlx::query_as(
+        "SELECT id FROM reasoning_traces WHERE claim_id = $1 ORDER BY created_at ASC LIMIT 1",
+    )
+    .bind(claim_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        canonical_trace_id,
+        Some(first_trace_id.0),
+        "canonical trace_id unchanged"
+    );
+
+    // Two HAS_TRACE + two DERIVED_FROM edges (hoisted on every submission).
+    // was_created marker partitions them 1+1: first-create + resubmit.
+    let has_trace_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'HAS_TRACE'",
+    )
+    .bind(claim_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(has_trace_count.0, 2, "two HAS_TRACE edges");
+
+    let has_trace_first: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'HAS_TRACE'
+         AND properties->>'was_created' = 'true'",
+    )
+    .bind(claim_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(has_trace_first.0, 1, "one HAS_TRACE with was_created=true");
+
+    let derived_from_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'DERIVED_FROM'",
+    )
+    .bind(claim_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(derived_from_count.0, 2, "two DERIVED_FROM edges");
+
+    // Two AUTHORED edges (helper emits one per submission)
+    let authored_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'AUTHORED'",
+    )
+    .bind(agent_id)
+    .bind(claim_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(authored_count.0, 2, "two AUTHORED edges (per spec helper)");
+
+    // Sanity: response.truth_value reading is asserted indirectly — if the
+    // migration writes the wrong truth_value back to claims, canonical_truth
+    // would diverge between calls. Just check it's finite and in range.
+    assert!(canonical_truth.is_finite() && (0.0..=1.0).contains(&canonical_truth));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Shared Option-A skip assertion — used by memorize / store_workflow /
+// improve_workflow tests in this file. After two identical submissions of the
+// same content, expect: one canonical claim row, one Evidence row, one
+// reasoning_traces row, zero DERIVED_FROM/HAS_TRACE edges, two AUTHORED edges.
+// ────────────────────────────────────────────────────────────────────────────
+
+async fn assert_option_a_skip(pool: &PgPool, agent_id: Uuid, content_hash: &[u8]) {
+    let claim_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(content_hash)
+            .bind(agent_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        claim_count.0, 1,
+        "Option A: exactly one canonical claim row"
+    );
+
+    let claim_id: (Uuid,) =
+        sqlx::query_as("SELECT id FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(content_hash)
+            .bind(agent_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    let claim_id = claim_id.0;
+
+    let evidence_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM evidence WHERE claim_id = $1")
+            .bind(claim_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        evidence_count.0, 1,
+        "Option A: only the first-create's Evidence row"
+    );
+
+    let trace_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM reasoning_traces WHERE claim_id = $1")
+            .bind(claim_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        trace_count.0, 1,
+        "Option A: only the first-create's reasoning_traces row"
+    );
+
+    let derived_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'DERIVED_FROM'",
+    )
+    .bind(claim_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        derived_count.0, 0,
+        "Option A: no DERIVED_FROM edge on resubmit"
+    );
+
+    let has_trace_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'HAS_TRACE'",
+    )
+    .bind(claim_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        has_trace_count.0, 0,
+        "Option A: no HAS_TRACE edge on resubmit"
+    );
+
+    let authored_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'AUTHORED'",
+    )
+    .bind(agent_id)
+    .bind(claim_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        authored_count.0, 2,
+        "Option A: two AUTHORED edges (one per submission)"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// memorize_resubmit_option_a_skip
+// ────────────────────────────────────────────────────────────────────────────
+
+use epigraph_mcp::types::MemorizeParams;
+
+#[tokio::test]
+async fn memorize_resubmit_option_a_skip() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0x33u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    let content = format!("memorize test {}", Uuid::new_v4());
+    let make_params = || MemorizeParams {
+        content: content.clone(),
+        confidence: Some(0.7),
+        tags: Some(vec!["s3a-test".to_string()]),
+    };
+
+    tools::memory::memorize(&server, make_params())
+        .await
+        .expect("first memorize");
+    tools::memory::memorize(&server, make_params())
+        .await
+        .expect("second memorize");
+
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let content_hash = ContentHasher::hash(content.as_bytes());
+
+    assert_option_a_skip(&pool, agent_id, content_hash.as_slice()).await;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// store_workflow_resubmit_option_a_skip
+// ────────────────────────────────────────────────────────────────────────────
+
+use epigraph_mcp::types::StoreWorkflowParams;
+
+#[tokio::test]
+async fn store_workflow_resubmit_option_a_skip() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0x44u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    let goal = format!("test workflow goal {}", Uuid::new_v4());
+    let make_params = || StoreWorkflowParams {
+        goal: goal.clone(),
+        steps: vec!["step1".to_string(), "step2".to_string()],
+        prerequisites: Some(vec!["prereq1".to_string()]),
+        expected_outcome: Some("outcome".to_string()),
+        confidence: Some(0.5),
+        tags: Some(vec!["s3a-test".to_string()]),
+    };
+
+    tools::workflows::store_workflow(&server, make_params())
+        .await
+        .expect("first store_workflow");
+    tools::workflows::store_workflow(&server, make_params())
+        .await
+        .expect("second store_workflow");
+
+    // Recompute the same canonical content_hash as the migrated tool.
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let canonical_content = serde_json::json!({
+        "goal": goal,
+        "steps": vec!["step1", "step2"],
+        "prerequisites": vec!["prereq1"],
+        "expected_outcome": "outcome",
+        "tags": vec!["s3a-test"],
+        "type": "workflow",
+        "generation": 0,
+        "use_count": 0,
+        "success_count": 0,
+        "failure_count": 0,
+        "avg_variance": 1.0,
+    });
+    let content_str = serde_json::to_string(&canonical_content).unwrap();
+    let content_hash = ContentHasher::hash(content_str.as_bytes());
+
+    assert_option_a_skip(&pool, agent_id, content_hash.as_slice()).await;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// improve_workflow_resubmit_option_a_skip
+// ────────────────────────────────────────────────────────────────────────────
+
+use epigraph_mcp::types::ImproveWorkflowParams;
+
+#[tokio::test]
+async fn improve_workflow_resubmit_option_a_skip() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0x55u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    // 1. Seed a parent workflow via store_workflow.
+    let parent_goal = format!("parent goal {}", Uuid::new_v4());
+    let parent_params = StoreWorkflowParams {
+        goal: parent_goal.clone(),
+        steps: vec!["s1".to_string()],
+        prerequisites: None,
+        expected_outcome: None,
+        confidence: Some(0.5),
+        tags: None,
+    };
+    tools::workflows::store_workflow(&server, parent_params)
+        .await
+        .expect("seed parent workflow");
+
+    // Look up the parent's claim_id by content_hash.
+    let parent_canonical = serde_json::json!({
+        "goal": parent_goal,
+        "steps": vec!["s1"],
+        "prerequisites": Vec::<String>::new(),
+        "expected_outcome": Option::<String>::None,
+        "tags": Vec::<String>::new(),
+        "type": "workflow",
+        "generation": 0,
+        "use_count": 0,
+        "success_count": 0,
+        "failure_count": 0,
+        "avg_variance": 1.0,
+    });
+    let parent_content_str = serde_json::to_string(&parent_canonical).unwrap();
+    let parent_hash = ContentHasher::hash(parent_content_str.as_bytes());
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let parent_id: (Uuid,) =
+        sqlx::query_as("SELECT id FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(parent_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let parent_id = parent_id.0;
+
+    // 2. Submit the same improve_workflow request twice.
+    let make_params = || ImproveWorkflowParams {
+        parent_workflow_id: parent_id.to_string(),
+        change_rationale: "test rationale".to_string(),
+        goal: Some("improved goal".to_string()),
+        steps: Some(vec!["s1-improved".to_string()]),
+        prerequisites: Some(vec!["new-prereq".to_string()]),
+        expected_outcome: Some("improved outcome".to_string()),
+        tags: Some(vec!["s3a-test".to_string()]),
+    };
+
+    tools::workflows::improve_workflow(&server, make_params())
+        .await
+        .expect("first improve_workflow");
+    tools::workflows::improve_workflow(&server, make_params())
+        .await
+        .expect("second improve_workflow");
+
+    // 3. Recompute the variant's canonical content_hash.
+    let variant_canonical = serde_json::json!({
+        "goal": "improved goal",
+        "steps": vec!["s1-improved"],
+        "prerequisites": vec!["new-prereq"],
+        "expected_outcome": "improved outcome",
+        "tags": vec!["s3a-test"],
+        "type": "workflow",
+        "generation": 1,
+        "parent_id": parent_id.to_string(),
+        "change_rationale": "test rationale",
+        "use_count": 0,
+        "success_count": 0,
+        "failure_count": 0,
+        "avg_variance": 1.0,
+    });
+    let variant_content_str = serde_json::to_string(&variant_canonical).unwrap();
+    let variant_hash = ContentHasher::hash(variant_content_str.as_bytes());
+
+    assert_option_a_skip(&pool, agent_id, variant_hash.as_slice()).await;
+
+    // Extra invariant: exactly one variant_of edge (idempotent on resubmit).
+    let variant_id: (Uuid,) =
+        sqlx::query_as("SELECT id FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(variant_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    let variant_of_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'variant_of'",
+    )
+    .bind(variant_id.0)
+    .bind(parent_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        variant_of_count.0, 1,
+        "variant_of edge created exactly once (Option A + idempotent variant_of)"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ingest_paper_resubmit_creates_per_call_evidence_no_dup_claim
+// ────────────────────────────────────────────────────────────────────────────
+
+use epigraph_mcp::types::{
+    ClaimRelationship, LiteratureClaim, LiteratureExtraction, LiteratureSource,
+};
+
+fn make_extraction(stmt1: &str, stmt2: &str, version: &str) -> LiteratureExtraction {
+    LiteratureExtraction {
+        source: LiteratureSource {
+            doi: "10.1000/test-doi".to_string(),
+            title: "Test Paper".to_string(),
+            // Empty: ingest_paper has a pre-existing dup-key bug on author
+            // re-creation (Agent::new uses hardcoded [0u8; 32] public_key).
+            // Out of scope for S3a; this test focuses on claim semantics.
+            authors: vec![],
+            journal: None,
+        },
+        claims: vec![
+            LiteratureClaim {
+                statement: stmt1.to_string(),
+                // Per-call supporting_text: evidence_content_hash_claim_unique
+                // (migration 031) requires (content_hash, claim_id) be unique,
+                // so resubmit must carry distinct evidence content to exercise
+                // the per-call Evidence-row branch.
+                supporting_text: format!("supporting text for {stmt1} ({version})"),
+                confidence: 0.8,
+                methodology: Some("statistical".to_string()),
+                section: Some("results".to_string()),
+                page: Some(3),
+                evidence_type: None,
+            },
+            LiteratureClaim {
+                statement: stmt2.to_string(),
+                supporting_text: format!("supporting text for {stmt2} ({version})"),
+                confidence: 0.7,
+                methodology: Some("statistical".to_string()),
+                section: Some("discussion".to_string()),
+                page: Some(7),
+                evidence_type: None,
+            },
+        ],
+        relationships: vec![ClaimRelationship {
+            source_index: 0,
+            target_index: 1,
+            relationship: "supports".to_string(),
+            strength: Some(0.8),
+        }],
+    }
+}
+
+#[tokio::test]
+async fn ingest_paper_resubmit_creates_per_call_evidence_no_dup_claim() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0x99u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    let stmt1 = format!("ingest test claim 1 {}", Uuid::new_v4());
+    let stmt2 = format!("ingest test claim 2 {}", Uuid::new_v4());
+    let extraction1 = make_extraction(&stmt1, &stmt2, "v1");
+    let extraction2 = make_extraction(&stmt1, &stmt2, "v2");
+
+    tools::ingestion::do_ingest(&server, &extraction1)
+        .await
+        .expect("first ingest");
+    tools::ingestion::do_ingest(&server, &extraction2)
+        .await
+        .expect("second ingest");
+
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let stmt1_hash = ContentHasher::hash(stmt1.as_bytes());
+
+    // One canonical claims row per unique statement
+    let claim1_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(stmt1_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(claim1_count.0, 1, "stmt1 has exactly one claims row");
+
+    let stmt2_hash = ContentHasher::hash(stmt2.as_bytes());
+    let claim2_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(stmt2_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(claim2_count.0, 1, "stmt2 has exactly one claims row");
+
+    // Get canonical UUIDs to query downstream tables
+    let claim1_id: (Uuid,) =
+        sqlx::query_as("SELECT id FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(stmt1_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let claim1_id = claim1_id.0;
+
+    let claim2_id: (Uuid,) =
+        sqlx::query_as("SELECT id FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(stmt2_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let claim2_id = claim2_id.0;
+
+    // Two evidence rows per canonical claim (one per ingest run)
+    let evidence_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM evidence WHERE claim_id = $1")
+            .bind(claim1_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(evidence_count.0, 2, "two evidence rows for stmt1 canonical");
+
+    // Two reasoning_traces rows per canonical claim
+    let trace_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM reasoning_traces WHERE claim_id = $1")
+            .bind(claim1_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        trace_count.0, 2,
+        "two reasoning_traces rows for stmt1 canonical"
+    );
+
+    // Hoisted verb-edges: HAS_TRACE + DERIVED_FROM emit on every submission
+    // (matches submit_claim's hoist; S3a fix #1 unified the rule across
+    // MCP writers). One per call × two calls = 2 of each.
+    let has_trace_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'HAS_TRACE'",
+    )
+    .bind(claim1_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        has_trace_count.0, 2,
+        "two HAS_TRACE edges (hoisted on every submission)"
+    );
+
+    let derived_from_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'DERIVED_FROM'",
+    )
+    .bind(claim1_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        derived_from_count.0, 2,
+        "two DERIVED_FROM edges (hoisted on every submission)"
+    );
+
+    // was_created marker on hoisted edges: one true (first-create) + one
+    // false (resubmit) per type. Lets downstream queries distinguish the
+    // two even after migration 109 dropped triple-uniqueness.
+    let has_trace_first: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'HAS_TRACE'
+         AND properties->>'was_created' = 'true'",
+    )
+    .bind(claim1_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(has_trace_first.0, 1, "one HAS_TRACE with was_created=true");
+
+    let has_trace_resubmit: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship = 'HAS_TRACE'
+         AND properties->>'was_created' = 'false'",
+    )
+    .bind(claim1_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        has_trace_resubmit.0, 1,
+        "one HAS_TRACE with was_created=false"
+    );
+
+    // DS-skip: only ONE mass_function row per canonical claim, despite two
+    // ingest calls (resubmit skipped DS batch entry).
+    let mf_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM mass_functions WHERE claim_id = $1")
+            .bind(claim1_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        mf_count.0, 1,
+        "DS auto-wire fired only on first call; resubmit skipped"
+    );
+
+    // Relationship-edge multi-emit: two SUPPORTS edges (one per run).
+    // Migration 109 widened 108 by dropping triple-uniqueness for all
+    // relationships, so verb-edges accumulate per submission per the
+    // architecture doc's "re-occurrence = new edge" rule.
+    let supports_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'SUPPORTS'",
+    )
+    .bind(claim1_id)
+    .bind(claim2_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        supports_count.0, 2,
+        "relationship edge multi-emit on resubmit (architecture rule 1)"
+    );
+
+    // AUTHORED edges: two per canonical claim (one per ingest call)
+    let authored_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'AUTHORED'",
+    )
+    .bind(agent_id)
+    .bind(claim1_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        authored_count.0, 2,
+        "two AUTHORED edges per canonical claim"
+    );
+}

--- a/docs/superpowers/plans/2026-04-29-s3a-mcp-writer-migration-port.md
+++ b/docs/superpowers/plans/2026-04-29-s3a-mcp-writer-migration-port.md
@@ -1,0 +1,765 @@
+# S3a MCP Writer Migration Port — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the S3a `epigraph-mcp` writer migration from `epigraph-internal` into `epigraph`. Migrates the five MCP writer tools (`submit_claim`, `memorize`, `store_workflow`, `improve_workflow`, `ingest_paper`) to the noun-claim canonical pattern using `ClaimRepository::create_or_get` via a new `claim_helper::create_claim_idempotent` shim. Replaces `idx_edges_unique_triple` with the architecture doc's "verb-event" semantics so each submission emits a distinct AUTHORED (and other relationship) edge.
+
+**Architecture:** Atomic migration. The schema change (drop `idx_edges_unique_triple`, replace with partial-then-no constraint) and the writer-tool rewrite must land together; with the migration alone, every existing `let _ = EdgeRepository::create(...)` callsite silently shifts from "dedup-by-constraint" to "accumulate" without the corresponding `was_created` edge property metadata that downstream consumers need to interpret the accumulation. Internal landed this as PR #8 for that reason; we mirror.
+
+**Tech Stack:** Rust workspace · sqlx 0.7 · Postgres · `epigraph-mcp` (rmcp framework) · cargo. Tests use `DATABASE_URL`-gated integration harness and `tracing-test` for log capture (new dev-dep).
+
+**Base branch:** `feat/s1-noun-claim-port` (PR #16). Slice 2 depends on `ClaimRepository::create_or_get` which lands in #16. Rebase onto `main` after #16 merges.
+
+**Out of scope (defer to later plans):**
+- `EpiGraphMcpFull::all_tools_json` / `list_mcp_tools` discovery additions in `crates/epigraph-mcp/src/lib.rs` and `src/server.rs` (lines after 53-63 of server.rs and the `pub fn list_tools` in lib.rs). Internal landed them inside PR #8 for timing; functionally they're tool-discovery, not writer-migration. Land with `routes/mcp_tools.rs` and `BadGateway` in a follow-up.
+- API handler at `routes/claims.rs:565` AUTHORED emit alignment to the new accumulating semantics (spec backlog item #10 — internal explicitly leaves this for later).
+- The internal *S3a plan* document (`docs/superpowers/plans/2026-04-26-s3a-epigraph-mcp-writer-migration.md`, 2706 lines) — internal artefact, not ported. The *design spec* (244 lines) IS ported because `claim_helper.rs` rustdoc references it.
+
+**Source refs (paste-ready git show targets):**
+- `internal-main:migrations/108_authored_edges_allow_multiple.sql`
+- `internal-main:migrations/109_drop_edges_triple_unique_constraint.sql`
+- `internal-main:crates/epigraph-mcp/src/claim_helper.rs`
+- `internal-main:crates/epigraph-mcp/src/tools/claims.rs`
+- `internal-main:crates/epigraph-mcp/src/tools/memory.rs`
+- `internal-main:crates/epigraph-mcp/src/tools/workflows.rs`
+- `internal-main:crates/epigraph-mcp/src/tools/ingestion.rs`
+- `internal-main:crates/epigraph-mcp/Cargo.toml`
+- `internal-main:crates/epigraph-mcp/tests/common/mod.rs`
+- `internal-main:crates/epigraph-mcp/tests/claim_helper_tests.rs`
+- `internal-main:crates/epigraph-mcp/tests/tool_resubmit_tests.rs`
+- `internal-main:docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `migrations/017_authored_edges_allow_multiple.sql` — port of internal `108_*`. Replaces `idx_edges_unique_triple` with a partial unique index excluding AUTHORED.
+- `migrations/018_drop_edges_triple_unique_constraint.sql` — port of internal `109_*`. Drops the partial index entirely; all relationships accumulate.
+- `crates/epigraph-mcp/src/claim_helper.rs` (61 lines) — `create_claim_idempotent` shim over `ClaimRepository::create_or_get` + AUTHORED verb-edge emission.
+- `crates/epigraph-mcp/tests/common/mod.rs` (90 lines) — shared test fixtures (DB pool, test agent setup, etc.).
+- `crates/epigraph-mcp/tests/claim_helper_tests.rs` (312 lines) — integration tests for the new helper.
+- `crates/epigraph-mcp/tests/tool_resubmit_tests.rs` (694 lines) — end-to-end resubmit tests for all 5 migrated tools.
+- `docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md` (244 lines) — design spec referenced by `claim_helper.rs` rustdoc.
+
+**Modify:**
+- `crates/epigraph-mcp/Cargo.toml` — add `[dev-dependencies] tracing-test = { version = "0.2", features = ["no-env-filter"] }`.
+- `crates/epigraph-mcp/src/lib.rs` — add `pub mod claim_helper;` (do **not** port `pub fn list_tools` — out of scope per header).
+- `crates/epigraph-mcp/src/tools/claims.rs` — migrate `submit_claim` to noun-claim pattern.
+- `crates/epigraph-mcp/src/tools/memory.rs` — migrate `memorize` to noun-claim pattern.
+- `crates/epigraph-mcp/src/tools/workflows.rs` — migrate `store_workflow` and `improve_workflow`.
+- `crates/epigraph-mcp/src/tools/ingestion.rs` — migrate `ingest_paper` (per-claim loop) to noun-claim pattern.
+
+**Boundary rationale:** `claim_helper` is a single-responsibility module (idempotent create + AUTHORED emit). Each tool file owns its writer migration; the shared shim keeps tool files focused on tool semantics. Tests follow the cargo `tests/` convention with a shared `common/mod.rs` fixture.
+
+---
+
+## Pre-Task: Worktree setup
+
+- [ ] **Step 1: Create isolated worktree off slice 1's branch**
+
+```bash
+cd /home/jeremy/epigraph
+git fetch origin feat/s1-noun-claim-port
+git worktree add -b feat/s3a-mcp-writer-port ../epigraph-wt-s3a-mcp /home/jeremy/epigraph-wt-s1-noun-claim
+cd ../epigraph-wt-s3a-mcp
+git log --oneline -1
+```
+
+Expected: tip is `56df3f02` (S1 plan commit) or whatever HEAD of `feat/s1-noun-claim-port` is.
+
+- [ ] **Step 2: Sanity-check baseline build (slice 1 carries forward)**
+
+```bash
+cargo check -p epigraph-mcp -p epigraph-db -p epigraph-api
+```
+
+Expected: clean compile. The S1 helpers must be present — `grep -c "create_or_get" crates/epigraph-db/src/repos/claim.rs` should be `>= 2`.
+
+---
+
+## Task 1: Port S3a design spec
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md`
+
+- [ ] **Step 1: Copy spec verbatim**
+
+```bash
+mkdir -p docs/superpowers/specs
+git show internal-main:docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md > docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md
+wc -l docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md
+```
+
+Expected: 244 lines.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md
+git commit -m "docs(spec): port S3a MCP writer migration design
+
+Cherry-picked from epigraph-internal:docs/superpowers/specs/. The
+claim_helper module ported in subsequent commits references this spec
+in its rustdoc — porting first prevents dangling links."
+```
+
+---
+
+## Task 2: Port migrations 017 + 018
+
+**Files:**
+- Create: `migrations/017_authored_edges_allow_multiple.sql`
+- Create: `migrations/018_drop_edges_triple_unique_constraint.sql`
+
+- [ ] **Step 1: Copy migration 017 (was internal 108) and rewrite header comment to reference the public-repo predecessor**
+
+```bash
+git show internal-main:migrations/108_authored_edges_allow_multiple.sql > migrations/017_authored_edges_allow_multiple.sql
+```
+
+Then edit the file's header comment block: the body says "The original idx_edges_unique_triple (migration 030) prevented AUTHORED accumulation". In the public repo, `idx_edges_unique_triple` lives in `001_initial_schema.sql:2561`, not migration 030. Replace the comment text:
+
+```
+-- The original idx_edges_unique_triple (migration 030) prevented AUTHORED
+-- accumulation: a second AUTHORED edge for the same (agent, claim) tripped
+```
+
+with:
+
+```
+-- The original idx_edges_unique_triple (defined in 001_initial_schema.sql)
+-- prevented AUTHORED accumulation: a second AUTHORED edge for the same
+-- (agent, claim) tripped
+```
+
+The DDL body (`DROP INDEX IF EXISTS idx_edges_unique_triple; CREATE UNIQUE INDEX idx_edges_unique_triple_non_authored ...`) is unchanged.
+
+- [ ] **Step 2: Copy migration 018 (was internal 109) and rewrite "migration 108" / "migration 030" references**
+
+```bash
+git show internal-main:migrations/109_drop_edges_triple_unique_constraint.sql > migrations/018_drop_edges_triple_unique_constraint.sql
+```
+
+Edit the header comment: every literal "migration 108" → "migration 017", and "migration 030" → "001_initial_schema.sql". Use:
+
+```bash
+sed -i 's/migration 108/migration 017/g; s/migration 030/001_initial_schema.sql/g' migrations/018_drop_edges_triple_unique_constraint.sql
+```
+
+Verify:
+
+```bash
+grep -n "migration 017\|001_initial_schema" migrations/018_drop_edges_triple_unique_constraint.sql | head -5
+```
+
+Expected: at least one match for each.
+
+The DDL body (`DROP INDEX IF EXISTS idx_edges_unique_triple_non_authored;`) is unchanged.
+
+- [ ] **Step 3: Apply against the test DB**
+
+```bash
+export DATABASE_URL=postgres://epigraph:epigraph@127.0.0.1:5432/epigraph_s3a_port_test
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "DROP DATABASE IF EXISTS epigraph_s3a_port_test;"
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "CREATE DATABASE epigraph_s3a_port_test OWNER epigraph;"
+sqlx migrate run --source migrations
+```
+
+Expected: `Applied 017/migrate authored edges allow multiple` and `Applied 018/migrate drop edges triple unique constraint`.
+
+- [ ] **Step 4: Verify schema state**
+
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d epigraph_s3a_port_test -c "\d edges" | grep -i "unique_triple\|UNIQUE"
+```
+
+Expected: NO `idx_edges_unique_triple` and NO `idx_edges_unique_triple_non_authored`. Only `edges_pkey` should remain on edges.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/017_authored_edges_allow_multiple.sql migrations/018_drop_edges_triple_unique_constraint.sql
+git commit -m "feat(migrations): port 017/018 — verb-edge accumulation
+
+Ports internal migrations 108 + 109. 017 replaces the
+idx_edges_unique_triple constraint (defined in 001_initial_schema.sql)
+with a partial index excluding AUTHORED; 018 drops that partial index
+so every relationship accumulates per submission per the architecture
+doc's verb-event semantics.
+
+Application code is responsible for idempotency where a relationship
+is semantically a noun-edge. The four pre-existing let-_-EdgeRepo
+callsites (RELATES_TO in routes/edges.rs, span edges in routes/spans.rs,
+PERSPECTIVE_OF in mcp/perspectives.rs, attribution edges in
+routes/conventions.rs) shift from silent-dedup to silent-accumulate;
+their semantics are filed for follow-up audit per the internal
+migration 109 header comment.
+
+See docs/architecture/noun-claims-and-verb-edges.md and
+docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md."
+```
+
+---
+
+## Task 3: Add `tracing-test` dev-dependency
+
+**Files:**
+- Modify: `crates/epigraph-mcp/Cargo.toml`
+
+- [ ] **Step 1: Locate the dependencies section**
+
+```bash
+grep -n "^\[dependencies\]\|^\[dev-dependencies\]\|^\[features\]" crates/epigraph-mcp/Cargo.toml
+```
+
+Expected: `[dependencies]` exists; `[dev-dependencies]` may or may not. `[features]` follows.
+
+- [ ] **Step 2: Insert `[dev-dependencies]` block before `[features]`**
+
+If `[dev-dependencies]` does not yet exist in the file, insert this block immediately before the `[features]` line:
+
+```toml
+[dev-dependencies]
+# `no-env-filter` is REQUIRED for integration tests in tests/* to capture
+# events emitted from src/ (different crate target). Without it, the macro's
+# default env filter scopes capture to the test crate only.
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
+
+```
+
+If `[dev-dependencies]` already exists, append the `tracing-test = ...` line (with the comment block above it) inside it.
+
+- [ ] **Step 3: Build to fetch the new dep**
+
+```bash
+cargo build -p epigraph-mcp --tests 2>&1 | tail -10
+```
+
+Expected: `Compiling tracing-test v0.2.x` then clean finish. The first build may take a minute as `tracing-test` has its own dep tree (tracing-subscriber etc., already in workspace).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/Cargo.toml Cargo.lock
+git commit -m "chore(mcp): add tracing-test dev-dep for tool resubmit tests
+
+Required by tests/tool_resubmit_tests.rs to capture log events from
+src/ via the no-env-filter feature; integration test crate target is
+distinct from src crate target."
+```
+
+---
+
+## Task 4: Port `claim_helper` module
+
+**Files:**
+- Create: `crates/epigraph-mcp/src/claim_helper.rs`
+- Modify: `crates/epigraph-mcp/src/lib.rs`
+
+- [ ] **Step 1: Copy `claim_helper.rs` verbatim**
+
+```bash
+git show internal-main:crates/epigraph-mcp/src/claim_helper.rs > crates/epigraph-mcp/src/claim_helper.rs
+wc -l crates/epigraph-mcp/src/claim_helper.rs
+```
+
+Expected: 61 lines.
+
+- [ ] **Step 2: Register the module in `lib.rs`**
+
+Find the existing `pub mod` lines:
+
+```bash
+grep -n "^pub mod" crates/epigraph-mcp/src/lib.rs
+```
+
+Add `pub mod claim_helper;` to the list, alphabetically before `pub mod embed;`. Edit the existing block:
+
+```rust
+#![allow(clippy::doc_markdown)]
+
+pub mod embed;
+```
+
+becomes:
+
+```rust
+#![allow(clippy::doc_markdown)]
+
+pub mod claim_helper;
+pub mod embed;
+```
+
+**Do NOT** port the `pub fn list_tools` and `pub use server::EpiGraphMcpFull` discovery additions from `internal-main:lib.rs` — those are out of scope per the plan header.
+
+- [ ] **Step 3: Compile**
+
+```bash
+cargo check -p epigraph-mcp 2>&1 | tail -10
+```
+
+Expected: clean. Common failure: `epigraph-db` not in `[dependencies]` — verify `crates/epigraph-mcp/Cargo.toml` already lists `epigraph-db`. If not, add it (workspace-style) and re-check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/claim_helper.rs crates/epigraph-mcp/src/lib.rs
+git commit -m "feat(mcp): add claim_helper::create_claim_idempotent
+
+Idempotent canonical claim creation + AUTHORED verb-edge emission for
+MCP-layer writers. Composes ClaimRepository::create_or_get inside a
+connection scope, then fire-and-forget AUTHORED on the pool. Mirrors
+the API handler pattern at routes/claims.rs:444-576.
+
+See docs/architecture/noun-claims-and-verb-edges.md and
+docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md."
+```
+
+---
+
+## Task 5: Port test fixture `tests/common/mod.rs`
+
+**Files:**
+- Create: `crates/epigraph-mcp/tests/common/mod.rs`
+
+- [ ] **Step 1: Copy verbatim**
+
+```bash
+mkdir -p crates/epigraph-mcp/tests/common
+git show internal-main:crates/epigraph-mcp/tests/common/mod.rs > crates/epigraph-mcp/tests/common/mod.rs
+wc -l crates/epigraph-mcp/tests/common/mod.rs
+```
+
+Expected: 90 lines.
+
+- [ ] **Step 2: Compile (test target only)**
+
+```bash
+cargo test -p epigraph-mcp --no-run 2>&1 | tail -10
+```
+
+Expected: clean compile. The fixture is unused at this point; rustc may warn `dead_code`. Suppress only if the fixture file already has a `#[allow(dead_code)]` at the top (verbatim port — leave as is). If a hard error appears, the fixture's imports are out-of-sync — re-read both versions and reconcile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/epigraph-mcp/tests/common/mod.rs
+git commit -m "test(mcp): port shared test fixture for tool resubmit suite
+
+Provides DB pool setup, test agent insertion, and edge-count helpers
+shared between claim_helper_tests.rs and tool_resubmit_tests.rs."
+```
+
+---
+
+## Task 6: Port `claim_helper_tests.rs`
+
+**Files:**
+- Create: `crates/epigraph-mcp/tests/claim_helper_tests.rs`
+
+- [ ] **Step 1: Copy verbatim**
+
+```bash
+git show internal-main:crates/epigraph-mcp/tests/claim_helper_tests.rs > crates/epigraph-mcp/tests/claim_helper_tests.rs
+wc -l crates/epigraph-mcp/tests/claim_helper_tests.rs
+```
+
+Expected: 312 lines.
+
+- [ ] **Step 2: Compile**
+
+```bash
+cargo test -p epigraph-mcp --no-run 2>&1 | tail -10
+```
+
+Expected: clean compile.
+
+- [ ] **Step 3: Run against test DB**
+
+```bash
+export DATABASE_URL=postgres://epigraph:epigraph@127.0.0.1:5432/epigraph_s3a_port_test
+cargo test -p epigraph-mcp --test claim_helper_tests -- --test-threads=1
+```
+
+Expected: all tests pass. The fixture sets up a fresh test DB row state per test (truncates between tests if implemented that way — read `common/mod.rs` if you need to debug).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/tests/claim_helper_tests.rs
+git commit -m "test(mcp): port claim_helper integration tests
+
+Exercises create_claim_idempotent: was_created branching, AUTHORED
+edge emission per submission (post-018 accumulation), error
+propagation from ClaimRepository::create_or_get, AUTHORED-failure
+log-and-swallow behavior."
+```
+
+---
+
+## Task 7: Migrate `submit_claim` (tools/claims.rs)
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/tools/claims.rs`
+
+This and Tasks 8–10 each rewrite a single tool's writer body. The diffs are large but mechanical: replace the legacy `ClaimRepository::create(&server.pool, &claim).await?` + manual edge emission with `crate::claim_helper::create_claim_idempotent(&server.pool, &claim, "<tool_name>").await?`, then emit the per-submission verb-edges (DERIVED_FROM, HAS_TRACE, etc.) on every branch with `was_created` recorded in edge properties.
+
+- [ ] **Step 1: Apply the migration via cherry-pick equivalent**
+
+The simplest faithful port is to write the file's new state directly from `internal-main`:
+
+```bash
+git show internal-main:crates/epigraph-mcp/src/tools/claims.rs > crates/epigraph-mcp/src/tools/claims.rs
+```
+
+**Caveat:** if `tools/claims.rs` has diverged on epigraph main since slice 1 (it shouldn't, but `git diff main internal-main -- crates/epigraph-mcp/src/tools/claims.rs` should be the only difference vs your worktree's pre-port state), this clobbers any in-tree changes. Verify before clobbering:
+
+```bash
+git diff origin/main -- crates/epigraph-mcp/src/tools/claims.rs | head -20
+```
+
+Expected: empty (no public-repo changes since fork point on this file). If non-empty, STOP — three-way merge required.
+
+- [ ] **Step 2: Compile**
+
+```bash
+cargo check -p epigraph-mcp 2>&1 | tail -10
+```
+
+Expected: clean. Likely surface errors:
+- `EdgeRepository` import added — already in the new file.
+- `crate::claim_helper` path — registered in Task 4.
+- Workflow / dataset return types — should match because `submit_claim`'s public signature is unchanged.
+
+- [ ] **Step 3: Run any unit tests in the file**
+
+```bash
+cargo test -p epigraph-mcp --lib claims 2>&1 | tail -10
+```
+
+Expected: pass (or "no tests" — the migration is exercised end-to-end by `tool_resubmit_tests.rs` in Task 11).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/claims.rs
+git commit -m "feat(mcp): migrate submit_claim to noun-claim canonical pattern
+
+Replaces ClaimRepository::create with claim_helper::create_claim_idempotent.
+Emits per-submission DERIVED_FROM and HAS_TRACE verb-edges on both
+branches (post-018 accumulation), with was_created recorded in edge
+properties. Trace and Evidence remain noun-claims with their own
+UUIDs and signatures.
+
+API handler at routes/claims.rs still follows the pre-S3a
+skip-on-resubmit rule for these edges; alignment is spec backlog #10."
+```
+
+---
+
+## Task 8: Migrate `memorize` (tools/memory.rs)
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/tools/memory.rs`
+
+- [ ] **Step 1: Pre-clobber check**
+
+```bash
+git diff origin/main -- crates/epigraph-mcp/src/tools/memory.rs | head -20
+```
+
+Expected: empty. If non-empty: STOP, three-way merge.
+
+- [ ] **Step 2: Replace file with internal-main version**
+
+```bash
+git show internal-main:crates/epigraph-mcp/src/tools/memory.rs > crates/epigraph-mcp/src/tools/memory.rs
+```
+
+- [ ] **Step 3: Compile**
+
+```bash
+cargo check -p epigraph-mcp 2>&1 | tail -10
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/memory.rs
+git commit -m "feat(mcp): migrate memorize to noun-claim canonical pattern
+
+Routes memorize through claim_helper::create_claim_idempotent so
+re-memorize calls return the existing canonical claim with
+was_created=false instead of inserting a duplicate row (which
+post-013 would 409 anyway). AUTHORED edge accumulates per call."
+```
+
+---
+
+## Task 9: Migrate `store_workflow` and `improve_workflow` (tools/workflows.rs)
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/tools/workflows.rs`
+
+This is the largest tool diff (326 diff lines).
+
+- [ ] **Step 1: Pre-clobber check**
+
+```bash
+git diff origin/main -- crates/epigraph-mcp/src/tools/workflows.rs | head -20
+```
+
+Expected: empty.
+
+- [ ] **Step 2: Replace file**
+
+```bash
+git show internal-main:crates/epigraph-mcp/src/tools/workflows.rs > crates/epigraph-mcp/src/tools/workflows.rs
+```
+
+- [ ] **Step 3: Compile**
+
+```bash
+cargo check -p epigraph-mcp 2>&1 | tail -10
+```
+
+Expected: clean. `store_workflow` and `improve_workflow` both route through `create_claim_idempotent`. `improve_workflow` additionally has a `variant_of` edge that must be skipped on the `was_created=false` branch (the migrated code already does this — see internal commit `78fada9`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/workflows.rs
+git commit -m "feat(mcp): migrate store_workflow + improve_workflow to noun-claim canonical pattern
+
+Both tools route through claim_helper::create_claim_idempotent.
+improve_workflow skips its variant_of noun-edge emission on the
+was_created=false branch (resubmit returns the existing canonical
+workflow row; the variant_of edge already exists)."
+```
+
+---
+
+## Task 10: Migrate `ingest_paper` (tools/ingestion.rs) — **MERGED PORT (not clobber)**
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/tools/ingestion.rs`
+
+**Discovered during execution 2026-04-29:** the public-repo `tools/ingestion.rs` contains an entire `ingest_document` / `do_ingest_document` block (plus DOI/arxiv resolution helpers) added by PR #14 (extract-claims pipeline) that is absent from `internal-main`. A clobber drops these functions and breaks `server.rs` wiring. The faithful port is a merge: take internal's writer-migration body for `ingest_paper` / `ingest_paper_url` / `do_ingest`, then append the public-only `ingest_document` block.
+
+- [ ] **Step 1: Build merged file via shell helper**
+
+```bash
+WT=/home/jeremy/epigraph-wt-s3a-mcp
+TARGET=$WT/crates/epigraph-mcp/src/tools/ingestion.rs
+PUB_TMP=/tmp/ingestion_pub.rs
+INT_TMP=/tmp/ingestion_int.rs
+
+cd $WT
+git show origin/main:crates/epigraph-mcp/src/tools/ingestion.rs > $PUB_TMP
+git show internal-main:crates/epigraph-mcp/src/tools/ingestion.rs > $INT_TMP
+
+# Public's import set (lines 1-25) is a superset of internal's; use it.
+sed -n '1,25p' $PUB_TMP > $TARGET
+echo "" >> $TARGET
+
+# Internal's body from line 20 onward (everything after its imports).
+sed -n '20,$p' $INT_TMP >> $TARGET
+
+# Public's ingest_document block (line 307 onward).
+sed -n '307,$p' $PUB_TMP >> $TARGET
+```
+
+Expected: ~786 lines total.
+
+- [ ] **Step 2: Compile + verify single definitions**
+
+```bash
+cargo check -p epigraph-mcp 2>&1 | tail -10
+grep -n "pub async fn ingest_document\b\|PIPELINE_VERSION\|pub async fn do_ingest_document" crates/epigraph-mcp/src/tools/ingestion.rs
+```
+
+Expected: clean compile. Single definitions of `ingest_document`, `do_ingest_document`, `PIPELINE_VERSION`. The merge boundary may leave a stray blank line that `cargo fmt --all` cleans up in Task 12.
+
+- [ ] **Step 3: Run the public ingest_document_smoke test**
+
+```bash
+DATABASE_URL=… cargo test -p epigraph-mcp --test ingest_document_smoke -- --test-threads=1
+```
+
+Expected: 3 tests pass (`happy_path_ingests_full_hierarchy`, `re_ingest_hits_version_gate`, `cross_paper_atom_and_author_converge`). Confirms the merge preserved public's `ingest_document` semantics.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/ingestion.rs
+git commit -m "feat(mcp): migrate ingest_paper per-claim loop to noun-claim canonical pattern
+
+Each extracted claim routes through claim_helper::create_claim_idempotent.
+SUPPORTS edges between two canonical claims accumulate per submission
+per migration 018 (this case is what motivated 018 — see migration
+header). The ingest_document tool already used a different pattern
+and is unaffected."
+```
+
+---
+
+## Task 11: Port `tool_resubmit_tests.rs`
+
+**Files:**
+- Create: `crates/epigraph-mcp/tests/tool_resubmit_tests.rs`
+
+- [ ] **Step 1: Copy verbatim**
+
+```bash
+git show internal-main:crates/epigraph-mcp/tests/tool_resubmit_tests.rs > crates/epigraph-mcp/tests/tool_resubmit_tests.rs
+wc -l crates/epigraph-mcp/tests/tool_resubmit_tests.rs
+```
+
+Expected: 694 lines.
+
+- [ ] **Step 2: Compile**
+
+```bash
+cargo test -p epigraph-mcp --no-run 2>&1 | tail -10
+```
+
+Expected: clean. The test file uses `tracing-test` (added in Task 3), `common::*` fixtures (Task 5), and the migrated tools (Tasks 7–10).
+
+- [ ] **Step 3: Run against test DB**
+
+```bash
+export DATABASE_URL=postgres://epigraph:epigraph@127.0.0.1:5432/epigraph_s3a_port_test
+cargo test -p epigraph-mcp --test tool_resubmit_tests -- --test-threads=1
+```
+
+Expected: all tests pass. The suite covers all 5 migrated tools: each tool's resubmit path returns `was_created=false` for repeat content, accumulates verb-edges per submission, persists Trace/Evidence, and logs AUTHORED-emit failures without aborting.
+
+If a test fails on schema state (e.g., `idx_edges_unique_triple` lingering): drop and recreate the DB:
+
+```bash
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "DROP DATABASE IF EXISTS epigraph_s3a_port_test;"
+PGPASSWORD=epigraph psql -h 127.0.0.1 -U epigraph -d postgres -c "CREATE DATABASE epigraph_s3a_port_test OWNER epigraph;"
+```
+
+The fixture re-runs migrations on first connection.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/tests/tool_resubmit_tests.rs
+git commit -m "test(mcp): port tool resubmit end-to-end suite
+
+694-line integration suite covering all 5 migrated MCP writer tools
+(submit_claim, memorize, store_workflow, improve_workflow,
+ingest_paper). Verifies was_created branching, verb-edge
+accumulation per submission, AUTHORED-emit log-and-swallow on
+EdgeRepository failure."
+```
+
+---
+
+## Task 12: Workspace verification
+
+- [ ] **Step 1: Scoped clippy on touched crates (lib only — workspace tests have pre-existing baseline noise)**
+
+```bash
+cargo clippy -p epigraph-mcp -p epigraph-db --lib -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 2: fmt-check**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no diff. If diff: `cargo fmt --all` and add a `style: cargo fmt` commit.
+
+- [ ] **Step 3: Run touched-crate tests against test DB**
+
+```bash
+export DATABASE_URL=postgres://epigraph:epigraph@127.0.0.1:5432/epigraph_s3a_port_test
+cargo test -p epigraph-mcp -p epigraph-db -- --test-threads=1 2>&1 | tail -30
+```
+
+Expected: all pass. Watch for:
+- `claim_repo_helpers` (slice 1): still green (constraint name unchanged).
+- `claim_helper_tests` (Task 6): green.
+- `tool_resubmit_tests` (Task 11): green.
+- Any pre-existing `epigraph-mcp` tests: green (the migrations don't break the existing test fixtures because all relationships still PRIMARY-KEY-unique on `edges.id`).
+
+- [ ] **Step 4: Sanity-check the four flagged let-_-EdgeRepo callsites still compile (audit deferred)**
+
+```bash
+cargo check -p epigraph-api 2>&1 | tail -10
+```
+
+Expected: clean. The `routes/edges.rs`, `routes/spans.rs`, `mcp/perspectives.rs`, `routes/conventions.rs` callsites continue to use `let _ = EdgeRepository::create(...)` — now silent-accumulate instead of silent-dedup. Behavior shift documented in migration 018 header comment; full audit is the spec's `s3a-followup` backlog item.
+
+---
+
+## Task 13: Push and open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/s3a-mcp-writer-port
+```
+
+- [ ] **Step 2: Open PR (depends on #16)**
+
+```bash
+gh pr create --title "feat: port S3a MCP writer migration from epigraph-internal" --base feat/s1-noun-claim-port --body "$(cat <<'EOF'
+## Summary
+- Ports the S3a MCP writer migration from `epigraph-internal` (PR #8 there).
+- Adds migrations 017/018 to drop `idx_edges_unique_triple` so every relationship accumulates per submission per the architecture doc's verb-event semantics.
+- Adds `claim_helper::create_claim_idempotent` shim over `ClaimRepository::create_or_get` (from #16) + AUTHORED verb-edge emission.
+- Migrates 5 MCP writer tools: `submit_claim`, `memorize`, `store_workflow`, `improve_workflow`, `ingest_paper`.
+
+## Depends on
+- #16 (S1 noun-claim foundation) — provides `ClaimRepository::create_or_get`. **Rebase onto main after #16 merges.**
+
+## Excluded (follow-up)
+- `EpiGraphMcpFull::all_tools_json` / `list_mcp_tools` discovery additions in `lib.rs` and `server.rs` — bundled with `routes/mcp_tools.rs` follow-up, not writer-migration scope.
+- API handler `routes/claims.rs:565` AUTHORED emit alignment — spec backlog #10.
+- Audit of pre-existing `let _ = EdgeRepository::create(...)` callsites in `routes/edges.rs`, `routes/spans.rs`, `mcp/perspectives.rs`, `routes/conventions.rs` — flagged in migration 018 header comment.
+
+## Coverage notes for reviewers
+- `claim_helper_tests.rs` (312 lines) covers the new helper directly.
+- `tool_resubmit_tests.rs` (694 lines) covers all 5 migrated tools end-to-end.
+- The four pre-existing `let _ = EdgeRepository::create(...)` callsites shift from silent-dedup to silent-accumulate. No regression test is added for them in this PR; migration 018 header comment files the audit.
+
+## Test plan
+- [x] `cargo fmt --all -- --check` clean
+- [x] `cargo clippy -p epigraph-mcp -p epigraph-db --lib -- -D warnings` clean
+- [x] `DATABASE_URL=… cargo test -p epigraph-mcp -p epigraph-db -- --test-threads=1` — all green
+- [ ] **Manual:** `submit_claim` MCP tool returns `was_created=false` on a content-hash repeat for the same agent
+- [ ] **Manual:** Two `submit_claim` calls produce two distinct AUTHORED edges (post-018 accumulation)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist
+
+1. **Scope coverage:** all 5 writer tools migrated ✓; helpers + tests ported ✓; design spec ported ✓; migrations 017/018 ported ✓; tracing-test dev-dep added ✓.
+
+2. **Excluded scope held:** `list_mcp_tools` server.rs/lib.rs additions NOT ported ✓; `routes/claims.rs:565` API alignment NOT ported ✓; internal S3a *plan* (2706 lines) NOT ported ✓.
+
+3. **Type/method consistency:**
+   - `crate::claim_helper::create_claim_idempotent` — name matches Task 4 (definition) and Tasks 7–10 (call sites).
+   - Migration filenames match the renumbering (017/018, not 108/109).
+   - Constraint name `idx_edges_unique_triple` referenced consistently — defined in `001_initial_schema.sql`, dropped in 017, residual partial dropped in 018.
+
+4. **Dependency on slice 1 explicit:** plan header states "Base branch: `feat/s1-noun-claim-port`"; PR command uses `--base feat/s1-noun-claim-port`.
+
+5. **No placeholders:** every step has the exact `git show` command or sed line or commit message.
+
+6. **Migration sed safety:** the sed in Task 2 Step 2 only rewrites in the new 018 file (which I created in step 1), not anywhere else. Verify by checking `migrations/` files only.

--- a/docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md
+++ b/docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md
@@ -1,0 +1,244 @@
+# S3a — `epigraph-mcp` Writer Migration Design
+
+**Date:** 2026-04-26
+**Branch:** `feat/s3a-mcp-writer-migration` (created off `chore/migration-renumber-2026-04-25` so S1 helpers are the base); separate PR from #6
+**Status:** Approved for spec → plan → implementation
+**Sub-project of:** Noun-Claims and Verb-Edges architecture (S3a — first writer migration after S1 foundation)
+
+---
+
+## Why this design exists
+
+S1 of the noun-claims-and-verb-edges architecture shipped on branch `chore/migration-renumber-2026-04-25` (PR #6, currently OPEN — pending merge): `docs/architecture/noun-claims-and-verb-edges.md`, idempotent claim-create primitive `if_not_exists` on `POST /api/v1/claims`, migrations 106/107 split. S3a is a follow-on on a child branch and is queued behind PR #6 in the merge order; PR #6 must land before S3a's PR can be merged. The architecture's sub-project map orders the rollout as **S3a → S2 → (S3b–S3d in parallel) → S4** because writers must stop accumulating new duplicates before the S2 backfill begins — otherwise every backfill batch is immediately re-dirtied.
+
+S3a migrates the canonical-codebase writer that contributed Cause 2's ~72k duplicate rows: `epigraph-internal/crates/epigraph-mcp`, the live MCP server. Five callsites in `crates/epigraph-mcp/src/tools/{claims,memory,workflows,workflows,ingestion}.rs` currently call `ClaimRepository::create()` unconditionally; every same-agent same-content resubmission produces a fresh `claims` row. Once 107 lands (S4), those resubmissions would error with `409 Conflict`. S3a switches the five callsites to the noun-claim-canonical pattern: idempotent create via `create_or_get`, with each submission emitting an AUTHORED verb-edge as the lifecycle event marker.
+
+## Goals and non-goals
+
+**S3a ships:**
+
+- A shared helper `create_claim_idempotent(pool, claim, tool_name)` in `crates/epigraph-mcp/src/claim_helper.rs` that wraps `ClaimRepository::create_or_get` plus AUTHORED edge emission.
+- Migration of all 5 callsites in `crates/epigraph-mcp/src/tools/{claims,memory,workflows,ingestion}.rs` to use the helper.
+- Per-tool resubmit semantics (Option A or Option B per the table in §"Per-tool migration").
+- Tier-1 helper unit tests + Tier-2 integration tests for `submit_claim` and `ingest_paper`.
+
+**S3a explicitly does NOT ship:**
+
+- **No live-DB writes.** Migration 107 is not applied; the S2 backfill is not run.
+- **No Layer 2 (embedding near-neighbor) dedup** for `ingest_paper`. Layer 0 (byte-identical content_hash) only. Layer 2's threshold tuning needs labeled pairs from S2 backfill; doing it before S2 means tuning blind.
+- **No per-run `paper_artifact` noun-claim** for `ingest_paper`. The architecture doc's worked example uses this pattern for S3c (V2 ingest scripts with source-coordinate dedup); S3a's MCP `ingest_paper` stays agent-direct and emits AUTHORED only.
+- **No edge signing for AUTHORED.** Mirrors the API handler at `routes/claims.rs:565` which passes `None` for signature fields. The architecture doc explicitly defers edge signing.
+- **No migration of the ~44 internal Rust callers** of legacy `ClaimRepository::create()` / `create_with_tx()` (test files, epigraph-api routes, other crates). Only the 5 epigraph-mcp callers are migrated. Legacy methods stay.
+- **No removal of legacy `ClaimRepository::create()` / `create_with_tx()`.** They remain with their cross-agent collapse bug, documented as legacy.
+
+## Architecture
+
+### The shared helper
+
+A new module `crates/epigraph-mcp/src/claim_helper.rs` exposes one function:
+
+```rust
+/// Idempotently create a claim by (content_hash, agent_id) and emit an AUTHORED
+/// verb-edge marking the submission lifecycle event.
+///
+/// Mirrors the API handler's pattern at routes/claims.rs:444-576: create_or_get
+/// inside a connection scope, then fire-and-forget AUTHORED edge on the pool
+/// after the connection is released. AUTHORED failure is logged via tracing::warn!
+/// but not propagated — orphan claims are tolerated per the architecture doc's
+/// atomicity policy. Each submission emits a distinct AUTHORED edge regardless of
+/// `was_created`, because each submission is an authorship verb-event.
+pub async fn create_claim_idempotent(
+    pool: &PgPool,
+    claim: &Claim,
+    tool_name: &'static str,
+) -> Result<(Claim, bool), McpError> {
+    let mut conn = pool.acquire().await.map_err(internal_error)?;
+    let (claim, was_created) = ClaimRepository::create_or_get(&mut *conn, claim)
+        .await
+        .map_err(internal_error)?;
+    drop(conn);
+
+    if let Err(e) = EdgeRepository::create(
+        pool,
+        claim.agent_id.as_uuid(), "agent",
+        claim.id.as_uuid(), "claim",
+        "AUTHORED",
+        Some(json!({"tool": tool_name, "was_created": was_created})),
+        None, None,
+    ).await {
+        tracing::warn!(
+            claim_id = %claim.id.as_uuid(),
+            tool = tool_name,
+            error = %e,
+            "AUTHORED verb-edge emit failed; claim row persisted as orphan"
+        );
+    }
+
+    Ok((claim, was_created))
+}
+```
+
+**Design choices:**
+
+- **Helper lives in `epigraph-mcp`, not `epigraph-db`.** AUTHORED edge emission is MCP-layer policy. Putting it on `ClaimRepository` would force the AUTHORED emit on every internal caller of `create_or_get` (44 callsites across the workspace, many of which don't want AUTHORED). The dedup primitive stays at the data layer; the verb-edge emission stays at the writer layer.
+- **`tool_name: &'static str`** forces compile-time-literal callsite values (`"memorize"`, `"submit_claim"`, etc.) — typo-resistant.
+- **Connection-scoped, not transactional.** Mirrors the API handler at `routes/claims.rs:560-576`, which commits the claim INSERT then fires AUTHORED on the pool fire-and-forget. Post-107 race recovery is handled inside `create_or_get` itself; no MCP-side retry needed.
+- **AUTHORED `let _` swallowed-or-warned.** Matches API behavior; orphans are tolerated per atomicity policy. One small improvement over the API: emits a `tracing::warn!` on edge failure so observability tooling can flag orphans without grepping fire-and-forget bugs.
+
+## Per-tool migration
+
+| Callsite | Tool | Resubmit semantics | Resubmit branch (`was_created == false`) |
+|---|---|---|---|
+| `claims.rs:134` | `submit_claim` | **Option B** (preserve evidence) | Create Evidence + ReasoningTrace as standalone noun-claims; emit `claim --[DERIVED_FROM @ T]--> evidence` and `claim --[HAS_TRACE @ T]--> trace` verb-edges (relationship names match the API handler at `routes/claims.rs:587-614`); **skip** `update_trace_id` (canonical claim's `trace_id` is immutable post-creation); skip DS auto-wire (canonical truth was set on first create). |
+| `memory.rs:72` | `memorize` | **Option A** (skip everything) | Skip Evidence + Trace + `update_trace_id` + DS auto-wire. AUTHORED edge (already emitted by helper) is the only persisted artifact of the resubmission. |
+| `workflows.rs:144` | `store_workflow` | **Option A** | Same as `memorize`. The workflow-definition JSON is canonical; resubmission is a no-op. |
+| `workflows.rs:590` | `improve_workflow` | **Option A** + idempotent `variant_of` | Skip Evidence + Trace, `update_trace_id`, and `embed_and_store` (no DS auto-wire exists in this tool today, so there is nothing to skip on that axis); **also skip** the `variant_of` edge creation (the parent→variant relationship is set when the variant is first created; resubmits don't create new sibling-variants). The AUTHORED edge captures "I tried to improve this again." |
+| `ingestion.rs:218` | `ingest_paper` (per-claim loop) | **Option B** | Per LLM-extracted claim: if `was_created=true`, full sequence (Evidence + Trace + `update_trace_id` + DS batch entry collection + relationship edges later). If `was_created=false`, create Evidence + Trace as standalone noun-claims linked via `DERIVED_FROM` / `HAS_TRACE` edges; **skip** DS batch entry (would re-wire canonical truth), skip `embed_and_store` (canonical embedding already exists); but **keep** the claim's UUID in `claim_uuids` so post-loop relationship-edge construction still emits inter-claim relationships from this run. **Side effect (intentional):** repeat `ingest_paper` runs over the same source produce duplicate `(source, target, relationship)` rows in `edges` — one per run. This is consistent with architecture rule 1 ("re-occurrence of the same lifecycle event = new edge") and matches what each run is actually saying ("this run asserts that X relates to Y"). Source-coordinate dedup for relationship edges is deferred to S3c (V2 ingest), where source coordinates are first-class; for S3a the relationship-edge multi-emit is the documented behavior. |
+
+**Common shape across all 5 callsites:**
+
+```rust
+let (claim, was_created) = create_claim_idempotent(&server.pool, &claim, "<tool_name>").await?;
+if was_created {
+    // existing post-create logic: Evidence + Trace + update_trace_id + DS + embed + edges
+} else {
+    // tool-specific resubmit branch (per table above)
+}
+```
+
+**Per-callsite refactor: re-read `claim.id` after the helper.** Both `claims.rs:92` (`let claim_uuid = claim.id.as_uuid();`) and `memory.rs:38` capture the claim UUID *before* the create call; today that's harmless because every create produces a fresh row. After S3a, on `was_created=false` the helper returns the canonical row whose UUID differs from the locally-generated one. Every downstream use — DS auto-wire's `claim_uuid` arg, `embed_and_store`, `ClaimRepository::update_truth_value`, the response body's `claim_id`, and `ingestion.rs`'s pushes into `claim_ids` / `claim_uuids` / `ds_entries.claim_id` — must read from the shadowed `claim` returned by the helper. Each per-callsite migration commit removes or relocates the early `claim_uuid` capture.
+
+**Truth-value clobber risk** in `claims.rs`: the existing flow updates `truth_value` from DS pignistic after auto-wire. On `was_created=false` with Option B, DS auto-wire is skipped, so no clobber. On `was_created=true` with Option B, the flow is identical to today.
+
+**Truth-value response divergence (related fix).** Today, `submit_claim`'s response `truth_value` field falls back to `raw_truth` (the new submission's `confidence * weight`) when DS is unavailable. On `was_created=false` Option B, that path would report a value never written to the DB — the canonical row carries first-create's truth. The migration must read `claim.truth_value.value()` from the returned canonical row in the `was_created=false` branch. The Tier-2 `submit_claim_resubmit_creates_evidence_trace_via_edges` test asserts response.truth_value matches DB.truth_value across both calls.
+
+## Resubmit semantics rationale
+
+**Why Option A for memorize / store_workflow / improve_workflow:**
+- Same content from same agent rarely brings new information. Memorize-it-again is a "noise" event the AUTHORED verb-edge captures cleanly without growing canonical state.
+- The workflow-definition JSON is canonical: same JSON content_hash means the user re-stored the same workflow definition, not a new one.
+
+**Why Option B for submit_claim / ingest_paper:**
+- Each `submit_claim` call inherently carries a new `evidence_data` value. Discarding that on resubmit loses real information — the user is providing a new piece of evidence supporting an existing claim.
+- Each `ingest_paper` call extracts from a (possibly different) paper context. Even with byte-identical extracted text, the supporting passage / DOI / page reference may differ. Preserving these as new Evidence nouns linked to the canonical claim via `DERIVED_FROM` edges is the architecture-doc-faithful way to record multi-source attestation.
+
+**Relationship-naming divergence from API handler.** The API handler emits `HAS_TRACE` / `DERIVED_FROM` only on `was_created=true` (first-create lineage). MCP's Option B reuses the same relationship names but emits them on `was_created=false` resubmits. Rationale: in MCP, agent identity is server-derived and stable, so every resubmit IS an owner-request; the architecture doc's "non-owner mutation" concern doesn't apply. Reusing the relationship names keeps graph queries uniform — "all evidence for claim X" is one query against `DERIVED_FROM` regardless of which writer emitted the edge. The semantic invariant becomes: `HAS_TRACE` / `DERIVED_FROM` accumulate over a claim's lifetime; the canonical `trace_id` column reflects only the original create. Backlog item filed to align the API to the same accumulating semantics later.
+
+**Why standalone noun-claims with verb-edges, not `update_trace_id`:**
+- `update_trace_id` mutates the canonical claim's `trace_id` field. Repeated mutation by re-submissions would clobber the canonical claim's primary trace, conflating multiple submissions' traces into one slot.
+- Evidence and ReasoningTrace are themselves entities with their own `id`, `agent_id`, `signature`. Each is a noun-claim by the architecture's definition. Linking them via verb-edges preserves their identity and lets graph queries traverse "all evidence for this claim" without ambiguity.
+
+## Failure semantics & error handling
+
+**Helper failure modes:**
+
+1. **`pool.acquire()` failure** — propagates as `McpError::internal_error`.
+2. **`create_or_get` failure** — propagates as `McpError::internal_error`. Includes pre-107 race window (architecture-doc-tolerated; S2 cleans up).
+3. **AUTHORED edge failure** — logged via `tracing::warn!`, swallowed. Returns `Ok((claim, was_created))`. The `claims` row exists but lacks an AUTHORED anchor.
+
+**Per-tool callsite failure semantics:**
+
+- Each tool's existing post-create logic (Evidence + Trace + DS + embed + relationships) keeps its current `?` propagation. If Evidence creation fails after `create_claim_idempotent` returns Ok, the claim is orphan-with-AUTHORED-but-no-trace — a tolerated state per atomicity policy. S2-style sweeps can collect these.
+- Existing `tracing::warn!` patterns in DS auto-wire failure paths are preserved.
+
+**Behavior change for end users of MCP tools:**
+
+After S3a, repeat calls to the 5 tools with the same content from the same MCP agent return the canonical claim's UUID instead of a fresh UUID. Anything downstream that relied on a fresh UUID per call will see the same UUID on resubmits. **Risk surface:** agent code that uses MCP tool return UUIDs as call-deduplication keys. Spot-check epigraph-agent code paths during S3a implementation; flag any reliance on uniqueness-of-returned-UUID-per-call as a separate fix item (logged as an EpiGraph backlog claim).
+
+**Pre-107 race window:** the architecture doc's pre-107 race applies — two concurrent same-agent calls may both report `was_created=true` and produce two rows. S2 cleans up. No MCP-specific mitigation needed.
+
+**Post-107 race recovery:** when migration 107 lands, the (content_hash, agent_id) UNIQUE constraint catches concurrent inserts. `create_or_get` handles the retry path internally per the existing spec.
+
+## Tests
+
+epigraph-mcp has zero tests today. S3a adds the first.
+
+### Tier 1 (mandatory) — Helper unit tests
+
+`crates/epigraph-mcp/tests/claim_helper_tests.rs`. Patterns after `crates/epigraph-db/tests/claim_repo_helpers.rs` — same `try_test_pool` / `test_pool_or_skip!` macro / pre-107 / post-107 fixture toggling.
+
+| Test | Asserts |
+|---|---|
+| `helper_creates_when_absent` | First call returns `was_created=true`; one row in `claims`; one row in `edges` with `relationship='AUTHORED'`, `properties->>'tool'='test_tool'`, `properties->>'was_created'='true'`. |
+| `helper_returns_existing_when_present` | Second call (same content_hash+agent) returns `was_created=false`; only one row in `claims`; **two** AUTHORED edges in `edges` (one per call), the second has `properties->>'was_created'='false'`. |
+| `helper_emits_authored_on_both_branches` | Cross-checks: with `was_created=true` AND `was_created=false`, AUTHORED edge always fires. |
+| `helper_post_107_race_recovery` | Post-107 fixture; concurrent two-insert race recovers via `create_or_get`'s internal `DbError::DuplicateKey` retry; one row, `was_created=false` for the loser. |
+| `helper_pre_107_no_constraint` | Pre-107 fixture; helper still works, second call still returns existing row (find-then-insert path, not race-recovery path). |
+| `helper_authored_failure_does_not_propagate` | Use `tracing-test` to capture log output; force AUTHORED failure (e.g., drop edges constraint or use a malformed agent_id reference); confirm helper returns `Ok` and emits a `tracing::warn!`. |
+
+### Tier 2 (high-value subset) — Per-tool integration tests
+
+`crates/epigraph-mcp/tests/tool_resubmit_tests.rs`. Builds an `EpiGraphMcpFull` with a stub signer (deterministic Ed25519 keypair) and the test pool. Tests the trickiest two tools:
+
+| Test | Asserts |
+|---|---|
+| `submit_claim_resubmit_creates_evidence_trace_via_edges` | Call `submit_claim` twice with same content + different `evidence_data`. After second call: one `claims` row; **two** `evidence` rows; **two** `reasoning_traces` rows; canonical claim's `trace_id` unchanged from first create; second call's evidence + trace linked to claim via `DERIVED_FROM` + `HAS_TRACE` edges. |
+| `ingest_paper_resubmit_creates_per_call_evidence_no_dup_claim` | Call `ingest_paper` twice with the same DOI + same extracted-claim text. After second call: one `claims` row per unique LLM-extracted statement; per-call evidence + trace rows preserved via `DERIVED_FROM` / `HAS_TRACE` edges; `embed_and_store` not called again on resubmit (counting embedder stub); `auto_wire_ds_for_claim` not invoked on resubmit. |
+
+### Deferred Tier 2 tests (logged as backlog claims)
+
+memorize, store_workflow, improve_workflow follow Option A (skip-everything-on-resubmit). The helper unit tests already cover the dedup primitive; tool-level Option A tests would mostly assert "didn't call X." Manually verifiable. Logged as a backlog item.
+
+### Test infrastructure invariants
+
+- **`--test-threads=1` mandatory.** Mirrors S1 test policy (the pre-107/post-107 fixture toggling races otherwise).
+- **DATABASE_URL must point at a clean test DB**, not the live `epigraph-postgres` docker container (which has 95k duplicate (content_hash, agent_id) groups). The `add_unique_constraint` helper's `DELETE` would attempt to dedup all 95k inline — destructive on the live DB. Either (a) `sqlx database create` a separate DB and point DATABASE_URL there, or (b) spin up a second pgvector container on a different port. The implementation plan's pre-flight findings will document this.
+- **Silent-skip detection.** Mirrors S1: scan test output for `Skipping DB test:` after each run. A skip-when-DATABASE_URL-is-set is a vacuous pass.
+- **`tracing-test` dev-dep required.** `crates/epigraph-mcp/Cargo.toml` does not yet have `tracing-test` in `[dev-dependencies]`; the helper unit test `helper_authored_failure_does_not_propagate` requires it for `tracing::warn!` capture. Add it as part of commit 1 (the helper module + Tier-1 tests).
+
+## Out of scope (logged as EpiGraph backlog claims)
+
+All deferred items are submitted to EpiGraph via `submit_claim` with labels `["backlog", "high-urgency", "s3a-followup"]` so they're queryable by future planning sessions. Items:
+
+1. **Layer 2 (embedding near-neighbor) dedup for `ingest_paper`.** Threshold tuning needs S2-labeled pairs; revisit after S2 ships.
+2. **Per-run `paper_artifact` noun-claim** for `ingest_paper`. The architecture doc's worked-example pattern, deferred to S3c (V2 ingest) where source coordinates make it natural.
+3. **Edge signing for AUTHORED edges.** Schema-supported (migration 073); not yet implemented in any writer.
+4. **S3b — `epigraph-agent` `submit_claim` builtin migration.** Independent sub-project; same drift exists in the agent harness.
+5. **S3c — V2 ingest scripts migration.** May be skipped if V2 deprecates first.
+6. **S3d — V2 `epigraph-nano/provenance.rs` migration.** Cause 3 source.
+7. **Migrate ~44 internal Rust callers** of legacy `ClaimRepository::create()` / `create_with_tx()` (test files in epigraph-db + epigraph-api integration tests + epigraph-api/routes/{claims,conventions}.rs). Out-of-band cleanup.
+8. **Remove legacy `ClaimRepository::create()` / `create_with_tx()`** methods. Gated on (7).
+9. **Tier-2 integration tests for memorize, store_workflow, improve_workflow.** Deferred from S3a.
+10. **Spot-check epigraph-agent for reliance on per-call MCP-tool UUID uniqueness.** Risk surface from S3a's behavior change.
+11. **Align API handler's `HAS_TRACE` / `DERIVED_FROM` emission to accumulating semantics.** S3a's MCP Option B emits these on resubmit; the API handler at `routes/claims.rs:585-614` only emits on first create. Align the API later so query semantics are uniform across writers.
+
+## Risk and rollback
+
+- **Branch on its own PR.** Separate from PR #6. Each of the 6 commits (Approach 2) is independently revertable.
+- **No live-DB writes.** Source-only PR; rollback is `git reset --hard origin/main` on the S3a branch.
+- **Behavior change for MCP tool callers.** Documented above. Spot-checked during implementation.
+- **First tests added to epigraph-mcp.** Test infrastructure (try_test_pool helper, fixtures) is the first of its kind in this crate; pattern is copied from claim_repo_helpers.rs to maximize consistency.
+- **Five callsites, six commits.** Each commit is atomic and per-tool (commit 1 = helper module + tests; commits 2–6 = one callsite migration each, with focused tests). Reviewer can validate the helper once and skim the rest.
+
+## Sub-project map (after S3a)
+
+S1 (helpers shipped on `chore/migration-renumber-2026-04-25`; PR #6 OPEN, pending merge) → **S3a (this design)** → S2 → S3b–S3d (parallel) → S4.
+
+- **S3a** unblocks S2 by stopping new dups from accumulating in the canonical codebase's MCP server.
+- **S2** can begin once S3a is deployed and the dup count stops growing in canonical-codebase write paths. (V2 writers — Causes 1 and 3 — still need S3c/S3d if V2 stays alive; otherwise V2 deprecation removes the threat.)
+- **S3b–S3d** parallelisable with S2 once S3a deploys.
+- **S4** applies migration 107 once S2 backfill is verified clean.
+
+Each sub-project gets its own brainstorm → spec → plan cycle.
+
+## PR commit sequence (Approach 2)
+
+1. `feat(mcp): add create_claim_idempotent helper for noun-claim canonical create`
+   New file `crates/epigraph-mcp/src/claim_helper.rs`. Helper module + Tier-1 unit tests + a `mod claim_helper;` line in `lib.rs`. No callsite changes yet.
+
+2. `feat(mcp): migrate submit_claim to noun-claim canonical pattern`
+   Edits `crates/epigraph-mcp/src/tools/claims.rs:134`. Adds Option B resubmit branch (Evidence + Trace + `DERIVED_FROM` / `HAS_TRACE` edges, skip `update_trace_id`, skip DS auto-wire). One Tier-2 integration test.
+
+3. `feat(mcp): migrate memorize to noun-claim canonical pattern`
+   Edits `crates/epigraph-mcp/src/tools/memory.rs:72`. Option A resubmit branch.
+
+4. `feat(mcp): migrate store_workflow to noun-claim canonical pattern`
+   Edits `crates/epigraph-mcp/src/tools/workflows.rs:144`. Option A resubmit branch.
+
+5. `feat(mcp): migrate improve_workflow to noun-claim canonical pattern`
+   Edits `crates/epigraph-mcp/src/tools/workflows.rs:590`. Option A + idempotent variant_of skip.
+
+6. `feat(mcp): migrate ingest_paper per-claim loop to noun-claim canonical pattern`
+   Edits `crates/epigraph-mcp/src/tools/ingestion.rs:218`. Option B per loop iteration. One Tier-2 integration test.
+
+Total: 6 commits, ~400 lines (helper + tests + 5 small callsite branches).

--- a/migrations/017_authored_edges_allow_multiple.sql
+++ b/migrations/017_authored_edges_allow_multiple.sql
@@ -1,0 +1,25 @@
+-- AUTHORED verb-edge accumulation per architecture doc
+-- (docs/architecture/noun-claims-and-verb-edges.md §"Cause 1"):
+--
+--   "The auto-emitted AUTHORED verb-edge on each submission is preserved —
+--    each submission is a distinct verb-event even when the noun-claim
+--    already exists."
+--
+-- The original idx_edges_unique_triple (defined in 001_initial_schema.sql)
+-- prevented AUTHORED accumulation: a second AUTHORED edge for the same
+-- (agent, claim) tripped
+-- the unique violation, and the API handler at routes/claims.rs:565 silently
+-- swallowed it via `let _ = ...`. The architecture doc's "verb-event"
+-- semantics was aspirational and never realized in the schema.
+--
+-- This migration replaces the constraint with a partial unique index that
+-- excludes AUTHORED, so AUTHORED edges accumulate one-per-submission while
+-- every other relationship type continues to enforce triple-uniqueness. No
+-- in-tree code uses ON CONFLICT (source_id, target_id, relationship), so the
+-- behavior change is contained to AUTHORED accumulation.
+
+DROP INDEX IF EXISTS idx_edges_unique_triple;
+
+CREATE UNIQUE INDEX idx_edges_unique_triple_non_authored
+  ON edges (source_id, target_id, relationship)
+  WHERE relationship != 'AUTHORED';

--- a/migrations/018_drop_edges_triple_unique_constraint.sql
+++ b/migrations/018_drop_edges_triple_unique_constraint.sql
@@ -1,0 +1,46 @@
+-- Widen migration 017 to all verb-edges, not just AUTHORED.
+--
+-- Migration 017 introduced idx_edges_unique_triple_non_authored — a partial
+-- unique index that excluded AUTHORED but kept triple-uniqueness for every
+-- other relationship. That preserved the original 001_initial_schema.sql
+-- behavior for DERIVED_FROM, HAS_TRACE, SUPPORTS, CONTRADICTS, variant_of, etc.
+--
+-- That ran into S3a Task 6 (ingest_paper resubmit), where SUPPORTS edges
+-- between two canonical claims need to multi-emit per submission per the
+-- architecture doc's "re-occurrence = new edge" rule. With the partial
+-- index in place, the second do_ingest's SUPPORTS insert tripped the
+-- constraint.
+--
+-- This migration drops the remaining constraint so every relationship
+-- behaves like a verb-edge: accumulating per-submission. Application
+-- code is responsible for idempotency where the relationship is
+-- semantically a noun-edge (e.g., improve_workflow's variant_of edge,
+-- which the migrated code already skips on the was_created=false branch).
+--
+-- The PRIMARY KEY on edges.id continues to ensure row-level uniqueness;
+-- only the (source_id, target_id, relationship) triple-uniqueness is gone.
+--
+-- BLAST RADIUS — read carefully before merging.
+--
+-- This is a global semantic change: every edge accumulates by default. The
+-- following callsites previously relied on the index for silent dedup via
+-- `let _ = EdgeRepository::create(...)` (now they multi-emit, and any
+-- call-site needing dedup must enforce it in application code):
+--
+--   crates/epigraph-api/src/routes/edges.rs       — RELATES_TO bidirectional
+--   crates/epigraph-api/src/routes/spans.rs       — generated, uses_evidence, attributed_to
+--   crates/epigraph-api/src/routes/conventions.rs — AUTHORED, SUPPORTS, TRACES, HAS_TRACE
+--   crates/epigraph-api/src/routes/workflows.rs   — AUTHORED on workflow variants
+--
+-- AUTHORED accumulation in the conventions and workflows routes is
+-- intentional post-S3a (matches architecture doc). The remaining (RELATES_TO,
+-- three span edges) need a per-callsite audit to decide between (a)
+-- verb-event accumulation (current default), (b) explicit
+-- existence-check-then-insert for noun-edge semantics. Backlog item filed
+-- with s3a-followup label: "Audit non-AUTHORED let-_-EdgeRepo callsites
+-- for noun-edge vs verb-event semantics post-migration-018."
+--
+-- No `ON CONFLICT (source_id, target_id, relationship)` upsert sites exist
+-- in crates/, so no INSERT … ON CONFLICT statements break.
+
+DROP INDEX IF EXISTS idx_edges_unique_triple_non_authored;


### PR DESCRIPTION
## Summary
- Ports the S3a MCP writer migration from `epigraph-internal` (PR #8 there).
- Migrations 017/018 drop `idx_edges_unique_triple` so every relationship accumulates per submission per the architecture doc's verb-event semantics.
- New `claim_helper::create_claim_idempotent` shim over `ClaimRepository::create_or_get` (from #16) + AUTHORED verb-edge emission.
- Migrates 5 MCP writer tools to the noun-claim canonical pattern: `submit_claim`, `memorize`, `store_workflow`, `improve_workflow`, `ingest_paper`.
- Adds `tracing-test` dev-dep for the integration tests' log-capture macro.

## Depends on
- #16 (S1 noun-claim foundation) — this PR's `claim_helper` calls `ClaimRepository::create_or_get` which lands there. **Rebase onto `main` after #16 merges.**

## Mid-execution finding
`crates/epigraph-mcp/src/tools/ingestion.rs` has the public-only `ingest_document` block (added by PR #14, extract-claims) that does not exist in `internal-main`. A naive clobber would drop those functions. The port is a **merged file**: internal's writer-migration body for `ingest_paper` / `do_ingest` + public's `ingest_document` block. Verified by re-running the public `ingest_document_smoke` test — 3 / 3 pass. Plan doc updated to record this.

## Excluded (follow-up)
- `EpiGraphMcpFull::all_tools_json` / `list_mcp_tools` discovery additions in `lib.rs` and `server.rs` — bundled with `routes/mcp_tools.rs` follow-up, not writer-migration scope.
- API handler `routes/claims.rs` AUTHORED emit alignment — spec backlog #10.
- Audit of pre-existing `let _ = EdgeRepository::create(...)` callsites in `routes/{edges,spans,conventions,workflows}.rs` — these shift from silent-dedup to silent-accumulate. Migration 018's header comment files this as `s3a-followup` work.

## Coverage
- `tests/claim_helper_tests.rs` (312 lines, 6 tests) — new helper directly. **6 / 6 pass.**
- `tests/tool_resubmit_tests.rs` (694 lines, 5 tests) — all 5 migrated tools end-to-end. **5 / 5 pass.**
- `tests/ingest_document_smoke.rs` — pre-existing public smoke for `ingest_document`, re-run to verify the merged port. **3 / 3 pass.**

## Test plan
- [x] `cargo fmt --all -- --check` clean (one trailing blank line introduced by the merge cleaned up by a `style:` commit).
- [x] `cargo clippy -p epigraph-mcp -p epigraph-db --lib -- -D warnings` clean.
- [x] `DATABASE_URL=… cargo test -p epigraph-mcp -p epigraph-db -- --test-threads=1` — all green (no failures across helpers, claim_helper, tool resubmit, ingest_document_smoke, and existing suites).
- [x] `cargo check -p epigraph-api` — clean. The four flagged `let _ = EdgeRepository::create(...)` callsites still compile; runtime semantics shift documented in 018 header.
- [ ] **Manual:** `submit_claim` MCP tool returns `was_created=false` on a content-hash repeat for the same agent.
- [ ] **Manual:** Two `submit_claim` calls produce two distinct AUTHORED edges (post-018 accumulation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)