### PR TITLE
fix(api): extend graph allowlist + expose filtered_edge_count (depends on feat/graph-communities)

### DIFF
--- a/crates/epigraph-api/src/routes/graph_overview.rs
+++ b/crates/epigraph-api/src/routes/graph_overview.rs
@@ -35,32 +35,53 @@ const MAX_HOPS: i32 = 3;
 const NODE_EDGE_LIMIT: i64 = 5_000;
 
 /// Claim-level edge relationships exposed to the graph view.
-/// Covers the dominant relationship types in the corpus (hierarchical
-/// decomposition, corroboration, support/contradiction, refinement, etc.)
-/// plus their case variants. Anything not on this list (e.g. `same_source`,
-/// `produced`, `CONTAINS`) is omitted to keep the subgraph readable.
+///
+/// Covers the dominant epistemic relationship types in the corpus —
+/// hierarchical decomposition, corroboration, support/contradiction,
+/// refinement, equivalence, evidence, etc. — plus their case variants.
+///
+/// Excluded by design (kept out to keep the subgraph readable):
+///   `same_source`, `produced` — provenance, not epistemic
+///   `has_method_capability` — agent↔method, not claim↔claim
+///   `section_follows`, `CONTAINS` — document structure
+///   `DUPLICATE` — flagged for triage, not render
 const GRAPH_EDGE_RELATIONSHIPS: &[&str] = &[
+    // Hierarchical
     "decomposes_to",
-    "CORROBORATES",
-    "corroborates",
-    "continues_argument",
     "refines",
     "REFINES",
+    "specializes",
+    // Corroboration / support
+    "CORROBORATES",
+    "corroborates",
     "supports",
     "SUPPORTS",
+    "provides_evidence",
+    "asserts",
+    "enables",
+    // Contradiction / challenge
     "refutes",
     "contradicts",
     "CONTRADICTS",
+    "challenges",
+    // Argument continuation
+    "continues_argument",
+    "elaborates",
+    // Equivalence / variants
+    "same_as",
+    "equivalent_to",
+    "analogous",
+    "variant_of",
+    "definitional_variant_of",
+    // Generic / cross-reference
     "relates_to",
     "RELATES_TO",
+    // Lineage / temporal
     "supersedes",
+    "SUPERSEDES",
     "derived_from",
     "DERIVED_FROM",
     "derives_from",
-    "same_as",
-    "analogous",
-    "asserts",
-    "enables",
 ];
 
 // ---------------------------------------------------------------------------

--- a/crates/epigraph-api/src/routes/graph_overview.rs
+++ b/crates/epigraph-api/src/routes/graph_overview.rs
@@ -139,6 +139,11 @@ pub struct ClusterSubgraphResponse {
     pub total_size: i64,
     pub nodes: Vec<GraphNodeDto>,
     pub edges: Vec<GraphEdgeDto>,
+    /// Count of edges between the returned `nodes` whose `relationship` is
+    /// not in `GRAPH_EDGE_RELATIONSHIPS` (e.g. `produced`, `same_source`,
+    /// `CONTAINS`). Lets the GUI render "this node has N relationships not
+    /// shown in the readability tier" instead of an ambiguous empty payload.
+    pub filtered_edge_count: i64,
 }
 
 #[derive(Deserialize)]
@@ -307,7 +312,7 @@ pub async fn expand_cluster(
         .collect();
 
     let node_ids: Vec<Uuid> = nodes.iter().map(|n| n.id).collect();
-    let edges = fetch_subgraph_edges(pool, &node_ids).await?;
+    let (edges, filtered_edge_count) = fetch_subgraph_edges(pool, &node_ids).await?;
 
     Ok(Json(ClusterSubgraphResponse {
         cluster_id: cluster_id.to_string(),
@@ -315,6 +320,7 @@ pub async fn expand_cluster(
         total_size,
         nodes,
         edges,
+        filtered_edge_count,
     }))
 }
 
@@ -397,7 +403,7 @@ pub async fn graph_neighborhood(
             .collect()
     };
 
-    let edges = fetch_subgraph_edges(pool, &node_ids).await?;
+    let (edges, filtered_edge_count) = fetch_subgraph_edges(pool, &node_ids).await?;
     let total_size = nodes.len() as i64;
 
     Ok(Json(ClusterSubgraphResponse {
@@ -406,6 +412,7 @@ pub async fn graph_neighborhood(
         total_size,
         nodes,
         edges,
+        filtered_edge_count,
     }))
 }
 
@@ -413,20 +420,20 @@ pub async fn graph_neighborhood(
 async fn fetch_subgraph_edges(
     pool: &sqlx::PgPool,
     node_ids: &[Uuid],
-) -> Result<Vec<GraphEdgeDto>, ApiError> {
+) -> Result<(Vec<GraphEdgeDto>, i64), ApiError> {
     if node_ids.is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), 0));
     }
 
     let rows = sqlx::query(
         r#"
-        SELECT source_id, target_id, relationship
+        SELECT source_id, target_id, relationship,
+               (relationship = ANY($2::text[])) AS is_allowed
         FROM edges
         WHERE source_type = 'claim'
           AND target_type = 'claim'
           AND source_id = ANY($1::uuid[])
           AND target_id = ANY($1::uuid[])
-          AND relationship = ANY($2::text[])
         LIMIT $3
         "#,
     )
@@ -439,14 +446,21 @@ async fn fetch_subgraph_edges(
         message: format!("Subgraph edge query failed: {}", e),
     })?;
 
-    Ok(rows
-        .into_iter()
-        .map(|r| GraphEdgeDto {
-            source: r.get("source_id"),
-            target: r.get("target_id"),
-            relationship: r.get("relationship"),
-        })
-        .collect())
+    let mut edges = Vec::new();
+    let mut filtered: i64 = 0;
+    for r in rows {
+        let is_allowed: bool = r.get("is_allowed");
+        if is_allowed {
+            edges.push(GraphEdgeDto {
+                source: r.get("source_id"),
+                target: r.get("target_id"),
+                relationship: r.get("relationship"),
+            });
+        } else {
+            filtered += 1;
+        }
+    }
+    Ok((edges, filtered))
 }
 
 // ---------------------------------------------------------------------------
@@ -611,6 +625,7 @@ pub async fn expand_community(
             total_size: 0,
             nodes: Vec::new(),
             edges: Vec::new(),
+            filtered_edge_count: 0,
         }));
     };
     let run_id: Uuid = run_row.get("id");
@@ -664,7 +679,7 @@ pub async fn expand_community(
         .collect();
 
     let node_ids: Vec<Uuid> = nodes.iter().map(|n| n.id).collect();
-    let edges = fetch_subgraph_edges(pool, &node_ids).await?;
+    let (edges, filtered_edge_count) = fetch_subgraph_edges(pool, &node_ids).await?;
 
     Ok(Json(ClusterSubgraphResponse {
         cluster_id: community_id.to_string(),
@@ -672,6 +687,7 @@ pub async fn expand_community(
         total_size,
         nodes,
         edges,
+        filtered_edge_count,
     }))
 }
 
@@ -700,6 +716,7 @@ pub async fn expand_community(
         total_size: 0,
         nodes: Vec::new(),
         edges: Vec::new(),
+        filtered_edge_count: 0,
     }))
 }
 
@@ -743,6 +760,7 @@ pub async fn expand_cluster(
         total_size: 0,
         nodes: Vec::new(),
         edges: Vec::new(),
+        filtered_edge_count: 0,
     }))
 }
 
@@ -757,6 +775,7 @@ pub async fn graph_neighborhood(
         total_size: 0,
         nodes: Vec::new(),
         edges: Vec::new(),
+        filtered_edge_count: 0,
     }))
 }
 
@@ -805,5 +824,20 @@ mod tests {
                 "should not be in allowlist: {rel}",
             );
         }
+    }
+
+    #[test]
+    fn cluster_subgraph_response_serializes_filtered_count() {
+        use super::ClusterSubgraphResponse;
+        let r = ClusterSubgraphResponse {
+            cluster_id: "x".into(),
+            truncated: false,
+            total_size: 1,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            filtered_edge_count: 7,
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["filtered_edge_count"], 7);
     }
 }

--- a/crates/epigraph-api/src/routes/graph_overview.rs
+++ b/crates/epigraph-api/src/routes/graph_overview.rs
@@ -738,3 +738,51 @@ pub async fn graph_neighborhood(
         edges: Vec::new(),
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::GRAPH_EDGE_RELATIONSHIPS;
+
+    /// Relationship types we expect to traverse. Adding a row here without
+    /// adding the matching string to GRAPH_EDGE_RELATIONSHIPS will fail this
+    /// test, which is the point: the allowlist is the single source of truth
+    /// for which edges the GUI can expand.
+    const EXPECTED_INCLUDED: &[&str] = &[
+        // Pre-existing (regression-protect)
+        "decomposes_to", "CORROBORATES", "corroborates", "continues_argument",
+        "refines", "REFINES", "supports", "SUPPORTS", "refutes",
+        "contradicts", "CONTRADICTS", "relates_to", "RELATES_TO",
+        "supersedes", "derived_from", "DERIVED_FROM", "derives_from",
+        "same_as", "analogous", "asserts", "enables",
+        // Newly added in this PR
+        "variant_of", "equivalent_to", "provides_evidence", "challenges",
+        "specializes", "definitional_variant_of", "elaborates", "SUPERSEDES",
+    ];
+
+    /// Relationships the design explicitly excludes — keep them out so a
+    /// future "just add everything" refactor doesn't pollute the subgraph.
+    const EXPECTED_EXCLUDED: &[&str] = &[
+        "same_source", "produced", "has_method_capability",
+        "section_follows", "CONTAINS", "DUPLICATE",
+    ];
+
+    #[test]
+    fn allowlist_contains_expected_relationships() {
+        for rel in EXPECTED_INCLUDED {
+            assert!(
+                GRAPH_EDGE_RELATIONSHIPS.contains(rel),
+                "missing from allowlist: {rel}",
+            );
+        }
+    }
+
+    #[test]
+    fn allowlist_excludes_design_excluded_relationships() {
+        for rel in EXPECTED_EXCLUDED {
+            assert!(
+                !GRAPH_EDGE_RELATIONSHIPS.contains(rel),
+                "should not be in allowlist: {rel}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #13.

⚠️ **Draft / prereq dependency.** This PR is stacked on the unmerged \`feat/graph-communities\` branch (4 commits not yet on origin). The first 4 commits in this PR are from that branch and should be reviewed/merged separately. Only the last 3 commits are this PR's actual scope:

- \`f85fbf0d\` test(api): pin graph allowlist contents (failing)
- \`8b4fa2bd\` fix(api): extend graph allowlist with 8 missing valid types
- \`df5d2663\` feat(api): expose filtered_edge_count on graph subgraph responses

Please rebase this PR onto \`main\` after \`feat/graph-communities\` lands, or merge \`feat/graph-communities\` first and then this PR will only show its own 3 commits.

---

## What changed (this PR's scope)

Two related changes to \`/api/v1/graph/neighborhood\` and the cluster/community expand endpoints (which share \`fetch_subgraph_edges\` in \`crates/epigraph-api/src/routes/graph_overview.rs\`):

### 1. Extend the allowlist (8 missing valid types)

\`GRAPH_EDGE_RELATIONSHIPS\` is the allowlist that decides which claim↔claim relationships the readability-tier graph view traverses. Audit against the live corpus showed 8 valid epistemic relationship types existed in the data but were missing from the allowlist — orphaning ~5% of claims (10,089 / 191,240) on right-click expand.

Added: \`variant_of\` (28 edges), \`equivalent_to\` (12), \`provides_evidence\` (5), \`challenges\` (2), \`specializes\` (2), \`SUPERSEDES\` (uppercase sibling of an already-listed type, 1 edge), \`definitional_variant_of\` (1), \`elaborates\` (1).

Stayed excluded by design (provenance / structural / triage, not epistemic): \`same_source\`, \`produced\`, \`has_method_capability\`, \`section_follows\`, \`CONTAINS\`, \`DUPLICATE\`.

The constant is now grouped by category (Hierarchical / Corroboration / Contradiction / Argument continuation / Equivalence / Cross-reference / Lineage) so future contributors can place new types unambiguously.

### 2. Expose \`filtered_edge_count\` on subgraph responses

Adds a new \`filtered_edge_count: i64\` field to \`ClusterSubgraphResponse\` so the GUI can disambiguate "true leaf node" from "had relationships but they were filtered". Computed by changing the SQL inside \`fetch_subgraph_edges\` to return ALL edges between requested nodes (still bounded by \`NODE_EDGE_LIMIT = 5000\`) tagged with an \`is_allowed\` boolean, then partitioning them in Rust.

**Important semantic note:** \`filtered_edge_count\` counts excluded edges *between returned \`nodes\`*. For the cluster/community expand endpoints, that's the natural answer: "this subgraph has N excluded internal edges". For \`/graph/neighborhood\`'s seed-only path (when BFS finds zero allowlisted neighbors), the seed has no other returned nodes to be between, so \`filtered_edge_count\` will be \`0\` — even if the seed has e.g. one \`produced\` edge. The reporter's specific reproduction seed will continue to return \`{n:1, e:0, filtered_edge_count:0}\`. Their underlying ask was actually configurability — see follow-up.

## Empirical impact (live corpus, 2026-04-29)

| Metric | Before | After |
|--------|-------:|------:|
| Claims orphaned by allowlist | 10,089 | 10,029 |
| Newly-reachable claims | — | 60 |

Modest because most of the ~10k orphaned claims have only \`produced\` / \`same_source\` (intentionally excluded provenance edges), not the 8 newly-added types. Those orphans are not bugs — they're claims whose only relationships are document-structure or agent-action provenance, correctly suppressed from the readability tier.

## Out of scope (follow-up issue to be filed)

The reporter's actual fix request was a \`?relationships=…\` query param to override the allowlist. That would obsolete \`filtered_edge_count\` for power users. Filing as a follow-up.

## Test plan

- [x] Unit: allowlist membership pinned (\`graph_overview::tests::allowlist_contains_expected_relationships\`).
- [x] Unit: design-excluded relationships pinned (\`graph_overview::tests::allowlist_excludes_design_excluded_relationships\`).
- [x] Unit: \`filtered_edge_count\` field serializes (\`graph_overview::tests::cluster_subgraph_response_serializes_filtered_count\`).
- [x] \`cargo test -p epigraph-api --lib graph_overview::tests\` — 3 passed; 0 failed.
- [x] \`cargo build -p epigraph-api\` — clean.
- [x] \`cargo clippy -p epigraph-api --lib --no-deps\` — clean.
- [x] SQL probe of new \`fetch_subgraph_edges\` query against live corpus: confirmed correct partitioning of allowed vs filtered for a 2-node neighborhood with mixed-relationship edges.
- [ ] (After feat/graph-communities lands) End-to-end: rebuild API, hit \`/graph/neighborhood\` with a previously-orphaned claim (\`07a4d856-fe6a-4ef4-b8ff-7526a9b2c1ff\` has an \`equivalent_to\` neighbor — should now return n=2, e=1).
- [ ] (Optional follow-up) Add \`#[sqlx::test]\` integration test that seeds claims + edges of mixed types and asserts \`fetch_subgraph_edges\` counts correctly. Deferred per advisor: SQL is ~10 lines and obvious; unit tests on constant + serialization carry the regression bar.

## Known limitations

- \`cargo build --no-default-features\` on this crate fails with 32 errors — verified pre-existing on \`main\`, not introduced here. This PR's no-db stubs were updated correctly so the wiring is consistent for whoever fixes the broader no-db path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)