### PR TITLE
feat: port multi-provider external identity from epigraph-internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1032,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,9 +1229,11 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "pkcs1",
  "prometheus-client",
  "rand 0.8.5",
  "reqwest",
+ "rsa",
  "serde",
  "serde_json",
  "serde_with",
@@ -1213,6 +1243,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
+ "toml",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -1220,6 +1251,7 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -2742,6 +2774,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5547,6 +5589,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -54,6 +54,7 @@ tower-http = { version = "0.5", features = ["trace", "cors"] }  # HTTP middlewar
 serde = { workspace = true }  # Serialization
 serde_json = { workspace = true }  # JSON support
 serde_with = { workspace = true }  # Helper macros for serde
+toml = "0.8"  # provider config parsing
 uuid = { workspace = true }  # UUID support
 chrono = { workspace = true }  # Date/time handling
 thiserror = { workspace = true }  # Error derive macros
@@ -88,6 +89,10 @@ epigraph-db = { workspace = true }  # E2E encrypted subgraph tests
 blake3 = { workspace = true }  # Content hashing in E2E tests
 ed25519-dalek = { workspace = true }  # Agent signing keys in E2E tests
 rand = { workspace = true }  # Key generation in E2E tests
+wiremock = "0.6"  # HTTP fixture for OAuth provider integration tests
+rsa = "0.9"  # RSA keypair fixture for OAuth tests
+pkcs1 = "0.7"  # PKCS#1 encoding for RSA fixtures
+toml = "0.8"  # provider config TOML parsing in tests
 
 [[test]]
 name = "graph_routes_test"

--- a/crates/epigraph-api/src/bin/server.rs
+++ b/crates/epigraph-api/src/bin/server.rs
@@ -181,6 +181,18 @@ async fn main() {
     #[cfg(not(feature = "db"))]
     let state = AppState::new(config).with_embedding_service(embedding_service);
 
+    // Load external identity providers from providers.toml.
+    // EPIGRAPH_PROVIDERS_CONFIG overrides the default path. Missing config is
+    // a hard startup error to prevent silent degradation to an empty registry.
+    let state = {
+        let providers_path = std::env::var("EPIGRAPH_PROVIDERS_CONFIG")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from("providers.toml"));
+        let providers = epigraph_api::oauth::providers::build_registry(providers_path.as_path())
+            .expect("failed to build providers registry");
+        state.with_providers(providers)
+    };
+
     // Start background job runner with ClusterGraph handler (db feature only).
     // The runner uses PostgresJobQueue for durable persistence.  The cron loop
     // fires 60 s after startup then every 24 h thereafter.

--- a/crates/epigraph-api/src/errors.rs
+++ b/crates/epigraph-api/src/errors.rs
@@ -50,6 +50,9 @@ pub enum ApiError {
 
     #[error("Conflict: {reason}")]
     Conflict { reason: String },
+
+    #[error("Bad gateway: {reason}")]
+    BadGateway { reason: String },
 }
 
 /// JSON error response structure
@@ -126,6 +129,11 @@ impl IntoResponse for ApiError {
             ApiError::Conflict { reason } => (
                 StatusCode::CONFLICT,
                 "Conflict",
+                Some(serde_json::json!({ "reason": reason })),
+            ),
+            ApiError::BadGateway { reason } => (
+                StatusCode::BAD_GATEWAY,
+                "BadGateway",
                 Some(serde_json::json!({ "reason": reason })),
             ),
         };

--- a/crates/epigraph-api/src/oauth/device.rs
+++ b/crates/epigraph-api/src/oauth/device.rs
@@ -1,37 +1,43 @@
-//! OAuth2 Authorization Code exchange for browser-based Google login.
+//! Generic browser-based OAuth2 redirect flow for any OIDC redirect provider.
 //!
-//! POST /oauth/google/auth-url   — returns the Google consent URL + PKCE verifier
-//! POST /oauth/google/exchange   — exchanges auth code + verifier for EpiGraph tokens
+//! POST /oauth/{provider}/auth-url   — returns the consent URL + PKCE verifier
+//! POST /oauth/{provider}/exchange   — exchanges auth code + verifier for EpiGraph tokens
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ApiError;
 use crate::state::AppState;
 
-// ── Request / Response types ────────────────────────────────────────
-
 #[derive(Debug, Serialize)]
 pub struct AuthUrlResponse {
     pub auth_url: String,
     pub code_verifier: String,
+    /// CSRF binding token. The caller must verify this matches the `state` returned
+    /// on the redirect callback before calling `/oauth/{provider}/exchange`.
+    pub state: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct AuthUrlRequest {
+    /// Optional override; falls back to provider config or EPIGRAPH_REDIRECT_URI.
+    pub redirect_uri: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct ExchangeRequest {
-    /// The authorization code from Google (or full redirect URL containing it)
     pub code: String,
-    /// The PKCE code_verifier that was generated with the auth URL
     pub code_verifier: String,
+    pub redirect_uri: Option<String>,
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────
-
-/// Generate PKCE code_verifier and code_challenge (S256).
 fn generate_pkce() -> (String, String) {
     use base64::Engine;
     use sha2::Digest;
-
     let verifier_bytes: [u8; 32] = rand::random();
     let verifier = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(verifier_bytes);
     let challenge_hash = sha2::Sha256::digest(verifier.as_bytes());
@@ -39,16 +45,20 @@ fn generate_pkce() -> (String, String) {
     (verifier, challenge)
 }
 
-/// Extract the authorization code from user input.
-/// They might paste the raw code or the full redirect URL.
+/// Generate an OAuth `state` value (32 random bytes, base64url-encoded). Used as a
+/// CSRF binding token that the caller must verify on the redirect callback.
+fn generate_state() -> String {
+    use base64::Engine;
+    let bytes: [u8; 32] = rand::random();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
 fn extract_code(input: &str) -> String {
     let trimmed = input.trim();
     if trimmed.contains("code=") {
-        // Parse query string from URL like http://127.0.0.1:1?code=4/0A...&scope=...
         if let Some(query_part) = trimmed.split('?').nth(1) {
             for pair in query_part.split('&') {
                 if let Some(val) = pair.strip_prefix("code=") {
-                    // URL-decode the value
                     return percent_decode(val);
                 }
             }
@@ -76,195 +86,145 @@ fn percent_decode(input: &str) -> String {
     result
 }
 
-// ── Endpoints ───────────────────────────────────────────────────────
+/// Resolve the redirect URI in priority order:
+/// 1. Caller-supplied (request body `redirect_uri`).
+/// 2. Provider-configured default (from `OidcRedirectFlow::default_redirect_uri`).
+/// 3. Legacy fallback: `EPIGRAPH_REDIRECT_URI` env var, defaulting to `http://127.0.0.1:1`.
+fn resolve_redirect_uri(caller: Option<&str>, provider_default: Option<&str>) -> String {
+    if let Some(uri) = caller {
+        return uri.to_string();
+    }
+    if let Some(uri) = provider_default {
+        return uri.to_string();
+    }
+    std::env::var("EPIGRAPH_REDIRECT_URI").unwrap_or_else(|_| "http://127.0.0.1:1".to_string())
+}
 
-/// POST /oauth/google/auth-url
-///
-/// Returns a Google consent URL and the PKCE code_verifier the client must
-/// send back when exchanging the resulting authorization code.
 #[cfg(feature = "db")]
-pub async fn google_auth_url_endpoint(
-    State(_state): State<AppState>,
+pub async fn auth_url_endpoint(
+    State(state): State<AppState>,
+    Path(provider_name): Path<String>,
+    body: Option<Json<AuthUrlRequest>>,
 ) -> Result<(StatusCode, Json<AuthUrlResponse>), ApiError> {
-    let client_id = std::env::var("GOOGLE_CLIENT_ID").map_err(|_| ApiError::InternalError {
-        message: "GOOGLE_CLIENT_ID not configured on server".to_string(),
-    })?;
+    if state.providers.by_name(&provider_name).is_none() {
+        return Err(ApiError::NotFound {
+            entity: "provider".into(),
+            id: provider_name.clone(),
+        });
+    }
+    let flow = state
+        .providers
+        .redirect_flow(&provider_name)
+        .ok_or(ApiError::BadRequest {
+            message: format!("provider {provider_name} does not support redirect flow"),
+        })?;
 
+    let req = body.map(|Json(b)| b).unwrap_or_default();
     let redirect_uri =
-        std::env::var("EPIGRAPH_REDIRECT_URI").unwrap_or_else(|_| "http://127.0.0.1:1".to_string());
-
+        resolve_redirect_uri(req.redirect_uri.as_deref(), flow.default_redirect_uri());
     let (verifier, challenge) = generate_pkce();
-
-    let auth_url = format!(
-        "https://accounts.google.com/o/oauth2/v2/auth\
-         ?client_id={client_id}\
-         &redirect_uri={}\
-         &response_type=code\
-         &scope=openid+email+profile\
-         &code_challenge={challenge}\
-         &code_challenge_method=S256\
-         &access_type=offline",
-        redirect_uri.as_str(),
-    );
+    let csrf_state = generate_state();
+    let auth_url = flow.build_auth_url(&csrf_state, &challenge, &redirect_uri);
 
     Ok((
         StatusCode::OK,
         Json(AuthUrlResponse {
             auth_url,
             code_verifier: verifier,
+            state: csrf_state,
         }),
     ))
 }
 
-/// POST /oauth/google/exchange
-///
-/// Exchanges a Google authorization code + PKCE verifier for EpiGraph tokens.
-/// The client obtains the code by completing Google sign-in in a browser tab
-/// and copying the code from the redirect URL.
 #[cfg(feature = "db")]
-pub async fn google_exchange_endpoint(
+pub async fn exchange_endpoint(
     State(state): State<AppState>,
+    Path(provider_name): Path<String>,
     Json(req): Json<ExchangeRequest>,
 ) -> Result<(StatusCode, Json<super::token::TokenResponse>), ApiError> {
-    use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+    use crate::oauth::providers::{provision_external_user, ProviderError};
 
-    let client_id = std::env::var("GOOGLE_CLIENT_ID").map_err(|_| ApiError::InternalError {
-        message: "GOOGLE_CLIENT_ID not configured".to_string(),
-    })?;
-    let client_secret =
-        std::env::var("GOOGLE_CLIENT_SECRET").map_err(|_| ApiError::InternalError {
-            message: "GOOGLE_CLIENT_SECRET not configured".to_string(),
+    let provider = state
+        .providers
+        .by_name(&provider_name)
+        .ok_or(ApiError::NotFound {
+            entity: "provider".into(),
+            id: provider_name.clone(),
         })?;
-
-    let redirect_uri =
-        std::env::var("EPIGRAPH_REDIRECT_URI").unwrap_or_else(|_| "http://127.0.0.1:1".to_string());
+    let flow = state
+        .providers
+        .redirect_flow(&provider_name)
+        .ok_or(ApiError::BadRequest {
+            message: format!("provider {provider_name} does not support redirect flow"),
+        })?;
 
     let code = extract_code(&req.code);
     if code.is_empty() {
         return Err(ApiError::BadRequest {
-            message: "No authorization code found in input".to_string(),
+            message: "No authorization code found in input".into(),
         });
     }
 
-    // Exchange the authorization code for Google tokens
-    let params = [
-        ("client_id", client_id.as_str()),
-        ("client_secret", client_secret.as_str()),
-        ("code", code.as_str()),
-        ("code_verifier", req.code_verifier.as_str()),
-        ("grant_type", "authorization_code"),
-        ("redirect_uri", redirect_uri.as_str()),
-    ];
+    let redirect_uri =
+        resolve_redirect_uri(req.redirect_uri.as_deref(), flow.default_redirect_uri());
 
-    let resp = reqwest::Client::new()
-        .post("https://oauth2.googleapis.com/token")
-        .form(&params)
-        .send()
+    let id_token = flow
+        .exchange_code(&code, &redirect_uri, &req.code_verifier)
         .await
-        .map_err(|e| ApiError::InternalError {
-            message: format!("Failed to contact Google token endpoint: {e}"),
+        .map_err(|e| match e {
+            ProviderError::Upstream(msg) => ApiError::BadGateway { reason: msg },
+            ProviderError::InvalidAssertion(msg) => ApiError::BadRequest { message: msg },
+            ProviderError::Config(msg) => ApiError::InternalError { message: msg },
+            ProviderError::JwksFetch(msg) => ApiError::ServiceUnavailable {
+                service: format!("JWKS unavailable: {msg}"),
+            },
         })?;
 
-    let body = resp.text().await.unwrap_or_default();
-    let parsed: serde_json::Value =
-        serde_json::from_str(&body).map_err(|e| ApiError::InternalError {
-            message: format!("Failed to parse Google token response: {e}"),
-        })?;
+    let identity = match provider.validate(&id_token).await {
+        Ok(id) => id,
+        Err(e) => {
+            crate::oauth::providers::provision::emit_oauth_audit(
+                &state.db_pool,
+                "oauth_assertion_rejected",
+                false,
+                serde_json::json!({
+                    "provider": provider.name(),
+                    "flow": "redirect",
+                    "reason": format!("{e}"),
+                }),
+            );
+            return Err(match e {
+                ProviderError::InvalidAssertion(msg) => ApiError::Unauthorized { reason: msg },
+                ProviderError::JwksFetch(msg) => ApiError::ServiceUnavailable {
+                    service: format!("JWKS unavailable: {msg}"),
+                },
+                ProviderError::Upstream(msg) => ApiError::BadGateway { reason: msg },
+                ProviderError::Config(msg) => ApiError::InternalError { message: msg },
+            });
+        }
+    };
 
-    if let Some(error) = parsed.get("error").and_then(|e| e.as_str()) {
-        let desc = parsed
-            .get("error_description")
-            .and_then(|d| d.as_str())
-            .unwrap_or("unknown error");
-        return Err(ApiError::BadRequest {
-            message: format!("Google token exchange failed: {error}: {desc}"),
-        });
-    }
-
-    // Extract and validate the ID token
-    let id_token_str =
-        parsed
-            .get("id_token")
-            .and_then(|v| v.as_str())
-            .ok_or(ApiError::InternalError {
-                message: "Google returned no id_token".to_string(),
-            })?;
-
-    let header = decode_header(id_token_str).map_err(|e| ApiError::BadRequest {
-        message: format!("Invalid ID token header: {e}"),
-    })?;
-    let kid = header.kid.ok_or(ApiError::BadRequest {
-        message: "ID token missing kid header".to_string(),
-    })?;
-
-    // Fetch Google's JWKS
-    let jwks_url = "https://www.googleapis.com/oauth2/v3/certs";
-    let jwks_resp = reqwest::get(jwks_url)
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: format!("Failed to fetch Google JWKS: {e}"),
-        })?;
-    let jwks_body: serde_json::Value =
-        jwks_resp
-            .json()
-            .await
-            .map_err(|e| ApiError::InternalError {
-                message: format!("Failed to parse Google JWKS: {e}"),
-            })?;
-
-    let keys = jwks_body["keys"]
-        .as_array()
-        .ok_or(ApiError::InternalError {
-            message: "Google JWKS has no keys array".to_string(),
-        })?;
-    let jwk = keys
-        .iter()
-        .find(|k| k["kid"].as_str() == Some(&kid))
-        .ok_or(ApiError::Unauthorized {
-            reason: "ID token kid not found in Google JWKS".to_string(),
-        })?;
-
-    let n = jwk["n"].as_str().ok_or(ApiError::InternalError {
-        message: "Google JWK missing 'n' field".to_string(),
-    })?;
-    let e_val = jwk["e"].as_str().ok_or(ApiError::InternalError {
-        message: "Google JWK missing 'e' field".to_string(),
-    })?;
-
-    let decoding_key =
-        DecodingKey::from_rsa_components(n, e_val).map_err(|err| ApiError::InternalError {
-            message: format!("Failed to build RSA key from Google JWK: {err}"),
-        })?;
-
-    let mut validation = Validation::new(Algorithm::RS256);
-    validation.set_audience(&[&client_id]);
-    validation.set_issuer(&["https://accounts.google.com", "accounts.google.com"]);
-
-    let token_data =
-        decode::<super::token::GoogleIdTokenClaims>(id_token_str, &decoding_key, &validation)
-            .map_err(|e| ApiError::Unauthorized {
-                reason: format!("Google ID token validation failed: {e}"),
-            })?;
-
-    // Use shared provisioning logic
-    super::token::provision_google_user(&state, &token_data.claims, None).await
+    provision_external_user(&state, provider.as_ref(), &identity, None).await
 }
 
 #[cfg(not(feature = "db"))]
-pub async fn google_auth_url_endpoint(
-    State(_state): State<AppState>,
+pub async fn auth_url_endpoint(
+    State(_): State<AppState>,
+    Path(_): Path<String>,
+    _body: Option<Json<AuthUrlRequest>>,
 ) -> Result<(StatusCode, Json<AuthUrlResponse>), ApiError> {
     Err(ApiError::ServiceUnavailable {
-        service: "database required for OAuth2".to_string(),
+        service: "database required for OAuth2".into(),
     })
 }
 
 #[cfg(not(feature = "db"))]
-pub async fn google_exchange_endpoint(
-    State(_state): State<AppState>,
-    Json(_req): Json<ExchangeRequest>,
+pub async fn exchange_endpoint(
+    State(_): State<AppState>,
+    Path(_): Path<String>,
+    Json(_): Json<ExchangeRequest>,
 ) -> Result<(StatusCode, Json<super::token::TokenResponse>), ApiError> {
     Err(ApiError::ServiceUnavailable {
-        service: "database required for OAuth2".to_string(),
+        service: "database required for OAuth2".into(),
     })
 }

--- a/crates/epigraph-api/src/oauth/mod.rs
+++ b/crates/epigraph-api/src/oauth/mod.rs
@@ -3,11 +3,12 @@
 pub mod device;
 pub mod introspect;
 pub mod jwt;
+pub mod providers;
 pub mod register;
 pub mod revoke;
 pub mod token;
 
-pub use device::{google_auth_url_endpoint, google_exchange_endpoint};
+pub use device::{auth_url_endpoint, exchange_endpoint};
 pub use introspect::introspect_endpoint;
 pub use jwt::{EpiGraphClaims, JwtConfig};
 pub use register::{register_endpoint, RegisterRequest, RegisterResponse};

--- a/crates/epigraph-api/src/oauth/providers/cloudflare_access.rs
+++ b/crates/epigraph-api/src/oauth/providers/cloudflare_access.rs
@@ -1,0 +1,144 @@
+//! Cloudflare Access provider — assertion-only (no redirect dance).
+//!
+//! Validates `Cf-Access-Jwt-Assertion` JWTs against Cloudflare Access's JWKS.
+
+use async_trait::async_trait;
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use serde::Deserialize;
+
+use super::config::ProviderConfig;
+use super::jwks::JwksCache;
+use super::traits::{ExternalIdentity, ExternalIdentityProvider, ProviderError};
+
+#[derive(Debug, Deserialize)]
+struct CfClaims {
+    sub: String,
+    email: Option<String>,
+    name: Option<String>,
+    /// CF Access emits `aud` as an array (one element typically).
+    /// jsonwebtoken's `Validation::set_audience` handles either string or array shape.
+    iss: String,
+    iat: u64,
+    exp: u64,
+}
+
+pub struct CloudflareAccessProvider {
+    name: String,
+    grant_type: String,
+    issuer: String,
+    jwks_url: String,
+    audience: String,
+    auto_provision: bool,
+    default_scopes: Vec<String>,
+    jwks: JwksCache,
+}
+
+impl CloudflareAccessProvider {
+    pub fn from_config(cfg: &ProviderConfig, jwks: JwksCache) -> Result<Self, ProviderError> {
+        let resolve_env = |var: &str| -> Result<String, ProviderError> {
+            std::env::var(var).map_err(|_| ProviderError::Config(format!("env var {var} not set")))
+        };
+        let audience = match (&cfg.audience, &cfg.audience_env) {
+            (Some(a), _) => a.clone(),
+            (_, Some(env)) => resolve_env(env)?,
+            _ => {
+                return Err(ProviderError::Config(
+                    "audience/audience_env required".into(),
+                ))
+            }
+        };
+        Ok(Self {
+            name: cfg.name.clone(),
+            grant_type: cfg.grant_type.clone(),
+            issuer: cfg.issuer.clone(),
+            jwks_url: cfg.jwks_url.clone(),
+            audience,
+            auto_provision: cfg.auto_provision,
+            default_scopes: cfg.default_scopes.clone(),
+            jwks,
+        })
+    }
+
+    async fn validate_with_kid(
+        &self,
+        assertion: &str,
+        refetch: bool,
+    ) -> Result<ExternalIdentity, ProviderError> {
+        let header = decode_header(assertion)
+            .map_err(|e| ProviderError::InvalidAssertion(format!("bad header: {e}")))?;
+        let kid = header
+            .kid
+            .ok_or_else(|| ProviderError::InvalidAssertion("missing kid".into()))?;
+        let keys = if refetch {
+            self.jwks.refetch(&self.jwks_url).await?
+        } else {
+            self.jwks.get(&self.jwks_url).await?
+        };
+        let arr = keys
+            .as_array()
+            .ok_or_else(|| ProviderError::JwksFetch("keys not an array".into()))?;
+        let key = arr.iter().find(|k| k["kid"].as_str() == Some(&kid));
+        let key = match key {
+            Some(k) => k,
+            None if !refetch => return Box::pin(self.validate_with_kid(assertion, true)).await,
+            None => {
+                return Err(ProviderError::InvalidAssertion(format!(
+                    "kid {kid} not in JWKS"
+                )))
+            }
+        };
+        let n = key["n"]
+            .as_str()
+            .ok_or_else(|| ProviderError::JwksFetch("missing 'n'".into()))?;
+        let e = key["e"]
+            .as_str()
+            .ok_or_else(|| ProviderError::JwksFetch("missing 'e'".into()))?;
+        let decoding = DecodingKey::from_rsa_components(n, e)
+            .map_err(|err| ProviderError::JwksFetch(format!("bad RSA key: {err}")))?;
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_audience(&[&self.audience]);
+        validation.set_issuer(&[self.issuer.as_str()]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        validation.leeway = 60;
+
+        let data = decode::<CfClaims>(assertion, &decoding, &validation)
+            .map_err(|e| ProviderError::InvalidAssertion(format!("validation failed: {e}")))?;
+
+        let raw = serde_json::json!({
+            "sub": data.claims.sub,
+            "email": data.claims.email,
+            "name": data.claims.name,
+            "iss": data.claims.iss,
+            "iat": data.claims.iat,
+            "exp": data.claims.exp,
+        });
+
+        Ok(ExternalIdentity {
+            subject: data.claims.sub,
+            email: data.claims.email,
+            email_verified: true, // CF gates by IdP — treat as verified
+            name: data.claims.name,
+            raw_claims: raw,
+        })
+    }
+}
+
+#[async_trait]
+impl ExternalIdentityProvider for CloudflareAccessProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn grant_type(&self) -> &str {
+        &self.grant_type
+    }
+    async fn validate(&self, assertion: &str) -> Result<ExternalIdentity, ProviderError> {
+        self.validate_with_kid(assertion, false).await
+    }
+    fn auto_provision(&self) -> bool {
+        self.auto_provision
+    }
+    fn default_scopes(&self) -> &[String] {
+        &self.default_scopes
+    }
+}

--- a/crates/epigraph-api/src/oauth/providers/config.rs
+++ b/crates/epigraph-api/src/oauth/providers/config.rs
@@ -1,0 +1,256 @@
+//! TOML schema for `providers.toml` and validation.
+//!
+//! Sample:
+//!
+//! ```toml
+//! [[provider]]
+//! name = "google"
+//! flow = "redirect"
+//! grant_type = "google_id_token"
+//! issuer = "https://accounts.google.com"
+//! extra_issuers = ["accounts.google.com"]
+//! jwks_url = "https://www.googleapis.com/oauth2/v3/certs"
+//! audience_env = "GOOGLE_CLIENT_ID"
+//! client_id_env = "GOOGLE_CLIENT_ID"
+//! client_secret_env = "GOOGLE_CLIENT_SECRET"
+//! auth_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+//! token_endpoint = "https://oauth2.googleapis.com/token"
+//! redirect_uri_env = "EPIGRAPH_REDIRECT_URI"
+//! auto_provision = true
+//! default_scopes = ["claims:read", "claims:write"]
+//! ```
+
+use std::path::Path;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ProviderConfigError {
+    #[error("io: {0}")]
+    Io(String),
+    #[error("toml parse: {0}")]
+    Parse(String),
+    #[error("missing env var {0}")]
+    MissingEnv(String),
+    #[error("invalid provider name {0:?}: must match [a-z0-9-]+")]
+    InvalidName(String),
+    #[error("duplicate provider name: {0}")]
+    DuplicateName(String),
+    #[error("duplicate grant_type: {0}")]
+    DuplicateGrantType(String),
+    #[error("provider {name}: missing required field {field} for flow={flow}")]
+    MissingField {
+        name: String,
+        flow: String,
+        field: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProvidersConfig {
+    #[serde(rename = "provider", default)]
+    pub providers: Vec<ProviderConfig>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ProviderConfig {
+    pub name: String,
+    pub flow: ProviderFlow,
+    pub grant_type: String,
+    pub issuer: String,
+    #[serde(default)]
+    pub extra_issuers: Vec<String>,
+    pub jwks_url: String,
+    pub audience: Option<String>,
+    pub audience_env: Option<String>,
+    pub client_id_env: Option<String>,
+    pub client_secret_env: Option<String>,
+    pub auth_endpoint: Option<String>,
+    pub token_endpoint: Option<String>,
+    /// Optional literal redirect URI; takes precedence over `redirect_uri_env`.
+    pub redirect_uri: Option<String>,
+    /// Optional env-var name to read the redirect URI from. Lower priority than `redirect_uri`.
+    pub redirect_uri_env: Option<String>,
+    #[serde(default = "default_true")]
+    pub auto_provision: bool,
+    #[serde(default)]
+    pub default_scopes: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderFlow {
+    Redirect,
+    Assertion,
+}
+
+impl ProvidersConfig {
+    /// Read TOML from disk and parse. Does not resolve env vars or validate.
+    pub fn load_from_path(path: &Path) -> Result<Self, ProviderConfigError> {
+        let text =
+            std::fs::read_to_string(path).map_err(|e| ProviderConfigError::Io(e.to_string()))?;
+        Self::parse(&text)
+    }
+
+    pub fn parse(text: &str) -> Result<Self, ProviderConfigError> {
+        toml::from_str(text).map_err(|e| ProviderConfigError::Parse(e.to_string()))
+    }
+
+    /// Validate cross-cutting invariants: unique names/grant_types, name format,
+    /// required fields per flow.
+    pub fn validate(&self) -> Result<(), ProviderConfigError> {
+        let mut seen_names = std::collections::HashSet::new();
+        let mut seen_grants = std::collections::HashSet::new();
+        for p in &self.providers {
+            validate_name(&p.name)?;
+            if !seen_names.insert(&p.name) {
+                return Err(ProviderConfigError::DuplicateName(p.name.clone()));
+            }
+            if !seen_grants.insert(&p.grant_type) {
+                return Err(ProviderConfigError::DuplicateGrantType(
+                    p.grant_type.clone(),
+                ));
+            }
+            match p.flow {
+                ProviderFlow::Redirect => {
+                    require(&p.name, "redirect", "auth_endpoint", &p.auth_endpoint)?;
+                    require(&p.name, "redirect", "token_endpoint", &p.token_endpoint)?;
+                    require(&p.name, "redirect", "client_id_env", &p.client_id_env)?;
+                    require(
+                        &p.name,
+                        "redirect",
+                        "client_secret_env",
+                        &p.client_secret_env,
+                    )?;
+                }
+                ProviderFlow::Assertion => {
+                    if p.audience.is_none() && p.audience_env.is_none() {
+                        return Err(ProviderConfigError::MissingField {
+                            name: p.name.clone(),
+                            flow: "assertion".into(),
+                            field: "audience or audience_env".into(),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn require<T>(
+    name: &str,
+    flow: &str,
+    field: &str,
+    val: &Option<T>,
+) -> Result<(), ProviderConfigError> {
+    if val.is_none() {
+        Err(ProviderConfigError::MissingField {
+            name: name.into(),
+            flow: flow.into(),
+            field: field.into(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_name(name: &str) -> Result<(), ProviderConfigError> {
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(ProviderConfigError::InvalidName(name.to_string()));
+    }
+    Ok(())
+}
+
+/// Resolve an env-var reference; returns the value or `MissingEnv`.
+pub fn resolve_env(var_name: &str) -> Result<String, ProviderConfigError> {
+    std::env::var(var_name).map_err(|_| ProviderConfigError::MissingEnv(var_name.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_redirect() -> &'static str {
+        r#"
+[[provider]]
+name = "google"
+flow = "redirect"
+grant_type = "google_id_token"
+issuer = "https://accounts.google.com"
+jwks_url = "https://www.googleapis.com/oauth2/v3/certs"
+audience_env = "GOOGLE_CLIENT_ID"
+client_id_env = "GOOGLE_CLIENT_ID"
+client_secret_env = "GOOGLE_CLIENT_SECRET"
+auth_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+token_endpoint = "https://oauth2.googleapis.com/token"
+default_scopes = ["claims:read"]
+"#
+    }
+
+    #[test]
+    fn parses_redirect_provider() {
+        let cfg = ProvidersConfig::parse(sample_redirect()).unwrap();
+        assert_eq!(cfg.providers.len(), 1);
+        assert_eq!(cfg.providers[0].name, "google");
+        assert_eq!(cfg.providers[0].flow, ProviderFlow::Redirect);
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn missing_redirect_field_rejected() {
+        let mut cfg = ProvidersConfig::parse(sample_redirect()).unwrap();
+        cfg.providers[0].auth_endpoint = None;
+        let err = cfg.validate().unwrap_err();
+        match err {
+            ProviderConfigError::MissingField { field, .. } => {
+                assert_eq!(field, "auth_endpoint")
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        let text = format!("{}{}", sample_redirect(), sample_redirect());
+        let cfg = ProvidersConfig::parse(&text).unwrap();
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, ProviderConfigError::DuplicateName(_)));
+    }
+
+    #[test]
+    fn invalid_name_format_rejected() {
+        let mut cfg = ProvidersConfig::parse(sample_redirect()).unwrap();
+        cfg.providers[0].name = "Google".into();
+        assert!(matches!(
+            cfg.validate(),
+            Err(ProviderConfigError::InvalidName(_))
+        ));
+    }
+
+    #[test]
+    fn assertion_flow_requires_audience() {
+        let text = r#"
+[[provider]]
+name = "cf"
+flow = "assertion"
+grant_type = "cf_jwt"
+issuer = "https://team.cloudflareaccess.com"
+jwks_url = "https://team.cloudflareaccess.com/cdn-cgi/access/certs"
+"#;
+        let cfg = ProvidersConfig::parse(text).unwrap();
+        assert!(matches!(
+            cfg.validate(),
+            Err(ProviderConfigError::MissingField { .. })
+        ));
+    }
+}

--- a/crates/epigraph-api/src/oauth/providers/google.rs
+++ b/crates/epigraph-api/src/oauth/providers/google.rs
@@ -1,0 +1,255 @@
+//! Google identity provider — implements both ExternalIdentityProvider and OidcRedirectFlow.
+
+use async_trait::async_trait;
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use serde::Deserialize;
+
+use super::config::ProviderConfig;
+use super::jwks::JwksCache;
+use super::traits::{ExternalIdentity, ExternalIdentityProvider, OidcRedirectFlow, ProviderError};
+
+/// Percent-encode a query-string value per RFC 3986 unreserved set.
+fn pct_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleClaims {
+    sub: String,
+    email: Option<String>,
+    email_verified: Option<bool>,
+    name: Option<String>,
+    iat: u64,
+    exp: u64,
+}
+
+pub struct GoogleProvider {
+    name: String,
+    grant_type: String,
+    issuer_primary: String,
+    extra_issuers: Vec<String>,
+    jwks_url: String,
+    audience: String,
+    client_id: String,
+    client_secret: String,
+    auth_endpoint: String,
+    token_endpoint: String,
+    default_redirect_uri: Option<String>,
+    auto_provision: bool,
+    default_scopes: Vec<String>,
+    jwks: JwksCache,
+}
+
+impl GoogleProvider {
+    pub fn from_config(cfg: &ProviderConfig, jwks: JwksCache) -> Result<Self, ProviderError> {
+        let resolve_env = |var: &str| -> Result<String, ProviderError> {
+            std::env::var(var).map_err(|_| ProviderError::Config(format!("env var {var} not set")))
+        };
+
+        let audience = match (&cfg.audience, &cfg.audience_env) {
+            (Some(a), _) => a.clone(),
+            (_, Some(env)) => resolve_env(env)?,
+            _ => {
+                return Err(ProviderError::Config(
+                    "audience/audience_env required".into(),
+                ))
+            }
+        };
+        let client_id = resolve_env(
+            cfg.client_id_env
+                .as_deref()
+                .ok_or_else(|| ProviderError::Config("client_id_env required".into()))?,
+        )?;
+        let client_secret = resolve_env(
+            cfg.client_secret_env
+                .as_deref()
+                .ok_or_else(|| ProviderError::Config("client_secret_env required".into()))?,
+        )?;
+        let auth_endpoint = cfg
+            .auth_endpoint
+            .clone()
+            .ok_or_else(|| ProviderError::Config("auth_endpoint required".into()))?;
+        let token_endpoint = cfg
+            .token_endpoint
+            .clone()
+            .ok_or_else(|| ProviderError::Config("token_endpoint required".into()))?;
+
+        let default_redirect_uri = match (&cfg.redirect_uri, &cfg.redirect_uri_env) {
+            (Some(u), _) => Some(u.clone()),
+            (_, Some(env)) => Some(resolve_env(env)?),
+            _ => None,
+        };
+
+        Ok(Self {
+            name: cfg.name.clone(),
+            grant_type: cfg.grant_type.clone(),
+            issuer_primary: cfg.issuer.clone(),
+            extra_issuers: cfg.extra_issuers.clone(),
+            jwks_url: cfg.jwks_url.clone(),
+            audience,
+            client_id,
+            client_secret,
+            auth_endpoint,
+            token_endpoint,
+            default_redirect_uri,
+            auto_provision: cfg.auto_provision,
+            default_scopes: cfg.default_scopes.clone(),
+            jwks,
+        })
+    }
+
+    fn issuers(&self) -> Vec<&str> {
+        let mut v = vec![self.issuer_primary.as_str()];
+        v.extend(self.extra_issuers.iter().map(|s| s.as_str()));
+        v
+    }
+
+    async fn validate_with_kid(
+        &self,
+        assertion: &str,
+        refetch: bool,
+    ) -> Result<ExternalIdentity, ProviderError> {
+        let header = decode_header(assertion)
+            .map_err(|e| ProviderError::InvalidAssertion(format!("bad header: {e}")))?;
+        let kid = header
+            .kid
+            .ok_or_else(|| ProviderError::InvalidAssertion("missing kid".into()))?;
+
+        let keys = if refetch {
+            self.jwks.refetch(&self.jwks_url).await?
+        } else {
+            self.jwks.get(&self.jwks_url).await?
+        };
+        let arr = keys
+            .as_array()
+            .ok_or_else(|| ProviderError::JwksFetch("keys not an array".into()))?;
+        let key = arr.iter().find(|k| k["kid"].as_str() == Some(&kid));
+        let key = match key {
+            Some(k) => k,
+            None if !refetch => {
+                // One forced refetch on kid miss.
+                return Box::pin(self.validate_with_kid(assertion, true)).await;
+            }
+            None => {
+                return Err(ProviderError::InvalidAssertion(format!(
+                    "kid {kid} not in JWKS"
+                )))
+            }
+        };
+
+        let n = key["n"]
+            .as_str()
+            .ok_or_else(|| ProviderError::JwksFetch("missing 'n'".into()))?;
+        let e = key["e"]
+            .as_str()
+            .ok_or_else(|| ProviderError::JwksFetch("missing 'e'".into()))?;
+        let decoding = DecodingKey::from_rsa_components(n, e)
+            .map_err(|err| ProviderError::JwksFetch(format!("bad RSA key: {err}")))?;
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_audience(&[&self.audience]);
+        validation.set_issuer(&self.issuers());
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        validation.leeway = 60;
+
+        let data = decode::<GoogleClaims>(assertion, &decoding, &validation)
+            .map_err(|e| ProviderError::InvalidAssertion(format!("validation failed: {e}")))?;
+        let raw = serde_json::json!({
+            "sub": data.claims.sub,
+            "email": data.claims.email,
+            "email_verified": data.claims.email_verified,
+            "name": data.claims.name,
+            "iat": data.claims.iat,
+            "exp": data.claims.exp,
+        });
+        Ok(ExternalIdentity {
+            subject: data.claims.sub,
+            email: data.claims.email,
+            email_verified: data.claims.email_verified.unwrap_or(false),
+            name: data.claims.name,
+            raw_claims: raw,
+        })
+    }
+}
+
+#[async_trait]
+impl ExternalIdentityProvider for GoogleProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn grant_type(&self) -> &str {
+        &self.grant_type
+    }
+    async fn validate(&self, assertion: &str) -> Result<ExternalIdentity, ProviderError> {
+        self.validate_with_kid(assertion, false).await
+    }
+    fn auto_provision(&self) -> bool {
+        self.auto_provision
+    }
+    fn default_scopes(&self) -> &[String] {
+        &self.default_scopes
+    }
+}
+
+#[async_trait]
+impl OidcRedirectFlow for GoogleProvider {
+    fn build_auth_url(&self, state: &str, pkce_challenge: &str, redirect_uri: &str) -> String {
+        format!(
+            "{}?client_id={}&redirect_uri={}&response_type=code\
+             &scope=openid+email+profile&code_challenge={}&code_challenge_method=S256\
+             &access_type=offline&state={}",
+            self.auth_endpoint,
+            pct_encode(&self.client_id),
+            pct_encode(redirect_uri),
+            pct_encode(pkce_challenge),
+            pct_encode(state),
+        )
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        redirect_uri: &str,
+        pkce_verifier: &str,
+    ) -> Result<String, ProviderError> {
+        let params = [
+            ("client_id", self.client_id.as_str()),
+            ("client_secret", self.client_secret.as_str()),
+            ("code", code),
+            ("code_verifier", pkce_verifier),
+            ("grant_type", "authorization_code"),
+            ("redirect_uri", redirect_uri),
+        ];
+        let resp = reqwest::Client::new()
+            .post(&self.token_endpoint)
+            .form(&params)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Upstream(format!("token POST failed: {e}")))?;
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| ProviderError::Upstream(format!("bad token response: {e}")))?;
+        if let Some(err) = body.get("error").and_then(|v| v.as_str()) {
+            return Err(ProviderError::Upstream(format!(
+                "idp returned error: {err}"
+            )));
+        }
+        body.get("id_token")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| ProviderError::Upstream("response missing id_token".into()))
+    }
+
+    fn default_redirect_uri(&self) -> Option<&str> {
+        self.default_redirect_uri.as_deref()
+    }
+}

--- a/crates/epigraph-api/src/oauth/providers/jwks.rs
+++ b/crates/epigraph-api/src/oauth/providers/jwks.rs
@@ -1,0 +1,289 @@
+//! Cached JWKS fetcher shared by all providers.
+//!
+//! - TTL: 1h.
+//! - Stale-grace: 5m beyond TTL if upstream is unreachable on refresh.
+//! - Kid-not-found: a single forced refetch; if still missing, validation fails.
+//! - Concurrent fetches for the same URL are coalesced (single-flight).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use super::traits::ProviderError;
+
+const TTL: Duration = Duration::from_secs(60 * 60);
+const STALE_GRACE: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Clone)]
+struct Entry {
+    keys: Value, // the "keys" array as a Value
+    fetched_at: Instant,
+}
+
+#[derive(Default)]
+struct Inner {
+    entries: HashMap<String, Entry>,
+    /// Per-URL coalescing locks. Holding the mutex serializes refresh for that URL.
+    locks: HashMap<String, Arc<Mutex<()>>>,
+}
+
+#[derive(Default, Clone)]
+pub struct JwksCache {
+    inner: Arc<Mutex<Inner>>,
+    fetcher: Option<Arc<dyn JwksFetcher>>,
+}
+
+#[async_trait::async_trait]
+pub trait JwksFetcher: Send + Sync {
+    async fn fetch(&self, url: &str) -> Result<Value, String>;
+}
+
+struct ReqwestFetcher;
+
+#[async_trait::async_trait]
+impl JwksFetcher for ReqwestFetcher {
+    async fn fetch(&self, url: &str) -> Result<Value, String> {
+        let resp = reqwest::get(url).await.map_err(|e| e.to_string())?;
+        if !resp.status().is_success() {
+            return Err(format!("status {}", resp.status()));
+        }
+        resp.json::<Value>().await.map_err(|e| e.to_string())
+    }
+}
+
+impl JwksCache {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner::default())),
+            fetcher: Some(Arc::new(ReqwestFetcher)),
+        }
+    }
+
+    /// Test-only constructor that injects a custom fetcher.
+    #[cfg(test)]
+    pub fn with_fetcher(fetcher: Arc<dyn JwksFetcher>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner::default())),
+            fetcher: Some(fetcher),
+        }
+    }
+
+    /// Fetch (or return cached) JWKS keys array for the given URL.
+    pub async fn get(&self, url: &str) -> Result<Value, ProviderError> {
+        if let Some(keys) = self.fresh(url).await {
+            return Ok(keys);
+        }
+        self.refresh(url).await
+    }
+
+    /// Force a refetch (used when a kid lookup misses on cached JWKS).
+    /// Bypasses the TTL check to guarantee an upstream fetch.
+    pub async fn refetch(&self, url: &str) -> Result<Value, ProviderError> {
+        self.refresh_internal(url, true).await
+    }
+
+    async fn fresh(&self, url: &str) -> Option<Value> {
+        let inner = self.inner.lock().await;
+        let entry = inner.entries.get(url)?;
+        if entry.fetched_at.elapsed() < TTL {
+            Some(entry.keys.clone())
+        } else {
+            None
+        }
+    }
+
+    async fn refresh(&self, url: &str) -> Result<Value, ProviderError> {
+        self.refresh_internal(url, false).await
+    }
+
+    async fn refresh_internal(&self, url: &str, force_fetch: bool) -> Result<Value, ProviderError> {
+        // Acquire per-URL lock for single-flight coalescing.
+        let lock = {
+            let mut inner = self.inner.lock().await;
+            inner
+                .locks
+                .entry(url.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = lock.lock().await;
+
+        // Re-check freshness after acquiring the lock — another caller may have refreshed.
+        // Skip this check if force_fetch is true (used by refetch).
+        if !force_fetch {
+            if let Some(keys) = self.fresh(url).await {
+                return Ok(keys);
+            }
+        }
+
+        let fetcher = self
+            .fetcher
+            .as_ref()
+            .expect("JwksCache::new must set fetcher");
+        match fetcher.fetch(url).await {
+            Ok(body) => {
+                let keys = body
+                    .get("keys")
+                    .cloned()
+                    .ok_or_else(|| ProviderError::JwksFetch("missing 'keys' array".into()))?;
+                let mut inner = self.inner.lock().await;
+                inner.entries.insert(
+                    url.to_string(),
+                    Entry {
+                        keys: keys.clone(),
+                        fetched_at: Instant::now(),
+                    },
+                );
+                Ok(keys)
+            }
+            Err(e) => {
+                // Stale-grace: serve cached value if still within TTL+STALE_GRACE.
+                let inner = self.inner.lock().await;
+                if let Some(entry) = inner.entries.get(url) {
+                    if entry.fetched_at.elapsed() < TTL + STALE_GRACE {
+                        tracing::warn!(url, error = %e, "JWKS refresh failed, serving stale cache");
+                        return Ok(entry.keys.clone());
+                    }
+                }
+                Err(ProviderError::JwksFetch(e))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingFetcher {
+        count: AtomicUsize,
+        body: Value,
+    }
+
+    #[async_trait::async_trait]
+    impl JwksFetcher for CountingFetcher {
+        async fn fetch(&self, _url: &str) -> Result<Value, String> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(self.body.clone())
+        }
+    }
+
+    fn body() -> Value {
+        serde_json::json!({"keys":[{"kid":"a","kty":"RSA"}]})
+    }
+
+    #[tokio::test]
+    async fn caches_within_ttl() {
+        let f = Arc::new(CountingFetcher {
+            count: AtomicUsize::new(0),
+            body: body(),
+        });
+        let cache = JwksCache::with_fetcher(f.clone());
+        cache.get("https://example/jwks").await.unwrap();
+        cache.get("https://example/jwks").await.unwrap();
+        assert_eq!(f.count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn coalesces_concurrent_misses() {
+        let f = Arc::new(CountingFetcher {
+            count: AtomicUsize::new(0),
+            body: body(),
+        });
+        let cache = JwksCache::with_fetcher(f.clone());
+        let mut handles = vec![];
+        for _ in 0..10 {
+            let c = cache.clone();
+            handles.push(tokio::spawn(async move {
+                c.get("https://example/jwks").await.unwrap()
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(
+            f.count.load(Ordering::SeqCst),
+            1,
+            "10 concurrent gets must hit upstream exactly once"
+        );
+    }
+
+    struct FailingFetcher {
+        count: AtomicUsize,
+        succeed_first: bool,
+        body: Value,
+    }
+
+    #[async_trait::async_trait]
+    impl JwksFetcher for FailingFetcher {
+        async fn fetch(&self, _url: &str) -> Result<Value, String> {
+            let n = self.count.fetch_add(1, Ordering::SeqCst);
+            if n == 0 && self.succeed_first {
+                Ok(self.body.clone())
+            } else {
+                Err("upstream 503".into())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_grace_serves_old_value() {
+        let f = Arc::new(FailingFetcher {
+            count: AtomicUsize::new(0),
+            succeed_first: true,
+            body: body(),
+        });
+        let cache = JwksCache::with_fetcher(f.clone());
+
+        // Seed cache.
+        cache.get("https://example/jwks").await.unwrap();
+
+        // Force a refetch — upstream is now failing, but stale cache should serve.
+        let result = cache.refetch("https://example/jwks").await.unwrap();
+        assert_eq!(result, body().get("keys").cloned().unwrap());
+    }
+
+    #[tokio::test]
+    async fn cold_failure_returns_error() {
+        let f = Arc::new(FailingFetcher {
+            count: AtomicUsize::new(0),
+            succeed_first: false,
+            body: body(),
+        });
+        let cache = JwksCache::with_fetcher(f);
+        let err = cache.get("https://example/jwks").await.unwrap_err();
+        assert!(matches!(err, ProviderError::JwksFetch(_)));
+    }
+
+    #[tokio::test]
+    async fn refetch_forces_upstream_call_even_when_fresh() {
+        let f = Arc::new(CountingFetcher {
+            count: AtomicUsize::new(0),
+            body: body(),
+        });
+        let cache = JwksCache::with_fetcher(f.clone());
+        // Seed the cache.
+        cache.get("https://example/jwks").await.unwrap();
+        assert_eq!(f.count.load(Ordering::SeqCst), 1);
+
+        // get() within TTL must not refetch.
+        cache.get("https://example/jwks").await.unwrap();
+        assert_eq!(
+            f.count.load(Ordering::SeqCst),
+            1,
+            "fresh get should not hit upstream"
+        );
+
+        // refetch() MUST hit upstream even when cache is fresh — that's its whole purpose.
+        cache.refetch("https://example/jwks").await.unwrap();
+        assert_eq!(
+            f.count.load(Ordering::SeqCst),
+            2,
+            "refetch must bypass cache"
+        );
+    }
+}

--- a/crates/epigraph-api/src/oauth/providers/mod.rs
+++ b/crates/epigraph-api/src/oauth/providers/mod.rs
@@ -1,0 +1,65 @@
+//! Multi-provider external identity registry.
+//!
+//! See `docs/superpowers/specs/2026-04-26-multi-provider-identity-design.md`.
+
+// Submodules are wired in subsequent tasks as their contents land.
+pub mod cloudflare_access;
+pub mod config;
+pub mod google;
+pub mod jwks;
+pub mod provision;
+mod registry;
+pub use registry::ProviderRegistry;
+mod traits;
+pub use provision::provision_external_user;
+pub use traits::{ExternalIdentity, ExternalIdentityProvider, OidcRedirectFlow, ProviderError};
+
+use std::path::Path;
+use std::sync::Arc;
+
+use self::cloudflare_access::CloudflareAccessProvider;
+use self::config::{ProviderFlow, ProvidersConfig};
+use self::google::GoogleProvider;
+use self::jwks::JwksCache;
+
+/// Build a registry from a `providers.toml` path.
+///
+/// Currently dispatches `flow=redirect` to GoogleProvider and `flow=assertion` to CloudflareAccessProvider.
+/// When adding more redirect providers, switch on `name` here.
+pub fn build_registry(path: &Path) -> Result<Arc<ProviderRegistry>, String> {
+    let mut registry = ProviderRegistry::empty();
+    if !path.exists() {
+        return Err(format!(
+            "providers.toml not found at {path:?}; copy from providers.toml at repo root or set EPIGRAPH_PROVIDERS_CONFIG"
+        ));
+    }
+
+    let cfg = ProvidersConfig::load_from_path(path).map_err(|e| e.to_string())?;
+    cfg.validate().map_err(|e| e.to_string())?;
+    let jwks = JwksCache::new();
+
+    for p in cfg.providers {
+        match p.flow {
+            ProviderFlow::Redirect => {
+                let google =
+                    GoogleProvider::from_config(&p, jwks.clone()).map_err(|e| e.to_string())?;
+                let arc = Arc::new(google);
+                registry
+                    .register(
+                        arc.clone() as Arc<dyn ExternalIdentityProvider>,
+                        Some(arc as Arc<dyn OidcRedirectFlow>),
+                    )
+                    .map_err(|e| e.to_string())?;
+            }
+            ProviderFlow::Assertion => {
+                let cf = CloudflareAccessProvider::from_config(&p, jwks.clone())
+                    .map_err(|e| e.to_string())?;
+                registry
+                    .register(Arc::new(cf) as Arc<dyn ExternalIdentityProvider>, None)
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+    }
+    tracing::info!(count = registry.names().count(), "Loaded provider registry");
+    Ok(Arc::new(registry))
+}

--- a/crates/epigraph-api/src/oauth/providers/provision.rs
+++ b/crates/epigraph-api/src/oauth/providers/provision.rs
@@ -1,0 +1,168 @@
+//! Provider-agnostic provisioning: synthesize client_id, find-or-create, issue tokens.
+
+use axum::{http::StatusCode, Json};
+use chrono::{Duration, Utc};
+
+use super::traits::{ExternalIdentity, ExternalIdentityProvider};
+use crate::errors::ApiError;
+use crate::oauth::token::TokenResponse;
+use crate::state::AppState;
+
+#[cfg(feature = "db")]
+pub async fn provision_external_user(
+    state: &AppState,
+    provider: &dyn ExternalIdentityProvider,
+    identity: &ExternalIdentity,
+    requested_scope: Option<&str>,
+) -> Result<(StatusCode, Json<TokenResponse>), ApiError> {
+    use epigraph_db::repos::oauth_client::OAuthClientRepository;
+    use epigraph_db::repos::refresh_token::RefreshTokenRepository;
+
+    let email = identity.email.clone().unwrap_or_default();
+    let name = identity.name.clone().unwrap_or_else(|| email.clone());
+
+    let oauth_client_id = format!("{}:{}", provider.name(), identity.subject);
+
+    let client =
+        match OAuthClientRepository::get_by_client_id(&state.db_pool, &oauth_client_id).await {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                if !provider.auto_provision() {
+                    return Err(ApiError::Forbidden {
+                        reason: "user not provisioned and auto_provision disabled".into(),
+                    });
+                }
+                let scopes = provider.default_scopes().to_vec();
+                let id = OAuthClientRepository::create(
+                    &state.db_pool,
+                    &oauth_client_id,
+                    None,
+                    &name,
+                    "human",
+                    &scopes,
+                    &scopes,
+                    "active",
+                    None,
+                    None,
+                    None,
+                    Some(&email),
+                )
+                .await
+                .map_err(|e| ApiError::InternalError {
+                    message: format!("Failed to create human client: {e}"),
+                })?;
+                tracing::info!(
+                    provider = provider.name(),
+                    client_id = %oauth_client_id,
+                    email = %email,
+                    "Auto-provisioned human OAuth client"
+                );
+                emit_oauth_audit(
+                    &state.db_pool,
+                    "oauth_human_provisioned",
+                    true,
+                    serde_json::json!({
+                        "provider": provider.name(),
+                        "client_id": oauth_client_id,
+                        "email": email,
+                    }),
+                );
+                OAuthClientRepository::get_by_id(&state.db_pool, id)
+                    .await
+                    .map_err(|e| ApiError::InternalError {
+                        message: e.to_string(),
+                    })?
+                    .ok_or(ApiError::InternalError {
+                        message: "Failed to read newly created client".into(),
+                    })?
+            }
+            Err(e) => {
+                return Err(ApiError::InternalError {
+                    message: e.to_string(),
+                })
+            }
+        };
+
+    let ttl = Duration::hours(1);
+    let effective_scopes = match requested_scope {
+        Some(req) => req
+            .split(' ')
+            .map(|s| s.to_string())
+            .filter(|s| client.granted_scopes.contains(s))
+            .collect::<Vec<_>>(),
+        None => client.granted_scopes.clone(),
+    };
+
+    let (access_token, _jti) = state
+        .jwt_config
+        .issue_access_token(
+            client.id,
+            effective_scopes.clone(),
+            "human",
+            None,
+            None,
+            ttl,
+        )
+        .map_err(|e| ApiError::InternalError {
+            message: format!("JWT signing failed: {e}"),
+        })?;
+
+    let refresh_token = {
+        use rand::Rng;
+        let raw: [u8; 32] = rand::thread_rng().gen();
+        let token_str = hex::encode(raw);
+        let hash = blake3::hash(&raw);
+        let refresh_ttl = Duration::days(30);
+        RefreshTokenRepository::create(
+            &state.db_pool,
+            hash.as_bytes(),
+            client.id,
+            &effective_scopes,
+            Utc::now() + refresh_ttl,
+        )
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: e.to_string(),
+        })?;
+        token_str
+    };
+
+    Ok((
+        StatusCode::OK,
+        Json(TokenResponse {
+            access_token,
+            token_type: "Bearer".into(),
+            expires_in: ttl.num_seconds(),
+            refresh_token: Some(refresh_token),
+            scope: effective_scopes.join(" "),
+        }),
+    ))
+}
+
+/// Fire-and-forget audit row emit. Failure to write is logged at warn level only.
+#[cfg(feature = "db")]
+pub fn emit_oauth_audit(
+    pool: &sqlx::PgPool,
+    event_type: &str,
+    success: bool,
+    details: serde_json::Value,
+) {
+    use epigraph_db::repos::security_event::{SecurityEventRepository, SecurityEventRow};
+    let pool = pool.clone();
+    let row = SecurityEventRow {
+        id: uuid::Uuid::new_v4(),
+        event_type: event_type.to_string(),
+        agent_id: None,
+        success: Some(success),
+        details,
+        ip_address: None,
+        user_agent: None,
+        correlation_id: None,
+        created_at: chrono::Utc::now(),
+    };
+    tokio::spawn(async move {
+        if let Err(e) = SecurityEventRepository::log(&pool, row).await {
+            tracing::warn!("Failed to persist OAuth audit event: {e}");
+        }
+    });
+}

--- a/crates/epigraph-api/src/oauth/providers/registry.rs
+++ b/crates/epigraph-api/src/oauth/providers/registry.rs
@@ -1,0 +1,130 @@
+//! Provider registry: name and grant_type lookup.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::traits::{ExternalIdentityProvider, OidcRedirectFlow};
+
+#[derive(Default)]
+pub struct ProviderRegistry {
+    by_name: HashMap<String, Arc<dyn ExternalIdentityProvider>>,
+    by_grant_type: HashMap<String, Arc<dyn ExternalIdentityProvider>>,
+    redirect_flows: HashMap<String, Arc<dyn OidcRedirectFlow>>,
+}
+
+impl ProviderRegistry {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Register an identity provider. Optionally also a redirect-flow capability.
+    pub fn register(
+        &mut self,
+        provider: Arc<dyn ExternalIdentityProvider>,
+        redirect_flow: Option<Arc<dyn OidcRedirectFlow>>,
+    ) -> Result<(), String> {
+        let name = provider.name().to_string();
+        let grant = provider.grant_type().to_string();
+        if self.by_name.contains_key(&name) {
+            return Err(format!("duplicate provider name: {name}"));
+        }
+        if self.by_grant_type.contains_key(&grant) {
+            return Err(format!("duplicate grant_type: {grant}"));
+        }
+        self.by_name.insert(name.clone(), provider.clone());
+        self.by_grant_type.insert(grant, provider);
+        if let Some(rf) = redirect_flow {
+            self.redirect_flows.insert(name, rf);
+        }
+        Ok(())
+    }
+
+    pub fn by_name(&self, name: &str) -> Option<Arc<dyn ExternalIdentityProvider>> {
+        self.by_name.get(name).cloned()
+    }
+
+    pub fn by_grant_type(&self, gt: &str) -> Option<Arc<dyn ExternalIdentityProvider>> {
+        self.by_grant_type.get(gt).cloned()
+    }
+
+    pub fn redirect_flow(&self, name: &str) -> Option<Arc<dyn OidcRedirectFlow>> {
+        self.redirect_flows.get(name).cloned()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.by_name.keys().map(|s| s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oauth::providers::traits::{
+        ExternalIdentity, ExternalIdentityProvider, ProviderError,
+    };
+    use async_trait::async_trait;
+
+    struct StubProvider {
+        name: String,
+        grant: String,
+    }
+
+    #[async_trait]
+    impl ExternalIdentityProvider for StubProvider {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn grant_type(&self) -> &str {
+            &self.grant
+        }
+        async fn validate(&self, _: &str) -> Result<ExternalIdentity, ProviderError> {
+            unimplemented!()
+        }
+        fn auto_provision(&self) -> bool {
+            true
+        }
+        fn default_scopes(&self) -> &[String] {
+            &[]
+        }
+    }
+
+    fn stub(name: &str, grant: &str) -> Arc<dyn ExternalIdentityProvider> {
+        Arc::new(StubProvider {
+            name: name.into(),
+            grant: grant.into(),
+        })
+    }
+
+    #[test]
+    fn lookup_by_name_and_grant_type() {
+        let mut r = ProviderRegistry::empty();
+        r.register(stub("google", "google_id_token"), None).unwrap();
+        assert!(r.by_name("google").is_some());
+        assert!(r.by_grant_type("google_id_token").is_some());
+        assert!(r.by_name("missing").is_none());
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        let mut r = ProviderRegistry::empty();
+        r.register(stub("google", "google_id_token"), None).unwrap();
+        let err = r
+            .register(stub("google", "different_grant"), None)
+            .unwrap_err();
+        assert!(err.contains("duplicate provider name"));
+    }
+
+    #[test]
+    fn duplicate_grant_type_rejected() {
+        let mut r = ProviderRegistry::empty();
+        r.register(stub("google", "google_id_token"), None).unwrap();
+        let err = r
+            .register(stub("other", "google_id_token"), None)
+            .unwrap_err();
+        assert!(err.contains("duplicate grant_type"));
+    }
+}

--- a/crates/epigraph-api/src/oauth/providers/traits.rs
+++ b/crates/epigraph-api/src/oauth/providers/traits.rs
@@ -1,0 +1,71 @@
+//! Core traits and types for external identity providers.
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// Identity extracted from a validated external assertion.
+#[derive(Debug, Clone)]
+pub struct ExternalIdentity {
+    /// Becomes the suffix in `client_id = "{provider}:{subject}"`.
+    pub subject: String,
+    pub email: Option<String>,
+    pub email_verified: bool,
+    pub name: Option<String>,
+    /// Full claims for audit/debug. Never log this directly — it may contain PII.
+    pub raw_claims: serde_json::Value,
+}
+
+#[derive(Debug, Error)]
+pub enum ProviderError {
+    /// Bad signature, expired, wrong issuer, wrong audience, malformed JWT.
+    #[error("invalid assertion: {0}")]
+    InvalidAssertion(String),
+    /// Upstream JWKS unreachable and stale-grace exhausted.
+    #[error("JWKS fetch failed: {0}")]
+    JwksFetch(String),
+    /// Misconfigured at startup.
+    #[error("provider config error: {0}")]
+    Config(String),
+    /// Upstream IdP returned an error during redirect-flow exchange.
+    #[error("upstream IdP error: {0}")]
+    Upstream(String),
+}
+
+#[async_trait]
+pub trait ExternalIdentityProvider: Send + Sync {
+    /// Stable identifier — used as the prefix in `client_id` and the path
+    /// segment in `/oauth/{name}/...`. Must match `[a-z0-9-]+` and be unique
+    /// in the registry.
+    fn name(&self) -> &str;
+
+    /// The `grant_type` string this provider responds to in `POST /oauth/token`.
+    /// Unique within the registry.
+    fn grant_type(&self) -> &str;
+
+    /// Validate the inbound assertion (a JWT) and extract identity.
+    async fn validate(&self, assertion: &str) -> Result<ExternalIdentity, ProviderError>;
+
+    fn auto_provision(&self) -> bool;
+    fn default_scopes(&self) -> &[String];
+}
+
+#[async_trait]
+pub trait OidcRedirectFlow: Send + Sync {
+    fn build_auth_url(&self, state: &str, pkce_challenge: &str, redirect_uri: &str) -> String;
+
+    /// Exchange the IdP-returned code for an `id_token` JWT (still IdP-signed).
+    /// The caller passes the resulting JWT to `ExternalIdentityProvider::validate`.
+    async fn exchange_code(
+        &self,
+        code: &str,
+        redirect_uri: &str,
+        pkce_verifier: &str,
+    ) -> Result<String, ProviderError>;
+
+    /// Provider-configured default redirect URI, used when the caller doesn't supply one.
+    /// Returns `None` when no provider-level default is configured (callers fall back
+    /// to environment-variable defaults at the route layer).
+    fn default_redirect_uri(&self) -> Option<&str> {
+        None
+    }
+}

--- a/crates/epigraph-api/src/oauth/token.rs
+++ b/crates/epigraph-api/src/oauth/token.rs
@@ -1,9 +1,9 @@
 //! POST /oauth/token — OAuth2 token issuance.
 //!
-//! Supports three grant types:
+//! Supports:
 //! - client_credentials with Ed25519 proof (agents) or client_secret (services)
 //! - refresh_token (all client types)
-//! - google_id_token (browser-based human login via Google Identity Services)
+//! - external provider grant types (registered via providers.toml; e.g. google_id_token, cloudflare_access_jwt)
 
 use axum::{extract::State, http::StatusCode, Json};
 use chrono::{Duration, Utc};
@@ -29,6 +29,8 @@ pub struct TokenRequest {
     pub scope: Option<String>,
     /// For google_id_token grant: the Google ID token JWT
     pub id_token: Option<String>,
+    /// Generic external-provider assertion (preferred over id_token for non-Google).
+    pub assertion: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -49,10 +51,16 @@ pub async fn token_endpoint(
     match req.grant_type.as_str() {
         "client_credentials" => handle_client_credentials(&state, &req).await,
         "refresh_token" => handle_refresh_token(&state, &req).await,
-        "google_id_token" => handle_google_id_token(&state, &req).await,
-        _ => Err(ApiError::BadRequest {
-            message: format!("Unsupported grant_type: {}", req.grant_type),
-        }),
+        other => {
+            // Look up an external provider by grant_type.
+            if let Some(provider) = state.providers.by_grant_type(other) {
+                handle_external_grant(&state, provider, &req).await
+            } else {
+                Err(ApiError::BadRequest {
+                    message: format!("Unsupported grant_type: {other}"),
+                })
+            }
+        }
     }
 }
 
@@ -64,6 +72,49 @@ pub async fn token_endpoint(
     Err(ApiError::ServiceUnavailable {
         service: "database required for OAuth2".to_string(),
     })
+}
+
+#[cfg(feature = "db")]
+async fn handle_external_grant(
+    state: &AppState,
+    provider: std::sync::Arc<dyn crate::oauth::providers::ExternalIdentityProvider>,
+    req: &TokenRequest,
+) -> Result<(StatusCode, Json<TokenResponse>), ApiError> {
+    use crate::oauth::providers::{provision_external_user, ProviderError};
+
+    let assertion =
+        req.assertion
+            .as_deref()
+            .or(req.id_token.as_deref())
+            .ok_or(ApiError::BadRequest {
+                message: "assertion required".into(),
+            })?;
+
+    let identity = match provider.validate(assertion).await {
+        Ok(id) => id,
+        Err(e) => {
+            crate::oauth::providers::provision::emit_oauth_audit(
+                &state.db_pool,
+                "oauth_assertion_rejected",
+                false,
+                serde_json::json!({
+                    "provider": provider.name(),
+                    "grant_type": req.grant_type,
+                    "reason": format!("{e}"),
+                }),
+            );
+            return Err(match e {
+                ProviderError::InvalidAssertion(msg) => ApiError::Unauthorized { reason: msg },
+                ProviderError::JwksFetch(msg) => ApiError::ServiceUnavailable {
+                    service: format!("JWKS unavailable: {msg}"),
+                },
+                ProviderError::Upstream(msg) => ApiError::BadGateway { reason: msg },
+                ProviderError::Config(msg) => ApiError::InternalError { message: msg },
+            });
+        }
+    };
+
+    provision_external_user(state, provider.as_ref(), &identity, req.scope.as_deref()).await
 }
 
 // ── Agent assertion verification ─────────────────────────────────────────
@@ -428,263 +479,6 @@ async fn handle_refresh_token(
             scope: effective_scopes.join(" "),
         }),
     ))
-}
-
-/// Google ID token JWT claims (subset we care about).
-#[cfg(feature = "db")]
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-pub(crate) struct GoogleIdTokenClaims {
-    /// Google account ID (stable, unique per user)
-    sub: String,
-    /// User's email address
-    email: Option<String>,
-    /// Whether Google has verified the email
-    email_verified: Option<bool>,
-    /// Display name
-    name: Option<String>,
-    /// Issued at
-    iat: u64,
-    /// Expiry
-    exp: u64,
-    /// Audience (should be our Google client ID)
-    aud: String,
-    /// Issuer (should be accounts.google.com)
-    iss: String,
-}
-
-/// Provision (find or create) a human OAuth client from validated Google ID token claims,
-/// then issue EpiGraph access + refresh tokens.
-///
-/// Called by both `handle_google_id_token` (browser flow) and the device code flow.
-#[cfg(feature = "db")]
-pub(crate) async fn provision_google_user(
-    state: &AppState,
-    claims: &GoogleIdTokenClaims,
-    requested_scope: Option<&str>,
-) -> Result<(StatusCode, Json<TokenResponse>), ApiError> {
-    use epigraph_db::repos::oauth_client::OAuthClientRepository;
-
-    let email = claims.email.clone().unwrap_or_default();
-    let name = claims.name.clone().unwrap_or_else(|| email.clone());
-
-    // The oauth_clients.client_id for Google-authed humans is "google:<sub>"
-    let oauth_client_id = format!("google:{}", claims.sub);
-
-    // Find or create the human client
-    let client = match OAuthClientRepository::get_by_client_id(&state.db_pool, &oauth_client_id)
-        .await
-    {
-        Ok(Some(client)) => client,
-        Ok(None) => {
-            // Auto-provision: create a new human client with default scopes
-            let default_scopes = vec![
-                "claims:read".to_string(),
-                "claims:write".to_string(),
-                "claims:challenge".to_string(),
-                "evidence:read".to_string(),
-                "evidence:submit".to_string(),
-                "edges:read".to_string(),
-                "edges:write".to_string(),
-                "agents:read".to_string(),
-                "agents:write".to_string(),
-                "groups:read".to_string(),
-                "groups:manage".to_string(),
-                "analysis:belief".to_string(),
-                "analysis:propagation".to_string(),
-                "analysis:reasoning".to_string(),
-                "analysis:gaps".to_string(),
-                "analysis:structural".to_string(),
-                "analysis:hypothesis".to_string(),
-                "analysis:political".to_string(),
-                "clients:register".to_string(),
-            ];
-
-            let id = OAuthClientRepository::create(
-                &state.db_pool,
-                &oauth_client_id,
-                None, // no secret — Google ID token is the credential
-                &name,
-                "human",
-                &default_scopes,
-                &default_scopes, // auto-grant all default scopes
-                "active",
-                None, // no agent_id
-                None, // no owner_id (humans own themselves)
-                None, // no legal entity
-                Some(&email),
-            )
-            .await
-            .map_err(|e| ApiError::InternalError {
-                message: format!("Failed to create human client: {e}"),
-            })?;
-
-            tracing::info!(email = %email, client_id = %oauth_client_id, "Auto-provisioned human OAuth client via Google Sign-In");
-
-            OAuthClientRepository::get_by_id(&state.db_pool, id)
-                .await
-                .map_err(|e| ApiError::InternalError {
-                    message: e.to_string(),
-                })?
-                .ok_or(ApiError::InternalError {
-                    message: "Failed to read newly created client".to_string(),
-                })?
-        }
-        Err(e) => {
-            return Err(ApiError::InternalError {
-                message: e.to_string(),
-            })
-        }
-    };
-
-    // Issue EpiGraph tokens (same logic as client_credentials for humans)
-    let ttl = Duration::hours(1);
-
-    let effective_scopes = {
-        let granted = &client.granted_scopes;
-        match requested_scope {
-            Some(requested) => {
-                let requested: Vec<String> = requested.split(' ').map(|s| s.to_string()).collect();
-                requested
-                    .into_iter()
-                    .filter(|s| granted.contains(s))
-                    .collect::<Vec<_>>()
-            }
-            None => granted.clone(),
-        }
-    };
-
-    let (access_token, _jti) = state
-        .jwt_config
-        .issue_access_token(
-            client.id,
-            effective_scopes.clone(),
-            "human",
-            None, // humans have no owner
-            None, // humans have no agent_id
-            ttl,
-        )
-        .map_err(|e| ApiError::InternalError {
-            message: format!("JWT signing failed: {e}"),
-        })?;
-
-    // Generate refresh token
-    let refresh_token = {
-        use rand::Rng;
-        let raw: [u8; 32] = rand::thread_rng().gen();
-        let token_str = hex::encode(raw);
-        let hash = blake3::hash(&raw);
-        let refresh_ttl = Duration::days(30);
-        epigraph_db::repos::refresh_token::RefreshTokenRepository::create(
-            &state.db_pool,
-            hash.as_bytes(),
-            client.id,
-            &effective_scopes,
-            Utc::now() + refresh_ttl,
-        )
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: e.to_string(),
-        })?;
-        token_str
-    };
-
-    Ok((
-        StatusCode::OK,
-        Json(TokenResponse {
-            access_token,
-            token_type: "Bearer".to_string(),
-            expires_in: ttl.num_seconds(),
-            refresh_token: Some(refresh_token),
-            scope: effective_scopes.join(" "),
-        }),
-    ))
-}
-
-/// Handle `grant_type=google_id_token`.
-///
-/// Verifies a Google ID token JWT using Google's public JWKS, then
-/// finds or creates a `human` oauth_client keyed by `google:<sub>`.
-/// Issues EpiGraph access + refresh tokens.
-#[cfg(feature = "db")]
-async fn handle_google_id_token(
-    state: &AppState,
-    req: &TokenRequest,
-) -> Result<(StatusCode, Json<TokenResponse>), ApiError> {
-    use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
-
-    let id_token = req.id_token.as_deref().ok_or(ApiError::BadRequest {
-        message: "id_token required for google_id_token grant".to_string(),
-    })?;
-
-    let google_client_id =
-        std::env::var("GOOGLE_CLIENT_ID").map_err(|_| ApiError::InternalError {
-            message: "GOOGLE_CLIENT_ID not configured on server".to_string(),
-        })?;
-
-    // Decode the JWT header to find the key ID (kid)
-    let header = decode_header(id_token).map_err(|e| ApiError::BadRequest {
-        message: format!("Invalid ID token header: {e}"),
-    })?;
-    let kid = header.kid.ok_or(ApiError::BadRequest {
-        message: "ID token missing kid header".to_string(),
-    })?;
-
-    // Fetch Google's JWKS
-    let jwks_url = "https://www.googleapis.com/oauth2/v3/certs";
-    let jwks_resp = reqwest::get(jwks_url)
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: format!("Failed to fetch Google JWKS: {e}"),
-        })?;
-    let jwks_body: serde_json::Value =
-        jwks_resp
-            .json()
-            .await
-            .map_err(|e| ApiError::InternalError {
-                message: format!("Failed to parse Google JWKS: {e}"),
-            })?;
-
-    // Find the matching key
-    let keys = jwks_body["keys"]
-        .as_array()
-        .ok_or(ApiError::InternalError {
-            message: "Google JWKS has no keys array".to_string(),
-        })?;
-
-    let jwk = keys
-        .iter()
-        .find(|k| k["kid"].as_str() == Some(&kid))
-        .ok_or(ApiError::Unauthorized {
-            reason: "ID token kid not found in Google JWKS".to_string(),
-        })?;
-
-    let n = jwk["n"].as_str().ok_or(ApiError::InternalError {
-        message: "Google JWK missing 'n' field".to_string(),
-    })?;
-    let e = jwk["e"].as_str().ok_or(ApiError::InternalError {
-        message: "Google JWK missing 'e' field".to_string(),
-    })?;
-
-    let decoding_key =
-        DecodingKey::from_rsa_components(n, e).map_err(|err| ApiError::InternalError {
-            message: format!("Failed to build RSA key from Google JWK: {err}"),
-        })?;
-
-    // Validate the Google ID token
-    let mut validation = Validation::new(Algorithm::RS256);
-    validation.set_audience(&[&google_client_id]);
-    validation.set_issuer(&["https://accounts.google.com", "accounts.google.com"]);
-
-    let token_data =
-        decode::<GoogleIdTokenClaims>(id_token, &decoding_key, &validation).map_err(|e| {
-            ApiError::Unauthorized {
-                reason: format!("Google ID token validation failed: {e}"),
-            }
-        })?;
-
-    let claims = token_data.claims;
-    provision_google_user(state, &claims, req.scope.as_deref()).await
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -679,12 +679,12 @@ pub fn create_router(state: AppState) -> Router {
         .route("/oauth/revoke", post(crate::oauth::revoke_endpoint))
         .route("/oauth/introspect", post(crate::oauth::introspect_endpoint))
         .route(
-            "/oauth/google/auth-url",
-            post(crate::oauth::google_auth_url_endpoint),
+            "/oauth/:provider/auth-url",
+            post(crate::oauth::auth_url_endpoint),
         )
         .route(
-            "/oauth/google/exchange",
-            post(crate::oauth::google_exchange_endpoint),
+            "/oauth/:provider/exchange",
+            post(crate::oauth::exchange_endpoint),
         );
 
     // Apply rate limiting and body limit as outermost layers
@@ -1032,12 +1032,12 @@ pub fn create_router(state: AppState) -> Router {
         .route("/oauth/revoke", post(crate::oauth::revoke_endpoint))
         .route("/oauth/introspect", post(crate::oauth::introspect_endpoint))
         .route(
-            "/oauth/google/auth-url",
-            post(crate::oauth::google_auth_url_endpoint),
+            "/oauth/:provider/auth-url",
+            post(crate::oauth::auth_url_endpoint),
         )
         .route(
-            "/oauth/google/exchange",
-            post(crate::oauth::google_exchange_endpoint),
+            "/oauth/:provider/exchange",
+            post(crate::oauth::exchange_endpoint),
         );
 
     // Apply rate limiting and body limit as outermost layers

--- a/crates/epigraph-api/src/state.rs
+++ b/crates/epigraph-api/src/state.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use epigraph_db::PgPool;
 
 use crate::middleware::SignatureVerificationState;
+use crate::oauth::providers::ProviderRegistry;
 use crate::routes::harvest::HarvesterClient;
 use crate::security::audit::InMemorySecurityAuditLog;
 use crate::security::AgentRateLimiter;
@@ -224,6 +225,11 @@ pub struct AppState {
     /// Defaults to [`NoOpOrchestrationBackend`] (silent drop). Enterprise deployments
     /// inject a durable queue implementation via `with_orchestration_backend`.
     pub orchestration_backend: SharedOrchestrationBackend,
+
+    /// External identity provider registry. Built once at startup from `providers.toml`.
+    /// Empty by default — server still works for agent/service auth and existing tokens,
+    /// but external `grant_type=*` requests return 400 unsupported_grant_type.
+    pub providers: Arc<ProviderRegistry>,
 }
 
 /// API configuration options
@@ -261,6 +267,7 @@ impl AppState {
             encryption_provider: Arc::new(NoOpEncryptionProvider::new()),
             policy_gate: Arc::new(NoOpPolicyGate::new()),
             orchestration_backend: Arc::new(NoOpOrchestrationBackend::new()),
+            providers: Arc::new(ProviderRegistry::empty()),
         }
     }
 
@@ -305,6 +312,7 @@ impl AppState {
             encryption_provider: Arc::new(NoOpEncryptionProvider::new()),
             policy_gate: Arc::new(NoOpPolicyGate::new()),
             orchestration_backend: Arc::new(NoOpOrchestrationBackend::new()),
+            providers: Arc::new(ProviderRegistry::empty()),
         }
     }
 
@@ -334,6 +342,7 @@ impl AppState {
             encryption_provider: Arc::new(NoOpEncryptionProvider::new()),
             policy_gate: Arc::new(NoOpPolicyGate::new()),
             orchestration_backend: Arc::new(NoOpOrchestrationBackend::new()),
+            providers: Arc::new(ProviderRegistry::empty()),
         }
     }
 
@@ -365,6 +374,7 @@ impl AppState {
             encryption_provider: Arc::new(NoOpEncryptionProvider::new()),
             policy_gate: Arc::new(NoOpPolicyGate::new()),
             orchestration_backend: Arc::new(NoOpOrchestrationBackend::new()),
+            providers: Arc::new(ProviderRegistry::empty()),
         }
     }
 
@@ -396,6 +406,7 @@ impl AppState {
             encryption_provider: Arc::new(NoOpEncryptionProvider::new()),
             policy_gate: Arc::new(NoOpPolicyGate::new()),
             orchestration_backend: Arc::new(NoOpOrchestrationBackend::new()),
+            providers: Arc::new(ProviderRegistry::empty()),
         }
     }
 
@@ -429,6 +440,7 @@ impl AppState {
             encryption_provider: Arc::new(NoOpEncryptionProvider::new()),
             policy_gate: Arc::new(NoOpPolicyGate::new()),
             orchestration_backend: Arc::new(NoOpOrchestrationBackend::new()),
+            providers: Arc::new(ProviderRegistry::empty()),
         }
     }
 
@@ -550,6 +562,17 @@ impl AppState {
     #[must_use]
     pub fn with_orchestration_backend(mut self, backend: SharedOrchestrationBackend) -> Self {
         self.orchestration_backend = backend;
+        self
+    }
+
+    /// Replace the external-provider registry (builder pattern).
+    ///
+    /// Call at startup after loading `providers.toml`. When omitted, the registry
+    /// is empty — agent/service/refresh auth still works; external grant types
+    /// return 400 unsupported_grant_type.
+    #[must_use]
+    pub fn with_providers(mut self, providers: Arc<ProviderRegistry>) -> Self {
+        self.providers = providers;
         self
     }
 }

--- a/crates/epigraph-api/tests/oauth_db.rs
+++ b/crates/epigraph-api/tests/oauth_db.rs
@@ -1,0 +1,232 @@
+//! DB-touching integration tests for the OAuth provider routes.
+//!
+//! These use `#[sqlx::test(migrations = "../../migrations")]` which spins up
+//! a fresh per-test database — they require a live Postgres reachable via
+//! `DATABASE_URL` and are skipped otherwise.
+
+mod oauth_providers;
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+use epigraph_api::oauth::providers::{
+    config::{ProviderConfig, ProviderFlow},
+    google::GoogleProvider,
+    jwks::JwksCache,
+    ExternalIdentityProvider, OidcRedirectFlow, ProviderRegistry,
+};
+use epigraph_api::{create_router, ApiConfig, AppState};
+
+use oauth_providers::fixtures::ProviderFixture;
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn config() -> ApiConfig {
+    ApiConfig {
+        require_signatures: false,
+        max_request_size: 1024 * 1024,
+    }
+}
+
+fn google_cfg(jwks_url: &str, auto_provision: bool, env_suffix: &str) -> ProviderConfig {
+    let cid_var = format!("DB_TEST_GOOGLE_CLIENT_ID_{env_suffix}");
+    let sec_var = format!("DB_TEST_GOOGLE_CLIENT_SECRET_{env_suffix}");
+    std::env::set_var(&cid_var, "test-audience");
+    std::env::set_var(&sec_var, "test-secret");
+    ProviderConfig {
+        name: "google".into(),
+        flow: ProviderFlow::Redirect,
+        grant_type: "google_id_token".into(),
+        issuer: "https://accounts.google.com".into(),
+        extra_issuers: vec![],
+        jwks_url: jwks_url.into(),
+        audience: None,
+        audience_env: Some(cid_var.clone()),
+        client_id_env: Some(cid_var),
+        client_secret_env: Some(sec_var),
+        auth_endpoint: Some("https://example/auth".into()),
+        token_endpoint: Some("https://example/token".into()),
+        redirect_uri: None,
+        redirect_uri_env: None,
+        auto_provision,
+        default_scopes: vec!["claims:read".into(), "claims:write".into()],
+    }
+}
+
+fn registry_with_google(provider: GoogleProvider) -> Arc<ProviderRegistry> {
+    let mut r = ProviderRegistry::empty();
+    let arc = Arc::new(provider);
+    r.register(
+        arc.clone() as Arc<dyn ExternalIdentityProvider>,
+        Some(arc as Arc<dyn OidcRedirectFlow>),
+    )
+    .unwrap();
+    Arc::new(r)
+}
+
+async fn post_json(app: axum::Router, uri: &str, body: Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+fn signed_jwt(fx: &ProviderFixture, sub: &str, email: &str) -> String {
+    fx.sign(&json!({
+        "iss": "https://accounts.google.com",
+        "aud": "test-audience",
+        "sub": sub,
+        "email": email,
+        "email_verified": true,
+        "name": email,
+        "iat": now(),
+        "exp": now() + 600,
+    }))
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn first_time_provisioning_creates_oauth_client(pool: PgPool) {
+    let fx = ProviderFixture::new().await;
+    let provider = GoogleProvider::from_config(
+        &google_cfg(&fx.jwks_url, true, "PROVISION_OK"),
+        JwksCache::new(),
+    )
+    .unwrap();
+    let registry = registry_with_google(provider);
+    let state = AppState::with_db(pool.clone(), config()).with_providers(registry);
+    let app = create_router(state);
+
+    let jwt = signed_jwt(&fx, "11223344", "alice@example.com");
+    let (status, body) = post_json(
+        app,
+        "/oauth/token",
+        json!({"grant_type": "google_id_token", "assertion": jwt, "scope": "claims:read claims:write"}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert!(
+        body.get("access_token").is_some(),
+        "expected access_token in body, got {body}"
+    );
+    assert_eq!(
+        body.get("token_type").and_then(|v| v.as_str()),
+        Some("Bearer")
+    );
+
+    // Verify the oauth_clients row.
+    let row: (String, String, String, Vec<String>) = sqlx::query_as(
+        "SELECT client_id, status, client_type, granted_scopes FROM oauth_clients WHERE client_id = $1",
+    )
+    .bind("google:11223344")
+    .fetch_one(&pool)
+    .await
+    .expect("oauth_clients row should exist");
+
+    assert_eq!(row.0, "google:11223344");
+    assert_eq!(row.1, "active");
+    assert_eq!(row.2, "human");
+    assert!(row.3.contains(&"claims:read".to_string()));
+    assert!(row.3.contains(&"claims:write".to_string()));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn second_provisioning_is_idempotent(pool: PgPool) {
+    let fx = ProviderFixture::new().await;
+    let provider = GoogleProvider::from_config(
+        &google_cfg(&fx.jwks_url, true, "IDEMPOTENT"),
+        JwksCache::new(),
+    )
+    .unwrap();
+    let registry = registry_with_google(provider);
+
+    // First call.
+    let state = AppState::with_db(pool.clone(), config()).with_providers(registry.clone());
+    let app1 = create_router(state);
+    let jwt1 = signed_jwt(&fx, "55667788", "bob@example.com");
+    let (s1, _b1) = post_json(
+        app1,
+        "/oauth/token",
+        json!({"grant_type": "google_id_token", "assertion": jwt1}),
+    )
+    .await;
+    assert_eq!(s1, StatusCode::OK);
+
+    // Second call (fresh JWT to avoid replay-cache hits, same sub).
+    let state2 = AppState::with_db(pool.clone(), config()).with_providers(registry);
+    let app2 = create_router(state2);
+    let jwt2 = signed_jwt(&fx, "55667788", "bob@example.com");
+    let (s2, _b2) = post_json(
+        app2,
+        "/oauth/token",
+        json!({"grant_type": "google_id_token", "assertion": jwt2}),
+    )
+    .await;
+    assert_eq!(s2, StatusCode::OK);
+
+    // Exactly one row.
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM oauth_clients WHERE client_id = $1")
+        .bind("google:55667788")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        count.0, 1,
+        "second provisioning must not create a duplicate row"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn auto_provision_disabled_returns_403(pool: PgPool) {
+    let fx = ProviderFixture::new().await;
+    let provider = GoogleProvider::from_config(
+        &google_cfg(&fx.jwks_url, false, "AUTO_OFF"),
+        JwksCache::new(),
+    )
+    .unwrap();
+    let registry = registry_with_google(provider);
+    let state = AppState::with_db(pool.clone(), config()).with_providers(registry);
+    let app = create_router(state);
+
+    let jwt = signed_jwt(&fx, "99000099", "carol@example.com");
+    let (status, body) = post_json(
+        app,
+        "/oauth/token",
+        json!({"grant_type": "google_id_token", "assertion": jwt}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+
+    // No row should have been created.
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM oauth_clients WHERE client_id = $1")
+        .bind("google:99000099")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        count.0, 0,
+        "no oauth_clients row should be created when auto_provision=false"
+    );
+}

--- a/crates/epigraph-api/tests/oauth_http.rs
+++ b/crates/epigraph-api/tests/oauth_http.rs
@@ -1,0 +1,209 @@
+//! HTTP-level integration tests for the OAuth provider routes.
+//!
+//! These tests exercise the router → registry → handler dispatch without
+//! touching the database. They run against `AppState::new(config)` which uses
+//! `connect_lazy` for the DB pool — DB queries are never issued because the
+//! 4xx response is returned before any handler reaches a repository call.
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+use epigraph_api::oauth::providers::{
+    cloudflare_access::CloudflareAccessProvider, config::ProviderConfig, config::ProviderFlow,
+    google::GoogleProvider, jwks::JwksCache, ExternalIdentityProvider, OidcRedirectFlow,
+    ProviderRegistry,
+};
+use epigraph_api::{create_router, ApiConfig, AppState};
+
+fn ensure_database_url_for_lazy_pool() {
+    if std::env::var("DATABASE_URL").is_err() {
+        std::env::set_var(
+            "DATABASE_URL",
+            "postgres://test_dummy:test_dummy@localhost/test_dummy",
+        );
+    }
+}
+
+fn config() -> ApiConfig {
+    ApiConfig {
+        require_signatures: false,
+        max_request_size: 1024 * 1024,
+    }
+}
+
+fn google_cfg() -> ProviderConfig {
+    std::env::set_var("HTTP_TEST_GOOGLE_CLIENT_ID", "test-aud");
+    std::env::set_var("HTTP_TEST_GOOGLE_CLIENT_SECRET", "test-secret");
+    ProviderConfig {
+        name: "google".into(),
+        flow: ProviderFlow::Redirect,
+        grant_type: "google_id_token".into(),
+        issuer: "https://accounts.google.com".into(),
+        extra_issuers: vec![],
+        jwks_url: "https://example/jwks".into(),
+        audience: None,
+        audience_env: Some("HTTP_TEST_GOOGLE_CLIENT_ID".into()),
+        client_id_env: Some("HTTP_TEST_GOOGLE_CLIENT_ID".into()),
+        client_secret_env: Some("HTTP_TEST_GOOGLE_CLIENT_SECRET".into()),
+        auth_endpoint: Some("https://example/auth".into()),
+        token_endpoint: Some("https://example/token".into()),
+        redirect_uri: None,
+        redirect_uri_env: None,
+        auto_provision: true,
+        default_scopes: vec![],
+    }
+}
+
+fn cf_cfg() -> ProviderConfig {
+    ProviderConfig {
+        name: "cloudflare-access".into(),
+        flow: ProviderFlow::Assertion,
+        grant_type: "cloudflare_access_jwt".into(),
+        issuer: "https://team.cloudflareaccess.com".into(),
+        extra_issuers: vec![],
+        jwks_url: "https://example/cf-jwks".into(),
+        audience: Some("cf-aud".into()),
+        audience_env: None,
+        client_id_env: None,
+        client_secret_env: None,
+        auth_endpoint: None,
+        token_endpoint: None,
+        redirect_uri: None,
+        redirect_uri_env: None,
+        auto_provision: true,
+        default_scopes: vec![],
+    }
+}
+
+fn registry_with(google: bool, cf: bool) -> Arc<ProviderRegistry> {
+    let mut r = ProviderRegistry::empty();
+    let jwks = JwksCache::new();
+    if google {
+        let g = GoogleProvider::from_config(&google_cfg(), jwks.clone()).unwrap();
+        let arc = Arc::new(g);
+        r.register(
+            arc.clone() as Arc<dyn ExternalIdentityProvider>,
+            Some(arc as Arc<dyn OidcRedirectFlow>),
+        )
+        .unwrap();
+    }
+    if cf {
+        let c = CloudflareAccessProvider::from_config(&cf_cfg(), jwks).unwrap();
+        r.register(Arc::new(c) as Arc<dyn ExternalIdentityProvider>, None)
+            .unwrap();
+    }
+    Arc::new(r)
+}
+
+fn app(registry: Arc<ProviderRegistry>) -> axum::Router {
+    ensure_database_url_for_lazy_pool();
+    let state = AppState::new(config()).with_providers(registry);
+    create_router(state)
+}
+
+async fn post_json(app: axum::Router, uri: &str, body: serde_json::Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+// ── /oauth/token tests ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn unknown_grant_type_returns_400() {
+    let app = app(registry_with(true, false));
+    let (status, body) = post_json(
+        app,
+        "/oauth/token",
+        serde_json::json!({"grant_type": "totally_made_up_grant"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let msg = body
+        .get("details")
+        .and_then(|d| d.get("message"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("Unsupported grant_type"),
+        "expected unsupported_grant_type message, got body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn external_grant_with_no_assertion_returns_400() {
+    let app = app(registry_with(true, false));
+    let (status, body) = post_json(
+        app,
+        "/oauth/token",
+        serde_json::json!({"grant_type": "google_id_token"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let msg = body
+        .get("details")
+        .and_then(|d| d.get("message"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("assertion"),
+        "expected assertion-required message, got body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn empty_registry_external_grant_returns_400() {
+    let app = app(registry_with(false, false)); // empty registry
+    let (status, _body) = post_json(
+        app,
+        "/oauth/token",
+        serde_json::json!({"grant_type": "google_id_token", "id_token": "x"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── /oauth/{provider}/* tests ────────────────────────────────────────────
+
+#[tokio::test]
+async fn unknown_provider_returns_404() {
+    let app = app(registry_with(true, false));
+    let (status, _body) =
+        post_json(app, "/oauth/nonexistent/auth-url", serde_json::json!({})).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn redirect_flow_on_assertion_provider_returns_400() {
+    let app = app(registry_with(false, true)); // CF only (assertion-flow)
+    let (status, body) = post_json(
+        app,
+        "/oauth/cloudflare-access/auth-url",
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let msg = body
+        .get("details")
+        .and_then(|d| d.get("message"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("does not support redirect flow"),
+        "expected does-not-support-redirect message, got body: {body}"
+    );
+}

--- a/crates/epigraph-api/tests/oauth_providers/fixtures.rs
+++ b/crates/epigraph-api/tests/oauth_providers/fixtures.rs
@@ -1,0 +1,70 @@
+//! RSA keypair + wiremock JWKS server + JWT signing helper.
+
+use base64::Engine;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::traits::PublicKeyParts;
+use rsa::{RsaPrivateKey, RsaPublicKey};
+use serde::Serialize;
+use serde_json::json;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+pub const TEST_KID: &str = "test-key-1";
+
+pub struct ProviderFixture {
+    pub mock_server: MockServer,
+    pub jwks_url: String,
+    private_key: RsaPrivateKey,
+}
+
+impl ProviderFixture {
+    pub async fn new() -> Self {
+        let mut rng = rand::thread_rng();
+        let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("generate RSA key");
+        let public_key = RsaPublicKey::from(&private_key);
+
+        let n_b64 =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key.n().to_bytes_be());
+        let e_b64 =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key.e().to_bytes_be());
+
+        let jwks_body = json!({
+            "keys": [{
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": TEST_KID,
+                "n": n_b64,
+                "e": e_b64,
+            }]
+        });
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(jwks_body))
+            .mount(&mock_server)
+            .await;
+
+        let jwks_url = format!("{}/jwks", mock_server.uri());
+
+        Self {
+            mock_server,
+            jwks_url,
+            private_key,
+        }
+    }
+
+    /// Sign arbitrary JSON claims with the fixture key, matching the JWKS kid.
+    pub fn sign<C: Serialize>(&self, claims: &C) -> String {
+        let pem = self
+            .private_key
+            .to_pkcs1_pem(pkcs1::LineEnding::LF)
+            .unwrap()
+            .to_string();
+        let key = EncodingKey::from_rsa_pem(pem.as_bytes()).expect("encoding key");
+        let mut header = Header::new(jsonwebtoken::Algorithm::RS256);
+        header.kid = Some(TEST_KID.into());
+        encode(&header, claims, &key).expect("sign jwt")
+    }
+}

--- a/crates/epigraph-api/tests/oauth_providers/fixtures.rs
+++ b/crates/epigraph-api/tests/oauth_providers/fixtures.rs
@@ -13,6 +13,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 pub const TEST_KID: &str = "test-key-1";
 
 pub struct ProviderFixture {
+    #[allow(dead_code)] // shared across test binaries; not all use the mock_server handle.
     pub mock_server: MockServer,
     pub jwks_url: String,
     private_key: RsaPrivateKey,

--- a/crates/epigraph-api/tests/oauth_providers/mod.rs
+++ b/crates/epigraph-api/tests/oauth_providers/mod.rs
@@ -1,0 +1,3 @@
+//! Shared fixtures for OAuth provider integration tests.
+
+pub mod fixtures;

--- a/crates/epigraph-api/tests/oauth_redirect_flow.rs
+++ b/crates/epigraph-api/tests/oauth_redirect_flow.rs
@@ -1,0 +1,113 @@
+//! Integration tests for the redirect-flow endpoints.
+
+mod oauth_providers;
+
+use epigraph_api::oauth::providers::{
+    config::{ProviderConfig, ProviderFlow},
+    google::GoogleProvider,
+    jwks::JwksCache,
+    OidcRedirectFlow,
+};
+
+use oauth_providers::fixtures::ProviderFixture;
+
+fn google_cfg(jwks_url: &str, token_endpoint: &str) -> ProviderConfig {
+    std::env::set_var("RT_GOOGLE_CLIENT_ID", "test-audience");
+    std::env::set_var("RT_GOOGLE_CLIENT_SECRET", "test-secret");
+    ProviderConfig {
+        name: "google".into(),
+        flow: ProviderFlow::Redirect,
+        grant_type: "google_id_token".into(),
+        issuer: "https://accounts.google.com".into(),
+        extra_issuers: vec!["accounts.google.com".into()],
+        jwks_url: jwks_url.into(),
+        audience: None,
+        audience_env: Some("RT_GOOGLE_CLIENT_ID".into()),
+        client_id_env: Some("RT_GOOGLE_CLIENT_ID".into()),
+        client_secret_env: Some("RT_GOOGLE_CLIENT_SECRET".into()),
+        auth_endpoint: Some("https://accounts.google.com/o/oauth2/v2/auth".into()),
+        token_endpoint: Some(token_endpoint.into()),
+        redirect_uri: None,
+        redirect_uri_env: None,
+        auto_provision: true,
+        default_scopes: vec!["claims:read".into()],
+    }
+}
+
+#[tokio::test]
+async fn build_auth_url_includes_pkce_challenge_and_redirect() {
+    let fx = ProviderFixture::new().await;
+    let provider = GoogleProvider::from_config(
+        &google_cfg(&fx.jwks_url, "https://example/token"),
+        JwksCache::new(),
+    )
+    .unwrap();
+
+    let url = provider.build_auth_url("CSRF_STATE", "PKCE_CHALLENGE", "http://localhost:9999");
+    // After percent-encoding (Task 6 fix): redirect_uri's `:`, `/` become %3A and %2F.
+    assert!(url.contains("client_id=test-audience"), "url: {url}");
+    assert!(
+        url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A9999"),
+        "url: {url}"
+    );
+    assert!(url.contains("code_challenge=PKCE_CHALLENGE"), "url: {url}");
+    assert!(url.contains("response_type=code"), "url: {url}");
+    assert!(
+        url.contains("state=CSRF_STATE"),
+        "state must propagate: {url}"
+    );
+}
+
+#[tokio::test]
+async fn exchange_code_propagates_id_token_from_idp() {
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    let fx = ProviderFixture::new().await;
+    // Mock the token endpoint on the same wiremock server.
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"id_token": "the-id-token-value"})),
+        )
+        .mount(&fx.mock_server)
+        .await;
+
+    let token_endpoint = format!("{}/token", fx.mock_server.uri());
+    let provider =
+        GoogleProvider::from_config(&google_cfg(&fx.jwks_url, &token_endpoint), JwksCache::new())
+            .unwrap();
+
+    let id_token = provider
+        .exchange_code("auth-code", "http://localhost:9999", "verifier")
+        .await
+        .unwrap();
+    assert_eq!(id_token, "the-id-token-value");
+}
+
+#[tokio::test]
+async fn exchange_code_propagates_idp_error() {
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    let fx = ProviderFixture::new().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({"error": "invalid_grant"})))
+        .mount(&fx.mock_server)
+        .await;
+
+    let token_endpoint = format!("{}/token", fx.mock_server.uri());
+    let provider =
+        GoogleProvider::from_config(&google_cfg(&fx.jwks_url, &token_endpoint), JwksCache::new())
+            .unwrap();
+
+    let err = provider
+        .exchange_code("auth-code", "http://localhost:9999", "verifier")
+        .await
+        .unwrap_err();
+    let s = format!("{err:?}");
+    assert!(s.contains("Upstream") || s.contains("invalid_grant"), "{s}");
+}

--- a/crates/epigraph-api/tests/oauth_token_grant.rs
+++ b/crates/epigraph-api/tests/oauth_token_grant.rs
@@ -1,0 +1,228 @@
+//! Integration tests for external-grant token issuance via the provider trait.
+
+mod oauth_providers;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use epigraph_api::oauth::providers::{
+    cloudflare_access::CloudflareAccessProvider, config::ProviderConfig, config::ProviderFlow,
+    google::GoogleProvider, jwks::JwksCache, ExternalIdentityProvider, ProviderError,
+};
+use serde_json::json;
+
+use oauth_providers::fixtures::ProviderFixture;
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn google_cfg(jwks_url: &str) -> ProviderConfig {
+    ProviderConfig {
+        name: "google".into(),
+        flow: ProviderFlow::Redirect,
+        grant_type: "google_id_token".into(),
+        issuer: "https://accounts.google.com".into(),
+        extra_issuers: vec!["accounts.google.com".into()],
+        jwks_url: jwks_url.into(),
+        audience: Some("test-audience".into()),
+        audience_env: None,
+        client_id_env: None,
+        client_secret_env: None,
+        auth_endpoint: Some("https://example/auth".into()),
+        token_endpoint: Some("https://example/token".into()),
+        redirect_uri: None,
+        redirect_uri_env: None,
+        auto_provision: true,
+        default_scopes: vec!["claims:read".into()],
+    }
+}
+
+#[tokio::test]
+async fn google_validate_accepts_signed_token() {
+    let fx = ProviderFixture::new().await;
+    std::env::set_var("TEST_GOOGLE_CLIENT_ID_OK", "test-audience");
+    std::env::set_var("TEST_GOOGLE_CLIENT_SECRET_OK", "test-secret");
+    let mut cfg = google_cfg(&fx.jwks_url);
+    cfg.client_id_env = Some("TEST_GOOGLE_CLIENT_ID_OK".into());
+    cfg.client_secret_env = Some("TEST_GOOGLE_CLIENT_SECRET_OK".into());
+    let provider = GoogleProvider::from_config(&cfg, JwksCache::new()).unwrap();
+
+    let claims = json!({
+        "iss": "https://accounts.google.com",
+        "aud": "test-audience",
+        "sub": "1234567890",
+        "email": "alice@example.com",
+        "email_verified": true,
+        "name": "Alice",
+        "iat": now(),
+        "exp": now() + 600,
+    });
+    let jwt = fx.sign(&claims);
+
+    let id = provider.validate(&jwt).await.unwrap();
+    assert_eq!(id.subject, "1234567890");
+    assert_eq!(id.email.as_deref(), Some("alice@example.com"));
+    assert!(id.email_verified);
+}
+
+#[tokio::test]
+async fn google_validate_rejects_wrong_issuer() {
+    let fx = ProviderFixture::new().await;
+    std::env::set_var("TEST_GOOGLE_CLIENT_ID_ISS", "test-audience");
+    std::env::set_var("TEST_GOOGLE_CLIENT_SECRET_ISS", "test-secret");
+    let mut cfg = google_cfg(&fx.jwks_url);
+    cfg.client_id_env = Some("TEST_GOOGLE_CLIENT_ID_ISS".into());
+    cfg.client_secret_env = Some("TEST_GOOGLE_CLIENT_SECRET_ISS".into());
+    let provider = GoogleProvider::from_config(&cfg, JwksCache::new()).unwrap();
+
+    let claims = json!({
+        "iss": "https://attacker.example",
+        "aud": "test-audience",
+        "sub": "x",
+        "iat": now(),
+        "exp": now() + 600,
+    });
+    let jwt = fx.sign(&claims);
+    let err = provider.validate(&jwt).await.unwrap_err();
+    assert!(matches!(err, ProviderError::InvalidAssertion(_)));
+}
+
+#[tokio::test]
+async fn google_validate_rejects_wrong_audience() {
+    let fx = ProviderFixture::new().await;
+    std::env::set_var("TEST_GOOGLE_CLIENT_ID_AUD", "test-audience");
+    std::env::set_var("TEST_GOOGLE_CLIENT_SECRET_AUD", "test-secret");
+    let mut cfg = google_cfg(&fx.jwks_url);
+    cfg.client_id_env = Some("TEST_GOOGLE_CLIENT_ID_AUD".into());
+    cfg.client_secret_env = Some("TEST_GOOGLE_CLIENT_SECRET_AUD".into());
+    let provider = GoogleProvider::from_config(&cfg, JwksCache::new()).unwrap();
+
+    let claims = json!({
+        "iss": "https://accounts.google.com",
+        "aud": "different-audience",
+        "sub": "x",
+        "iat": now(),
+        "exp": now() + 600,
+    });
+    let jwt = fx.sign(&claims);
+    let err = provider.validate(&jwt).await.unwrap_err();
+    assert!(matches!(err, ProviderError::InvalidAssertion(_)));
+}
+
+#[tokio::test]
+async fn google_validate_rejects_expired() {
+    let fx = ProviderFixture::new().await;
+    std::env::set_var("TEST_GOOGLE_CLIENT_ID_EXP", "test-audience");
+    std::env::set_var("TEST_GOOGLE_CLIENT_SECRET_EXP", "test-secret");
+    let mut cfg = google_cfg(&fx.jwks_url);
+    cfg.client_id_env = Some("TEST_GOOGLE_CLIENT_ID_EXP".into());
+    cfg.client_secret_env = Some("TEST_GOOGLE_CLIENT_SECRET_EXP".into());
+    let provider = GoogleProvider::from_config(&cfg, JwksCache::new()).unwrap();
+
+    let claims = json!({
+        "iss": "https://accounts.google.com",
+        "aud": "test-audience",
+        "sub": "x",
+        "iat": now() - 3600,
+        "exp": now() - 600,
+    });
+    let jwt = fx.sign(&claims);
+    let err = provider.validate(&jwt).await.unwrap_err();
+    assert!(matches!(err, ProviderError::InvalidAssertion(_)));
+}
+
+fn cf_cfg(jwks_url: &str) -> ProviderConfig {
+    ProviderConfig {
+        name: "cloudflare-access".into(),
+        flow: ProviderFlow::Assertion,
+        grant_type: "cloudflare_access_jwt".into(),
+        issuer: "https://team.cloudflareaccess.com".into(),
+        extra_issuers: vec![],
+        jwks_url: jwks_url.into(),
+        audience: Some("cf-aud-tag".into()),
+        audience_env: None,
+        client_id_env: None,
+        client_secret_env: None,
+        auth_endpoint: None,
+        token_endpoint: None,
+        redirect_uri: None,
+        redirect_uri_env: None,
+        auto_provision: true,
+        default_scopes: vec!["claims:read".into()],
+    }
+}
+
+#[tokio::test]
+async fn cloudflare_validate_accepts_array_audience() {
+    let fx = ProviderFixture::new().await;
+    let provider =
+        CloudflareAccessProvider::from_config(&cf_cfg(&fx.jwks_url), JwksCache::new()).unwrap();
+
+    // Real CF tokens emit aud as an array.
+    let claims = json!({
+        "iss": "https://team.cloudflareaccess.com",
+        "aud": ["cf-aud-tag"],
+        "sub": "user-123",
+        "email": "bob@example.com",
+        "iat": now(),
+        "exp": now() + 600,
+    });
+    let jwt = fx.sign(&claims);
+    let id = provider.validate(&jwt).await.unwrap();
+    assert_eq!(id.subject, "user-123");
+}
+
+#[tokio::test]
+async fn cloudflare_validate_rejects_wrong_aud() {
+    let fx = ProviderFixture::new().await;
+    let provider =
+        CloudflareAccessProvider::from_config(&cf_cfg(&fx.jwks_url), JwksCache::new()).unwrap();
+    let claims = json!({
+        "iss": "https://team.cloudflareaccess.com",
+        "aud": ["other-tag"],
+        "sub": "user-123",
+        "iat": now(),
+        "exp": now() + 600,
+    });
+    let jwt = fx.sign(&claims);
+    let err = provider.validate(&jwt).await.unwrap_err();
+    assert!(matches!(err, ProviderError::InvalidAssertion(_)));
+}
+
+#[tokio::test]
+async fn unknown_kid_triggers_refetch_then_fails() {
+    let fx = ProviderFixture::new().await;
+    let provider =
+        CloudflareAccessProvider::from_config(&cf_cfg(&fx.jwks_url), JwksCache::new()).unwrap();
+
+    // Sign with a kid the JWKS doesn't know.
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use rsa::pkcs1::EncodeRsaPrivateKey;
+    let mut rng = rand::thread_rng();
+    let bogus_key = rsa::RsaPrivateKey::new(&mut rng, 2048).unwrap();
+    let pem = bogus_key
+        .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+        .unwrap()
+        .to_string();
+    let mut header = Header::new(jsonwebtoken::Algorithm::RS256);
+    header.kid = Some("nonexistent-kid".into());
+    let claims = json!({
+        "iss": "https://team.cloudflareaccess.com",
+        "aud": ["cf-aud-tag"],
+        "sub": "x",
+        "iat": now(),
+        "exp": now() + 600,
+    });
+    let jwt = encode(
+        &header,
+        &claims,
+        &EncodingKey::from_rsa_pem(pem.as_bytes()).unwrap(),
+    )
+    .unwrap();
+
+    let err = provider.validate(&jwt).await.unwrap_err();
+    assert!(matches!(err, ProviderError::InvalidAssertion(_)));
+}

--- a/docs/superpowers/plans/2026-04-29-s3-multi-provider-oauth-port.md
+++ b/docs/superpowers/plans/2026-04-29-s3-multi-provider-oauth-port.md
@@ -1,0 +1,242 @@
+# Multi-Provider OAuth Identity Port — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Port the multi-provider external identity system from `epigraph-internal` (PR #7 there). Adds an `oauth/providers/` submodule with a provider trait, JWKS cache, Google + Cloudflare Access providers, TOML config loader, registry, and provisioning. Refactors `oauth/token.rs` and `oauth/device.rs` to dispatch through the registry. Wires startup loading from `providers.toml`.
+
+**Architecture:** Plugin pattern. `ExternalIdentityProvider` trait + `ProviderRegistry` indexed by name and grant_type. Two ship-ready impls: `GoogleProvider` (OIDC redirect flow) and `CloudflareAccessProvider` (assertion flow). `JwksCache` provides single-flight + stale-grace fetching. `provision_external_user` is the provider-agnostic provisioning seam. Existing agent / service / refresh auth paths unchanged.
+
+**Tech Stack:** Rust workspace · axum · sqlx 0.7 · jsonwebtoken · reqwest · TOML config · `wiremock` for HTTP fixtures (new dev-dep).
+
+**Base branch:** `origin/main` (independent of slices 4 + 5 in flight).
+
+**Out of scope:**
+- `crates/epigraph-api/Cargo.toml` change adding `dep:epigraph-mcp` to the `db` feature (couples with `routes/mcp_tools.rs`, separate slice).
+- The internal removal of `dep:epigraph-cli` from the `genai` feature (the Claude CLI exclusion has its own scrub branch).
+- The internal removal of `epigraph-jobs` from `[dependencies]` and the deletion of the cluster-graph job runner from `bin/server.rs` — public still uses these.
+- Removal of the `[[test]] graph_routes_test` Cargo entry — public-only test config; keep.
+
+## File Structure
+
+**Create (new in this slice):**
+- `crates/epigraph-api/src/oauth/providers/mod.rs` (registry build helper)
+- `crates/epigraph-api/src/oauth/providers/traits.rs` (ExternalIdentityProvider trait + ProviderError)
+- `crates/epigraph-api/src/oauth/providers/registry.rs` (lookup by name + grant_type)
+- `crates/epigraph-api/src/oauth/providers/jwks.rs` (JwksCache)
+- `crates/epigraph-api/src/oauth/providers/config.rs` (TOML schema + validation)
+- `crates/epigraph-api/src/oauth/providers/google.rs` (GoogleProvider)
+- `crates/epigraph-api/src/oauth/providers/cloudflare_access.rs` (CloudflareAccessProvider)
+- `crates/epigraph-api/src/oauth/providers/provision.rs` (provision_external_user)
+- `crates/epigraph-api/tests/oauth_db.rs` (DB-level provisioning tests)
+- `crates/epigraph-api/tests/oauth_http.rs` (HTTP-level provider routes tests)
+- `crates/epigraph-api/tests/oauth_redirect_flow.rs` (redirect flow exchange test)
+- `crates/epigraph-api/tests/oauth_token_grant.rs` (token grant tests)
+- `crates/epigraph-api/tests/oauth_providers/mod.rs` + `fixtures.rs` (RSA + wiremock fixtures)
+- `providers.toml` (sample config at workspace root)
+
+**Modify:**
+- `crates/epigraph-api/Cargo.toml` — add `toml = "0.8"` and `wiremock = "0.6"` dev-dep. Keep `epigraph-jobs`, `epigraph-cli`, `[[test]] graph_routes_test` (public-only).
+- `crates/epigraph-api/src/oauth/mod.rs` — register `pub mod providers;`.
+- `crates/epigraph-api/src/oauth/token.rs` — replace with internal version (dispatches to registry).
+- `crates/epigraph-api/src/oauth/device.rs` — replace with internal version (dispatches to registry).
+- `crates/epigraph-api/src/state.rs` — add `providers: Arc<ProviderRegistry>` field; init `ProviderRegistry::empty()` in all constructors; add `with_providers` builder.
+- `crates/epigraph-api/src/bin/server.rs` — surgical insert of providers.toml load + `state.with_providers(...)` chain. Leave the existing job runner / cluster graph wiring alone.
+
+---
+
+## Pre-Task: Worktree
+
+```bash
+cd /home/jeremy/epigraph
+git fetch origin main
+git worktree add -b feat/s3-multi-provider-oauth-port /home/jeremy/epigraph-wt-oauth origin/main
+cd /home/jeremy/epigraph-wt-oauth
+cargo check -p epigraph-api
+```
+
+Expected: clean compile baseline.
+
+---
+
+## Task 1: Cargo.toml additions
+
+Add to `crates/epigraph-api/Cargo.toml`:
+- `toml = "0.8"` in `[dependencies]` (provider config parsing).
+- `wiremock = "0.6"` in `[dev-dependencies]` (HTTP test fixtures).
+
+**Do not** copy internal-main's Cargo.toml verbatim — it removes `epigraph-jobs`, `epigraph-cli` and the `[[test]] graph_routes_test` entry. Surgical adds only.
+
+Verify: `cargo build -p epigraph-api --tests` fetches the new deps.
+
+Commit: `chore(api): add toml + wiremock deps for OAuth provider config and tests`
+
+---
+
+## Task 2: Port `oauth/providers/` submodule (8 new files)
+
+```bash
+mkdir -p crates/epigraph-api/src/oauth/providers
+for f in mod.rs traits.rs registry.rs jwks.rs config.rs google.rs cloudflare_access.rs provision.rs; do
+    git show internal-main:crates/epigraph-api/src/oauth/providers/$f > crates/epigraph-api/src/oauth/providers/$f
+done
+wc -l crates/epigraph-api/src/oauth/providers/*.rs
+```
+
+Expected total: ~1400 lines across the 8 files (mod 65, traits 71, registry 130, jwks 289, config 256, google 255, cloudflare 144, provision 168).
+
+Don't compile yet — needs token.rs/device.rs integration in later tasks.
+
+Commit: `feat(oauth): scaffold multi-provider identity submodule`
+
+---
+
+## Task 3: Register submodule in `oauth/mod.rs`
+
+```bash
+git diff origin/main internal-main -- crates/epigraph-api/src/oauth/mod.rs
+```
+
+Apply the additions verbatim (small diff, ~3 lines). Commit: `feat(oauth): wire providers submodule in oauth/mod.rs`.
+
+---
+
+## Task 4: state.rs surgery
+
+Apply surgically (do not clobber — there are 4 constructors plus extensive other state):
+
+1. Add `use crate::oauth::providers::ProviderRegistry;` near the existing `use crate::middleware::SignatureVerificationState;`.
+2. Add field to `pub struct AppState`:
+   ```rust
+   /// External identity provider registry. Built once at startup from `providers.toml`.
+   /// Empty by default — server still works for agent/service auth and existing tokens,
+   /// but external `grant_type=*` requests return 400 unsupported_grant_type.
+   pub providers: Arc<ProviderRegistry>,
+   ```
+3. In each constructor (`AppState::new`, `with_db`, `with_signature_verifier`, etc.), add `providers: Arc::new(ProviderRegistry::empty()),` to the struct literal.
+4. Add `with_providers` builder near `with_orchestration_backend`:
+   ```rust
+   /// Replace the external-provider registry. Idiomatic builder.
+   ///
+   /// Call at startup after loading `providers.toml`. When omitted, the registry
+   /// is empty — agent/service/refresh auth still works; external grant types
+   /// return 400 unsupported_grant_type.
+   #[must_use]
+   pub fn with_providers(mut self, providers: Arc<ProviderRegistry>) -> Self {
+       self.providers = providers;
+       self
+   }
+   ```
+
+Verify: `grep -c "providers: Arc::new(ProviderRegistry::empty())" crates/epigraph-api/src/state.rs` matches the constructor count.
+
+Commit: `feat(state): add providers field + with_providers builder`.
+
+---
+
+## Task 5: Replace `oauth/token.rs`
+
+```bash
+git show internal-main:crates/epigraph-api/src/oauth/token.rs > crates/epigraph-api/src/oauth/token.rs
+```
+
+Compile: `cargo check -p epigraph-api 2>&1 | tail -20`. Expect clean.
+
+Likely surface error: missing imports if internal token.rs uses something public's doesn't have. Inspect the file head; cross-reference with `crates/epigraph-api/src/oauth/mod.rs` exports.
+
+Commit: `feat(oauth): dispatch token grants through provider registry`.
+
+---
+
+## Task 6: Replace `oauth/device.rs`
+
+```bash
+git show internal-main:crates/epigraph-api/src/oauth/device.rs > crates/epigraph-api/src/oauth/device.rs
+```
+
+Compile + commit: `feat(oauth): dispatch device flow through provider registry`.
+
+---
+
+## Task 7: Wire `bin/server.rs` (surgical add only)
+
+Locate the line after `let state = AppState::with_db(pool, config).with_embedding_service(embedding_service);` (don't touch the surrounding `#[cfg(feature = "db")]` block or the job runner wiring that follows).
+
+Insert immediately after the `let state = ...` line:
+
+```rust
+    // Load external identity providers from providers.toml.
+    // EPIGRAPH_PROVIDERS_CONFIG overrides the default path.
+    let state = {
+        let providers_path = std::env::var("EPIGRAPH_PROVIDERS_CONFIG")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from("providers.toml"));
+        let providers = epigraph_api::oauth::providers::build_registry(providers_path.as_path())
+            .expect("failed to build providers registry");
+        state.with_providers(providers)
+    };
+```
+
+This must run after both `db` and `not(db)` paths have set `state`. If the existing structure makes that awkward, place the block after the `let state = ...` line that's outside the cfg gates. (Read internal-main's server.rs for guidance, but DO NOT clobber: it removes the job runner.)
+
+Compile + commit: `feat(server): load providers.toml into AppState at startup`.
+
+---
+
+## Task 8: Port `providers.toml` sample
+
+```bash
+git show internal-main:providers.toml > providers.toml
+```
+
+This is a sample config at the workspace root.
+
+Commit: `chore: add sample providers.toml`.
+
+---
+
+## Task 9: Port test fixtures + 4 test files
+
+```bash
+mkdir -p crates/epigraph-api/tests/oauth_providers
+for f in fixtures.rs mod.rs; do
+    git show internal-main:crates/epigraph-api/tests/oauth_providers/$f > crates/epigraph-api/tests/oauth_providers/$f
+done
+for f in oauth_db.rs oauth_http.rs oauth_redirect_flow.rs oauth_token_grant.rs; do
+    git show internal-main:crates/epigraph-api/tests/$f > crates/epigraph-api/tests/$f
+done
+```
+
+Compile: `cargo test -p epigraph-api --no-run 2>&1 | tail -20`.
+
+Commit: `test(oauth): port DB + HTTP + redirect + token-grant integration suites`.
+
+---
+
+## Task 10: Verification
+
+```bash
+# Apply migrations (DB has been pre-created at epigraph_oauth_test).
+DATABASE_URL=postgres://epigraph:epigraph@127.0.0.1:5432/epigraph_oauth_test sqlx migrate run --source migrations
+
+# Tests
+DATABASE_URL=postgres://epigraph:epigraph@127.0.0.1:5432/epigraph_oauth_test cargo test -p epigraph-api -- --test-threads=1
+
+# Lint scoped (workspace clippy has pre-existing baseline noise)
+cargo clippy -p epigraph-api --lib --tests -- -D warnings
+
+# fmt
+cargo fmt --all -- --check
+```
+
+All green. Note any pre-existing baseline issues in PR body.
+
+---
+
+## Task 11: Push + PR
+
+```bash
+git push -u origin feat/s3-multi-provider-oauth-port
+gh pr create --title "feat: port multi-provider external identity from epigraph-internal" --base main --body "..."
+```
+
+PR body sections: Summary, Excluded scope, Architecture, Coverage, Test plan.

--- a/providers.toml
+++ b/providers.toml
@@ -1,0 +1,38 @@
+# Example providers.toml — copy to providers.toml and edit, or set EPIGRAPH_PROVIDERS_CONFIG to override path.
+
+[[provider]]
+name              = "google"
+flow              = "redirect"
+grant_type        = "google_id_token"
+issuer            = "https://accounts.google.com"
+extra_issuers     = ["accounts.google.com"]
+jwks_url          = "https://www.googleapis.com/oauth2/v3/certs"
+audience_env      = "GOOGLE_CLIENT_ID"
+client_id_env     = "GOOGLE_CLIENT_ID"
+client_secret_env = "GOOGLE_CLIENT_SECRET"
+auth_endpoint     = "https://accounts.google.com/o/oauth2/v2/auth"
+token_endpoint    = "https://oauth2.googleapis.com/token"
+redirect_uri_env  = "EPIGRAPH_REDIRECT_URI"
+auto_provision    = true
+default_scopes = [
+  "claims:read", "claims:write", "claims:challenge",
+  "evidence:read", "evidence:submit",
+  "edges:read", "edges:write",
+  "agents:read", "agents:write",
+  "groups:read", "groups:manage",
+  "analysis:belief", "analysis:propagation", "analysis:reasoning",
+  "analysis:gaps", "analysis:structural", "analysis:hypothesis",
+  "analysis:political",
+  "clients:register",
+]
+
+# Uncomment to enable Cloudflare Access:
+# [[provider]]
+# name           = "cloudflare-access"
+# flow           = "assertion"
+# grant_type     = "cloudflare_access_jwt"
+# issuer         = "https://your-team.cloudflareaccess.com"
+# jwks_url       = "https://your-team.cloudflareaccess.com/cdn-cgi/access/certs"
+# audience_env   = "CF_ACCESS_AUD"
+# auto_provision = true
+# default_scopes = ["claims:read", "claims:write", "evidence:read", "evidence:submit"]


### PR DESCRIPTION
## Summary
Ports the multi-provider external identity system from epigraph-internal (PR #7 there). Adds an `oauth/providers/` submodule with a provider trait, JWKS cache (single-flight + stale-grace), TOML config loader, registry, and provisioning. Refactors `oauth/token.rs` and `oauth/device.rs` to dispatch through the registry. Wires startup loading from `providers.toml`.

## Architecture
- `ExternalIdentityProvider` trait + `ProviderError` (`oauth/providers/traits.rs`)
- `ProviderRegistry` indexed by name and grant_type (`registry.rs`)
- `JwksCache` with single-flight coalescing + stale-grace fetch (`jwks.rs`)
- TOML schema + validation (`config.rs`)
- Two ship-ready impls: `GoogleProvider` (OIDC redirect flow) + `CloudflareAccessProvider` (assertion-only)
- `provision_external_user` is the provider-agnostic provisioning seam (`provision.rs`)
- New routes: `/oauth/:provider/auth-url` and `/oauth/:provider/exchange` (provider-parameterized; replaces `/oauth/google/*`)
- `AppState` gains `providers: Arc<ProviderRegistry>` field; defaults empty in all 6 constructors
- Startup loads `providers.toml` (`EPIGRAPH_PROVIDERS_CONFIG` overrides path); missing config is a hard startup error

## Excluded (keep follow-up scope tight)
- The internal-main Cargo.toml change adding `dep:epigraph-mcp` to the `db` feature — couples with `routes/mcp_tools.rs` (separate slice).
- The internal-main removal of `dep:epigraph-cli` from the `genai` feature — Claude CLI exclusion has its own scrub branch.
- The internal-main removal of `epigraph-jobs` and the cluster-graph job runner from `bin/server.rs` — public still uses these.
- The internal-main removal of `[[test]] graph_routes_test` Cargo entry — public-only test config.

## Mid-execution finding
`ApiError::BadGateway` was deferred from slice 1 (#16) — needed here by `oauth/token.rs` and `oauth/device.rs` for upstream provider failures. Added in this slice.

## Coverage (855 lines of new test code)
- `oauth_db.rs` — 3 DB-level provisioning tests.
- `oauth_http.rs` — 5 HTTP-level provider routes tests.
- `oauth_redirect_flow.rs` — 3 auth-url builder + exchange_code tests.
- `oauth_token_grant.rs` — 7 Google + Cloudflare Access provider validation tests including JWKS refetch on unknown kid.
- `oauth_providers/{mod,fixtures}.rs` — RSA + wiremock fixtures shared across the 4 binaries.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p epigraph-api --lib -- -D warnings` clean (workspace clippy + tests fail on pre-existing baseline noise; documented for triage)
- [x] All 18 OAuth tests pass against `epigraph_oauth_test` DB
- [ ] **Manual:** copy `providers.toml`, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`, run server, verify `/oauth/google/auth-url` returns a valid URL + `/oauth/google/exchange` issues a JWT for a real Google ID token

🤖 Generated with [Claude Code](https://claude.com/claude-code)