### PR TITLE
fix(api): lift 10k row cap on unfiltered claim listing

### DIFF
--- a/crates/epigraph-api/src/routes/claims_query.rs
+++ b/crates/epigraph-api/src/routes/claims_query.rs
@@ -306,14 +306,11 @@ pub async fn list_claims_query(
         || sort_order != "desc";
 
     if !needs_in_memory_filters {
-        let total = ClaimRepository::count(
-            &state.db_pool,
-            params.content_contains.as_deref(),
-        )
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: format!("Database count failed: {}", e),
-        })? as usize;
+        let total = ClaimRepository::count(&state.db_pool, params.content_contains.as_deref())
+            .await
+            .map_err(|e| ApiError::InternalError {
+                message: format!("Database count failed: {}", e),
+            })? as usize;
 
         let rows = ClaimRepository::list(
             &state.db_pool,

--- a/crates/epigraph-api/src/routes/claims_query.rs
+++ b/crates/epigraph-api/src/routes/claims_query.rs
@@ -288,9 +288,68 @@ pub async fn list_claims_query(
         None => None,
     };
 
-    // ---- Query PostgreSQL ----
-    // Fetch claims from DB, apply remaining filters in-memory.
-    // We push the content_contains search down to PostgreSQL ILIKE macro for efficiency.
+    // ---- Fast path: no post-fetch filters, default sort ----
+    // The legacy in-memory pipeline below caps the working set at 10_000 rows
+    // and reports `total` as the slice length, which understates the true table
+    // count on large databases. When the request needs no truth/agent/date/
+    // methodology/evidence-type filtering and uses the default sort, we can let
+    // PostgreSQL do COUNT(*) + LIMIT/OFFSET directly.
+    let needs_in_memory_filters = params.truth_min.is_some()
+        || params.truth_max.is_some()
+        || params.agent_id.is_some()
+        || params.is_current.is_some()
+        || params.created_after.is_some()
+        || params.created_before.is_some()
+        || methodology_ids.is_some()
+        || evidence_type_ids.is_some()
+        || sort_by != "created_at"
+        || sort_order != "desc";
+
+    if !needs_in_memory_filters {
+        let total = ClaimRepository::count(
+            &state.db_pool,
+            params.content_contains.as_deref(),
+        )
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Database count failed: {}", e),
+        })? as usize;
+
+        let rows = ClaimRepository::list(
+            &state.db_pool,
+            limit as i64,
+            offset as i64,
+            params.content_contains.as_deref(),
+        )
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Database query failed: {}", e),
+        })?;
+
+        let paginated: Vec<ClaimSummary> = rows
+            .into_iter()
+            .map(|c| ClaimSummary {
+                id: c.id.as_uuid(),
+                statement: c.content.clone(),
+                content: c.content.clone(),
+                truth_value: c.truth_value.value(),
+                agent_id: c.agent_id.as_uuid(),
+                is_current: c.is_current,
+                created_at: c.created_at,
+                updated_at: c.updated_at,
+            })
+            .collect();
+
+        return Ok(Json(ClaimListResponse {
+            claims: paginated,
+            total,
+            limit,
+            offset,
+        }));
+    }
+
+    // ---- Slow path: filters/sort require fetching a working set into memory ----
+    // Capped at 10_000 rows; the reported `total` reflects the filtered slice.
     let all_claims = ClaimRepository::list(
         &state.db_pool,
         10_000,


### PR DESCRIPTION
## Summary

Cherry-picked from \`feat/graph-communities\` (commit \`d769b0ad\`), which is being abandoned in favor of the already-merged graph backend from #8.

The filter pipeline in \`list_claims_query\` loaded up to 10,000 rows into memory then reported \`total = slice.len()\` — so \`/api/v1/claims\` always capped \`total\` at 10000 even on databases with 389k+ claims, and pagination beyond row 10k was impossible.

This adds a fast path: when no truth/agent/date/methodology/evidence-type filters are present and the request uses the default created_at-desc sort, defer to \`ClaimRepository::count()\` plus a SQL LIMIT/OFFSET. \`content_contains\` is honoured by the SQL ILIKE in count() and list(), so it stays on the fast path. Filtered/sorted requests still take the legacy in-memory path; that cap can be raised in a follow-up once filters are pushed into SQL.

## Test plan

- [x] \`cargo build -p epigraph-api\` — clean.
- [ ] Manual: \`curl /api/v1/claims?limit=100\` reports \`total\` matching \`SELECT COUNT(*) FROM claims WHERE is_current = true\` (was capped at 10000 before).
- [ ] Manual: pagination at \`offset=10000+\` returns rows (was 0 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)