### PR TITLE
fix(cli): gate sqlx import + db_connect behind `db` feature

### DIFF
--- a/crates/epigraph-cli/src/lib.rs
+++ b/crates/epigraph-cli/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod enrichment;
 
+#[cfg(feature = "db")]
 use sqlx::PgPool;
 use std::sync::Arc;
 
 /// Connect to postgres via DATABASE_URL environment variable.
+#[cfg(feature = "db")]
 pub async fn db_connect() -> Result<PgPool, Box<dyn std::error::Error>> {
     let url = std::env::var("DATABASE_URL").map_err(|_| {
         "DATABASE_URL not set — set it to postgresql://epigraph:epigraph@127.0.0.1:5432/epigraph"


### PR DESCRIPTION
## Summary

Closes #25.

\`crates/epigraph-cli/src/lib.rs\` declared a \`db\` feature (gating \`epigraph-db\` + \`sqlx\` deps) but used \`sqlx::PgPool\` and defined \`db_connect\` unconditionally. Consumers that tried \`default-features = false\` failed to compile with \`unresolved import sqlx\`.

## Fix

Two \`#[cfg(feature = \"db\")]\` attributes — one on the \`use\` statement, one on the \`db_connect\` function. \`embedding_service()\` doesn't depend on sqlx so it stays unconditional.

## Verification

- \`cargo build -p epigraph-cli --lib --no-default-features\` — succeeds (was failing).
- \`cargo build -p epigraph-cli\` — still succeeds (bin targets unchanged).

Bin targets (\`compare_routes\`, \`analyze_graph\`, etc.) call \`db_connect\` directly and therefore still require the \`db\` feature, but that's expected — they're DB-coupled tools. Lib consumers (e.g. anything pulling in just the \`enrichment::\` module for the LLM trait) can now skip the DB stack.

## Surfaced by

Building [\`epigraph-claude-cli\`](https://github.com/epigraph-io/epigraph-claude-cli) — a private overlay that provides \`ClaudeCliClient\` (an \`LlmClient\` impl that delegates to the Claude Code CLI for OAuth-prepaid auth) — needed only the \`LlmClient\` trait + \`LlmError\`. After this lands, that overlay can drop \`default-features\` and avoid pulling in the full DB stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)