### PR TITLE
docs: port design specs from epigraph-internal

### DIFF
--- a/docs/superpowers/specs/2026-04-25-noun-claims-and-verb-edges-design.md
+++ b/docs/superpowers/specs/2026-04-25-noun-claims-and-verb-edges-design.md
@@ -1,0 +1,312 @@
+# Noun-Claims and Verb-Edges — S1: Foundation Design
+
+> **Origin:** Ported from `epigraph-internal` (private dev repo) as historical
+> design context. The implementation landed on this repo as **#16**. Branch /
+> PR-number references below point to the original `epigraph-internal` artifacts.
+
+**Date:** 2026-04-25
+**Branch:** `chore/migration-renumber-2026-04-25` (lands in PR #6)
+**Status:** Approved for spec → plan → implementation
+**Sub-project of:** Noun-Claims and Verb-Edges architecture (S1 of S1–S4)
+
+---
+
+## Why this design exists
+
+While preparing to apply migration 106 (which adds `UNIQUE (content_hash, agent_id)` on `claims`), live-DB probes turned up ~95,214 duplicate `(content_hash, agent_id)` groups covering 262,274 of 389,739 claim rows (67% of the table). 413,380 edges, 95,496 mass functions, and 2,283 evidence rows reference rows in those groups. The dups are not random:
+
+- **Cause 1 — textbook/paper ingest scripts (~173k dup rows, 65%).** `scripts/ingest_textbook_cdst.py` (and its paper sibling) in the deprecated EpigraphV2 repo use `psql` direct INSERT with `ON CONFLICT (id) DO NOTHING`. The PK conflict target catches nothing because each run mints fresh UUIDs. Re-runs on the same source produce fresh duplicate rows. March 2 / March 30 / March 31 spikes (160k rows on March 30 alone) are textbook re-runs.
+- **Cause 2 — MCP-driven Claude agent (~72k dup rows, 28%).** Agent `f741ab67…` (display name `did:key:z6MknhYrJfEUVjke4vZDUwYMhVkvSzXfkwmTA7DvqjeGKBZM`, properties `{"model":"claude-agent","source":"epigraph-nano-mcp"}`) submits via the `epigraph-nano-mcp` MCP server during agent runtime. Same agent submits the same content multiple times because the MCP submission path doesn't dedup on `(content_hash, agent_id)`.
+- **Cause 3 — host provenance recording (~18 April rows but steady drip).** `EpigraphV2/EpigraphV2/epigraph-nano/src/host/provenance.rs` records lifecycle events as full claim rows where `content_hash = hash(container_name)` for spawn events, `hash(task_id:status)` for executions, etc. Same container spawning twice or same task running on schedule legitimately collides on `(content_hash, agent_id)`. The intuition that this was a "30 ms race" was wrong (advisor caught it): the gaps are 14 seconds to 32 hours apart.
+
+The diagnosis is convergent: migration 106's `UNIQUE` constraint reflects an architectural intent (one claim per `(content_hash, agent_id)`) that the codebase has drifted from. The right fix is not to weaken the constraint or to apply it against a dirty table — it is to restore the architecture and bring the data back to it.
+
+## The architecture
+
+**Two element types, each with its own role:**
+
+- **Noun-claim** — a `claims` row representing an entity or assertion that has stable identity. Its `(content_hash, agent_id)` is the canonical key: there is at most one row per `(content_hash, agent)`. Examples:
+  - "Container `epiclaw-tg-7173612411` exists for group `telegram-7173612411`"
+  - "Task `epistemic-gaps` is scheduled"
+  - The textbook fact "evidence supports H₀ at confidence 0.8"
+  - The message body "ok"
+
+- **Verb-edge** — an `edges` row representing a timestamped occurrence or relationship involving one or more noun-claims. The edge's `created_at` (and optional `valid_from` / `valid_to`) carries the event time; `properties` JSONB carries event metadata; `relationship` carries the verb; `signature` / `signer_id` give the same audit guarantee as claim signatures. Examples:
+  - `host_agent --[spawned @ 2026-04-25T03:03:59Z, props={group: "epistemic-gaps"}]--> container_claim`
+  - `host_agent --[executed @ 2026-04-25T07:43:13Z, props={status: completed, duration_ms: 1342}]--> task_claim`
+  - `paper_artifact --[asserts @ 2026-03-30T23:50:03Z, props={extraction_run: "2026-03-30"}]--> textbook_fact_claim`
+
+**Three rules that fall out of this:**
+
+1. **Re-occurrence of the same lifecycle event = new edge, not new claim.** Migration 106's `UNIQUE (content_hash, agent_id)` becomes naturally correct.
+2. **Re-ingesting the same source content = new edge from a (per-run) source-artifact noun to the existing fact-claim, not a duplicated fact-claim.**
+3. **`provenance_log` (cryptographic audit) is unchanged.** Every claim/edge create still gets a row there. The change is what writers *create*: more edges, fewer duplicate claims.
+
+**Why this fits existing schema:** the `edges` table already carries `created_at`, `valid_from`/`valid_to`, `properties` JSONB, `labels`, `signature`, `signer_id`. The schema was designed for this; the writers drifted. No new columns are required.
+
+## Goals and non-goals
+
+**S1 ships:**
+
+- Pattern documentation that any future writer can follow.
+- Idempotent claim creation primitive on the existing API (`if_not_exists` flag).
+- Migration 106 in a shape that is applicable to the live DB today.
+- Migration 107 holding the deferred `UNIQUE` constraint with the prerequisite documented in the file header.
+- Disposition doc, README, PR body all updated to reflect the new sequenced plan.
+
+**S1 explicitly does NOT ship:**
+
+- Backfilling the 95k existing duplicate groups → that's S2.
+- Modifying any writer (`epigraph-mcp` submission paths, `epigraph-agent` `submit_claim` builtin, V2 `epigraph-nano/provenance.rs`, V2 ingest scripts) → that's S3 (sub-plans S3a–S3d).
+- Applying the `UNIQUE` constraint to the live DB → that's S4 (depends on S2 done).
+- A combined "create-claim-and-edge" atomic helper endpoint. The two-call sequence is sufficient until evidence proves otherwise. YAGNI.
+
+## API surface
+
+**One change to the existing claim-create endpoint, three new repo helpers, plus documentation.**
+
+### `POST /api/v1/claims` — add `if_not_exists` field
+
+New optional request body field:
+
+```json
+{
+  "content": "...",
+  "content_hash": "...",
+  "agent_id": "...",
+  "if_not_exists": true
+}
+```
+
+Behavior:
+
+- `if_not_exists: false` (default): the request inserts unconditionally (raw INSERT). Pre-107: this writes a row even if `(content_hash, agent_id)` already exists, increasing duplicate count (S2 backfill cleans up). Post-107: a `(content_hash, agent_id)` collision returns a constraint-violation error surfaced as `409 Conflict` to the client.
+- `if_not_exists: true`: server checks for an existing row by `(content_hash, agent_id)`; returns the existing claim's id if found; else inserts. Response body adds `was_created: bool` so the caller can tell which branch ran.
+
+**Note on existing dedup.** `ClaimRepository::create()` and `create_with_tx()` today perform an implicit dedup-on-`content_hash`-alone (`crates/epigraph-db/src/repos/claim.rs:70-92` and `:149-170`) that returns the first agent's row regardless of requester — a noun-claim invariant violation. The blast radius of removing this is wide (~44 internal callers across 11 files including `epigraph-mcp` tools and the integration test suite); fixing it as part of S1 would balloon the PR. S1 therefore **adds new helpers** that the API endpoint routes to, and leaves the legacy methods untouched. Internal callers continue using legacy behavior until a follow-up task migrates them. The legacy dedup bug is documented but not fixed here.
+
+Implementation surface (estimated):
+
+- `crates/epigraph-db/src/repos/claim.rs` — three new helpers, all taking `&mut PgConnection` so the caller can compose with edge creation in the same transaction:
+  - `find_by_content_hash_and_agent(conn, content_hash, agent_id) -> Option<Claim>` — find-only.
+  - `create_or_get(conn, claim) -> (Claim, was_created: bool)` — finds by `(content_hash, agent_id)` then inserts if absent. **Post-107 race handling:** on a unique-violation during the INSERT (a concurrent writer won the race), the helper catches the error, re-runs the find, and returns the resulting row with `was_created: false`. Pre-107, no constraint exists, so the catch path is unreachable and a concurrent race may produce two rows (per the race-window section).
+  - `create_strict(conn, claim) -> Claim` — raw INSERT, no dedup. Post-107, surfaces unique-violation; pre-107, inserts a duplicate.
+- `crates/epigraph-api/src/routes/claims.rs` — extend the create-claim handler:
+  - Branch on `if_not_exists`: `true` → `create_or_get`, `false` → `create_strict`. (The existing path through `create_with_tx` is replaced; legacy `create_with_tx` remains for internal callers.)
+  - Add `was_created: bool` to `ClaimResponse`.
+  - Map unique-violation errors on the `if_not_exists: false` path to `409 Conflict` (only fires post-107).
+- Tests cover:
+  - `if_not_exists: true` returns the existing claim with `was_created: false` when `(content_hash, agent_id)` already exists.
+  - `if_not_exists: true` inserts and returns `was_created: true` when no existing row matches.
+  - `if_not_exists: false` writes a new row pre-107 even when `(content_hash, agent_id)` already exists.
+  - Post-107: `if_not_exists: false` collision returns `409 Conflict`.
+  - Post-107: two concurrent `if_not_exists: true` calls produce one row — first writer wins; second catches the unique-violation from the constraint and returns the existing row.
+  - The pre-107 concurrent-`if_not_exists: true` case (which may produce two rows) is documented as a tolerated transitional state and is **not** added as a passing test, because the test would be inherently racy and would flake. S2 cleans up any rows the race produces.
+  - **Test fixture note.** Post-107 assertions only hold against a DB that has migration 107 applied. The post-107 tests apply migration 107 in their fixture setup (e.g., `sqlx::migrate!()` against the test pool, or a per-test SQL execution of the `ALTER TABLE` statement). Tests that exercise pre-107 behavior must run on a fixture without 107 applied — keep these in a separate test module so the migration state is explicit per test.
+
+### `POST /api/v1/edges` — no change
+
+Each call already creates a new edge, which is the correct semantics for verb-edges. `created_at`, `properties`, `valid_from`, `valid_to`, `signature`, `signer_id` already supported. No new fields, no new endpoint.
+
+### `if_not_exists: true` × `privacy_tier`
+
+`if_not_exists: true` is rejected with `400 Bad Request` when `privacy_tier != "public"`. Encrypted claims store ciphertext keyed by group epoch in `claim_encryption`; cross-group dedup on plaintext hash would either leak content equality across groups (privacy violation) or no-op against the `[private]` placeholder content. A coherent dedup design for encrypted claims is an open question deferred to a future spec — until then, encrypted submissions stay on the existing `if_not_exists: false` (raw insert) path.
+
+### `if_not_exists: true` × `properties`, `labels`, `content_hash` override
+
+Today the handler runs `UPDATE claims SET content_hash = COALESCE(...), properties = COALESCE(...) WHERE id = $1` and a separate `UPDATE claims SET labels = $1` after the insert (`claims.rs:417-452`). With `if_not_exists: true`, two concerns arise:
+
+- **Mutating an existing canonical noun-claim from a different caller's request is surprising.** It bypasses ownership/authorisation checks and can clobber metadata that another agent set previously. So when `was_created: false`, the handler skips the `properties` / `labels` UPDATEs entirely. The returned response reflects the existing row's metadata, not the request's. Callers needing metadata changes go through a separate PATCH (existing labels endpoint, future properties endpoint).
+- **`content_hash` override + `if_not_exists: true` is rejected with `400 Bad Request`.** The override is a textbook-ingest-script feature (Cause 1) that S3c retires; new callers should not combine override and idempotent-create. When the override is omitted, the server-computed BLAKE3 hash is used for the `(content_hash, agent_id)` lookup. Post-107 the override UPDATE could itself violate the constraint (override sets a hash already used by another row of the same agent); that surfaces as `409 Conflict` from the UPDATE on the `if_not_exists: false` path. New ingestion paths should compute hashes server-side and stop using the override.
+
+### Auto-emitted `AUTHORED` edge
+
+`POST /api/v1/claims` already emits `agent --[AUTHORED]--> claim` after every successful create call (`claims.rs:503-514`). This is preserved unchanged: `if_not_exists: true` returning an existing claim still emits a fresh AUTHORED edge. Each submission is a distinct verb-event — the noun-claim is canonical, the AUTHORED edges are the timestamped occurrences. This is the noun-claim/verb-edge architecture in microcosm and is documented as the canonical pattern in `docs/architecture/noun-claims-and-verb-edges.md`.
+
+### Pre-107 race window (acknowledged, not solved)
+
+Until migration 107 lands, the DB has no `(content_hash, agent_id)` UNIQUE constraint. Two concurrent `if_not_exists: true` requests for the same key can both find no existing row and both insert, producing two rows where `if_not_exists: true` semantically promised one. Once migration 107 is applied, the second insert fails with a constraint violation; the handler catches that error and returns the existing row.
+
+S1 does **not** add advisory-lock serialization in the pre-107 window. Rationale:
+
+- The race window already exists for *every* claim-creation path today; S1 doesn't widen it.
+- S2 backfill will deduplicate any additional rows produced during the S1→S4 transition, so the race-window dups are temporary and bounded.
+- Adding a per-key advisory lock now adds non-trivial code that would be removed when 107 lands.
+
+This race-window behavior is documented in the architecture doc and in the `if_not_exists` field's API description so callers know that during the S1→S4 transition, two near-simultaneous `if_not_exists: true` calls for the same `(content_hash, agent_id)` may both report `was_created: true` and produce separate rows. Strict-semantics callers can mitigate by serializing per-key in their own writer (the canonical S3a path), or by tolerating the duplicate until S2 backfill collapses it. The handler does not attempt to detect or merge the race itself.
+
+### Recommended call sequence (in the architecture doc)
+
+```
+POST /api/v1/claims  {content, content_hash, agent_id, if_not_exists: true}
+    → {claim_id, was_created}
+
+POST /api/v1/edges   {source_id: actor_agent_id, source_type: "agent",
+                      target_id: claim_id, target_type: "claim",
+                      relationship: <verb>, properties: {...}, created_at: <T>}
+    → {edge_id}
+```
+
+Two calls. Two transactions. Composes cleanly.
+
+### Why two calls instead of an atomic helper
+
+- Both endpoints already exist; one optional flag is a smaller surface than a new route.
+- The two operations have different idempotency: claims are dedup'd, edges are appended. A combined endpoint would hide this distinction.
+- If composability problems show up later (race window between calls, performance under high event volume), a single-shot helper can wrap both — that wrapper is a thin upgrade, not an architectural redo.
+
+## Migration shape
+
+### Migration 106 (rewritten in place)
+
+Keeps everything except the `UNIQUE` constraint:
+
+1. `CREATE INDEX IF NOT EXISTS idx_edges_source_target_rel ON edges (source_id, target_id, relationship);` — kept.
+2. *(documented skip)* — `idx_claims_agent_id` already present from `001_initial_schema.sql`. Skip preserved.
+3. `CREATE INDEX IF NOT EXISTS idx_bp_messages_factor_id ON bp_messages (factor_id);` — kept.
+4. ~~`ALTER TABLE claims ADD CONSTRAINT uq_claims_content_hash_agent UNIQUE (content_hash, agent_id);`~~ — moved to migration 107.
+5. `COMMENT ON COLUMN activities.agent_id IS '...';` — kept.
+6. `ALTER TABLE activities ALTER COLUMN agent_id DROP NOT NULL;` — kept.
+
+Header comment in migration 106 gets a paragraph: "The `(content_hash, agent_id)` UNIQUE constraint originally bundled here was extracted to migration 107 because it requires a prerequisite deduplication backfill (see `docs/architecture/noun-claims-and-verb-edges.md`). Every remaining statement in this file is idempotent or a no-op against the live DB and can be applied immediately."
+
+After this rewrite, migration 106 is **applicable to the live DB today**. PR #6 still ships it as `pending`; a subsequent user-authorized `sqlx migrate run` lands it cleanly.
+
+### Migration 107 (new file)
+
+`migrations/107_claims_unique_content_hash_agent.sql`:
+
+```sql
+-- Migration 107: enforce noun-claim canonicality
+--
+-- Adds the (content_hash, agent_id) UNIQUE constraint that was originally
+-- drafted in migration 106 and extracted here when the noun-claims-and-
+-- verb-edges architecture was formalised (see docs/architecture/
+-- noun-claims-and-verb-edges.md).
+--
+-- PREREQUISITE: this migration will FAIL until the deduplication backfill
+-- (sub-project S2) has reduced the 95,000+ existing duplicate (content_hash,
+-- agent_id) groups in the claims table to one canonical row per group.
+-- Running it on a dirty table produces:
+--
+--   ERROR:  could not create unique index "uq_claims_content_hash_agent"
+--   DETAIL: Key (content_hash, agent_id)=(\x..., ...) is duplicated.
+--
+-- The migration is intentionally not wrapped with NOT VALID + later
+-- VALIDATE: the constraint represents a real architectural invariant; any
+-- future apply attempt should refuse on a dirty table rather than silently
+-- defer enforcement.
+
+ALTER TABLE claims
+  ADD CONSTRAINT uq_claims_content_hash_agent UNIQUE (content_hash, agent_id);
+```
+
+After PR #6 merges, `sqlx migrate info` shows `106/pending` and `107/pending`. A user-authorized `sqlx migrate run` lands 106 cleanly. 107 stays pending until S2 completes; trying to run it earlier fails loudly with a clear constraint-violation error pointing back to the disposition doc.
+
+### Why fail loud rather than `CREATE UNIQUE INDEX CONCURRENTLY` + `NOT VALID`
+
+The constraint represents a real architectural invariant. A partially-validated state where existing dups are grandfathered would corrupt the meaning of the constraint going forward — every future query that depends on `(content_hash, agent_id)` uniqueness for correctness would have a silent failure surface against unflagged historical rows. Failing loud forces backfill discipline.
+
+### Why not a partial index conditioned on `is_current`, `labels`, etc.
+
+- `is_current` belongs to the supersession/version mechanism (migrations 035, 081). Reusing it for dedup signaling would conflate two unrelated semantic dimensions.
+- `labels @> ARRAY['telemetry']` would push the dedup decision out to every writer's `labels` field — fragile, and lets bugs slip through silently.
+- Both options bake assumption into the schema. The clean architecture per this design has *no* legitimate `(content_hash, agent_id)` duplicates by construction. The constraint should reflect that.
+
+## Documentation deliverables
+
+### `docs/architecture/noun-claims-and-verb-edges.md` (new, canonical)
+
+Sections:
+
+- The pattern (noun-claim, verb-edge, definitions and rules).
+- Worked examples mapping each of the three causes onto the pattern (host telemetry, MCP submission, ingest scripts).
+- Recommended call sequence with the API surface.
+- **Atomicity policy.** Writers are responsible for retry/cleanup if the verb-edge call fails after the noun-claim call succeeds. Orphaned noun-claims are tolerated — they have no effect on graph queries that traverse from edges, and S2-style sweeps can collect them. S3 writer plans may add per-writer retry-on-edge-failure if the writer's audit semantics require strict consistency. The auto-emitted `AUTHORED` edge already gives every successful `POST /api/v1/claims` a baseline edge anchor, so total orphans only occur on transaction-commit failure.
+- **Boundary with the `activities` audit table.** `activities` rows describe events without graph traversal. Verb-edges replace `activities` for graph-traversable events (where the edge connects two entities and graph queries reach the event). `activities` remains for non-graph audit (bulk operations, system-level events without entity targets). S3d (host provenance porting) is the canonical migration target — host events currently written to `activities` move to verb-edges as part of that work. Migration 106's `ALTER TABLE activities ALTER COLUMN agent_id DROP NOT NULL` predates this architectural pivot and is preserved; it has no bearing on verb-edge semantics.
+- **Edge signing.** Schema supports `signature` / `signer_id` on edges (migration 073). S1 does not require edge signing; the existing `EdgeRepository::create` call passes `None` for signature fields. S3 writer plans specify the signing strategy per writer (host_agent has key material; ingest scripts may not). The "same audit guarantee as claim signatures" claim in the pattern definition is therefore aspirational — schema-supported, S3-realised.
+- Migration sequence (106 → 107) and the S2 backfill prerequisite.
+- Sub-project map (S1 done, S2/S3/S4 to follow with one-line stubs).
+
+### `docs/migration-106-disposition.md` (rewritten)
+
+Replaces the original four-options doc with the sequenced rollout. Sections:
+
+- Context (the dup probe data + three causes, with concrete counts).
+- The architectural pivot (link to the canonical architecture doc).
+- Migration sequence (106 here, 107 here, both pending; SHA-384 prefixes for both files).
+- The four-stage rollout (S1 done in this PR, S2 / S3 / S4 future plans).
+- What was rejected and why: `apply-as-is` (now embodied by 107 with the S2 prereq), `mark-applied-without-running` (semantic mismatch), `supersede-with-105` (V2's 105 pre-dates the architectural pivot, so superseding with it would re-import the old model — permanently obsolete), `defer` (rejected because the architecture cleanup is the priority Jeremy named).
+- Authorisation status: PR #6 ships S1 with no live-DB writes; applying migrations 106 and 107 to the live DB are separate user-authorized steps.
+
+### `migrations/README.md` slot-gap section update
+
+- Slot 099 still skipped (V2 numbering).
+- Slot 105 still skipped — the supersede option is **permanently obsolete** now (record this).
+- Slot 107 documented as pending until S2 backfill.
+- New-migration advice: "pick the next free slot ≥ 108 (slot 107 is reserved for the deferred constraint enforcement)."
+
+## PR #6 integration
+
+**Branch state:** `chore/migration-renumber-2026-04-25` is at `609111d`, pushed to `origin`, PR #6 open against `main`. Adding S1 means **appending new commits — no force-push**. Branch grows from 10 commits to ~16.
+
+**Proposed commit sequence** (each goes through subagent-driven-development: implementer → spec-reviewer → quality-reviewer):
+
+1. `docs(architecture): introduce noun-claims-and-verb-edges pattern`
+   New file `docs/architecture/noun-claims-and-verb-edges.md`. Self-contained — no other code referenced yet.
+
+2. `chore(migrations): split 106 — extract UNIQUE constraint to 107`
+   Edits `migrations/106_security_and_hardening.sql`: (a) removes statement 4 (the UNIQUE constraint), (b) updates the header comment from `-- Migration 002: Code review hardening` (a fossil from the original internal draft slot) to `-- Migration 106: Code review hardening (deferred UNIQUE moved to 107)`, (c) adds a paragraph explaining the split and pointing to the architecture doc. Adds `migrations/107_claims_unique_content_hash_agent.sql` with the constraint and the prerequisite-failure header comment. **Side effect:** this changes the SHA-384 of `migrations/106_security_and_hardening.sql`. The disposition doc's recorded hash (added in commit `adef3fa` and used in the `mark-applied-without-running` SQL) becomes stale; commit 5 reconciles it. Implementation step in the plan: compute the new SHA via `sha384sum migrations/106_security_and_hardening.sql` after the edit and embed it verbatim in the disposition doc rewrite.
+
+3. `feat(db): add find_by_content_hash_and_agent / create_or_get / create_strict helpers`
+   Three new methods in `crates/epigraph-db/src/repos/claim.rs`, all taking `&mut PgConnection`: a find-only (`find_by_content_hash_and_agent`), a find-or-insert on `(content_hash, agent_id)` (`create_or_get`), and a raw INSERT with no implicit dedup (`create_strict`). Existing `create()` and `create_with_tx()` unchanged — they retain the legacy implicit content-hash dedup, with a doc-comment flagging it as legacy and pointing to the new helpers. No callers wired up yet.
+
+4. `feat(api): add if_not_exists option to POST /api/v1/claims`
+   Request struct gets the new field; response gets `was_created`. Handler branches: `if_not_exists: true` → `create_or_get`, `if_not_exists: false` → `create_strict` (replacing the existing `create_with_tx` call site). Adds the `if_not_exists: true` × `privacy_tier`, `if_not_exists: true` × `content_hash` override, and `was_created: false` skip-metadata-UPDATE branches per spec. Maps unique-violation errors on `if_not_exists: false` to `409 Conflict`. Tests cover the cases enumerated in the API surface section. **Behavior change** for callers that did not set `if_not_exists` previously: post-107, duplicate `(content_hash, agent_id)` submissions begin returning `409` instead of silently returning the first agent's row. Pre-107 (between this PR merge and S4), the same callers may produce duplicate rows — S2 cleans them up. Internal Rust callers of `ClaimRepository::create()` / `create_with_tx()` are unaffected.
+
+5. `docs(migrations): rewrite 106 disposition for S1 architectural pivot`
+   Replaces the four-options structure with the sequenced rollout. Updates the recorded SHA-384 of migration 106 to its new (post-split) value.
+
+6. `docs(migrations): update README slot-gap for 107`
+   Small README edit per the section above.
+
+**PR body addendum** posted via `gh pr edit 6 --body …` after commits land:
+
+> ## Architectural pivot (added 2026-04-25)
+>
+> While preparing to apply migration 106, live-DB probes uncovered ~95k duplicate `(content_hash, agent_id)` groups. Diagnosis: the codebase had drifted from a "noun-claims and verb-edges" architecture that migration 106's UNIQUE constraint encodes. This PR now also includes S1 of a four-stage rollout to restore that architecture (full design at `docs/superpowers/specs/2026-04-25-noun-claims-and-verb-edges-design.md`):
+>
+> - **S1 (this PR):** pattern docs, idempotent claim creation primitive (`if_not_exists` flag), migration split (106 stays applicable; 107 holds the deferred constraint).
+> - **S2 (next plan):** backfill 95k existing duplicate groups to canonical claim + verb edges.
+> - **S3 (writers):** four sub-plans updating MCP, agent harness, ingest, host provenance.
+> - **S4 (final):** apply migration 107 once S2 is verified clean.
+>
+> Title stays "align internal numbering with live DB" — the renumber is still the primary contribution; S1 is a same-PR follow-on because it must edit migration 106 before it lands.
+
+Title remains as currently set.
+
+## Risk and rollback
+
+- **PR #6 size grows.** ~6 additional commits, ~600 additional lines (mostly docs + the architecture file). The reviewer surface is wider but each commit is independent and atomic; rollback of any one is `git revert`.
+- **Migration 106's SHA-384 changes.** The disposition doc's recorded hash becomes correct only after commit 5. Between commits 2 and 5 the on-branch state is internally inconsistent — but no live DB has applied either file yet, so the inconsistency is resolved before the merge boundary.
+- **API behavior change for default-flag callers.** With `if_not_exists` defaulting to `false`, the API path now routes through `create_strict` (raw INSERT) instead of `create_with_tx` (implicit content-hash dedup). Pre-107: callers who relied on the implicit dedup will see duplicate rows when re-submitting the same content. Post-107: those duplicates surface as `409 Conflict`. The mitigation is documented: callers that want dedup set `if_not_exists: true`. The pre-existing cross-agent collapse bug (Bob's request returning Alice's row) is also fixed for the API path. Internal Rust callers of `ClaimRepository::create()` / `create_with_tx()` are unaffected because those legacy methods are unchanged.
+- **No live-DB writes in S1.** Same rollback story as the renumber: `git reset --hard origin/main` undoes everything.
+
+## Sub-project map (after S1)
+
+**Sub-project ordering: S3a → S2 → (S3b–S3d in parallel) → S4.** Writers must be updated first so duplicates stop accumulating. Backfill (S2) cleans existing dups against a stable writer baseline. Constraint enforcement (S4) locks the door. Running S2 before S3a is wasteful — every backfill batch is immediately re-dirtied by the unfixed canonical writer. S3b–S3d (lower-volume writers) can run in parallel with S2 once S3a deploys, because their accretion rate is small relative to the backfill rate.
+
+- **S3a — `epigraph-mcp` submission paths** (Cause 2 in the canonical codebase, plus reaching cleanly into the rest of S3). Highest priority — `epigraph-internal/crates/epigraph-mcp` is the live MCP server, ~72k dup contribution from its V2 cousin tells us the same path will accumulate unless wired to `if_not_exists: true`. Each `epigraph-mcp` tool that calls `ClaimRepository::create()` is migrated to `create_or_get` (or to the API endpoint with `if_not_exists: true`, whichever fits). Future plan.
+
+- **S2 — Backfill duplicate claim groups.** Convert each of 95,214 existing `(content_hash, agent_id)` groups into one canonical claim plus (N-1) timestamped verb-edges using the dups' `created_at` values. Redirect the 413k existing edges, 95k MFs, and 2.3k evidence rows currently pointing at non-canonical rows. API-driven, batchable, reversible. Writes to live DB; gated on its own design + plan + user authorization. Runs after S3a so the canonical writer has stopped emitting new dups. **Additional prerequisite:** V2 ingest scripts are no longer running (either by V2 deprecation or by completing S3c). A live V2 textbook re-run mid-backfill would re-dirty 100k+ rows and force restart. Confirm the V2 host status before scheduling S2. Future spec.
+
+- **S3b–S3d — remaining writers** (parallelisable with S2):
+  - **S3b — `epigraph-agent` `submit_claim` builtin tool.** Memory says the next-gen harness is already event-oriented; S3b verifies and aligns.
+  - **S3c — Replace V2 ingest scripts** (Cause 1, ~173k dups, V2-resident). May be skipped since V2 is being deprecated.
+  - **S3d — V2 `epigraph-nano/provenance.rs`** (Cause 3, ~18 April rows but ongoing). Port to `epigraph-agent` or decommission with the V2 host.
+
+- **S4 — Apply migration 107.** Becomes a one-liner once writers are clean and S2's backfill has settled. User-authorized `sqlx migrate run`.
+
+- **(Out of band)** Migrate the ~44 internal Rust callers of `ClaimRepository::create()` / `create_with_tx()` to `create_or_get` or `create_strict` and remove the legacy implicit content-hash dedup. Independent of S2/S3/S4 (the API endpoint already routes around these legacy methods after S1); priority is low since the legacy callers are mostly tests and the cross-agent collapse bug is rare in practice. Future task.
+
+Each future sub-project gets its own brainstorm → spec → plan cycle.

--- a/docs/superpowers/specs/2026-04-26-multi-provider-identity-design.md
+++ b/docs/superpowers/specs/2026-04-26-multi-provider-identity-design.md
@@ -1,0 +1,449 @@
+# Multi-Provider External Identity Design
+
+> **Origin:** Ported from `epigraph-internal` (private dev repo) as historical
+> design context. The implementation landed on this repo as **#24**. Branch /
+> PR-number references below point to the original `epigraph-internal` artifacts.
+
+**Date:** 2026-04-26
+**Branch:** to be created at plan time (likely `feat/multi-provider-identity`, forked off `main`)
+**Status:** Draft for user review (post-brainstorm)
+
+---
+
+## Why this design exists
+
+EpiGraph's "human" OAuth path is hardwired to Google. Google-specific code is inlined in three places:
+
+- `crates/epigraph-api/src/oauth/device.rs` — browser auth-code flow at `/oauth/google/auth-url` and `/oauth/google/exchange`. `accounts.google.com` and `oauth2.googleapis.com/token` appear as string literals.
+- `crates/epigraph-api/src/oauth/token.rs` — `grant_type=google_id_token` handler with hardcoded JWKS URL `https://www.googleapis.com/oauth2/v3/certs`, hardcoded issuer allowlist, and a Google-specific claim struct `GoogleIdTokenClaims`.
+- `crates/epigraph-api/src/oauth/token.rs::provision_google_user` — synthesizes `oauth_clients.client_id = "google:{sub}"` and grants a fixed default scope set on first sight.
+
+A deployment that wants to put EpiGraph behind Cloudflare Access today has no clean integration point — it would have to fork and patch this code. We want deployments to plug in additional identity sources (Cloudflare Access first, others later) by configuration, not by patching `epigraph-internal`.
+
+This design generalizes the path from "external assertion arrives" to "EpiGraph JWT issued" behind a small trait registry. Google becomes one provider implementation; Cloudflare Access becomes a second. New providers are a single struct + a `providers.toml` entry.
+
+The bearer middleware, AuthContext, scope checking, EpiGraph JWT signing, agent/service auth, and the database schema are unchanged.
+
+## Goals and non-goals
+
+**This design ships:**
+
+- A trait abstraction (`ExternalIdentityProvider` + optional `OidcRedirectFlow`) over external identity sources.
+- A `ProviderRegistry` owned by `AppState`, populated from `providers.toml` at startup.
+- Two concrete implementations: `GoogleProvider` (redirect + assertion) and `CloudflareAccessProvider` (assertion-only).
+- A shared `JwksCache` so JWKS is no longer fetched on every assertion validation.
+- A generic `provision_external_user` helper replacing the current `provision_google_user`.
+- Provider-parameterized routes: `POST /oauth/{provider}/auth-url`, `POST /oauth/{provider}/exchange` (verbs match the existing Google routes). The existing `/oauth/google/...` paths keep working unchanged (because the provider's `name` is `"google"`).
+- Per-provider grant types in `POST /oauth/token`. `google_id_token` continues to work; `cloudflare_access_jwt` is added.
+- Tests covering both providers via mocked JWKS fixtures.
+
+**This design explicitly does NOT ship:**
+
+- **No identity stitching.** Each `(provider, external_subject)` pair remains its own `oauth_clients` row. A future spec may introduce a `external_identities` join table; out of scope here.
+- **No schema migration.** `oauth_clients` table is untouched.
+- **No new crate.** Everything lives inside `crates/epigraph-api`.
+- **No hot reload.** Config changes require a server restart.
+- **No changes to bearer middleware, AuthContext, scope checking, or EpiGraph JWT issuance/validation.**
+- **No changes to agent (Ed25519) or service (`client_secret`) auth paths.**
+- **No deployment-side sidecar.** The deployment owns whatever local glue (Caddy snippet, small adapter service, etc.) translates Cloudflare Access's `Cf-Access-Jwt-Assertion` header into a `POST /oauth/token` call. EpiGraph exposes the generalized API; the deployment builds against it.
+
+## Architecture
+
+### Module layout
+
+```
+crates/epigraph-api/src/oauth/
+├── mod.rs                  (re-exports)
+├── jwt.rs                  (unchanged — EpiGraph's own JWT signing)
+├── token.rs                (modified — generic provider dispatch)
+├── device.rs               (modified — generic redirect flow, no longer Google-only)
+├── register.rs             (unchanged)
+├── revoke.rs               (unchanged)
+├── introspect.rs           (unchanged)
+└── providers/              (NEW)
+    ├── mod.rs              (trait defs + ProviderRegistry + provision_external_user)
+    ├── config.rs           (TOML structs + env interpolation + load fn)
+    ├── jwks.rs             (cached JWKS fetcher — shared by all providers)
+    ├── google.rs           (GoogleProvider: ExternalIdentityProvider + OidcRedirectFlow)
+    └── cloudflare_access.rs (CloudflareAccessProvider: ExternalIdentityProvider only)
+```
+
+`AppState` gains one field: `pub providers: Arc<ProviderRegistry>`. Built once at startup from `providers.toml`. Immutable for process lifetime. Follows the existing "shared trait-object" pattern already used for `encryption_provider: SharedEncryptionProvider` in `state.rs`.
+
+The `/oauth/{provider}/auth-url` and `/oauth/{provider}/exchange` routes must be registered in **both** OAuth router blocks in `routes/mod.rs` (the `db` build at ~`:670–683` and the second build at ~`:1024–1036`). Both currently register `/oauth/google/auth-url` and `/oauth/google/exchange` as POST; the new generic routes replace them in both places.
+
+### Core types
+
+```rust
+/// Identity extracted from a validated external assertion.
+pub struct ExternalIdentity {
+    pub subject: String,        // becomes the suffix in client_id = "{provider}:{subject}"
+    pub email: Option<String>,
+    pub email_verified: bool,
+    pub name: Option<String>,
+    pub raw_claims: serde_json::Value,  // full claims for audit/debug
+}
+
+#[async_trait]
+pub trait ExternalIdentityProvider: Send + Sync {
+    /// Stable identifier — used as the prefix in client_id and the path segment in /oauth/{name}/...
+    /// Must match `[a-z0-9-]+`. Unique within the registry.
+    fn name(&self) -> &str;
+
+    /// The grant_type string this provider responds to in POST /oauth/token.
+    /// Unique within the registry.
+    fn grant_type(&self) -> &str;
+
+    /// Validate the inbound assertion (a JWT) and extract identity.
+    async fn validate(&self, assertion: &str) -> Result<ExternalIdentity, ProviderError>;
+
+    fn auto_provision(&self) -> bool;
+    fn default_scopes(&self) -> &[String];
+}
+
+/// Optional capability — only providers that initiate a browser auth-code flow.
+#[async_trait]
+pub trait OidcRedirectFlow: Send + Sync {
+    fn build_auth_url(&self, state: &str, pkce_challenge: &str, redirect_uri: &str) -> String;
+    async fn exchange_code(
+        &self,
+        code: &str,
+        redirect_uri: &str,
+        pkce_verifier: &str,
+    ) -> Result<String /* id_token JWT */, ProviderError>;
+}
+
+pub struct ProviderRegistry {
+    by_name: HashMap<String, Arc<dyn ExternalIdentityProvider>>,
+    by_grant_type: HashMap<String, Arc<dyn ExternalIdentityProvider>>,
+    redirect_flows: HashMap<String, Arc<dyn OidcRedirectFlow>>,
+}
+
+impl ProviderRegistry {
+    pub fn from_config(cfg: ProvidersConfig) -> Result<Self, ProviderConfigError>;
+    pub fn by_name(&self, name: &str) -> Option<Arc<dyn ExternalIdentityProvider>>;
+    pub fn by_grant_type(&self, gt: &str) -> Option<Arc<dyn ExternalIdentityProvider>>;
+    pub fn redirect_flow(&self, name: &str) -> Option<Arc<dyn OidcRedirectFlow>>;
+}
+
+pub enum ProviderError {
+    InvalidAssertion(String),  // bad signature, expired, wrong issuer, wrong audience
+    JwksFetch(String),         // upstream JWKS unreachable
+    Config(String),            // misconfigured at startup
+    Upstream(String),          // e.g., Google's token endpoint returned 5xx during redirect-flow exchange
+}
+```
+
+### Provisioning helper
+
+```rust
+/// Provider-agnostic version of today's provision_google_user.
+/// Synthesizes client_id = "{provider.name()}:{identity.subject}", auto-creates if missing
+/// (when provider.auto_provision()), grants provider.default_scopes(), issues EpiGraph tokens.
+pub async fn provision_external_user(
+    state: &AppState,
+    provider: &dyn ExternalIdentityProvider,
+    identity: &ExternalIdentity,
+    requested_scope: Option<&str>,
+) -> Result<(StatusCode, Json<TokenResponse>), ApiError>;
+```
+
+The current `provision_google_user` is deleted; its logic moves wholesale into `provision_external_user`. The shape is the same — `client_id` synthesis, find-or-create, scope intersection, access+refresh token issuance — only the inputs become provider-supplied rather than Google-hardcoded.
+
+`provision_google_user` has **two** call sites that must both migrate in the same PR:
+- `token.rs:687` — the `grant_type=google_id_token` token-grant handler.
+- `device.rs:250` — the redirect-flow exchange handler (after Google's token endpoint returns the `id_token`).
+
+Errors from `provision_external_user` (e.g. `auto_provision=false` for an unknown subject, DB write failures) are **not** `ProviderError` — they are mapped to HTTP responses inside the helper itself (see §Error handling). `ProviderError` is reserved for assertion-validation and config errors raised by the trait implementations.
+
+### JWKS caching
+
+`providers/jwks.rs` exposes a `JwksCache` keyed by JWKS URL.
+
+- TTL: 1 hour.
+- Stale-grace: serve cached values for an additional 5 minutes if upstream is unreachable during a refresh (avoids hard outages when Google or Cloudflare's JWKS endpoint flaps).
+- Kid-not-found: triggers a single forced refetch. If the kid is still missing post-refetch, the validation fails. No further retries.
+- Concurrent fetches for the same URL are coalesced (single in-flight request via `tokio::sync::Mutex` or a similar coalescer) so a thundering herd of validations doesn't issue N upstream calls.
+
+This replaces the per-validation `reqwest::get(jwks_url)` calls inline in `device.rs:200-226` and `token.rs:633-660`.
+
+## Configuration
+
+### TOML schema
+
+Path: `providers.toml` at repo root. Overridable via `EPIGRAPH_PROVIDERS_CONFIG` env var.
+
+```toml
+[[provider]]
+name              = "google"
+flow              = "redirect"                          # provider runs a browser auth-code dance
+grant_type        = "google_id_token"
+issuer            = "https://accounts.google.com"
+extra_issuers     = ["accounts.google.com"]             # legacy non-https form Google still emits
+jwks_url          = "https://www.googleapis.com/oauth2/v3/certs"
+audience_env      = "GOOGLE_CLIENT_ID"
+client_id_env     = "GOOGLE_CLIENT_ID"
+client_secret_env = "GOOGLE_CLIENT_SECRET"
+auth_endpoint     = "https://accounts.google.com/o/oauth2/v2/auth"
+token_endpoint    = "https://oauth2.googleapis.com/token"
+redirect_uri_env  = "EPIGRAPH_REDIRECT_URI"             # optional; caller-supplied wins, this is the fallback
+auto_provision    = true
+default_scopes = [
+  "claims:read", "claims:write", "claims:challenge",
+  "evidence:read", "evidence:submit",
+  "edges:read", "edges:write",
+  "agents:read", "agents:write",
+  "groups:read", "groups:manage",
+  "analysis:belief", "analysis:propagation", "analysis:reasoning",
+  "analysis:gaps", "analysis:structural", "analysis:hypothesis",
+  "analysis:political",
+  "clients:register",
+]
+
+[[provider]]
+name           = "cloudflare-access"
+flow           = "assertion"                            # validate-only, no redirect dance
+grant_type     = "cloudflare_access_jwt"
+issuer         = "https://your-team.cloudflareaccess.com"
+jwks_url       = "https://your-team.cloudflareaccess.com/cdn-cgi/access/certs"
+audience_env   = "CF_ACCESS_AUD"                        # the AUD tag of the CF Access app
+auto_provision = true
+default_scopes = ["claims:read", "claims:write", "evidence:read", "evidence:submit"]
+```
+
+### Schema rules
+
+- `flow = "redirect"` requires `auth_endpoint`, `token_endpoint`, `client_id_env`, `client_secret_env`. May optionally specify `redirect_uri` (literal) or `redirect_uri_env`. Provider impls both `ExternalIdentityProvider` and `OidcRedirectFlow`.
+- `flow = "assertion"` requires only `issuer`, `jwks_url`, `audience_env` (or literal `audience`). Provider impls `ExternalIdentityProvider` only.
+- `*_env` fields name an environment variable read at startup. **Secrets are never written into TOML.** A missing referenced env var is a startup error.
+- `audience` may be a literal in TOML instead of `audience_env` if the value is non-secret.
+- `name` must be unique, lowercase, `[a-z0-9-]+`. Becomes the `client_id` prefix and the URL path segment.
+- `grant_type` must be unique across providers.
+
+### Precedence
+
+- **`providers.toml` present:** TOML is authoritative. Environment variables are read only where TOML references them via `*_env` fields.
+- **`providers.toml` absent AND `GOOGLE_CLIENT_ID` set:** legacy mode. Server synthesizes a single `google` provider from environment variables (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`) matching the current behavior. Logged as a warning at startup; slated for removal in a follow-up.
+- **`providers.toml` absent AND no `GOOGLE_CLIENT_ID`:** server starts with an empty provider registry. EpiGraph's own JWT-bearer auth still works (existing tokens, agent assertions, service `client_secret`). Any `POST /oauth/token` with an external grant type returns `400 unsupported_grant_type`.
+
+### Startup validation
+
+- Parse TOML. On any error: log + exit non-zero.
+- Resolve referenced env vars. Missing env var → exit non-zero.
+- Reject: duplicate `name`, duplicate `grant_type`, invalid `name` format, missing required field for declared `flow`.
+- Probe each `jwks_url` once (HEAD or GET). Warn on unreachable; do not exit (network may flap; cache will retry on first real validation).
+- Build `ProviderRegistry`, inject into `AppState`.
+
+### Redirect URI resolution
+
+The redirect URI was previously a single server-wide env var (`EPIGRAPH_REDIRECT_URI`) read inline at `device.rs:94` and `device.rs:140`. Multi-provider needs per-provider control without breaking existing callers, who do **not** send a redirect URI today.
+
+Resolution order, used by both `/oauth/{provider}/auth-url` and `/oauth/{provider}/exchange`:
+
+1. If the request body includes `redirect_uri`, use it.
+2. Else, if the provider config (TOML) supplies `redirect_uri` (literal) or `redirect_uri_env` (env var name), use that.
+3. Else, in **legacy mode only** (synthesized `google` provider, see Precedence below), fall back to `EPIGRAPH_REDIRECT_URI`, defaulting to `http://127.0.0.1:1` if unset — matches today's behavior.
+
+Existing callers that send neither field continue to work via step 3. New deployments configure step 2 in `providers.toml`. The inline `std::env::var("EPIGRAPH_REDIRECT_URI")` calls move into the legacy-mode synthesizer; no other code path reads the env var directly.
+
+## Data flow
+
+### Token-grant path (used by both Google and Cloudflare Access)
+
+```
+1. Caller (sidecar or browser): POST /oauth/token
+                                grant_type=cloudflare_access_jwt   (or google_id_token)
+                                assertion=<JWT>
+                                scope="claims:read claims:write"   (optional)
+2. token::handle_token() reads grant_type
+3. registry.by_grant_type(grant_type) → Arc<dyn ExternalIdentityProvider>
+4. provider.validate(assertion):
+     a. JwksCache.get(provider.jwks_url) → cached or fetched JWKS
+     b. decode_header → kid
+     c. find key by kid (refetch JWKS once if miss)
+     d. jsonwebtoken::decode with provider's issuer + audience set in Validation
+     e. extract ExternalIdentity { subject, email, email_verified, name, raw_claims }
+5. provision_external_user(state, &provider, &identity, requested_scope):
+     a. client_id_synth = format!("{}:{}", provider.name(), identity.subject)
+     b. OAuthClientRepository::get_by_client_id(client_id_synth)
+     c. if missing && provider.auto_provision(): create with provider.default_scopes()
+     d. effective_scopes = intersection(client.granted_scopes, requested_scope or all)
+     e. issue EpiGraph access JWT (HS256, claims.client_type="human")
+     f. issue refresh token (32B random, blake3 hashed, stored)
+6. Return TokenResponse { access_token, token_type, expires_in, refresh_token, scope }
+```
+
+### Redirect path (Google today; any future OIDC provider)
+
+Wire shape matches today's `/oauth/google/auth-url` and `/oauth/google/exchange`: same verb (POST), same field names. New fields are additive and optional.
+
+```
+1. Caller:   POST /oauth/{provider}/auth-url
+              body: { redirect_uri?: string }       // optional; falls back to provider config or EPIGRAPH_REDIRECT_URI
+2. Handler verifies registry.redirect_flow(provider) → Some(...) ; if None (e.g. flow="assertion"), returns 400.
+3. flow.build_auth_url(state, pkce_challenge, redirect_uri) → consent URL
+4. Server returns { auth_url, code_verifier } to caller   // existing field name; unchanged
+5. Browser hits IdP, returns to redirect_uri with ?code=...
+6. Caller:   POST /oauth/{provider}/exchange
+              body: { code, code_verifier, redirect_uri? }    // existing field names; redirect_uri optional and falls back as in step 1
+7. flow.exchange_code(code, redirect_uri, code_verifier) → id_token (IdP-signed JWT)
+8. provider.validate(id_token) → ExternalIdentity   (same path as token-grant)
+9. provision_external_user(...) → TokenResponse
+```
+
+Note on routing for `flow="assertion"` providers: the `/oauth/{provider}/auth-url` and `/exchange` routes are registered uniformly for all providers, but the handler must check `registry.redirect_flow(name)` first and return 400 when the provider does not implement `OidcRedirectFlow`. The 404 case (unknown provider name) takes precedence over the 400 case.
+
+Steps 8–9 reuse the exact same code path as the token-grant flow. The redirect flow's only job is "exchange code for assertion JWT, then hand to validate."
+
+### Cloudflare Access deployment shape (illustrative)
+
+Cloudflare Access already gatekeeps the route at the edge and injects `Cf-Access-Jwt-Assertion` on every request to EpiGraph. The deployment runs a small adapter (Caddy snippet, tiny Go service, lambda — whatever's idiomatic). On a fresh session it:
+
+1. Reads the CF assertion header from the inbound request.
+2. POSTs to EpiGraph: `grant_type=cloudflare_access_jwt`, `assertion=<the CF JWT>`.
+3. Stores the returned EpiGraph access+refresh tokens in a session cookie (signed) or sidecar memory.
+4. On subsequent requests, replaces the CF assertion with `Authorization: Bearer <epigraph-access-token>`.
+5. When the EpiGraph access token expires, uses the refresh token (or just re-exchanges the current CF assertion).
+
+EpiGraph itself sees only `Authorization: Bearer ...` for non-token requests — exactly as today.
+
+## Error handling, observability, security
+
+### HTTP responses (`POST /oauth/token`)
+
+| Failure | Status | OAuth2 error code |
+|---|---|---|
+| Unknown `grant_type` (no provider registered) | 400 | `unsupported_grant_type` |
+| Missing `assertion` field | 400 | `invalid_request` |
+| Bad signature / wrong issuer / wrong audience / expired | 401 | `invalid_grant` |
+| JWKS fetch fails (upstream unreachable, cache cold) | 503 | `temporarily_unavailable` |
+| Provider has `auto_provision=false` and user not found | 403 | `access_denied` |
+| DB write fails during provisioning | 500 | `server_error` |
+
+### Redirect flow (`/oauth/{provider}/auth-url`, `/oauth/{provider}/exchange`)
+
+| Failure | Status |
+|---|---|
+| Unknown provider name in path | 404 |
+| Provider exists but `flow != "redirect"` | 400 |
+| Upstream token endpoint 5xx during exchange | 502 |
+| PKCE verifier mismatch | 400 |
+
+### Logging rules
+
+- Never log full assertions or ID tokens. Log: `provider=cloudflare-access subject=<sub> email=<email> outcome=success|invalid_grant reason=<short>`.
+- Validation failures emit a `security_event` row (existing table) with `event_type="oauth_assertion_rejected"`, `provider`, and reason. Reuses the existing audit pipeline.
+- Successful first-time provisioning emits `event_type="oauth_human_provisioned"`, provider, client_id.
+
+### Replay / freshness
+
+- Each provider validates `exp` strictly.
+- `iat` skew tolerance ±60s.
+- No nonce check for `flow="assertion"` providers (no nonce was bound at issuance — we did not initiate the IdP request).
+- For `flow="redirect"`, the `state` parameter and PKCE verifier already bind initiation to exchange.
+
+### Provider name as trust boundary
+
+`client_id = "{provider_name}:{subject}"` is the identity key. Two providers can both authenticate the same external `subject` value, but they create *different* `oauth_clients` rows because the prefix differs. A misconfigured or duplicated `provider.name` would silently merge identities — the `from_config` validator enforces unique names, lowercase format, and `[a-z0-9-]+` charset.
+
+## Testing
+
+### Test infrastructure (new)
+
+`crates/epigraph-api/tests/oauth_providers/fixtures.rs` provides:
+
+- An RSA keypair generated at test setup, exposed as a JWKS via `wiremock` HTTP fixtures.
+- A `sign_id_token(claims)` helper producing a JWT signed by that key with a matching `kid`.
+- Per-test `ProviderRegistry` builders pointing providers at the wiremock URL.
+
+Same fixture serves both Google and Cloudflare Access test flows; only issuer/audience differ.
+
+**New dev-dependencies** to add to `crates/epigraph-api/Cargo.toml`:
+- `wiremock` (HTTP mocking for JWKS + Google token endpoint).
+- RSA key generation: `rsa` + `rand` (already a workspace dep).
+
+`async-trait`, `jsonwebtoken`, `serde_json`, and `tokio` are already present.
+
+### Unit tests per provider
+
+For `providers/google.rs::tests` and `providers/cloudflare_access.rs::tests`:
+
+- Valid signed assertion → returns expected `ExternalIdentity`.
+- Wrong `iss` → `InvalidAssertion`.
+- Wrong `aud` → `InvalidAssertion`.
+- Expired (`exp` < now) → `InvalidAssertion`.
+- Future `iat` beyond skew tolerance → `InvalidAssertion`.
+- Missing `kid` in header → `InvalidAssertion`.
+- Unknown `kid` triggers JWKS refetch; if still missing → `InvalidAssertion`.
+
+### JwksCache unit tests
+
+In `providers/jwks.rs::tests`:
+
+- N concurrent `get(url)` calls during cache miss issue exactly one upstream fetch.
+- TTL expiry triggers refetch.
+- Kid-not-found triggers single refetch then fails if still missing.
+- Upstream 5xx during refresh: returns last cached result if still within stale-grace window; otherwise error.
+
+### Integration tests (token endpoint)
+
+In `crates/epigraph-api/tests/oauth_token_grant.rs` (new file — no oauth integration test exists today):
+
+- `grant_type=google_id_token` end-to-end: mocked JWT → 200 with EpiGraph tokens → use access token to hit a protected route → 200.
+- `grant_type=cloudflare_access_jwt` end-to-end: same shape.
+- Unknown `grant_type` → 400 `unsupported_grant_type`.
+- Invalid assertion → 401 `invalid_grant`.
+- Provider with `auto_provision=false` + unknown subject → 403 `access_denied`.
+- Provider with `auto_provision=true` + new subject → `oauth_clients` row created with correct `client_id` prefix, `name`, `email`; second call with same subject finds the existing row (no duplicate insert).
+
+### Integration test — redirect flow
+
+In `crates/epigraph-api/tests/oauth_redirect_flow.rs` (new file):
+
+- GET `/oauth/google/auth-url` returns auth URL containing `state` + PKCE challenge.
+- POST `/oauth/google/exchange` with mocked Google token endpoint (wiremock) returns EpiGraph tokens.
+- Provider with `flow="assertion"` rejects redirect-flow paths: GET `/oauth/cloudflare-access/auth-url` → 400.
+- Unknown provider: GET `/oauth/nonexistent/auth-url` → 404.
+
+### Config loading tests
+
+In `providers/config.rs::tests`:
+
+- Valid TOML round-trips.
+- Missing referenced env var → startup error.
+- Duplicate `name` / duplicate `grant_type` → startup error.
+- Invalid `name` format (uppercase, special chars) → startup error.
+- `flow="redirect"` without `auth_endpoint` → startup error.
+- Legacy mode: no TOML + `GOOGLE_CLIENT_ID` set → registry contains exactly one google provider matching today's behavior.
+- Empty mode: no TOML + no `GOOGLE_CLIENT_ID` → registry empty; server starts; external grant types return 400.
+
+### Tests that must be updated, not deleted
+
+Any current test calling `provision_google_user` directly is updated to call `provision_external_user` with a `google` provider built from a test config. Existing assertions on response shape and `oauth_clients` row contents stay the same (the synthesized `client_id` is identical: `google:{sub}`).
+
+## Backwards compatibility
+
+The default-named `google` provider preserves today's wire contract end-to-end:
+
+- **HTTP verbs unchanged.** `/oauth/google/auth-url` and `/oauth/google/exchange` remain `POST` (matches `routes/mod.rs:677–682` and `:1030–1035` today).
+- **Request/response field names unchanged.** `ExchangeRequest { code, code_verifier }` and `AuthUrlResponse { auth_url, code_verifier }` keep their existing names. The new optional `redirect_uri` field on the request is additive — callers that omit it fall through to provider config and ultimately to `EPIGRAPH_REDIRECT_URI` (legacy mode), matching today's server-side resolution.
+- **`grant_type=google_id_token` unchanged.** Existing token-grant calls keep working with `id_token` field as before.
+- **`oauth_clients.client_id` format unchanged.** Existing rows (`google:{sub}`) match the new synthesizer's output exactly.
+- **Legacy env-var-only mode preserved.** Deployments without `providers.toml` synthesize a single `google` provider from `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `EPIGRAPH_REDIRECT_URI` and behave exactly as today, with a deprecation warning at startup.
+
+Net effect: a deployment running today, with no config changes, sees identical behavior on the next restart.
+
+## Implementation notes (for the plan, not part of the abstraction)
+
+These were flagged during design review and should be checked when implementing:
+
+1. **Cloudflare Access `aud` is an array, not a string.** Real Cloudflare Access JWTs emit `aud: ["abc123..."]` (a one-element array). `jsonwebtoken::Validation::set_audience(&[configured_aud])` handles both string and array claim values, but the test fixture for `cloudflare_access` should explicitly use the array form to verify.
+2. **Existing in-memory token revocation set in `AppState.revoked_tokens` is unaffected.** It tracks EpiGraph-issued JWTs, not provider-issued assertions. No change needed.
+3. **The `register.rs` "first active human as agent owner" lookup is unaffected.** `register.rs:148–156` runs `SELECT id FROM oauth_clients WHERE client_type = 'human' AND status = 'active' ORDER BY created_at LIMIT 1` to populate `owner_id` when an agent registers. (Note: there is no separate "first-human admin-approval" code path — humans auto-provisioned via any external provider land directly as `status='active'` inside `provision_external_user`, same as today's `provision_google_user`.) Across multiple providers, "first active human" still means whoever signed in earliest by any path; semantics unchanged.
+4. **`jsonwebtoken::Validation::set_required_spec_claims` should include `["exp", "iss", "aud"]` for all providers.** The current Google validation does this implicitly via the validation struct defaults; make it explicit so a future provider implementation doesn't accidentally drop a required claim.
+
+## Open questions for the implementation plan
+
+- **Branch base:** off `main` or off the current S3a branch? S3a is unrelated; cleaner to fork from `main`.
+- **PR scoping:** single PR for the full refactor, or split (1) extract abstraction with Google-only, (2) add Cloudflare Access provider? Single is simpler to review since the abstraction without a second consumer can't be evaluated for fitness.
+- **Hot-reload deferral:** confirmed out of scope. Restart on config change.

--- a/docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md
+++ b/docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md
@@ -1,5 +1,9 @@
 # S3a — `epigraph-mcp` Writer Migration Design
 
+> **Origin:** Ported from `epigraph-internal` (private dev repo) as historical
+> design context. The implementation landed on this repo as **#17**. Branch /
+> PR-number references below point to the original `epigraph-internal` artifacts.
+
 **Date:** 2026-04-26
 **Branch:** `feat/s3a-mcp-writer-migration` (created off `chore/migration-renumber-2026-04-25` so S1 helpers are the base); separate PR from #6
 **Status:** Approved for spec → plan → implementation


### PR DESCRIPTION
## Summary

Lifts three design specs from \`epigraph-internal\` so the architectural rationale for already-shipped public PRs survives once \`epigraph-internal\` is retired.

| Ported file | Lines | Implementation PR |
|------|------|------|
| \`docs/superpowers/specs/2026-04-25-noun-claims-and-verb-edges-design.md\` | 308 | #16 |
| \`docs/superpowers/specs/2026-04-26-multi-provider-identity-design.md\` | 445 | #24 |
| \`docs/superpowers/specs/2026-04-26-s3a-epigraph-mcp-writer-migration-design.md\` | 244 | #17 |

Each spec gets an \"Origin\" preamble flagging that internal branch / PR-number references inside the body refer to \`epigraph-internal\` artifacts (not this repo).

## Why design specs and not the plans

The companion implementation plans (\`2026-04-25-noun-claims-and-verb-edges.md\` 2,187 lines, \`2026-04-26-multi-provider-identity.md\` 2,754 lines, \`2026-04-26-s3a-epigraph-mcp-writer-migration.md\` 2,706 lines) are execution-step recipes for the internal-side commits and have stale value once shipped. Public already has its own port-side plans (\`2026-04-29-s1-noun-claim-foundation-port.md\` etc.) covering the catch-up commits.

## Why migration-renumber is not ported

The fourth internal plan, \`2026-04-25-migration-renumber.md\`, describes renumbering internal migrations 092-103 — internal-specific work with no public equivalent. Not relevant.

## Context

Part of the [retire \`epigraph-internal\` workstream](https://github.com/epigraph-io/epigraph-claude-cli). Other steps in flight:

1. ✅ \`ClaudeCliClient\` extracted to private overlay [\`epigraph-claude-cli\`](https://github.com/epigraph-io/epigraph-claude-cli) (the only structurally-private code in internal).
2. ✅ Issue #25 + fix #26 — \`epigraph-cli\` feature gating so consumers like the overlay can drop the DB stack.
3. **This PR** — port design specs.
4. Pending — port any remaining migrations (019–109) and noun-claim follow-up commits as the catch-up port flow proceeds.
5. Pending — once binaries can be wired against \`epigraph-claude-cli\`, archive \`epigraph-internal\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)