### PR TITLE
fix(api): broaden graph view allowlist + expose filtered_edge_count

### DIFF
--- a/crates/epigraph-api/src/routes/graph.rs
+++ b/crates/epigraph-api/src/routes/graph.rs
@@ -11,6 +11,60 @@ use uuid::Uuid;
 
 use crate::AppState;
 
+/// Claim-level edge relationships exposed to the graph view.
+///
+/// Covers the dominant epistemic relationship types in the corpus —
+/// hierarchical decomposition, corroboration, support/contradiction,
+/// refinement, equivalence, evidence, etc. — plus their case variants.
+///
+/// This is intentionally *broader* than [`epigraph_jobs::cluster_graph::runner::EPISTEMIC_RELATIONSHIPS`]
+/// (which is the clustering job's edge set). Rendering filters by readability;
+/// clustering filters by what it weights as community-formation signal.
+///
+/// Excluded by design (kept out to keep the subgraph readable):
+///   `same_source`, `produced` — provenance, not epistemic
+///   `has_method_capability` — agent↔method, not claim↔claim
+///   `section_follows`, `CONTAINS` — document structure
+///   `DUPLICATE` — flagged for triage, not render
+const GRAPH_VIEW_RELATIONSHIPS: &[&str] = &[
+    // Hierarchical
+    "decomposes_to",
+    "refines",
+    "REFINES",
+    "specializes",
+    // Corroboration / support
+    "CORROBORATES",
+    "corroborates",
+    "supports",
+    "SUPPORTS",
+    "provides_evidence",
+    "asserts",
+    "enables",
+    // Contradiction / challenge
+    "refutes",
+    "contradicts",
+    "CONTRADICTS",
+    "challenges",
+    // Argument continuation
+    "continues_argument",
+    "elaborates",
+    // Equivalence / variants
+    "same_as",
+    "equivalent_to",
+    "analogous",
+    "variant_of",
+    "definitional_variant_of",
+    // Generic / cross-reference
+    "relates_to",
+    "RELATES_TO",
+    // Lineage / temporal
+    "supersedes",
+    "SUPERSEDES",
+    "derived_from",
+    "DERIVED_FROM",
+    "derives_from",
+];
+
 #[derive(Debug, Serialize)]
 pub struct OverviewResponse {
     pub run_id: Option<Uuid>,
@@ -52,6 +106,11 @@ pub struct ExpandResponse {
     pub total_size: i64,
     pub nodes: Vec<NodeOut>,
     pub edges: Vec<EdgeOut>,
+    /// Count of edges between the returned `nodes` whose `relationship` is
+    /// not in `GRAPH_VIEW_RELATIONSHIPS` (e.g. `produced`, `same_source`,
+    /// `CONTAINS`). Lets the GUI render "this node has N relationships not
+    /// shown in the readability tier" instead of an ambiguous empty payload.
+    pub filtered_edge_count: i64,
 }
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
@@ -173,9 +232,7 @@ pub async fn expand(
     };
 
     let budget = params.budget.max(1);
-    // Re-use the canonical list from epigraph-jobs rather than duplicating it.
-    let rel_list: Vec<&str> =
-        epigraph_jobs::cluster_graph::runner::EPISTEMIC_RELATIONSHIPS.to_vec();
+    let rel_list: Vec<&str> = GRAPH_VIEW_RELATIONSHIPS.to_vec();
     let nodes: Vec<NodeOut> = sqlx::query_as::<_, NodeOut>(
         "WITH degree AS (
             SELECT m.claim_id, COUNT(e.*) AS deg
@@ -206,16 +263,7 @@ pub async fn expand(
     .map_err(internal)?;
 
     let node_ids: Vec<Uuid> = nodes.iter().map(|n| n.id).collect();
-    let edges: Vec<EdgeOut> = sqlx::query_as::<_, EdgeOut>(
-        "SELECT source_id AS source, target_id AS target, relationship
-         FROM edges
-         WHERE source_id = ANY($1) AND target_id = ANY($1) AND relationship = ANY($2)",
-    )
-    .bind(&node_ids)
-    .bind(rel_list)
-    .fetch_all(pool)
-    .await
-    .map_err(internal)?;
+    let (edges, filtered_edge_count) = fetch_subgraph_edges(pool, &node_ids, &rel_list).await?;
 
     Ok(Json(ExpandResponse {
         cluster_id,
@@ -223,6 +271,7 @@ pub async fn expand(
         total_size,
         nodes,
         edges,
+        filtered_edge_count,
     }))
 }
 
@@ -234,8 +283,7 @@ pub async fn neighborhood(
     let pool: &PgPool = &state.db_pool;
     let hops = params.hops.clamp(1, 2);
     let budget = params.budget.max(1);
-    let rel_list: Vec<&str> =
-        epigraph_jobs::cluster_graph::runner::EPISTEMIC_RELATIONSHIPS.to_vec();
+    let rel_list: Vec<&str> = GRAPH_VIEW_RELATIONSHIPS.to_vec();
 
     let nodes: Vec<NodeOut> = sqlx::query_as::<_, NodeOut>(
         r#"
@@ -275,16 +323,7 @@ pub async fn neighborhood(
     }
 
     let ids: Vec<Uuid> = nodes.iter().map(|n| n.id).collect();
-    let edges: Vec<EdgeOut> = sqlx::query_as::<_, EdgeOut>(
-        "SELECT source_id AS source, target_id AS target, relationship
-         FROM edges
-         WHERE source_id = ANY($1) AND target_id = ANY($1) AND relationship = ANY($2)",
-    )
-    .bind(&ids)
-    .bind(rel_list)
-    .fetch_all(pool)
-    .await
-    .map_err(internal)?;
+    let (edges, filtered_edge_count) = fetch_subgraph_edges(pool, &ids, &rel_list).await?;
 
     Ok(Json(ExpandResponse {
         cluster_id: Uuid::nil(),
@@ -292,9 +331,146 @@ pub async fn neighborhood(
         total_size: nodes.len() as i64,
         nodes,
         edges,
+        filtered_edge_count,
     }))
+}
+
+/// Fetch edges *between* the given node ids, partitioned into:
+/// - edges whose `relationship` is in `rel_list` (returned as `edges`)
+/// - edges whose `relationship` is *not* in `rel_list` (returned as count)
+///
+/// Single round-trip: tags each row with an `is_allowed` flag computed in
+/// the SELECT list, then partitions in Rust.
+async fn fetch_subgraph_edges(
+    pool: &PgPool,
+    node_ids: &[Uuid],
+    rel_list: &[&str],
+) -> Result<(Vec<EdgeOut>, i64), (axum::http::StatusCode, String)> {
+    if node_ids.is_empty() {
+        return Ok((Vec::new(), 0));
+    }
+    let rows: Vec<(Uuid, Uuid, String, bool)> = sqlx::query_as(
+        "SELECT source_id, target_id, relationship,
+                (relationship = ANY($2)) AS is_allowed
+         FROM edges
+         WHERE source_id = ANY($1) AND target_id = ANY($1)",
+    )
+    .bind(node_ids)
+    .bind(rel_list)
+    .fetch_all(pool)
+    .await
+    .map_err(internal)?;
+
+    let mut edges = Vec::new();
+    let mut filtered: i64 = 0;
+    for (source, target, relationship, is_allowed) in rows {
+        if is_allowed {
+            edges.push(EdgeOut {
+                source,
+                target,
+                relationship,
+            });
+        } else {
+            filtered += 1;
+        }
+    }
+    Ok((edges, filtered))
 }
 
 fn internal(e: sqlx::Error) -> (axum::http::StatusCode, String) {
     (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Relationship types we expect the graph view to traverse.
+    /// Adding a row here without adding the matching string to
+    /// `GRAPH_VIEW_RELATIONSHIPS` will fail this test, which is the point:
+    /// the constant is the single source of truth for what the GUI's
+    /// expand-this-node action will surface.
+    const EXPECTED_INCLUDED: &[&str] = &[
+        // Hierarchical
+        "decomposes_to",
+        "refines",
+        "REFINES",
+        "specializes",
+        // Corroboration / support
+        "CORROBORATES",
+        "corroborates",
+        "supports",
+        "SUPPORTS",
+        "provides_evidence",
+        "asserts",
+        "enables",
+        // Contradiction / challenge
+        "refutes",
+        "contradicts",
+        "CONTRADICTS",
+        "challenges",
+        // Argument continuation
+        "continues_argument",
+        "elaborates",
+        // Equivalence / variants
+        "same_as",
+        "equivalent_to",
+        "analogous",
+        "variant_of",
+        "definitional_variant_of",
+        // Generic / cross-reference
+        "relates_to",
+        "RELATES_TO",
+        // Lineage / temporal
+        "supersedes",
+        "SUPERSEDES",
+        "derived_from",
+        "DERIVED_FROM",
+        "derives_from",
+    ];
+
+    /// Relationships the design explicitly excludes — keep them out so a
+    /// future "just add everything" refactor doesn't pollute the subgraph.
+    const EXPECTED_EXCLUDED: &[&str] = &[
+        "same_source",
+        "produced",
+        "has_method_capability",
+        "section_follows",
+        "CONTAINS",
+        "DUPLICATE",
+    ];
+
+    #[test]
+    fn graph_view_allowlist_contains_expected_relationships() {
+        for rel in EXPECTED_INCLUDED {
+            assert!(
+                GRAPH_VIEW_RELATIONSHIPS.contains(rel),
+                "missing from allowlist: {rel}",
+            );
+        }
+    }
+
+    #[test]
+    fn graph_view_allowlist_excludes_design_excluded_relationships() {
+        for rel in EXPECTED_EXCLUDED {
+            assert!(
+                !GRAPH_VIEW_RELATIONSHIPS.contains(rel),
+                "should not be in allowlist: {rel}",
+            );
+        }
+    }
+
+    #[test]
+    fn expand_response_serializes_filtered_count() {
+        let r = ExpandResponse {
+            cluster_id: Uuid::nil(),
+            truncated: false,
+            total_size: 1,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            filtered_edge_count: 7,
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["filtered_edge_count"], 7);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #13. Replaces obsolete draft #18 (which was based on the abandoned \`feat/graph-communities\` branch).

## Background

Issue #13 reported that \`/api/v1/graph/neighborhood\` returned seed-only responses. The reporter's diagnosed cause (\"vocabulary mismatch in the allowlist\") was right *for main's code*, but they were testing against a different deployment that already had a 21-entry allowlist (the abandoned \`feat/graph-communities\` branch).

On main, the situation is dramatically worse: \`routes/graph.rs\` shares \`EPISTEMIC_RELATIONSHIPS\` with the clustering job, which is just \`["SUPPORTS", "CONTRADICTS"]\`. Against the corpus (~272k claim↔claim edges) that's ~94 edges, so almost every right-click-expand returns the seed alone.

## What this PR does

### 1. Split rendering and clustering allowlists

Added \`GRAPH_VIEW_RELATIONSHIPS\` constant in \`routes/graph.rs\` covering 29 epistemic relationship types in the live corpus, grouped by category:

- **Hierarchical**: \`decomposes_to\`, \`refines\`/\`REFINES\`, \`specializes\`
- **Corroboration / support**: \`CORROBORATES\`/\`corroborates\`, \`supports\`/\`SUPPORTS\`, \`provides_evidence\`, \`asserts\`, \`enables\`
- **Contradiction / challenge**: \`refutes\`, \`contradicts\`/\`CONTRADICTS\`, \`challenges\`
- **Argument continuation**: \`continues_argument\`, \`elaborates\`
- **Equivalence / variants**: \`same_as\`, \`equivalent_to\`, \`analogous\`, \`variant_of\`, \`definitional_variant_of\`
- **Generic / cross-reference**: \`relates_to\`/\`RELATES_TO\`
- **Lineage / temporal**: \`supersedes\`/\`SUPERSEDES\`, \`derived_from\`/\`derives_from\`/\`DERIVED_FROM\`

Stayed excluded by design: \`same_source\`, \`produced\`, \`has_method_capability\`, \`section_follows\`, \`CONTAINS\`, \`DUPLICATE\` (provenance / agent / structural / triage — not epistemic).

The \`expand\` and \`neighborhood\` handlers now use \`GRAPH_VIEW_RELATIONSHIPS\` instead of \`epigraph_jobs::cluster_graph::runner::EPISTEMIC_RELATIONSHIPS\`. The clustering job's allowlist is **unchanged** — broadening that would change Louvain output and force a re-cluster, out of scope here. Easy follow-up if desired.

### 2. Expose \`filtered_edge_count\` on subgraph responses

Adds \`filtered_edge_count: i64\` to \`ExpandResponse\` so the GUI can render \"this node has N relationships not shown in the readability tier\" instead of an ambiguous empty payload. Computed in a new \`fetch_subgraph_edges\` helper that tags each row with an \`is_allowed\` flag (single round-trip) and partitions in Rust.

**Semantic note:** \`filtered_edge_count\` counts excluded edges *between returned nodes*. For \`/graph/neighborhood\`'s seed-only path (when BFS finds zero allowlisted neighbors), the seed has no other returned nodes to be \"between,\" so the count is 0 even if the seed has \`produced\` edges to other claims. Configurability via a \`?relationships=…\` query param (the reporter's actual third option) is filed as #19.

## Empirical impact

The shared 2-element allowlist on main meant ~99% of claims would right-click-expand to nothing. With \`GRAPH_VIEW_RELATIONSHIPS\` (29 entries), per the live-corpus probe, only ~5% (10,029 / 191,240) remain orphaned — and those are claims whose only relationships are intentionally-excluded provenance/structural edges.

| Metric | Before (main) | After |
|--------|--------------:|------:|
| Allowlist size | 2 | 29 |
| Claim-edges traversable | ~94 | ~232,000 |
| Claims orphaned | ~190,000 | ~10,029 |

## Test plan

- [x] Unit: rendering allowlist membership pinned (\`graph::tests::graph_view_allowlist_contains_expected_relationships\`).
- [x] Unit: design-excluded relationships pinned (\`graph::tests::graph_view_allowlist_excludes_design_excluded_relationships\`).
- [x] Unit: \`filtered_edge_count\` field serializes (\`graph::tests::expand_response_serializes_filtered_count\`).
- [x] \`cargo test -p epigraph-api --lib graph::tests\` — 3 passed; 0 failed.
- [x] \`cargo build -p epigraph-api\` — clean.
- [x] \`cargo clippy -p epigraph-api --lib --no-deps\` — clean.
- [x] SQL probe of the new \`fetch_subgraph_edges\` query against live corpus: confirmed correct partitioning of allowed vs filtered for a 2-node neighborhood with mixed-relationship edges.
- [ ] (After deploy) End-to-end: hit \`/graph/neighborhood\` with a previously-orphaned claim (\`07a4d856-fe6a-4ef4-b8ff-7526a9b2c1ff\` has an \`equivalent_to\` neighbor — should now return \`n=2, e=1\`).

## Out of scope

- Configurable \`?relationships=…\` query param (#19).
- Broadening the clustering job's \`EPISTEMIC_RELATIONSHIPS\` (would also change Louvain output).
- Any change to the existing \`graph_routes_test.rs\` integration tests — those were checked and don't assert against the allowlist contents, so they continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)