### PR TITLE
feat: address open issues #19, #28-#33

### DIFF
--- a/.sqlx/query-31e2715b8efa78b0ec3d656fc6cdb701c6700b45a2b28f67a51cf5415e56e9c2.json
+++ b/.sqlx/query-31e2715b8efa78b0ec3d656fc6cdb701c6700b45a2b28f67a51cf5415e56e9c2.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE claims SET properties = $2, updated_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "31e2715b8efa78b0ec3d656fc6cdb701c6700b45a2b28f67a51cf5415e56e9c2"
+}

--- a/crates/epigraph-api/src/routes/claims_query.rs
+++ b/crates/epigraph-api/src/routes/claims_query.rs
@@ -80,6 +80,11 @@ pub struct ClaimQueryParams {
     /// Filter by the agent who created the claim
     pub agent_id: Option<Uuid>,
 
+    /// Exclude claims created by this agent. Composes with `agent_id`
+    /// (if both are set, `agent_id` filters in and `exclude_agent_id`
+    /// filters out — useful for "all claims except those from the host").
+    pub exclude_agent_id: Option<Uuid>,
+
     /// Filter by current/superseded status
     pub is_current: Option<bool>,
 
@@ -297,6 +302,7 @@ pub async fn list_claims_query(
     let needs_in_memory_filters = params.truth_min.is_some()
         || params.truth_max.is_some()
         || params.agent_id.is_some()
+        || params.exclude_agent_id.is_some()
         || params.is_current.is_some()
         || params.created_after.is_some()
         || params.created_before.is_some()
@@ -369,6 +375,10 @@ pub async fn list_claims_query(
     }
     if let Some(agent_id) = params.agent_id {
         claims.retain(|c| c.agent_id.as_uuid() == agent_id);
+    }
+    // Filter out a specific agent (composes with agent_id above)
+    if let Some(exclude_agent_id) = params.exclude_agent_id {
+        claims.retain(|c| c.agent_id.as_uuid() != exclude_agent_id);
     }
     if let Some(is_current) = params.is_current {
         claims.retain(|c| c.is_current == is_current);
@@ -572,6 +582,11 @@ pub async fn list_claims_query(
     // Filter by agent_id
     if let Some(agent_id) = params.agent_id {
         claims.retain(|c| c.agent_id.as_uuid() == agent_id);
+    }
+
+    // Filter out a specific agent (composes with agent_id above)
+    if let Some(exclude_agent_id) = params.exclude_agent_id {
+        claims.retain(|c| c.agent_id.as_uuid() != exclude_agent_id);
     }
 
     // Filter by is_current
@@ -973,6 +988,35 @@ mod tests {
                 "All returned claims should belong to the target agent"
             );
         }
+    }
+
+    // ---- Test 8b: Filter out claims by agent_id (exclude_agent_id) ----
+
+    #[tokio::test]
+    async fn list_claims_excludes_agent_id() {
+        let state = AppState::new(ApiConfig::default());
+        let agent_a = AgentId::new();
+        let agent_b = AgentId::new();
+        insert_test_claim_with_agent(&state, "from agent A", 0.5, agent_a);
+        insert_test_claim_with_agent(&state, "from agent B", 0.5, agent_b);
+
+        let router = test_router(state);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(&format!(
+                        "/api/v1/claims?exclude_agent_id={}",
+                        agent_a.as_uuid()
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let resp = parse_response(response).await;
+        assert_eq!(resp.claims.len(), 1);
+        assert_eq!(resp.claims[0].content, "from agent B");
     }
 
     // ---- Test 9: Sort by truth_value ascending ----

--- a/crates/epigraph-api/src/routes/graph.rs
+++ b/crates/epigraph-api/src/routes/graph.rs
@@ -399,24 +399,28 @@ async fn fetch_subgraph_edges(
         return Ok((Vec::new(), 0));
     }
     let rows: Vec<(Uuid, Uuid, String, bool)> = match rel_list {
-        Some(allowlist) => sqlx::query_as(
-            "SELECT source_id, target_id, relationship, \
+        Some(allowlist) => {
+            sqlx::query_as(
+                "SELECT source_id, target_id, relationship, \
                     (relationship = ANY($2)) AS is_allowed \
              FROM edges \
              WHERE source_id = ANY($1) AND target_id = ANY($1)",
-        )
-        .bind(node_ids)
-        .bind(allowlist)
-        .fetch_all(pool)
-        .await,
-        None => sqlx::query_as(
-            "SELECT source_id, target_id, relationship, true AS is_allowed \
+            )
+            .bind(node_ids)
+            .bind(allowlist)
+            .fetch_all(pool)
+            .await
+        }
+        None => {
+            sqlx::query_as(
+                "SELECT source_id, target_id, relationship, true AS is_allowed \
              FROM edges \
              WHERE source_id = ANY($1) AND target_id = ANY($1)",
-        )
-        .bind(node_ids)
-        .fetch_all(pool)
-        .await,
+            )
+            .bind(node_ids)
+            .fetch_all(pool)
+            .await
+        }
     }
     .map_err(internal)?;
 
@@ -569,8 +573,16 @@ mod tests {
 
     #[test]
     fn resolve_filter_comma_separated_trims_and_filters_empty() {
-        let result = resolve_relationship_filter(Some("produced, same_source ,  ,CONTAINS")).unwrap();
-        assert_eq!(result, vec!["produced".to_string(), "same_source".to_string(), "CONTAINS".to_string()]);
+        let result =
+            resolve_relationship_filter(Some("produced, same_source ,  ,CONTAINS")).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                "produced".to_string(),
+                "same_source".to_string(),
+                "CONTAINS".to_string()
+            ]
+        );
     }
 }
 
@@ -605,13 +617,12 @@ mod integration_tests {
     /// Insert a system agent for tests (mirrors the pattern in policies.rs).
     async fn ensure_test_agent(pool: &PgPool) -> Uuid {
         let pub_key = vec![1u8; 32];
-        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
-            "SELECT id FROM agents WHERE public_key = $1",
-        )
-        .bind(&pub_key)
-        .fetch_optional(pool)
-        .await
-        .unwrap()
+        if let Some(id) =
+            sqlx::query_scalar::<_, Uuid>("SELECT id FROM agents WHERE public_key = $1")
+                .bind(&pub_key)
+                .fetch_optional(pool)
+                .await
+                .unwrap()
         {
             return id;
         }
@@ -673,13 +684,13 @@ mod integration_tests {
     /// with optional `?relationships=` override.
     fn neighborhood_request(node_id: Uuid, relationships: Option<&str>) -> Request<Body> {
         let uri = match relationships {
-            Some(r) => format!("/api/v1/graph/neighborhood?node_id={}&relationships={}", node_id, r),
+            Some(r) => format!(
+                "/api/v1/graph/neighborhood?node_id={}&relationships={}",
+                node_id, r
+            ),
             None => format!("/api/v1/graph/neighborhood?node_id={}", node_id),
         };
-        Request::builder()
-            .uri(uri)
-            .body(Body::empty())
-            .unwrap()
+        Request::builder().uri(uri).body(Body::empty()).unwrap()
     }
 
     #[sqlx::test(migrations = "../../migrations")]
@@ -691,7 +702,8 @@ mod integration_tests {
         let router = graph_router(state);
 
         // Without relationships override: edge is filtered.
-        let response = router.clone()
+        let response = router
+            .clone()
             .oneshot(neighborhood_request(a, None))
             .await
             .unwrap();

--- a/crates/epigraph-api/src/routes/graph.rs
+++ b/crates/epigraph-api/src/routes/graph.rs
@@ -65,6 +65,30 @@ const GRAPH_VIEW_RELATIONSHIPS: &[&str] = &[
     "derives_from",
 ];
 
+/// Resolve the effective relationship allowlist for a single request.
+///
+/// `None` → default (`GRAPH_VIEW_RELATIONSHIPS`).
+/// `Some("*")` or `Some("all")` → returns `None` (caller treats as "no filter").
+/// Otherwise → comma-split, trimmed, non-empty entries.
+fn resolve_relationship_filter(override_param: Option<&str>) -> Option<Vec<String>> {
+    match override_param {
+        None => Some(
+            GRAPH_VIEW_RELATIONSHIPS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        ),
+        Some(s) if s == "*" || s.eq_ignore_ascii_case("all") => None,
+        Some(s) => Some(
+            s.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect(),
+        ),
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct OverviewResponse {
     pub run_id: Option<Uuid>,
@@ -135,6 +159,11 @@ pub struct EdgeOut {
 pub struct ExpandParams {
     #[serde(default = "default_budget")]
     pub budget: i64,
+    /// Override the default relationship allowlist for this request.
+    /// Comma-separated list of relationship strings, or "*" / "all" for no filter.
+    /// When absent, uses `GRAPH_VIEW_RELATIONSHIPS`.
+    #[serde(default)]
+    pub relationships: Option<String>,
 }
 const fn default_budget() -> i64 {
     200
@@ -147,6 +176,11 @@ pub struct NeighborhoodParams {
     pub hops: i64,
     #[serde(default = "default_budget")]
     pub budget: i64,
+    /// Override the default relationship allowlist for this request.
+    /// Comma-separated list of relationship strings, or "*" / "all" for no filter.
+    /// When absent, uses `GRAPH_VIEW_RELATIONSHIPS`.
+    #[serde(default)]
+    pub relationships: Option<String>,
 }
 const fn default_hops() -> i64 {
     1
@@ -232,7 +266,17 @@ pub async fn expand(
     };
 
     let budget = params.budget.max(1);
-    let rel_list: Vec<&str> = GRAPH_VIEW_RELATIONSHIPS.to_vec();
+    let allowlist = resolve_relationship_filter(params.relationships.as_deref());
+    // For ordering by allowlisted-degree, fall back to the full default list
+    // when the request opts into "no filter" (i.e. `*`/`all`); otherwise the
+    // ORDER BY collapses to all-zero and ordering becomes arbitrary.
+    let degree_list: Vec<String> = match allowlist.as_deref() {
+        Some(list) => list.to_vec(),
+        None => GRAPH_VIEW_RELATIONSHIPS
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect(),
+    };
     let nodes: Vec<NodeOut> = sqlx::query_as::<_, NodeOut>(
         "WITH degree AS (
             SELECT m.claim_id, COUNT(e.*) AS deg
@@ -256,14 +300,15 @@ pub async fn expand(
     )
     .bind(cluster_id)
     .bind(run_id)
-    .bind(rel_list.clone())
+    .bind(degree_list)
     .bind(budget)
     .fetch_all(pool)
     .await
     .map_err(internal)?;
 
     let node_ids: Vec<Uuid> = nodes.iter().map(|n| n.id).collect();
-    let (edges, filtered_edge_count) = fetch_subgraph_edges(pool, &node_ids, &rel_list).await?;
+    let (edges, filtered_edge_count) =
+        fetch_subgraph_edges(pool, &node_ids, allowlist.as_deref()).await?;
 
     Ok(Json(ExpandResponse {
         cluster_id,
@@ -283,8 +328,13 @@ pub async fn neighborhood(
     let pool: &PgPool = &state.db_pool;
     let hops = params.hops.clamp(1, 2);
     let budget = params.budget.max(1);
-    let rel_list: Vec<&str> = GRAPH_VIEW_RELATIONSHIPS.to_vec();
+    let allowlist = resolve_relationship_filter(params.relationships.as_deref());
 
+    // BFS traverses via *all* edge types so that the response can report
+    // `filtered_edge_count` for nodes whose only edges are design-excluded
+    // (e.g. `produced`, `same_source`). The render filter applies in
+    // `fetch_subgraph_edges` below; the BFS only bounds the neighborhood by
+    // hop depth and the overall `budget`.
     let nodes: Vec<NodeOut> = sqlx::query_as::<_, NodeOut>(
         r#"
         WITH RECURSIVE bfs(id, depth) AS (
@@ -295,7 +345,6 @@ pub async fn neighborhood(
             FROM bfs b
             JOIN edges e
               ON (e.source_id = b.id OR e.target_id = b.id)
-             AND e.relationship = ANY($3)
             WHERE b.depth < $2
         )
         SELECT DISTINCT
@@ -307,12 +356,11 @@ pub async fn neighborhood(
                NULL::uuid AS cluster_id,
                NULL::float8 AS conflict_k
         FROM bfs b JOIN claims c ON c.id = b.id
-        LIMIT $4
+        LIMIT $3
         "#,
     )
     .bind(params.node_id)
     .bind(hops)
-    .bind(rel_list.clone())
     .bind(budget)
     .fetch_all(pool)
     .await
@@ -323,7 +371,8 @@ pub async fn neighborhood(
     }
 
     let ids: Vec<Uuid> = nodes.iter().map(|n| n.id).collect();
-    let (edges, filtered_edge_count) = fetch_subgraph_edges(pool, &ids, &rel_list).await?;
+    let (edges, filtered_edge_count) =
+        fetch_subgraph_edges(pool, &ids, allowlist.as_deref()).await?;
 
     Ok(Json(ExpandResponse {
         cluster_id: Uuid::nil(),
@@ -344,21 +393,31 @@ pub async fn neighborhood(
 async fn fetch_subgraph_edges(
     pool: &PgPool,
     node_ids: &[Uuid],
-    rel_list: &[&str],
+    rel_list: Option<&[String]>,
 ) -> Result<(Vec<EdgeOut>, i64), (axum::http::StatusCode, String)> {
     if node_ids.is_empty() {
         return Ok((Vec::new(), 0));
     }
-    let rows: Vec<(Uuid, Uuid, String, bool)> = sqlx::query_as(
-        "SELECT source_id, target_id, relationship,
-                (relationship = ANY($2)) AS is_allowed
-         FROM edges
-         WHERE source_id = ANY($1) AND target_id = ANY($1)",
-    )
-    .bind(node_ids)
-    .bind(rel_list)
-    .fetch_all(pool)
-    .await
+    let rows: Vec<(Uuid, Uuid, String, bool)> = match rel_list {
+        Some(allowlist) => sqlx::query_as(
+            "SELECT source_id, target_id, relationship, \
+                    (relationship = ANY($2)) AS is_allowed \
+             FROM edges \
+             WHERE source_id = ANY($1) AND target_id = ANY($1)",
+        )
+        .bind(node_ids)
+        .bind(allowlist)
+        .fetch_all(pool)
+        .await,
+        None => sqlx::query_as(
+            "SELECT source_id, target_id, relationship, true AS is_allowed \
+             FROM edges \
+             WHERE source_id = ANY($1) AND target_id = ANY($1)",
+        )
+        .bind(node_ids)
+        .fetch_all(pool)
+        .await,
+    }
     .map_err(internal)?;
 
     let mut edges = Vec::new();
@@ -472,5 +531,141 @@ mod tests {
         };
         let v = serde_json::to_value(&r).unwrap();
         assert_eq!(v["filtered_edge_count"], 7);
+    }
+}
+
+#[cfg(all(test, feature = "db"))]
+mod integration_tests {
+    use super::*;
+    use crate::state::{ApiConfig, AppState};
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    fn test_state(pool: PgPool) -> AppState {
+        AppState::with_db(pool, ApiConfig::default())
+    }
+
+    fn graph_router(state: AppState) -> Router {
+        Router::new()
+            .route("/api/v1/graph/neighborhood", get(neighborhood))
+            .route("/api/v1/graph/clusters/:id/expand", get(expand))
+            .with_state(state)
+    }
+
+    async fn parse_body(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// Insert a system agent for tests (mirrors the pattern in policies.rs).
+    async fn ensure_test_agent(pool: &PgPool) -> Uuid {
+        let pub_key = vec![1u8; 32];
+        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
+            "SELECT id FROM agents WHERE public_key = $1",
+        )
+        .bind(&pub_key)
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+        {
+            return id;
+        }
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(&pub_key)
+        .bind("graph-test-agent")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Seed two claims and return their ids.
+    async fn seed_two_claims(pool: &PgPool) -> (Uuid, Uuid) {
+        let agent_id = ensure_test_agent(pool).await;
+        let a_content = format!("graph-test-claim-a-{}", Uuid::new_v4());
+        let b_content = format!("graph-test-claim-b-{}", Uuid::new_v4());
+        let a_hash = epigraph_crypto::ContentHasher::hash(a_content.as_bytes());
+        let b_hash = epigraph_crypto::ContentHasher::hash(b_content.as_bytes());
+        let a = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value) \
+             VALUES ($1, $2, $3, 0.5) RETURNING id",
+        )
+        .bind(&a_content)
+        .bind(a_hash.as_slice())
+        .bind(agent_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let b = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value) \
+             VALUES ($1, $2, $3, 0.5) RETURNING id",
+        )
+        .bind(&b_content)
+        .bind(b_hash.as_slice())
+        .bind(agent_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        (a, b)
+    }
+
+    /// Seed a claim->claim edge with the given relationship.
+    async fn seed_edge(pool: &PgPool, source: Uuid, target: Uuid, relationship: &str) {
+        sqlx::query(
+            "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+             VALUES ($1, 'claim', $2, 'claim', $3)",
+        )
+        .bind(source)
+        .bind(target)
+        .bind(relationship)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Build a `GET /api/v1/graph/neighborhood` request scoped to `node_id`,
+    /// with optional `?relationships=` override.
+    fn neighborhood_request(node_id: Uuid, relationships: Option<&str>) -> Request<Body> {
+        let uri = match relationships {
+            Some(r) => format!("/api/v1/graph/neighborhood?node_id={}&relationships={}", node_id, r),
+            None => format!("/api/v1/graph/neighborhood?node_id={}", node_id),
+        };
+        Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn neighborhood_relationships_param_overrides_allowlist(pool: PgPool) {
+        let (a, b) = seed_two_claims(&pool).await;
+        seed_edge(&pool, a, b, "produced").await; // NOT in default allowlist
+
+        let state = test_state(pool.clone());
+        let router = graph_router(state);
+
+        // Without relationships override: edge is filtered.
+        let response = router.clone()
+            .oneshot(neighborhood_request(a, None))
+            .await
+            .unwrap();
+        let body: serde_json::Value = parse_body(response).await;
+        assert_eq!(body["edges"].as_array().unwrap().len(), 0);
+        assert_eq!(body["filtered_edge_count"], 1);
+
+        // With relationships=produced: edge is returned.
+        let response = router
+            .oneshot(neighborhood_request(a, Some("produced")))
+            .await
+            .unwrap();
+        let body: serde_json::Value = parse_body(response).await;
+        assert_eq!(body["edges"].as_array().unwrap().len(), 1);
+        assert_eq!(body["edges"][0]["relationship"], "produced");
     }
 }

--- a/crates/epigraph-api/src/routes/graph.rs
+++ b/crates/epigraph-api/src/routes/graph.rs
@@ -71,7 +71,7 @@ const GRAPH_VIEW_RELATIONSHIPS: &[&str] = &[
 /// `Some("*")` or `Some("all")` → returns `None` (caller treats as "no filter").
 /// Otherwise → comma-split, trimmed, non-empty entries.
 fn resolve_relationship_filter(override_param: Option<&str>) -> Option<Vec<String>> {
-    match override_param {
+    match override_param.map(str::trim).filter(|s| !s.is_empty()) {
         None => Some(
             GRAPH_VIEW_RELATIONSHIPS
                 .iter()
@@ -531,6 +531,46 @@ mod tests {
         };
         let v = serde_json::to_value(&r).unwrap();
         assert_eq!(v["filtered_edge_count"], 7);
+    }
+
+    #[test]
+    fn resolve_filter_none_returns_default_allowlist() {
+        let result = resolve_relationship_filter(None).unwrap();
+        // Pick any well-known default from GRAPH_VIEW_RELATIONSHIPS to avoid coupling
+        // this test to the full set. Either "decomposes_to" or "supports" is a stable
+        // choice — see the constant definition near the top of graph.rs.
+        assert!(result.contains(&"decomposes_to".to_string()));
+        assert!(result.contains(&"supports".to_string()));
+    }
+
+    #[test]
+    fn resolve_filter_empty_string_falls_back_to_default() {
+        let result = resolve_relationship_filter(Some("")).unwrap();
+        assert!(result.contains(&"decomposes_to".to_string()));
+    }
+
+    #[test]
+    fn resolve_filter_whitespace_only_falls_back_to_default() {
+        let result = resolve_relationship_filter(Some("   ")).unwrap();
+        assert!(result.contains(&"decomposes_to".to_string()));
+    }
+
+    #[test]
+    fn resolve_filter_star_returns_none() {
+        assert!(resolve_relationship_filter(Some("*")).is_none());
+    }
+
+    #[test]
+    fn resolve_filter_all_case_insensitive() {
+        assert!(resolve_relationship_filter(Some("ALL")).is_none());
+        assert!(resolve_relationship_filter(Some("All")).is_none());
+        assert!(resolve_relationship_filter(Some("all")).is_none());
+    }
+
+    #[test]
+    fn resolve_filter_comma_separated_trims_and_filters_empty() {
+        let result = resolve_relationship_filter(Some("produced, same_source ,  ,CONTAINS")).unwrap();
+        assert_eq!(result, vec!["produced".to_string(), "same_source".to_string(), "CONTAINS".to_string()]);
     }
 }
 

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -600,6 +600,18 @@ pub fn create_router(state: AppState) -> Router {
             "/api/v1/policies/decay-sweep",
             post(policies::decay_sweep),
         )
+        .route(
+            "/api/v1/policy-challenges",
+            post(policies::create_challenge),
+        )
+        .route(
+            "/api/v1/policy-challenges/:id",
+            get(policies::get_challenge),
+        )
+        .route(
+            "/api/v1/policy-challenges/:id/resolve",
+            post(policies::resolve_challenge),
+        )
         .route("/api/v1/methods/search", get(experiments::find_methods))
         .route(
             "/api/v1/methods/gap-analysis",

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -596,6 +596,10 @@ pub fn create_router(state: AppState) -> Router {
             "/api/v1/policies/:claim_id/outcome",
             post(policies::record_outcome),
         )
+        .route(
+            "/api/v1/policies/decay-sweep",
+            post(policies::decay_sweep),
+        )
         .route("/api/v1/methods/search", get(experiments::find_methods))
         .route(
             "/api/v1/methods/gap-analysis",

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -596,10 +596,7 @@ pub fn create_router(state: AppState) -> Router {
             "/api/v1/policies/:claim_id/outcome",
             post(policies::record_outcome),
         )
-        .route(
-            "/api/v1/policies/decay-sweep",
-            post(policies::decay_sweep),
-        )
+        .route("/api/v1/policies/decay-sweep", post(policies::decay_sweep))
         .route(
             "/api/v1/policy-challenges",
             post(policies::create_challenge),

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -66,6 +66,8 @@ mod negative_tests;
 pub mod ownership;
 pub mod papers;
 pub mod perspective;
+#[cfg(feature = "db")]
+pub mod policies;
 pub mod political;
 #[cfg(feature = "db")]
 pub mod provenance;

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -588,6 +588,10 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/v1/workflows", get(workflows::list_workflows))
         .route("/api/v1/workflows/search", get(workflows::search_workflows))
         .route("/api/v1/workflows/:id", get(workflows::get_workflow))
+        .route(
+            "/api/v1/policies/network",
+            get(policies::list_network_policies),
+        )
         .route("/api/v1/methods/search", get(experiments::find_methods))
         .route(
             "/api/v1/methods/gap-analysis",

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -592,6 +592,10 @@ pub fn create_router(state: AppState) -> Router {
             "/api/v1/policies/network",
             get(policies::list_network_policies),
         )
+        .route(
+            "/api/v1/policies/:claim_id/outcome",
+            post(policies::record_outcome),
+        )
         .route("/api/v1/methods/search", get(experiments::find_methods))
         .route(
             "/api/v1/methods/gap-analysis",

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -585,6 +585,7 @@ pub fn create_router(state: AppState) -> Router {
         )
         .route("/api/v1/workflows", get(workflows::list_workflows))
         .route("/api/v1/workflows/search", get(workflows::search_workflows))
+        .route("/api/v1/workflows/:id", get(workflows::get_workflow))
         .route("/api/v1/methods/search", get(experiments::find_methods))
         .route(
             "/api/v1/methods/gap-analysis",

--- a/crates/epigraph-api/src/routes/policies.rs
+++ b/crates/epigraph-api/src/routes/policies.rs
@@ -129,6 +129,33 @@ pub async fn record_outcome(
     })))
 }
 
+/// POST /api/v1/policies/decay-sweep — pull stale active policies toward 0.5.
+///
+/// Skips claims with `properties->>'decay_exempt' = 'true'`. Returns the
+/// number of rows updated.
+#[cfg(feature = "db")]
+pub async fn decay_sweep(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let result = sqlx::query(
+        "UPDATE claims SET \
+            truth_value = truth_value + 0.1 * (0.5 - truth_value), \
+            updated_at = NOW() \
+         WHERE 'policy:active' = ANY(labels) \
+           AND COALESCE((properties->>'decay_exempt')::boolean, false) IS NOT TRUE \
+           AND updated_at < NOW() - INTERVAL '90 days'",
+    )
+    .execute(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Decay sweep failed: {e}"),
+    })?;
+
+    Ok(Json(serde_json::json!({
+        "rows_affected": result.rows_affected(),
+    })))
+}
+
 #[cfg(all(test, feature = "db"))]
 mod tests {
     use super::*;
@@ -159,6 +186,10 @@ mod tests {
             .route(
                 "/api/v1/policies/:claim_id/outcome",
                 post(record_outcome),
+            )
+            .route(
+                "/api/v1/policies/decay-sweep",
+                post(decay_sweep),
             )
             .with_state(state)
     }
@@ -219,6 +250,39 @@ mod tests {
         .unwrap()
     }
 
+    /// Like `seed_policy` but additionally backdates `updated_at` to simulate
+    /// a stale or fresh policy. Used by the decay sweep test.
+    ///
+    /// The `claims_updated_at` trigger normally forces `updated_at = NOW()`
+    /// on every UPDATE, so we temporarily disable user triggers around the
+    /// backdating UPDATE.
+    async fn seed_policy_with_age(
+        pool: &PgPool,
+        host: &str,
+        port: i64,
+        protocol: &str,
+        truth: f64,
+        decay_exempt: bool,
+        days_old: i64,
+    ) -> Uuid {
+        let id = seed_policy(pool, host, port, protocol, truth, decay_exempt).await;
+        sqlx::query("ALTER TABLE claims DISABLE TRIGGER claims_updated_at")
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE claims SET updated_at = NOW() - ($2 || ' days')::interval WHERE id = $1")
+            .bind(id)
+            .bind(days_old.to_string())
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query("ALTER TABLE claims ENABLE TRIGGER claims_updated_at")
+            .execute(pool)
+            .await
+            .unwrap();
+        id
+    }
+
     async fn parse_body(response: axum::response::Response) -> serde_json::Value {
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         serde_json::from_slice(&bytes).unwrap()
@@ -275,5 +339,42 @@ mod tests {
             .unwrap();
         assert!(new_truth > 0.5, "expected truth to increase, got {new_truth}");
         assert!(new_truth <= 0.99);
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn decay_sweep_pulls_stale_truth_toward_one_half(pool: PgPool) {
+        let stale_id = seed_policy_with_age(&pool, "stale.com", 443, "https", 0.9, false, 100).await;
+        let fresh_id = seed_policy_with_age(&pool, "fresh.com", 443, "https", 0.9, false, 1).await;
+        let exempt_id = seed_policy_with_age(&pool, "exempt.com", 443, "https", 0.9, true, 100).await;
+        let state = test_state(pool.clone());
+
+        let router = policy_router(state);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/policies/decay-sweep")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = parse_body(response).await;
+        assert_eq!(body["rows_affected"], 1);
+
+        let stale_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+            .bind(stale_id)
+            .fetch_one(&pool).await.unwrap();
+        assert!(stale_truth < 0.9 && stale_truth > 0.5,
+            "stale should have decayed toward 0.5; got {stale_truth}");
+
+        let fresh_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+            .bind(fresh_id).fetch_one(&pool).await.unwrap();
+        assert_eq!(fresh_truth, 0.9, "fresh policy must not decay");
+
+        let exempt_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+            .bind(exempt_id).fetch_one(&pool).await.unwrap();
+        assert_eq!(exempt_truth, 0.9, "decay_exempt policy must not decay");
     }
 }

--- a/crates/epigraph-api/src/routes/policies.rs
+++ b/crates/epigraph-api/src/routes/policies.rs
@@ -308,26 +308,11 @@ mod tests {
     /// Build a router exposing the policy routes under test.
     fn policy_router(state: AppState) -> Router {
         Router::new()
-            .route(
-                "/api/v1/policies/network",
-                get(list_network_policies),
-            )
-            .route(
-                "/api/v1/policies/:claim_id/outcome",
-                post(record_outcome),
-            )
-            .route(
-                "/api/v1/policies/decay-sweep",
-                post(decay_sweep),
-            )
-            .route(
-                "/api/v1/policy-challenges",
-                post(create_challenge),
-            )
-            .route(
-                "/api/v1/policy-challenges/:id",
-                get(get_challenge),
-            )
+            .route("/api/v1/policies/network", get(list_network_policies))
+            .route("/api/v1/policies/:claim_id/outcome", post(record_outcome))
+            .route("/api/v1/policies/decay-sweep", post(decay_sweep))
+            .route("/api/v1/policy-challenges", post(create_challenge))
+            .route("/api/v1/policy-challenges/:id", get(get_challenge))
             .route(
                 "/api/v1/policy-challenges/:id/resolve",
                 post(resolve_challenge),
@@ -339,13 +324,12 @@ mod tests {
     /// going through the public API) and return its id.
     async fn ensure_system_agent(pool: &PgPool) -> Uuid {
         let pub_key = vec![0u8; 32];
-        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
-            "SELECT id FROM agents WHERE public_key = $1",
-        )
-        .bind(&pub_key)
-        .fetch_optional(pool)
-        .await
-        .unwrap()
+        if let Some(id) =
+            sqlx::query_scalar::<_, Uuid>("SELECT id FROM agents WHERE public_key = $1")
+                .bind(&pub_key)
+                .fetch_optional(pool)
+                .await
+                .unwrap()
         {
             return id;
         }
@@ -411,12 +395,14 @@ mod tests {
             .execute(pool)
             .await
             .unwrap();
-        sqlx::query("UPDATE claims SET updated_at = NOW() - ($2 || ' days')::interval WHERE id = $1")
-            .bind(id)
-            .bind(days_old.to_string())
-            .execute(pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "UPDATE claims SET updated_at = NOW() - ($2 || ' days')::interval WHERE id = $1",
+        )
+        .bind(id)
+        .bind(days_old.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
         sqlx::query("ALTER TABLE claims ENABLE TRIGGER claims_updated_at")
             .execute(pool)
             .await
@@ -519,15 +505,20 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert!(new_truth > 0.5, "expected truth to increase, got {new_truth}");
+        assert!(
+            new_truth > 0.5,
+            "expected truth to increase, got {new_truth}"
+        );
         assert!(new_truth <= 0.99);
     }
 
     #[sqlx::test(migrations = "../../migrations")]
     async fn decay_sweep_pulls_stale_truth_toward_one_half(pool: PgPool) {
-        let stale_id = seed_policy_with_age(&pool, "stale.com", 443, "https", 0.9, false, 100).await;
+        let stale_id =
+            seed_policy_with_age(&pool, "stale.com", 443, "https", 0.9, false, 100).await;
         let fresh_id = seed_policy_with_age(&pool, "fresh.com", 443, "https", 0.9, false, 1).await;
-        let exempt_id = seed_policy_with_age(&pool, "exempt.com", 443, "https", 0.9, true, 100).await;
+        let exempt_id =
+            seed_policy_with_age(&pool, "exempt.com", 443, "https", 0.9, true, 100).await;
         let state = test_state(pool.clone());
 
         let router = policy_router(state);
@@ -547,16 +538,26 @@ mod tests {
 
         let stale_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
             .bind(stale_id)
-            .fetch_one(&pool).await.unwrap();
-        assert!(stale_truth < 0.9 && stale_truth > 0.5,
-            "stale should have decayed toward 0.5; got {stale_truth}");
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(
+            stale_truth < 0.9 && stale_truth > 0.5,
+            "stale should have decayed toward 0.5; got {stale_truth}"
+        );
 
         let fresh_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
-            .bind(fresh_id).fetch_one(&pool).await.unwrap();
+            .bind(fresh_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
         assert_eq!(fresh_truth, 0.9, "fresh policy must not decay");
 
         let exempt_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
-            .bind(exempt_id).fetch_one(&pool).await.unwrap();
+            .bind(exempt_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
         assert_eq!(exempt_truth, 0.9, "decay_exempt policy must not decay");
     }
 
@@ -636,7 +637,9 @@ mod tests {
                 .fetch_one(&pool)
                 .await
                 .unwrap();
-        assert!((default_deny_truth - 0.63).abs() < 1e-6,
-            "expected 0.6 + 0.03 = 0.63, got {default_deny_truth}");
+        assert!(
+            (default_deny_truth - 0.63).abs() < 1e-6,
+            "expected 0.6 + 0.03 = 0.63, got {default_deny_truth}"
+        );
     }
 }

--- a/crates/epigraph-api/src/routes/policies.rs
+++ b/crates/epigraph-api/src/routes/policies.rs
@@ -7,7 +7,17 @@
 //!
 //! Reference implementation: `epigraph-nano/src/persistence.rs:7332-7530`.
 
+#[cfg(feature = "db")]
+use axum::{
+    extract::{Query, State},
+    Json,
+};
 use serde::Deserialize;
+#[cfg(feature = "db")]
+use uuid::Uuid;
+
+#[cfg(feature = "db")]
+use crate::{errors::ApiError, AppState};
 
 #[derive(Debug, Deserialize)]
 pub struct ListPoliciesQuery {
@@ -34,4 +44,160 @@ pub struct CreateChallengeRequest {
 #[derive(Debug, Deserialize)]
 pub struct ResolveChallengeRequest {
     pub approved: bool,
+}
+
+/// GET /api/v1/policies/network — list active network-access policies.
+#[cfg(feature = "db")]
+pub async fn list_network_policies(
+    State(state): State<AppState>,
+    Query(params): Query<ListPoliciesQuery>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let min_truth = params.min_truth.clamp(0.0, 1.0);
+    let rows: Vec<(Uuid, f64, serde_json::Value)> = sqlx::query_as(
+        "SELECT id, truth_value, properties \
+         FROM claims \
+         WHERE 'policy:active' = ANY(labels) \
+           AND 'policy:network' = ANY(labels) \
+           AND truth_value >= $1 \
+         ORDER BY truth_value DESC",
+    )
+    .bind(min_truth)
+    .fetch_all(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to list policies: {e}"),
+    })?;
+
+    let policies: Vec<serde_json::Value> = rows
+        .into_iter()
+        .map(|(id, truth_value, properties)| {
+            serde_json::json!({
+                "claim_id": id,
+                "host": properties.get("host"),
+                "port": properties.get("port"),
+                "protocol": properties.get("protocol"),
+                "truth_value": truth_value,
+                "decay_exempt": properties.get("decay_exempt").and_then(|v| v.as_bool()).unwrap_or(false),
+            })
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({ "policies": policies })))
+}
+
+#[cfg(all(test, feature = "db"))]
+mod tests {
+    use super::*;
+    use crate::state::{ApiConfig, AppState};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    // ── Test scaffolding ──
+
+    /// Build a minimal AppState backed by the given pool.
+    fn test_state(pool: PgPool) -> AppState {
+        AppState::with_db(pool, ApiConfig::default())
+    }
+
+    /// Build a router exposing just the policy list route under test.
+    fn policy_router(state: AppState) -> Router {
+        Router::new()
+            .route(
+                "/api/v1/policies/network",
+                get(list_network_policies),
+            )
+            .with_state(state)
+    }
+
+    /// Insert a system agent (mirrors `get_or_create_system_agent` but without
+    /// going through the public API) and return its id.
+    async fn ensure_system_agent(pool: &PgPool) -> Uuid {
+        let pub_key = vec![0u8; 32];
+        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
+            "SELECT id FROM agents WHERE public_key = $1",
+        )
+        .bind(&pub_key)
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+        {
+            return id;
+        }
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(&pub_key)
+        .bind("api-system-test")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Insert a claim labeled `policy:active` + `policy:network` with the
+    /// given network attributes in `properties`.
+    async fn seed_policy(
+        pool: &PgPool,
+        host: &str,
+        port: i64,
+        protocol: &str,
+        truth: f64,
+        decay_exempt: bool,
+    ) -> Uuid {
+        let agent_id = ensure_system_agent(pool).await;
+        let content = format!("policy:network {host}:{port}/{protocol}");
+        let content_hash = epigraph_crypto::ContentHasher::hash(content.as_bytes());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value, labels, properties) \
+             VALUES ($1, $2, $3, $4, ARRAY['policy:active','policy:network'], $5) RETURNING id",
+        )
+        .bind(&content)
+        .bind(content_hash.as_slice())
+        .bind(agent_id)
+        .bind(truth)
+        .bind(serde_json::json!({
+            "host": host,
+            "port": port,
+            "protocol": protocol,
+            "decay_exempt": decay_exempt,
+        }))
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    async fn parse_body(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    // ── Tests ──
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn list_network_policies_returns_active_policies_above_min_truth(pool: PgPool) {
+        seed_policy(&pool, "example.com", 443, "https", 0.92, false).await;
+        seed_policy(&pool, "blocked.com", 443, "https", 0.10, false).await;
+        let state = test_state(pool.clone());
+
+        let router = policy_router(state);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/policies/network?min_truth=0.5")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = parse_body(response).await;
+        let policies = body["policies"].as_array().unwrap();
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0]["host"], "example.com");
+    }
 }

--- a/crates/epigraph-api/src/routes/policies.rs
+++ b/crates/epigraph-api/src/routes/policies.rs
@@ -1,0 +1,37 @@
+//! /api/v1/policies/* — labeled-claim view over network access policies.
+//!
+//! All policies are stored as ordinary claims with `policy:active` and
+//! `policy:network` labels and `host`/`port`/`protocol`/`decay_exempt`
+//! fields in `properties`. Challenges are claims with `policy:challenge`
+//! and a `status` field in `properties`.
+//!
+//! Reference implementation: `epigraph-nano/src/persistence.rs:7332-7530`.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct ListPoliciesQuery {
+    #[serde(default = "default_min_truth")]
+    pub min_truth: f64,
+}
+const fn default_min_truth() -> f64 {
+    0.5
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OutcomeRequest {
+    pub supports: bool,
+    pub strength: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateChallengeRequest {
+    pub host: String,
+    pub port: i64,
+    pub protocol: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveChallengeRequest {
+    pub approved: bool,
+}

--- a/crates/epigraph-api/src/routes/policies.rs
+++ b/crates/epigraph-api/src/routes/policies.rs
@@ -129,6 +129,135 @@ pub async fn record_outcome(
     })))
 }
 
+/// POST /api/v1/policy-challenges — create a pending challenge claim.
+#[cfg(feature = "db")]
+pub async fn create_challenge(
+    State(state): State<AppState>,
+    Json(req): Json<CreateChallengeRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let sys_agent_id = crate::routes::workflows::get_or_create_system_agent(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Failed to resolve system agent: {e}"),
+        })?;
+
+    let content = format!(
+        "Network access challenge: {}:{} ({})",
+        req.host,
+        req.port,
+        req.protocol.as_deref().unwrap_or("any")
+    );
+    let content_hash = epigraph_crypto::ContentHasher::hash(content.as_bytes());
+
+    let id: Uuid = sqlx::query_scalar(
+        "INSERT INTO claims (content, content_hash, agent_id, truth_value, labels, properties) \
+         VALUES ($1, $2, $3, 0.5, ARRAY['policy','policy:challenge'], $4) \
+         RETURNING id",
+    )
+    .bind(&content)
+    .bind(content_hash.as_slice())
+    .bind(sys_agent_id)
+    .bind(serde_json::json!({
+        "host": req.host,
+        "port": req.port,
+        "protocol": req.protocol,
+        "status": "pending",
+    }))
+    .fetch_one(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to create challenge: {e}"),
+    })?;
+
+    Ok(Json(serde_json::json!({ "id": id })))
+}
+
+/// GET /api/v1/policy-challenges/:id — fetch a challenge by ID.
+#[cfg(feature = "db")]
+pub async fn get_challenge(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let row: Option<(Uuid, serde_json::Value)> = sqlx::query_as(
+        "SELECT id, properties FROM claims \
+         WHERE id = $1 AND 'policy:challenge' = ANY(labels)",
+    )
+    .bind(id)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to fetch challenge: {e}"),
+    })?;
+
+    let (id, properties) = row.ok_or(ApiError::NotFound {
+        entity: "policy-challenge".to_string(),
+        id: id.to_string(),
+    })?;
+
+    Ok(Json(serde_json::json!({
+        "id": id,
+        "host": properties.get("host"),
+        "port": properties.get("port"),
+        "protocol": properties.get("protocol"),
+        "status": properties.get("status"),
+    })))
+}
+
+/// POST /api/v1/policy-challenges/:id/resolve — approve or deny.
+///
+/// On `approved=false`, also strengthens the default-deny policy claim
+/// by +0.03 (capped at 0.99). Default-deny is identified by host='*' in properties.
+#[cfg(feature = "db")]
+pub async fn resolve_challenge(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<ResolveChallengeRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let new_status = if req.approved { "approved" } else { "denied" };
+
+    let updated: Option<(Uuid,)> = sqlx::query_as(
+        "UPDATE claims SET \
+            properties = jsonb_set(properties, '{status}', to_jsonb($2::text), true), \
+            updated_at = NOW() \
+         WHERE id = $1 AND 'policy:challenge' = ANY(labels) \
+         RETURNING id",
+    )
+    .bind(id)
+    .bind(new_status)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to resolve challenge: {e}"),
+    })?;
+
+    if updated.is_none() {
+        return Err(ApiError::NotFound {
+            entity: "policy-challenge".to_string(),
+            id: id.to_string(),
+        });
+    }
+
+    if !req.approved {
+        sqlx::query(
+            "UPDATE claims SET \
+                truth_value = LEAST(0.99, truth_value + 0.03), \
+                updated_at = NOW() \
+             WHERE 'policy:active' = ANY(labels) \
+               AND properties->>'host' = '*'",
+        )
+        .execute(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Failed to strengthen default-deny: {e}"),
+        })?;
+    }
+
+    Ok(Json(serde_json::json!({
+        "id": id,
+        "status": new_status,
+    })))
+}
+
 /// POST /api/v1/policies/decay-sweep — pull stale active policies toward 0.5.
 ///
 /// Skips claims with `properties->>'decay_exempt' = 'true'`. Returns the
@@ -190,6 +319,18 @@ mod tests {
             .route(
                 "/api/v1/policies/decay-sweep",
                 post(decay_sweep),
+            )
+            .route(
+                "/api/v1/policy-challenges",
+                post(create_challenge),
+            )
+            .route(
+                "/api/v1/policy-challenges/:id",
+                get(get_challenge),
+            )
+            .route(
+                "/api/v1/policy-challenges/:id/resolve",
+                post(resolve_challenge),
             )
             .with_state(state)
     }
@@ -288,6 +429,47 @@ mod tests {
         serde_json::from_slice(&bytes).unwrap()
     }
 
+    /// Insert a plain claim with no labels — used to verify that the
+    /// challenge GET handler returns 404 for non-challenge claims.
+    async fn seed_plain_claim(pool: &PgPool, content: &str) -> Uuid {
+        let agent_id = ensure_system_agent(pool).await;
+        let content_hash = epigraph_crypto::ContentHasher::hash(content.as_bytes());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value, labels, properties) \
+             VALUES ($1, $2, $3, 0.5, ARRAY[]::text[], '{}'::jsonb) RETURNING id",
+        )
+        .bind(content)
+        .bind(content_hash.as_slice())
+        .bind(agent_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Seed a pending challenge directly in the database (mirrors the
+    /// `create_challenge` handler's INSERT).
+    async fn create_challenge_via_handler(pool: &PgPool, host: &str, port: i64) -> Uuid {
+        let agent_id = ensure_system_agent(pool).await;
+        let content = format!("Network access challenge: {host}:{port} (any)");
+        let content_hash = epigraph_crypto::ContentHasher::hash(content.as_bytes());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value, labels, properties) \
+             VALUES ($1, $2, $3, 0.5, ARRAY['policy','policy:challenge'], $4) RETURNING id",
+        )
+        .bind(&content)
+        .bind(content_hash.as_slice())
+        .bind(agent_id)
+        .bind(serde_json::json!({
+            "host": host,
+            "port": port,
+            "protocol": serde_json::Value::Null,
+            "status": "pending",
+        }))
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
     // ── Tests ──
 
     #[sqlx::test(migrations = "../../migrations")]
@@ -376,5 +558,85 @@ mod tests {
         let exempt_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
             .bind(exempt_id).fetch_one(&pool).await.unwrap();
         assert_eq!(exempt_truth, 0.9, "decay_exempt policy must not decay");
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn create_challenge_returns_id_and_persists_pending(pool: PgPool) {
+        let state = test_state(pool.clone());
+        let router = policy_router(state.clone());
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/policy-challenges")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"host":"example.com","port":443}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = parse_body(response).await;
+        let id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+
+        let (labels, properties): (Vec<String>, serde_json::Value) =
+            sqlx::query_as("SELECT labels, properties FROM claims WHERE id = $1")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(labels.contains(&"policy:challenge".to_string()));
+        assert_eq!(properties["host"], "example.com");
+        assert_eq!(properties["port"], 443);
+        assert_eq!(properties["status"], "pending");
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn get_challenge_returns_404_when_not_a_challenge(pool: PgPool) {
+        let claim_id = seed_plain_claim(&pool, "not a challenge").await;
+        let state = test_state(pool.clone());
+        let router = policy_router(state);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/api/v1/policy-challenges/{claim_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn resolve_challenge_denied_strengthens_default_deny(pool: PgPool) {
+        // Default-deny policy is identified by host='*' in properties.
+        let default_deny_id = seed_policy(&pool, "*", 0, "*", 0.6, false).await;
+        let challenge_id = create_challenge_via_handler(&pool, "blocked.com", 443).await;
+        let state = test_state(pool.clone());
+
+        let router = policy_router(state.clone());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/api/v1/policy-challenges/{challenge_id}/resolve"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"approved": false}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let default_deny_truth: f64 =
+            sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+                .bind(default_deny_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!((default_deny_truth - 0.63).abs() < 1e-6,
+            "expected 0.6 + 0.03 = 0.63, got {default_deny_truth}");
     }
 }

--- a/crates/epigraph-api/src/routes/policies.rs
+++ b/crates/epigraph-api/src/routes/policies.rs
@@ -9,7 +9,7 @@
 
 #[cfg(feature = "db")]
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     Json,
 };
 use serde::Deserialize;
@@ -85,13 +85,57 @@ pub async fn list_network_policies(
     Ok(Json(serde_json::json!({ "policies": policies })))
 }
 
+/// POST /api/v1/policies/:claim_id/outcome — Bayesian-style nudge.
+///
+/// `supports = true` increases truth toward 1.0; `false` decreases.
+/// `strength` is the magnitude in (0, 1]; clamped server-side.
+#[cfg(feature = "db")]
+pub async fn record_outcome(
+    State(state): State<AppState>,
+    Path(claim_id): Path<Uuid>,
+    Json(req): Json<OutcomeRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let strength = req.strength.clamp(0.0, 1.0);
+    let signed = if req.supports { strength } else { -strength };
+
+    // Same closed-form update as epigraph-nano/src/persistence.rs:7430.
+    let row: Option<(f64,)> = sqlx::query_as(
+        "UPDATE claims SET \
+            truth_value = LEAST(0.99, GREATEST(0.01, \
+                truth_value + $1 * (1.0 - truth_value) * \
+                CASE WHEN $1 > 0 THEN 1.0 ELSE truth_value END)), \
+            updated_at = NOW() \
+         WHERE id = $2 AND 'policy:active' = ANY(labels) \
+         RETURNING truth_value",
+    )
+    .bind(signed)
+    .bind(claim_id)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to update policy outcome: {e}"),
+    })?;
+
+    let new_truth = row
+        .ok_or(ApiError::NotFound {
+            entity: "policy".to_string(),
+            id: claim_id.to_string(),
+        })?
+        .0;
+
+    Ok(Json(serde_json::json!({
+        "claim_id": claim_id,
+        "truth_value": new_truth,
+    })))
+}
+
 #[cfg(all(test, feature = "db"))]
 mod tests {
     use super::*;
     use crate::state::{ApiConfig, AppState};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use axum::routing::get;
+    use axum::routing::{get, post};
     use axum::Router;
     use http_body_util::BodyExt;
     use sqlx::PgPool;
@@ -105,12 +149,16 @@ mod tests {
         AppState::with_db(pool, ApiConfig::default())
     }
 
-    /// Build a router exposing just the policy list route under test.
+    /// Build a router exposing the policy routes under test.
     fn policy_router(state: AppState) -> Router {
         Router::new()
             .route(
                 "/api/v1/policies/network",
                 get(list_network_policies),
+            )
+            .route(
+                "/api/v1/policies/:claim_id/outcome",
+                post(record_outcome),
             )
             .with_state(state)
     }
@@ -199,5 +247,33 @@ mod tests {
         let policies = body["policies"].as_array().unwrap();
         assert_eq!(policies.len(), 1);
         assert_eq!(policies[0]["host"], "example.com");
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn outcome_supports_true_increases_truth_value(pool: PgPool) {
+        let claim_id = seed_policy(&pool, "example.com", 443, "https", 0.5, false).await;
+        let state = test_state(pool.clone());
+
+        let router = policy_router(state.clone());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/api/v1/policies/{claim_id}/outcome"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"supports": true, "strength": 0.05}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let new_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+            .bind(claim_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(new_truth > 0.5, "expected truth to increase, got {new_truth}");
+        assert!(new_truth <= 0.99);
     }
 }

--- a/crates/epigraph-api/src/routes/submit.rs
+++ b/crates/epigraph-api/src/routes/submit.rs
@@ -711,22 +711,21 @@ async fn validate_packet(
         #[cfg(feature = "db")]
         {
             let agent_id: Uuid = packet.claim.agent_id;
-            let pub_key_row: Option<(Vec<u8>,)> = sqlx::query_as(
-                "SELECT public_key FROM agents WHERE id = $1",
-            )
-            .bind(agent_id)
-            .fetch_optional(&state.db_pool)
-            .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    ErrorResponse::with_details(
-                        "InternalError",
-                        "Failed to look up agent public key",
-                        serde_json::json!({ "error": e.to_string() }),
-                    ),
-                )
-            })?;
+            let pub_key_row: Option<(Vec<u8>,)> =
+                sqlx::query_as("SELECT public_key FROM agents WHERE id = $1")
+                    .bind(agent_id)
+                    .fetch_optional(&state.db_pool)
+                    .await
+                    .map_err(|e| {
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            ErrorResponse::with_details(
+                                "InternalError",
+                                "Failed to look up agent public key",
+                                serde_json::json!({ "error": e.to_string() }),
+                            ),
+                        )
+                    })?;
 
             let pub_key_bytes: [u8; 32] = pub_key_row
                 .ok_or_else(|| {
@@ -780,11 +779,8 @@ async fn validate_packet(
             })?;
 
             // 4. Verify.
-            match epigraph_crypto::SignatureVerifier::verify(
-                &pub_key_bytes,
-                &canonical,
-                &sig_bytes,
-            ) {
+            match epigraph_crypto::SignatureVerifier::verify(&pub_key_bytes, &canonical, &sig_bytes)
+            {
                 Ok(true) => { /* fall through */ }
                 Ok(false) => {
                     return Err((

--- a/crates/epigraph-api/src/routes/submit.rs
+++ b/crates/epigraph-api/src/routes/submit.rs
@@ -90,6 +90,19 @@ const MAX_TRACE_INPUTS: usize = 50;
 #[serde(transparent)]
 pub struct OptionalTruth(pub Option<f64>);
 
+impl OptionalTruth {
+    /// Helper for `#[serde(skip_serializing_if = ...)]` on `ClaimSubmission`.
+    ///
+    /// When the wrapped value is `None`, the field is omitted entirely
+    /// from JSON output. This keeps round-tripping (serialize then
+    /// deserialize) symmetric with the deserializer, which rejects
+    /// explicit `null` but treats absent as valid.
+    #[must_use]
+    pub const fn is_none(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
 impl<'de> Deserialize<'de> for OptionalTruth {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -126,8 +139,10 @@ pub struct ClaimSubmission {
     /// Note: This is only a suggestion - actual truth is calculated from evidence
     ///
     /// Uses custom wrapper to reject explicit `null` values
-    /// (which could represent NaN from languages that serialize NaN as null)
-    #[serde(default)]
+    /// (which could represent NaN from languages that serialize NaN as null).
+    /// Serializes as absent (not `null`) when `None`, so re-deserializing
+    /// the canonical bytes still parses cleanly.
+    #[serde(default, skip_serializing_if = "OptionalTruth::is_none")]
     #[schema(value_type = Option<f64>)]
     pub initial_truth: OptionalTruth,
 
@@ -268,6 +283,36 @@ pub struct EpistemicPacket {
     pub signature: String,
 }
 
+impl EpistemicPacket {
+    /// Canonical byte representation of the packet *excluding* the signature
+    /// field. This is what the agent signs over and what the server
+    /// recomputes for verification.
+    ///
+    /// # Canonical Scheme
+    ///
+    /// The bytes are the canonical-JSON serialization of the tuple-like
+    /// view `(claim, evidence, reasoning_trace)`. The packet's `signature`
+    /// field is excluded so a client can sign these bytes and the server
+    /// can recompute identical bytes from the received packet for
+    /// verification.
+    ///
+    /// # Errors
+    /// Returns `CryptoError::SerializationError` if canonical serialization fails.
+    pub fn signable_bytes(&self) -> Result<Vec<u8>, epigraph_crypto::CryptoError> {
+        #[derive(serde::Serialize)]
+        struct PacketSignable<'a> {
+            claim: &'a ClaimSubmission,
+            evidence: &'a [EvidenceSubmission],
+            reasoning_trace: &'a ReasoningTraceSubmission,
+        }
+        epigraph_crypto::to_canonical_bytes(&PacketSignable {
+            claim: &self.claim,
+            evidence: &self.evidence,
+            reasoning_trace: &self.reasoning_trace,
+        })
+    }
+}
+
 /// Successful submission response
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct SubmitPacketResponse {
@@ -323,7 +368,7 @@ impl ErrorResponse {
 // =============================================================================
 
 /// Validate the epistemic packet and return any errors
-fn validate_packet(
+async fn validate_packet(
     packet: &EpistemicPacket,
     state: &AppState,
 ) -> Result<(), (StatusCode, ErrorResponse)> {
@@ -657,22 +702,115 @@ fn validate_packet(
             ));
         }
 
-        // TODO(security): Implement Ed25519 signature verification here.
-        // This requires fetching the agent's public key from the database by
-        // packet.claim.agent_id, decoding the hex signature into a [u8; 64],
-        // and calling SignatureVerifier::verify(pub_key, canonical_content, sig).
-        // validate_packet is currently a sync fn; wiring in DB access requires
-        // making it async (or moving verification to the async handler).
-        // Until that is implemented, we fail closed: any request on the
-        // require_signatures path is rejected.
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            ErrorResponse::with_details(
-                "SignatureError",
-                "Signature verification is not yet implemented; submissions require a verified identity",
-                serde_json::json!({ "field": "signature" }),
-            ),
-        ));
+        // 1. Look up the claim agent's public key.
+        //
+        // When the `db` feature is disabled, we have no public-key store to
+        // verify against, so we fail closed: any request on the
+        // require_signatures path is rejected. Builds with `db` enabled
+        // perform the real Ed25519 verification below.
+        #[cfg(feature = "db")]
+        {
+            let agent_id: Uuid = packet.claim.agent_id;
+            let pub_key_row: Option<(Vec<u8>,)> = sqlx::query_as(
+                "SELECT public_key FROM agents WHERE id = $1",
+            )
+            .bind(agent_id)
+            .fetch_optional(&state.db_pool)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ErrorResponse::with_details(
+                        "InternalError",
+                        "Failed to look up agent public key",
+                        serde_json::json!({ "error": e.to_string() }),
+                    ),
+                )
+            })?;
+
+            let pub_key_bytes: [u8; 32] = pub_key_row
+                .ok_or_else(|| {
+                    (
+                        StatusCode::UNAUTHORIZED,
+                        ErrorResponse::with_details(
+                            "SignatureError",
+                            "Agent not registered",
+                            serde_json::json!({ "field": "claim.agent_id" }),
+                        ),
+                    )
+                })?
+                .0
+                .try_into()
+                .map_err(|_| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        ErrorResponse::with_details(
+                            "InternalError",
+                            "Stored public key has wrong length",
+                            serde_json::json!({}),
+                        ),
+                    )
+                })?;
+
+            // 2. Decode the hex signature.
+            let mut sig_bytes = [0u8; 64];
+            hex::decode_to_slice(&packet.signature, &mut sig_bytes).map_err(|_| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    ErrorResponse::with_details(
+                        "SignatureError",
+                        "Signature contains invalid hex characters",
+                        serde_json::json!({ "field": "signature" }),
+                    ),
+                )
+            })?;
+
+            // 3. Recompute the canonical bytes the client should have signed.
+            // The canonical scheme: serialized (claim, evidence, reasoning_trace)
+            // tuple, signature field excluded. See EpistemicPacket::signable_bytes.
+            let canonical = packet.signable_bytes().map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ErrorResponse::with_details(
+                        "InternalError",
+                        "Failed to canonicalize packet for verification",
+                        serde_json::json!({ "error": e.to_string() }),
+                    ),
+                )
+            })?;
+
+            // 4. Verify.
+            match epigraph_crypto::SignatureVerifier::verify(
+                &pub_key_bytes,
+                &canonical,
+                &sig_bytes,
+            ) {
+                Ok(true) => { /* fall through */ }
+                Ok(false) | Err(_) => {
+                    return Err((
+                        StatusCode::UNAUTHORIZED,
+                        ErrorResponse::with_details(
+                            "SignatureError",
+                            "Signature verification failed",
+                            serde_json::json!({ "field": "signature" }),
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // Without the `db` feature there is no public-key store; fail closed.
+        #[cfg(not(feature = "db"))]
+        {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                ErrorResponse::with_details(
+                    "SignatureError",
+                    "Signature verification requires the `db` feature; submissions require a verified identity",
+                    serde_json::json!({ "field": "signature" }),
+                ),
+            ));
+        }
     }
 
     Ok(())
@@ -1188,7 +1326,7 @@ pub async fn submit_packet(
     }
 
     // 2. Validate the packet
-    if let Err((status, error)) = validate_packet(&packet, &state) {
+    if let Err((status, error)) = validate_packet(&packet, &state).await {
         return (status, Json(error)).into_response();
     }
 
@@ -1824,6 +1962,177 @@ mod event_tests {
             response.status(),
             StatusCode::CREATED,
             "Figure evidence submission should succeed"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "db"))]
+mod signature_verification_tests {
+    use super::*;
+    use crate::state::{ApiConfig, AppState};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::post;
+    use axum::Router;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    // ── Test scaffolding ──
+
+    /// Build an `AppState` backed by `pool` with `require_signatures` enabled.
+    fn test_state_with_required_signatures(pool: PgPool) -> AppState {
+        AppState::with_db(
+            pool,
+            ApiConfig {
+                require_signatures: true,
+                ..ApiConfig::default()
+            },
+        )
+    }
+
+    /// Insert an agent with the given Ed25519 public key into the agents
+    /// table. Returns the agent's UUID.
+    async fn seed_agent_with_pubkey(pool: &PgPool, pub_key: [u8; 32]) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(pub_key.as_slice())
+        .bind("signature-verification-test")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Build a minimal `ClaimSubmission` with the given content and agent.
+    fn build_test_claim_submission(agent_id: Uuid, content: &str) -> ClaimSubmission {
+        ClaimSubmission {
+            content: content.to_string(),
+            initial_truth: OptionalTruth(None),
+            agent_id,
+            idempotency_key: None,
+            properties: None,
+        }
+    }
+
+    /// Build a minimal `ReasoningTraceSubmission` with no inputs and no
+    /// inner signature. The packet-level signature is what we exercise.
+    fn build_test_trace() -> ReasoningTraceSubmission {
+        ReasoningTraceSubmission {
+            methodology: MethodologySubmission::Deductive,
+            inputs: vec![],
+            confidence: 0.8,
+            explanation: "Trace explanation for signature verification test.".to_string(),
+            signature: None,
+        }
+    }
+
+    /// Send the packet through the submit endpoint and return the response.
+    async fn submit_packet_endpoint(
+        state: AppState,
+        packet: EpistemicPacket,
+    ) -> axum::response::Response {
+        let router = Router::new()
+            .route("/api/v1/submit/packet", post(submit_packet))
+            .with_state(state);
+
+        let body = serde_json::to_string(&packet).unwrap();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/submit/packet")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        router.oneshot(request).await.unwrap()
+    }
+
+    // ── Tests ──
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn submit_with_valid_signature_succeeds(pool: PgPool) {
+        let signer = epigraph_crypto::AgentSigner::generate();
+        let pub_key = signer.public_key();
+        let agent_id = seed_agent_with_pubkey(&pool, pub_key).await;
+
+        let state = test_state_with_required_signatures(pool.clone());
+
+        let claim = build_test_claim_submission(agent_id, "Verifiable claim content.");
+        let evidence: Vec<EvidenceSubmission> = vec![];
+        let reasoning_trace = build_test_trace();
+
+        let mut packet = EpistemicPacket {
+            claim,
+            evidence,
+            reasoning_trace,
+            signature: String::new(),
+        };
+        let canonical = packet.signable_bytes().unwrap();
+        packet.signature = hex::encode(signer.sign(&canonical));
+
+        let response = submit_packet_endpoint(state, packet).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::CREATED,
+            "Valid Ed25519 signature should pass verification and create the claim"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn submit_with_invalid_signature_returns_401(pool: PgPool) {
+        let real_key = epigraph_crypto::AgentSigner::generate();
+        let attacker_key = epigraph_crypto::AgentSigner::generate();
+        let agent_id = seed_agent_with_pubkey(&pool, real_key.public_key()).await;
+
+        let state = test_state_with_required_signatures(pool.clone());
+
+        let claim = build_test_claim_submission(agent_id, "Forged content.");
+        let evidence: Vec<EvidenceSubmission> = vec![];
+        let reasoning_trace = build_test_trace();
+
+        let mut packet = EpistemicPacket {
+            claim,
+            evidence,
+            reasoning_trace,
+            signature: String::new(),
+        };
+        let canonical = packet.signable_bytes().unwrap();
+        // Sign with the attacker's key — wrong key for the agent's stored pubkey.
+        packet.signature = hex::encode(attacker_key.sign(&canonical));
+
+        let response = submit_packet_endpoint(state, packet).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "Signature signed by the wrong key must be rejected"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn submit_with_unknown_agent_id_returns_401(pool: PgPool) {
+        let signer = epigraph_crypto::AgentSigner::generate();
+        // Never seed this agent into the agents table.
+        let unknown_agent = Uuid::new_v4();
+
+        let state = test_state_with_required_signatures(pool.clone());
+
+        let claim = build_test_claim_submission(unknown_agent, "Orphan claim.");
+        let evidence: Vec<EvidenceSubmission> = vec![];
+        let reasoning_trace = build_test_trace();
+
+        let mut packet = EpistemicPacket {
+            claim,
+            evidence,
+            reasoning_trace,
+            signature: String::new(),
+        };
+        let canonical = packet.signable_bytes().unwrap();
+        packet.signature = hex::encode(signer.sign(&canonical));
+
+        let response = submit_packet_endpoint(state, packet).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "Submission for an unregistered agent must be rejected"
         );
     }
 }

--- a/crates/epigraph-api/src/routes/submit.rs
+++ b/crates/epigraph-api/src/routes/submit.rs
@@ -786,13 +786,28 @@ async fn validate_packet(
                 &sig_bytes,
             ) {
                 Ok(true) => { /* fall through */ }
-                Ok(false) | Err(_) => {
+                Ok(false) => {
                     return Err((
                         StatusCode::UNAUTHORIZED,
                         ErrorResponse::with_details(
                             "SignatureError",
                             "Signature verification failed",
                             serde_json::json!({ "field": "signature" }),
+                        ),
+                    ));
+                }
+                Err(e) => {
+                    tracing::error!(
+                        agent_id = %agent_id,
+                        error = %e,
+                        "Stored public key rejected by Ed25519 verifier — possibly corrupted in agents table"
+                    );
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        ErrorResponse::with_details(
+                            "InternalError",
+                            "Public key verification error",
+                            serde_json::json!({}),
                         ),
                     ));
                 }

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -976,13 +976,12 @@ mod tests {
     async fn ensure_system_agent(pool: &PgPool) -> Uuid {
         let pub_key = vec![0u8; 32];
         // Try existing first
-        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
-            "SELECT id FROM agents WHERE public_key = $1",
-        )
-        .bind(&pub_key)
-        .fetch_optional(pool)
-        .await
-        .unwrap()
+        if let Some(id) =
+            sqlx::query_scalar::<_, Uuid>("SELECT id FROM agents WHERE public_key = $1")
+                .bind(&pub_key)
+                .fetch_optional(pool)
+                .await
+                .unwrap()
         {
             return id;
         }

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -408,7 +408,7 @@ pub async fn get_workflow(
     Ok(Json(serde_json::json!({
         "workflow_id": row.id,
         "content": serde_json::from_str::<serde_json::Value>(&row.content)
-            .unwrap_or_else(|_| serde_json::Value::String(row.content)),
+            .unwrap_or(serde_json::Value::String(row.content)),
         "truth_value": row.truth_value,
         "properties": row.properties,
     })))

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -892,7 +892,7 @@ pub async fn record_behavioral_execution(
 // ── Internal helpers ──
 
 #[cfg(feature = "db")]
-async fn get_or_create_system_agent(pool: &sqlx::PgPool) -> Result<Uuid, ApiError> {
+pub(crate) async fn get_or_create_system_agent(pool: &sqlx::PgPool) -> Result<Uuid, ApiError> {
     let pub_key = [0u8; 32];
     if let Some(a) = epigraph_db::AgentRepository::get_by_public_key(pool, &pub_key)
         .await

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -382,6 +382,38 @@ pub async fn list_workflows(
     })))
 }
 
+/// GET /api/v1/workflows/:id - Fetch a single workflow by ID.
+///
+/// Returns 404 if the claim does not exist or is not labeled `workflow`.
+#[cfg(feature = "db")]
+pub async fn get_workflow(
+    State(state): State<AppState>,
+    Path(workflow_id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let row = sqlx::query_as::<_, WorkflowContentRow>(
+        "SELECT id, content, truth_value, properties \
+         FROM claims WHERE id = $1 AND 'workflow' = ANY(labels)",
+    )
+    .bind(workflow_id)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to fetch workflow: {e}"),
+    })?
+    .ok_or(ApiError::NotFound {
+        entity: "workflow".to_string(),
+        id: workflow_id.to_string(),
+    })?;
+
+    Ok(Json(serde_json::json!({
+        "workflow_id": row.id,
+        "content": serde_json::from_str::<serde_json::Value>(&row.content)
+            .unwrap_or_else(|_| serde_json::Value::String(row.content)),
+        "truth_value": row.truth_value,
+        "properties": row.properties,
+    })))
+}
+
 /// POST /api/v1/workflows/:id/outcome - Report execution outcome.
 #[cfg(feature = "db")]
 pub async fn report_outcome(
@@ -911,4 +943,155 @@ struct WorkflowContentRow {
     content: String,
     truth_value: Option<f64>,
     properties: Option<serde_json::Value>,
+}
+
+#[cfg(all(test, feature = "db"))]
+mod tests {
+    use super::*;
+    use crate::state::{ApiConfig, AppState};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    // ── Test scaffolding ──
+
+    /// Build a minimal AppState backed by the given pool.
+    fn test_state(pool: PgPool) -> AppState {
+        AppState::with_db(pool, ApiConfig::default())
+    }
+
+    /// Build a router exposing just the workflow GET-by-id route under test.
+    fn workflow_router(state: AppState) -> Router {
+        Router::new()
+            .route("/api/v1/workflows/:id", get(get_workflow))
+            .with_state(state)
+    }
+
+    /// Insert a system agent (mirrors `get_or_create_system_agent` but without
+    /// going through the public API) and return its id.
+    async fn ensure_system_agent(pool: &PgPool) -> Uuid {
+        let pub_key = vec![0u8; 32];
+        // Try existing first
+        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
+            "SELECT id FROM agents WHERE public_key = $1",
+        )
+        .bind(&pub_key)
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+        {
+            return id;
+        }
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(&pub_key)
+        .bind("api-system-test")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Insert a workflow-labeled claim with the given goal and steps.
+    /// Mirrors the canonical `store_workflow` SQL at workflows.rs:135.
+    async fn seed_test_workflow(pool: &PgPool, goal: &str, steps: &[&str]) -> Uuid {
+        let agent_id = ensure_system_agent(pool).await;
+        let empty: Vec<&str> = vec![];
+        let content = serde_json::json!({
+            "goal": goal,
+            "steps": steps,
+            "prerequisites": empty,
+            "expected_outcome": serde_json::Value::Null,
+            "tags": empty,
+        });
+        let content_str = content.to_string();
+        let content_hash = epigraph_crypto::ContentHasher::hash(content_str.as_bytes());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value, labels, properties) \
+             VALUES ($1, $2, $3, $4, ARRAY['workflow'], $5) RETURNING id",
+        )
+        .bind(&content_str)
+        .bind(content_hash.as_slice())
+        .bind(agent_id)
+        .bind(0.5_f64)
+        .bind(serde_json::json!({
+            "generation": 0,
+            "use_count": 0,
+            "success_count": 0,
+            "failure_count": 0,
+            "avg_variance": 0.0,
+        }))
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Insert a plain (non-workflow-labeled) claim and return its id.
+    async fn seed_plain_claim(pool: &PgPool, content: &str) -> Uuid {
+        let agent_id = ensure_system_agent(pool).await;
+        let content_hash = epigraph_crypto::ContentHasher::hash(content.as_bytes());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value) \
+             VALUES ($1, $2, $3, $4) RETURNING id",
+        )
+        .bind(content)
+        .bind(content_hash.as_slice())
+        .bind(agent_id)
+        .bind(0.5_f64)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    async fn parse_body(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    // ── Tests ──
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn get_workflow_returns_single_workflow(pool: PgPool) {
+        let state = test_state(pool.clone());
+        let workflow_id = seed_test_workflow(&pool, "deploy-canary", &["step1", "step2"]).await;
+
+        let router = workflow_router(state);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/api/v1/workflows/{workflow_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = parse_body(response).await;
+        assert_eq!(body["workflow_id"], workflow_id.to_string());
+        assert!(body["content"].is_string() || body["content"].is_object());
+        assert!(body["truth_value"].is_number());
+        assert!(body["properties"].is_object());
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn get_workflow_returns_404_for_non_workflow_claim(pool: PgPool) {
+        let state = test_state(pool.clone());
+        let claim_id = seed_plain_claim(&pool, "not a workflow").await;
+
+        let router = workflow_router(state);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/api/v1/workflows/{claim_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
 }

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -1590,11 +1590,12 @@ mod tests {
             .await
             .unwrap();
 
-        let row: (serde_json::Value,) = sqlx::query_as("SELECT properties FROM claims WHERE id = $1")
-            .bind(Uuid::from(persisted.id))
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+        let row: (serde_json::Value,) =
+            sqlx::query_as("SELECT properties FROM claims WHERE id = $1")
+                .bind(Uuid::from(persisted.id))
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert_eq!(row.0, props);
     }
 

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -147,13 +147,20 @@ impl ClaimRepository {
         properties: serde_json::Value,
     ) -> Result<(), DbError> {
         let id: Uuid = claim_id.into();
-        sqlx::query!(
+        let result = sqlx::query!(
             "UPDATE claims SET properties = $2, updated_at = NOW() WHERE id = $1",
             id,
             properties
         )
         .execute(pool)
         .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(DbError::NotFound {
+                entity: "Claim".to_string(),
+                id,
+            });
+        }
         Ok(())
     }
 

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -134,6 +134,29 @@ impl ClaimRepository {
         ))
     }
 
+    /// Set the `properties` JSONB column on an existing claim. Overwrites the
+    /// existing value (does not merge). Used by ingest to attach hierarchy
+    /// metadata (level, section, source_type, generality) at creation time.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool, properties))]
+    pub async fn set_properties(
+        pool: &PgPool,
+        claim_id: ClaimId,
+        properties: serde_json::Value,
+    ) -> Result<(), DbError> {
+        let id: Uuid = claim_id.into();
+        sqlx::query!(
+            "UPDATE claims SET properties = $2, updated_at = NOW() WHERE id = $1",
+            id,
+            properties
+        )
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
     /// Create a new claim within an existing transaction (LEGACY — implicit content-hash dedup)
     ///
     /// Same as `create()` but accepts a `&mut PgConnection` for transactional use.
@@ -1530,6 +1553,42 @@ mod tests {
             .await
             .unwrap();
         assert!(missing.iter().any(|(id, _)| *id == claim_id));
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn set_properties_writes_jsonb_column(pool: sqlx::PgPool) {
+        // Seed agent inline (no epigraph_test_support helper available),
+        // following the existing pattern in this test module.
+        let (agent_id, agent_pk): (Uuid, Vec<u8>) = sqlx::query_as(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels)
+             VALUES (sha256(gen_random_uuid()::text::bytea), 'set-props-test', 'system', ARRAY['test'])
+             RETURNING id, public_key",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let mut public_key = [0u8; 32];
+        public_key.copy_from_slice(&agent_pk);
+
+        let claim = Claim::new(
+            "Test claim for properties".to_string(),
+            AgentId::from_uuid(agent_id),
+            public_key,
+            TruthValue::clamped(0.5),
+        );
+        let persisted = ClaimRepository::create(&pool, &claim).await.unwrap();
+        let props = serde_json::json!({"level": 3, "section": "Body", "source_type": "Wiki"});
+
+        ClaimRepository::set_properties(&pool, persisted.id, props.clone())
+            .await
+            .unwrap();
+
+        let row: (serde_json::Value,) = sqlx::query_as("SELECT properties FROM claims WHERE id = $1")
+            .bind(Uuid::from(persisted.id))
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(row.0, props);
     }
 
     #[sqlx::test(migrations = "../../migrations")]

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -662,6 +662,15 @@ pub async fn do_ingest_document(
             .copied()
             .unwrap_or(edge.target_id);
 
+        // Filter self-loops introduced by content-hash dedup collapsing
+        // distinct planned UUIDs (e.g. compound paragraph and its sole
+        // atom that share text) onto the same persisted claim. The
+        // semantically correct outcome is a no-op decomposition; the DB
+        // would otherwise reject this with edges_no_self_loop.
+        if src == tgt && src_type == edge.target_type {
+            continue;
+        }
+
         EdgeRepository::create_if_not_exists(
             pool,
             src,

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -547,6 +547,16 @@ pub async fn do_ingest_document(
             continue;
         }
 
+        // Persist hierarchy metadata (level, section, source_type, generality)
+        // from the ingest plan onto the new claim's `properties` column.
+        ClaimRepository::set_properties(
+            pool,
+            ClaimId::from_uuid(persisted_id),
+            planned.properties.clone(),
+        )
+        .await
+        .map_err(internal_error)?;
+
         // New claim: write the supporting evidence and reasoning trace.
         let evidence_text = planned
             .supporting_text

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -296,6 +296,56 @@ async fn ingest_document_persists_planned_properties(pool: PgPool) {
     assert_eq!(level_zero, 1, "thesis (level 0) should be queryable by properties->>'level'");
 }
 
+#[sqlx::test(migrations = "../../migrations")]
+async fn ingest_document_handles_compound_equals_atom(pool: sqlx::PgPool) {
+    let server = make_server(pool.clone());
+
+    // Reproduces the wrhq 2026-04-30 collision: paragraph compound text
+    // is identical to its sole atom — same content_hash → same persisted
+    // claim → planned decomposes_to becomes a self-loop after id_map.
+    let extraction_json = serde_json::json!({
+        "source": {
+            "title": "compound-atom-test",
+            "doi": "wrhq:test/compound-atom-collision",
+            "source_type": "InternalDocument",
+            "authors": [{"name": "test", "affiliations": [], "roles": ["author"]}],
+            "year": 2026,
+            "metadata": {}
+        },
+        "thesis": "Test of compound==atom collision.",
+        "thesis_derivation": "TopDown",
+        "sections": [{
+            "title": "Body",
+            "summary": "One section, one paragraph, one atom.",
+            "paragraphs": [{
+                "compound": "Class B agents have a contract.active flag.",
+                "supporting_text": "Class B agents have a contract.active flag.",
+                "atoms": ["Class B agents have a contract.active flag."],
+                "generality": [0],
+                "confidence": 0.8,
+                "methodology": "extraction",
+                "evidence_type": "testimonial"
+            }]
+        }],
+        "relationships": []
+    });
+    let extraction: epigraph_ingest::schema::DocumentExtraction =
+        serde_json::from_value(extraction_json).expect("fixture parses");
+
+    // Must not panic and must not return Err with a CHECK violation.
+    let result = do_ingest_document(&server, &extraction).await;
+    assert!(result.is_ok(), "expected ingest to succeed, got: {result:?}");
+
+    // No self-loop edges should exist.
+    let self_loops: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM edges WHERE source_id = target_id"
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(self_loops, 0, "self-loop edges should be filtered, found {self_loops}");
+}
+
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
     let content = result.content.first().expect("at least one content block");
     content.as_text().expect("text content").text.clone()

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -275,25 +275,30 @@ async fn ingest_document_persists_planned_properties(pool: PgPool) {
     let server = make_server(pool.clone());
     let extraction: DocumentExtraction = serde_json::from_str(FIXTURE).expect("fixture parses");
 
-    do_ingest_document(&server, &extraction).await.expect("ingest succeeds");
+    do_ingest_document(&server, &extraction)
+        .await
+        .expect("ingest succeeds");
 
-    let count_with_props: i64 = sqlx::query_scalar(
-        "SELECT count(*) FROM claims WHERE properties::text != '{}'"
-    )
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert!(count_with_props > 0,
-        "expected at least one claim with non-empty properties");
+    let count_with_props: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM claims WHERE properties::text != '{}'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        count_with_props > 0,
+        "expected at least one claim with non-empty properties"
+    );
 
     // Thesis is at level 0 — confirm level-based filtering works.
-    let level_zero: i64 = sqlx::query_scalar(
-        "SELECT count(*) FROM claims WHERE properties->>'level' = '0'"
-    )
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(level_zero, 1, "thesis (level 0) should be queryable by properties->>'level'");
+    let level_zero: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM claims WHERE properties->>'level' = '0'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        level_zero, 1,
+        "thesis (level 0) should be queryable by properties->>'level'"
+    );
 }
 
 #[sqlx::test(migrations = "../../migrations")]
@@ -334,16 +339,21 @@ async fn ingest_document_handles_compound_equals_atom(pool: sqlx::PgPool) {
 
     // Must not panic and must not return Err with a CHECK violation.
     let result = do_ingest_document(&server, &extraction).await;
-    assert!(result.is_ok(), "expected ingest to succeed, got: {result:?}");
+    assert!(
+        result.is_ok(),
+        "expected ingest to succeed, got: {result:?}"
+    );
 
     // No self-loop edges should exist.
-    let self_loops: i64 = sqlx::query_scalar(
-        "SELECT count(*) FROM edges WHERE source_id = target_id"
-    )
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(self_loops, 0, "self-loop edges should be filtered, found {self_loops}");
+    let self_loops: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM edges WHERE source_id = target_id")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        self_loops, 0,
+        "self-loop edges should be filtered, found {self_loops}"
+    );
 }
 
 fn result_text(result: &rmcp::model::CallToolResult) -> String {

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -270,6 +270,32 @@ async fn cross_paper_atom_and_author_converge(pool: PgPool) {
     assert_eq!(authored_edges.0, 2, "alice authored both papers");
 }
 
+#[sqlx::test(migrations = "../../migrations")]
+async fn ingest_document_persists_planned_properties(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let extraction: DocumentExtraction = serde_json::from_str(FIXTURE).expect("fixture parses");
+
+    do_ingest_document(&server, &extraction).await.expect("ingest succeeds");
+
+    let count_with_props: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM claims WHERE properties::text != '{}'"
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(count_with_props > 0,
+        "expected at least one claim with non-empty properties");
+
+    // Thesis is at level 0 — confirm level-based filtering works.
+    let level_zero: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM claims WHERE properties->>'level' = '0'"
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(level_zero, 1, "thesis (level 0) should be queryable by properties->>'level'");
+}
+
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
     let content = result.content.first().expect("at least one content block");
     content.as_text().expect("text content").text.clone()

--- a/docs/superpowers/plans/2026-04-30-github-issues-batch.md
+++ b/docs/superpowers/plans/2026-04-30-github-issues-batch.md
@@ -1,0 +1,1717 @@
+# GitHub Issues Batch Implementation Plan (#19, #28–#33)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land all 7 open issues on `epigraph-io/epigraph` in a single coordinated effort, ordered to fix silent data loss first, unblock EpiClaw migration second, harden security third, and finish quality-of-life last.
+
+**Architecture:** Six independent phases inside one feature branch. Phase 1 fixes ingest correctness in `epigraph-mcp` + `epigraph-db`. Phases 2–4 add API endpoints in `epigraph-api`. Phase 5 plumbs Ed25519 verification through `submit.rs`. Phase 6 adds an opt-in `relationships` query param to graph routes. Each phase has its own commit and can be cherry-picked or reverted independently.
+
+**Tech Stack:** Rust 1.75+, Axum, sqlx, PostgreSQL 16, ed25519-dalek, blake3.
+
+---
+
+## Pre-flight
+
+This plan was written from spec, not from a brainstorming session. There is no pre-built worktree.
+
+- [ ] **Step 0.1: Create a fresh worktree off origin/main**
+
+```bash
+cd /home/jeremy/epigraph
+git fetch origin main
+git worktree add -b feat/github-issues-batch ../epigraph-wt-issues-batch origin/main
+cd ../epigraph-wt-issues-batch
+```
+
+Expected: working tree at HEAD `171fdd6f` (or newer if main moved). Verify:
+
+```bash
+git log --oneline -1
+# 171fdd6f docs: port design specs from epigraph-internal (#27)
+```
+
+- [ ] **Step 0.2: Confirm the toolchain works end-to-end**
+
+```bash
+cargo build -p epigraph-api -p epigraph-mcp -p epigraph-db --no-default-features --features db
+```
+
+Expected: clean build. If sqlx complains about offline-mode metadata, run `cargo sqlx prepare --workspace` against a live dev DB first.
+
+- [ ] **Step 0.3: Confirm the dev DB is reachable**
+
+```bash
+psql "$DATABASE_URL" -c '\dt claims' | head -3
+```
+
+Expected: one row, `public | claims | table | <owner>`. If the connection fails, follow the EpigraphV2 devcontainer DB recipe in CLAUDE.md.
+
+---
+
+## Phase 1 — Issue #30: Persist `PlannedClaim.properties` to `claims.properties`
+
+**Why first:** Silent data loss on every ingest. ~1,300 claims from yesterday's wiki run all have `properties = '{}'`. Level/section/generality filters return empty without a single error. Trivial fix, high payoff.
+
+**Approach:** Add a surgical `set_properties` repo method (one UPDATE per new claim). Don't touch the kernel `Claim` struct or `ClaimRepository::create`'s 44 callers. Only call `set_properties` on the *new-claim* path in `do_ingest_document` so re-ingesting an existing claim doesn't silently overwrite a sibling paper's properties.
+
+### Task 1.1: Add `ClaimRepository::set_properties`
+
+**Files:**
+- Modify: `crates/epigraph-db/src/repos/claim.rs` (add method to `impl ClaimRepository`)
+- Test: `crates/epigraph-db/src/repos/claim.rs` (extend existing `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1.1.1: Write the failing test**
+
+Add to the test module at the bottom of `claim.rs`:
+
+```rust
+#[sqlx::test]
+async fn set_properties_writes_jsonb_column(pool: sqlx::PgPool) {
+    let agent = epigraph_test_support::seed_agent(&pool).await;
+    let claim = Claim::new(
+        "Test claim for properties".to_string(),
+        agent.id,
+        agent.public_key,
+        TruthValue::clamped(0.5),
+    );
+    let persisted = ClaimRepository::create(&pool, &claim).await.unwrap();
+    let props = serde_json::json!({"level": 3, "section": "Body", "source_type": "Wiki"});
+
+    ClaimRepository::set_properties(&pool, persisted.id, props.clone())
+        .await
+        .unwrap();
+
+    let row: (serde_json::Value,) = sqlx::query_as("SELECT properties FROM claims WHERE id = $1")
+        .bind(Uuid::from(persisted.id))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.0, props);
+}
+```
+
+If `epigraph_test_support::seed_agent` does not exist verbatim, follow the existing test pattern in `claim.rs` for inserting an agent (search for `INSERT INTO agents` in the test module and copy that pattern).
+
+- [ ] **Step 1.1.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-db --features db set_properties_writes_jsonb_column
+```
+
+Expected: FAIL — `no method named set_properties`.
+
+- [ ] **Step 1.1.3: Implement `set_properties`**
+
+Add to `impl ClaimRepository` in `crates/epigraph-db/src/repos/claim.rs` (place near `create`, around line 140):
+
+```rust
+/// Set the `properties` JSONB column on an existing claim. Overwrites the
+/// existing value (does not merge). Used by ingest to attach hierarchy
+/// metadata (level, section, source_type, generality) at creation time.
+///
+/// # Errors
+/// Returns `DbError::QueryFailed` if the database query fails.
+#[instrument(skip(pool, properties))]
+pub async fn set_properties(
+    pool: &PgPool,
+    claim_id: ClaimId,
+    properties: serde_json::Value,
+) -> Result<(), DbError> {
+    let id: Uuid = claim_id.into();
+    sqlx::query!(
+        "UPDATE claims SET properties = $2, updated_at = NOW() WHERE id = $1",
+        id,
+        properties
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 1.1.4: Run the test to confirm it passes**
+
+```bash
+cargo test -p epigraph-db --features db set_properties_writes_jsonb_column
+```
+
+Expected: PASS.
+
+- [ ] **Step 1.1.5: Commit**
+
+```bash
+git add crates/epigraph-db/src/repos/claim.rs
+git commit -m "feat(db): add ClaimRepository::set_properties for ingest metadata"
+```
+
+### Task 1.2: Wire `set_properties` into `do_ingest_document` for new claims
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/tools/ingestion.rs:497-630` (the planned-claim loop)
+
+- [ ] **Step 1.2.1: Write the failing integration test**
+
+Add to `crates/epigraph-mcp/tests/ingestion_integration.rs` (create file if missing — follow the pattern of any existing integration test in that crate; if no such file/pattern exists, add the test inline at the bottom of `crates/epigraph-mcp/src/tools/ingestion.rs` under `#[cfg(test)]`):
+
+```rust
+#[sqlx::test]
+async fn ingest_document_persists_planned_properties(pool: sqlx::PgPool) {
+    let server = epigraph_mcp::test_support::spawn_test_server(pool.clone()).await;
+    let extraction = epigraph_mcp::test_support::minimal_extraction_with_one_atom(
+        "props-test:001",
+        "A single atomic claim with hierarchy metadata.",
+    );
+
+    do_ingest_document(&server, &extraction).await.unwrap();
+
+    let count_with_props: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM claims WHERE properties::text != '{}'"
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(count_with_props > 0,
+        "expected at least one claim with non-empty properties");
+
+    let level_zero: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM claims WHERE properties->>'level' = '0'"
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(level_zero, 1, "thesis (level 0) should be queryable by properties->>'level'");
+}
+```
+
+If `test_support::spawn_test_server` and `minimal_extraction_with_one_atom` do not exist, study how `do_ingest_document` is currently called in tests (`git grep -n 'do_ingest_document' crates/epigraph-mcp/`) and adapt. The test must drive a real `do_ingest_document` against a real `pool` so the DB write path is exercised.
+
+- [ ] **Step 1.2.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-mcp --features db ingest_document_persists_planned_properties
+```
+
+Expected: FAIL — `assertion failed: count_with_props > 0`.
+
+- [ ] **Step 1.2.3: Implement the fix**
+
+In `crates/epigraph-mcp/src/tools/ingestion.rs`, find the new-claim path (around line 555, just after `let formatted_evidence = format!(...);` and before the evidence-write block — the exact location is the branch that runs only when `persisted_id == planned.id && !already_had_trace`).
+
+Add this call **after** `ClaimRepository::create(...)` returns successfully and we've established this is a new claim (after the early `continue` for the dedup branch at line 547), but **before** any expensive embed/DS work — so a write failure aborts the per-claim loop early:
+
+```rust
+// Persist hierarchy metadata (level, section, source_type, generality)
+// from the ingest plan onto the new claim's `properties` column.
+ClaimRepository::set_properties(
+    pool,
+    ClaimId::from_uuid(persisted_id),
+    planned.properties.clone(),
+)
+.await
+.map_err(internal_error)?;
+```
+
+If `ClaimId::from_uuid` is not in scope, add it to the existing `use epigraph_core::...` block at the top of the file.
+
+- [ ] **Step 1.2.4: Run the test to confirm it passes**
+
+```bash
+cargo test -p epigraph-mcp --features db ingest_document_persists_planned_properties
+```
+
+Expected: PASS.
+
+- [ ] **Step 1.2.5: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/ingestion.rs crates/epigraph-mcp/tests/ingestion_integration.rs
+git commit -m "fix(ingest): persist PlannedClaim.properties to claims.properties (#30)"
+```
+
+---
+
+## Phase 2 — Issue #29: Drop self-loop `decomposes_to` edges after id_map remap
+
+**Why second:** Hard ingest crash on real corpus inputs (compound text == its single atom). Aborts mid-document, leaves partial state. Cheapest correct fix is filter-on-write inside `do_ingest_document`, not changing `ClaimRepository::create`'s dedup semantics (the doc comment on `create` explicitly defers cross-agent collapse to a separate migration).
+
+**Approach:** Issue's fix proposal #2. After the `id_map` remap of an edge's source/target, drop the edge if it would collapse to a self-loop on the same `(id, type)`. Five lines, additive, doesn't touch the kernel or repos.
+
+### Task 2.1: Filter self-loop edges in `do_ingest_document`
+
+**Files:**
+- Modify: `crates/epigraph-mcp/src/tools/ingestion.rs:636-672` (the edge-persist loop)
+
+- [ ] **Step 2.1.1: Write the failing test**
+
+Add to the same test module/file as Phase 1's integration test:
+
+```rust
+#[sqlx::test]
+async fn ingest_document_handles_compound_equals_atom(pool: sqlx::PgPool) {
+    let server = epigraph_mcp::test_support::spawn_test_server(pool.clone()).await;
+
+    // Reproduces the wrhq 2026-04-30 collision: paragraph compound text
+    // is identical to its sole atom — same content_hash → same persisted
+    // claim → planned decomposes_to becomes a self-loop after id_map.
+    let extraction_json = serde_json::json!({
+        "source": {
+            "title": "compound-atom-test",
+            "doi": "wrhq:test/compound-atom-collision",
+            "source_type": "InternalDocument",
+            "authors": [{"name": "test", "affiliations": [], "roles": ["author"]}],
+            "year": 2026,
+            "metadata": {}
+        },
+        "thesis": "Test of compound==atom collision.",
+        "thesis_derivation": "TopDown",
+        "sections": [{
+            "title": "Body",
+            "summary": "One section, one paragraph, one atom.",
+            "paragraphs": [{
+                "compound": "Class B agents have a contract.active flag.",
+                "supporting_text": "Class B agents have a contract.active flag.",
+                "atoms": ["Class B agents have a contract.active flag."],
+                "generality": [0],
+                "confidence": 0.8,
+                "methodology": "extraction",
+                "evidence_type": "testimonial"
+            }]
+        }],
+        "relationships": []
+    });
+    let extraction: epigraph_ingest::DocumentExtraction =
+        serde_json::from_value(extraction_json).unwrap();
+
+    // Must not panic and must not return Err with a CHECK violation.
+    let result = do_ingest_document(&server, &extraction).await;
+    assert!(result.is_ok(), "expected ingest to succeed, got: {result:?}");
+
+    // No self-loop edges should exist.
+    let self_loops: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM edges WHERE source_id = target_id"
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(self_loops, 0, "self-loop edges should be filtered, found {self_loops}");
+}
+```
+
+- [ ] **Step 2.1.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-mcp --features db ingest_document_handles_compound_equals_atom
+```
+
+Expected: FAIL — error from sqlx with `edges_no_self_loop` constraint violation, OR test returns `Err`.
+
+- [ ] **Step 2.1.3: Implement the fix**
+
+In `crates/epigraph-mcp/src/tools/ingestion.rs`, locate the edge-persist loop starting at the comment `// ── 5. Plan edges ──` (around line 635). After the existing remapping block sets `(src, src_type)` and `tgt`, but BEFORE the `EdgeRepository::create_if_not_exists` call, add:
+
+```rust
+        // Filter self-loops introduced by content-hash dedup collapsing
+        // distinct planned UUIDs (e.g. compound paragraph and its sole
+        // atom that share text) onto the same persisted claim. The
+        // semantically correct outcome is a no-op decomposition; the DB
+        // would otherwise reject this with edges_no_self_loop.
+        if src == tgt && src_type == edge.target_type {
+            continue;
+        }
+
+        EdgeRepository::create_if_not_exists(
+```
+
+The trailing `EdgeRepository::create_if_not_exists(` is the existing line — leave it intact. The `continue` skips the create call.
+
+- [ ] **Step 2.1.4: Run the test to confirm it passes**
+
+```bash
+cargo test -p epigraph-mcp --features db ingest_document_handles_compound_equals_atom
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.1.5: Run Phase 1's test to confirm no regression**
+
+```bash
+cargo test -p epigraph-mcp --features db ingest_document_persists_planned_properties
+```
+
+Expected: PASS (still).
+
+- [ ] **Step 2.1.6: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/ingestion.rs crates/epigraph-mcp/tests/ingestion_integration.rs
+git commit -m "fix(ingest): drop self-loop decomposes_to edges from compound==atom dedup (#29)"
+```
+
+---
+
+## Phase 3 — Issue #33: Add `exclude_agent_id` to `GET /api/v1/claims`
+
+**Why third:** Smallest of the EpiClaw-blocking endpoints. Verified on origin/main `claims_query.rs:85-89`: `created_after` and `created_before` already exist in `PaginationParams` and are wired into both code paths (~line 376 and ~line 583). Only `exclude_agent_id` is missing. ~20 LOC.
+
+### Task 3.1: Add `exclude_agent_id` filter
+
+**Files:**
+- Modify: `crates/epigraph-api/src/routes/claims_query.rs:70-100` (struct), `:370-380` and `:572-585` (filters — both `db` and non-`db` branches)
+
+- [ ] **Step 3.1.1: Write the failing test**
+
+Add to the existing `#[cfg(test)] mod tests` in `claims_query.rs`:
+
+```rust
+#[tokio::test]
+async fn list_claims_excludes_agent_id() {
+    let state = test_state().await;
+    let agent_a = AgentId::new();
+    let agent_b = AgentId::new();
+    insert_test_claim_with_agent(&state, "from agent A", 0.5, agent_a).await;
+    insert_test_claim_with_agent(&state, "from agent B", 0.5, agent_b).await;
+
+    let router = test_router(state);
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/v1/claims?exclude_agent_id={}", agent_a.as_uuid()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = parse_body(response).await;
+    let claims = body["claims"].as_array().unwrap();
+    assert_eq!(claims.len(), 1);
+    assert_eq!(claims[0]["content"], "from agent B");
+}
+```
+
+If helpers like `test_state`, `test_router`, `insert_test_claim_with_agent`, or `parse_body` look slightly different in the existing tests, mirror those exactly — don't invent new ones.
+
+- [ ] **Step 3.1.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-api --features db list_claims_excludes_agent_id
+```
+
+Expected: FAIL — unknown query parameter or wrong count.
+
+- [ ] **Step 3.1.3: Add the field to `PaginationParams`**
+
+In `crates/epigraph-api/src/routes/claims_query.rs`, find the `PaginationParams` struct (around line 70) and add this field after `pub agent_id: Option<Uuid>`:
+
+```rust
+    /// Exclude claims created by this agent. Composes with `agent_id`
+    /// (if both are set, `agent_id` filters in and `exclude_agent_id`
+    /// filters out — useful for "all claims except those from the host").
+    pub exclude_agent_id: Option<Uuid>,
+```
+
+- [ ] **Step 3.1.4: Apply the filter in both code paths**
+
+There are two `list_claims_query` functions (one with `db` feature at ~line 174, one fallback at ~line 452) and two filter blocks (~line 370 and ~line 572). In **each** filter block, locate the `// Filter by agent_id` block:
+
+```rust
+    // Filter by agent_id
+    if let Some(agent_id) = params.agent_id {
+        claims.retain(|c| c.agent_id.as_uuid() == agent_id);
+    }
+```
+
+Add directly after it:
+
+```rust
+    // Filter out a specific agent (composes with agent_id above)
+    if let Some(exclude_agent_id) = params.exclude_agent_id {
+        claims.retain(|c| c.agent_id.as_uuid() != exclude_agent_id);
+    }
+```
+
+Apply this addition to **both** filter blocks (~line 370 and ~line 572).
+
+- [ ] **Step 3.1.5: Run the test to confirm it passes**
+
+```bash
+cargo test -p epigraph-api --features db list_claims_excludes_agent_id
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.1.6: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/claims_query.rs
+git commit -m "feat(api): add exclude_agent_id filter to GET /api/v1/claims (#33)"
+```
+
+---
+
+## Phase 4 — Issue #31: `GET /api/v1/workflows/:id`
+
+**Why fourth:** Mirror of `GET /api/v1/claims/:id` filtered by the `'workflow'` label. ~30 LOC. Unblocks EpiClaw scheduler firing single-workflow lookups.
+
+### Task 4.1: Add `get_workflow` handler
+
+**Files:**
+- Modify: `crates/epigraph-api/src/routes/workflows.rs` (add handler near `list_workflows`, around line 384)
+- Modify: `crates/epigraph-api/src/routes/mod.rs:285-290` (register route)
+
+- [ ] **Step 4.1.1: Write the failing test**
+
+Add to `workflows.rs`'s test module (find existing `#[cfg(test)] mod tests` or create one matching the file's existing patterns):
+
+```rust
+#[tokio::test]
+async fn get_workflow_returns_single_workflow() {
+    let state = test_state().await;
+    let workflow_id = seed_test_workflow(&state, "deploy-canary", &["step1", "step2"]).await;
+
+    let router = workflow_router(state);
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/v1/workflows/{workflow_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = parse_body(response).await;
+    assert_eq!(body["workflow_id"], workflow_id.to_string());
+    assert!(body["content"].is_string() || body["content"].is_object());
+    assert!(body["truth_value"].is_number());
+    assert!(body["properties"].is_object());
+}
+
+#[tokio::test]
+async fn get_workflow_returns_404_for_non_workflow_claim() {
+    let state = test_state().await;
+    // Insert a claim WITHOUT 'workflow' label
+    let claim_id = seed_plain_claim(&state, "not a workflow").await;
+
+    let router = workflow_router(state);
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/v1/workflows/{claim_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+```
+
+If `seed_test_workflow` / `seed_plain_claim` don't exist, write minimal helpers in the test module — pattern off `store_workflow`'s SQL at `workflows.rs:135` for workflow seeding, and a plain `INSERT INTO claims (...) VALUES (...)` for non-workflow.
+
+- [ ] **Step 4.1.2: Run the tests to confirm they fail**
+
+```bash
+cargo test -p epigraph-api --features db get_workflow_returns_single_workflow get_workflow_returns_404_for_non_workflow_claim
+```
+
+Expected: FAIL — handler not found / route not registered.
+
+- [ ] **Step 4.1.3: Implement `get_workflow`**
+
+In `crates/epigraph-api/src/routes/workflows.rs`, add this handler after `list_workflows` (around line 385). Use the existing `WorkflowContentRow` struct already in the file (line 908):
+
+```rust
+/// GET /api/v1/workflows/:id - Fetch a single workflow by ID.
+///
+/// Returns 404 if the claim does not exist or is not labeled `workflow`.
+#[cfg(feature = "db")]
+pub async fn get_workflow(
+    State(state): State<AppState>,
+    Path(workflow_id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let row = sqlx::query_as::<_, WorkflowContentRow>(
+        "SELECT id, content, truth_value, properties \
+         FROM claims WHERE id = $1 AND 'workflow' = ANY(labels)",
+    )
+    .bind(workflow_id)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to fetch workflow: {e}"),
+    })?
+    .ok_or(ApiError::NotFound {
+        resource: format!("workflow {workflow_id}"),
+    })?;
+
+    Ok(Json(serde_json::json!({
+        "workflow_id": row.id,
+        "content": serde_json::from_str::<serde_json::Value>(&row.content)
+            .unwrap_or_else(|_| serde_json::Value::String(row.content)),
+        "truth_value": row.truth_value,
+        "properties": row.properties,
+    })))
+}
+```
+
+If `ApiError::NotFound` doesn't have a `resource` field with that exact name, check the existing `ApiError` enum in `crates/epigraph-api/src/errors.rs` and use whatever variant returns `404 Not Found` (search for `StatusCode::NOT_FOUND` in that file).
+
+- [ ] **Step 4.1.4: Register the route**
+
+In `crates/epigraph-api/src/routes/mod.rs`, find the workflow route block (around line 275–290) and add this route. Place it before the `:id/outcome` route so axum's path matching prefers the more specific routes first:
+
+```rust
+        .route("/api/v1/workflows/:id", get(workflows::get_workflow))
+```
+
+If `get` is not already imported at the top of `mod.rs`, add it to the existing axum imports.
+
+- [ ] **Step 4.1.5: Run the tests to confirm they pass**
+
+```bash
+cargo test -p epigraph-api --features db get_workflow_returns_single_workflow get_workflow_returns_404_for_non_workflow_claim
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.1.6: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/workflows.rs crates/epigraph-api/src/routes/mod.rs
+git commit -m "feat(api): add GET /api/v1/workflows/:id (#31)"
+```
+
+---
+
+## Phase 5 — Issue #28: Policy + policy-challenge endpoints
+
+**Why fifth:** Largest of the EpiClaw additions (~250 LOC). Reference impl exists in deprecated `epigraph-nano/src/persistence.rs:7332-7530`. All seven queries map cleanly to the public `claims` schema using existing labels (`policy:active`, `policy:network`, `policy:challenge`).
+
+**Approach:** One new module file. Seven handlers. Minimal types. Tests exercise each endpoint round-trip.
+
+### Task 5.1: Create the module skeleton and types
+
+**Files:**
+- Create: `crates/epigraph-api/src/routes/policies.rs`
+- Modify: `crates/epigraph-api/src/routes/mod.rs` (add `pub mod policies;` and route registrations)
+
+- [ ] **Step 5.1.1: Create the file with types and an empty handler stub**
+
+Write `crates/epigraph-api/src/routes/policies.rs`:
+
+```rust
+//! /api/v1/policies/* — labeled-claim view over network access policies.
+//!
+//! All policies are stored as ordinary claims with `policy:active` and
+//! `policy:network` labels and `host`/`port`/`protocol`/`decay_exempt`
+//! fields in `properties`. Challenges are claims with `policy:challenge`
+//! and a `status` field in `properties`.
+//!
+//! Reference implementation: `epigraph-nano/src/persistence.rs:7332-7530`.
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{errors::ApiError, AppState};
+
+#[derive(Debug, Deserialize)]
+pub struct ListPoliciesQuery {
+    #[serde(default = "default_min_truth")]
+    pub min_truth: f64,
+}
+const fn default_min_truth() -> f64 {
+    0.5
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OutcomeRequest {
+    pub supports: bool,
+    pub strength: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateChallengeRequest {
+    pub host: String,
+    pub port: i64,
+    pub protocol: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveChallengeRequest {
+    pub approved: bool,
+}
+```
+
+- [ ] **Step 5.1.2: Wire the module into `routes/mod.rs`**
+
+In `crates/epigraph-api/src/routes/mod.rs`, near the other `pub mod` lines (around line 35), add:
+
+```rust
+#[cfg(feature = "db")]
+pub mod policies;
+```
+
+Don't register routes yet — we'll add them after each handler exists.
+
+- [ ] **Step 5.1.3: Build to confirm types compile**
+
+```bash
+cargo check -p epigraph-api --features db
+```
+
+Expected: clean, no warnings about unused types (Rust will warn — `#[allow(dead_code)]` is fine to add to silence, but only on `pub` types if needed).
+
+- [ ] **Step 5.1.4: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/policies.rs crates/epigraph-api/src/routes/mod.rs
+git commit -m "scaffold(api): policies module with request/response types (#28)"
+```
+
+### Task 5.2: `GET /api/v1/policies/network`
+
+- [ ] **Step 5.2.1: Write the failing test**
+
+Add to `policies.rs` under `#[cfg(test)] mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // (use the same test scaffolding pattern as workflows.rs / claims_query.rs)
+
+    #[tokio::test]
+    async fn list_network_policies_returns_active_policies_above_min_truth() {
+        let state = test_state().await;
+        seed_policy(&state, "example.com", 443, "https", 0.92, false).await;
+        seed_policy(&state, "blocked.com", 443, "https", 0.10, false).await;
+
+        let router = policy_router(state);
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/policies/network?min_truth=0.5")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = parse_body(response).await;
+        let policies = body["policies"].as_array().unwrap();
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0]["host"], "example.com");
+    }
+}
+```
+
+`seed_policy` is a small helper to insert a `claims` row with `labels = ARRAY['policy:active','policy:network']` and the right `properties`/`truth_value`. Inline it in the test module.
+
+- [ ] **Step 5.2.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-api --features db list_network_policies_returns_active_policies_above_min_truth
+```
+
+Expected: FAIL — handler / route not present.
+
+- [ ] **Step 5.2.3: Implement the handler**
+
+In `policies.rs`:
+
+```rust
+/// GET /api/v1/policies/network — list active network-access policies.
+#[cfg(feature = "db")]
+pub async fn list_network_policies(
+    State(state): State<AppState>,
+    Query(params): Query<ListPoliciesQuery>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let min_truth = params.min_truth.clamp(0.0, 1.0);
+    let rows: Vec<(Uuid, f64, serde_json::Value)> = sqlx::query_as(
+        "SELECT id, truth_value, properties \
+         FROM claims \
+         WHERE 'policy:active' = ANY(labels) \
+           AND 'policy:network' = ANY(labels) \
+           AND truth_value >= $1 \
+         ORDER BY truth_value DESC",
+    )
+    .bind(min_truth)
+    .fetch_all(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to list policies: {e}"),
+    })?;
+
+    let policies: Vec<serde_json::Value> = rows
+        .into_iter()
+        .map(|(id, truth_value, properties)| {
+            serde_json::json!({
+                "claim_id": id,
+                "host": properties.get("host"),
+                "port": properties.get("port"),
+                "protocol": properties.get("protocol"),
+                "truth_value": truth_value,
+                "decay_exempt": properties.get("decay_exempt").and_then(|v| v.as_bool()).unwrap_or(false),
+            })
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({ "policies": policies })))
+}
+```
+
+- [ ] **Step 5.2.4: Register the route**
+
+In `crates/epigraph-api/src/routes/mod.rs`, after the existing graph routes (around line 410), add:
+
+```rust
+        .route("/api/v1/policies/network", get(policies::list_network_policies))
+```
+
+- [ ] **Step 5.2.5: Run the test to confirm it passes**
+
+```bash
+cargo test -p epigraph-api --features db list_network_policies_returns_active_policies_above_min_truth
+```
+
+Expected: PASS.
+
+- [ ] **Step 5.2.6: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/policies.rs crates/epigraph-api/src/routes/mod.rs
+git commit -m "feat(api): GET /api/v1/policies/network (#28)"
+```
+
+### Task 5.3: `POST /api/v1/policies/:claim_id/outcome`
+
+- [ ] **Step 5.3.1: Write the failing test**
+
+In `policies.rs` test module:
+
+```rust
+#[tokio::test]
+async fn outcome_supports_true_increases_truth_value() {
+    let state = test_state().await;
+    let claim_id = seed_policy(&state, "example.com", 443, "https", 0.5, false).await;
+
+    let router = policy_router(state.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/api/v1/policies/{claim_id}/outcome"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"supports": true, "strength": 0.05}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let new_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(&state.db_pool)
+        .await
+        .unwrap();
+    assert!(new_truth > 0.5, "expected truth to increase, got {new_truth}");
+    assert!(new_truth <= 0.99);
+}
+```
+
+- [ ] **Step 5.3.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-api --features db outcome_supports_true_increases_truth_value
+```
+
+Expected: FAIL.
+
+- [ ] **Step 5.3.3: Implement the handler**
+
+```rust
+/// POST /api/v1/policies/:claim_id/outcome — Bayesian-style nudge.
+///
+/// `supports = true` increases truth toward 1.0; `false` decreases.
+/// `strength` is the magnitude in (0, 1]; clamped server-side.
+#[cfg(feature = "db")]
+pub async fn record_outcome(
+    State(state): State<AppState>,
+    Path(claim_id): Path<Uuid>,
+    Json(req): Json<OutcomeRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let strength = req.strength.clamp(0.0, 1.0);
+    let signed = if req.supports { strength } else { -strength };
+
+    // Same closed-form update as epigraph-nano/src/persistence.rs:7430.
+    let row: Option<(f64,)> = sqlx::query_as(
+        "UPDATE claims SET \
+            truth_value = LEAST(0.99, GREATEST(0.01, \
+                truth_value + $1 * (1.0 - truth_value) * \
+                CASE WHEN $1 > 0 THEN 1.0 ELSE truth_value END)), \
+            updated_at = NOW() \
+         WHERE id = $2 AND 'policy:active' = ANY(labels) \
+         RETURNING truth_value",
+    )
+    .bind(signed)
+    .bind(claim_id)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to update policy outcome: {e}"),
+    })?;
+
+    let new_truth = row
+        .ok_or(ApiError::NotFound {
+            resource: format!("policy {claim_id}"),
+        })?
+        .0;
+
+    Ok(Json(serde_json::json!({
+        "claim_id": claim_id,
+        "truth_value": new_truth,
+    })))
+}
+```
+
+- [ ] **Step 5.3.4: Register the route**
+
+In `routes/mod.rs`:
+
+```rust
+        .route("/api/v1/policies/:claim_id/outcome", post(policies::record_outcome))
+```
+
+- [ ] **Step 5.3.5: Run the test, then commit**
+
+```bash
+cargo test -p epigraph-api --features db outcome_supports_true_increases_truth_value
+```
+
+Expected: PASS.
+
+```bash
+git add crates/epigraph-api/src/routes/policies.rs crates/epigraph-api/src/routes/mod.rs
+git commit -m "feat(api): POST /api/v1/policies/:id/outcome (#28)"
+```
+
+### Task 5.4: `POST /api/v1/policies/decay-sweep`
+
+- [ ] **Step 5.4.1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn decay_sweep_pulls_stale_truth_toward_one_half() {
+    let state = test_state().await;
+    let stale_id = seed_policy_with_age(&state, "stale.com", 443, "https", 0.9, false, 100).await;
+    let fresh_id = seed_policy_with_age(&state, "fresh.com", 443, "https", 0.9, false, 1).await;
+    let exempt_id = seed_policy_with_age(&state, "exempt.com", 443, "https", 0.9, true, 100).await;
+
+    let router = policy_router(state.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/policies/decay-sweep")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = parse_body(response).await;
+    assert_eq!(body["rows_affected"], 1);
+
+    let stale_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+        .bind(stale_id)
+        .fetch_one(&state.db_pool).await.unwrap();
+    assert!(stale_truth < 0.9 && stale_truth > 0.5);
+
+    let fresh_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+        .bind(fresh_id).fetch_one(&state.db_pool).await.unwrap();
+    assert_eq!(fresh_truth, 0.9);
+
+    let exempt_truth: f64 = sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+        .bind(exempt_id).fetch_one(&state.db_pool).await.unwrap();
+    assert_eq!(exempt_truth, 0.9);
+}
+```
+
+`seed_policy_with_age(state, host, port, protocol, truth, decay_exempt, days_old)` is another small helper — INSERT then `UPDATE claims SET updated_at = NOW() - INTERVAL '<days> days' WHERE id = $1`.
+
+- [ ] **Step 5.4.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-api --features db decay_sweep_pulls_stale_truth_toward_one_half
+```
+
+Expected: FAIL.
+
+- [ ] **Step 5.4.3: Implement the handler**
+
+```rust
+/// POST /api/v1/policies/decay-sweep — pull stale active policies toward 0.5.
+///
+/// Skips claims with `properties->>'decay_exempt' = 'true'`. Returns the
+/// number of rows updated.
+#[cfg(feature = "db")]
+pub async fn decay_sweep(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let result = sqlx::query(
+        "UPDATE claims SET \
+            truth_value = truth_value + 0.1 * (0.5 - truth_value), \
+            updated_at = NOW() \
+         WHERE 'policy:active' = ANY(labels) \
+           AND COALESCE((properties->>'decay_exempt')::boolean, false) IS NOT TRUE \
+           AND updated_at < NOW() - INTERVAL '90 days'",
+    )
+    .execute(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Decay sweep failed: {e}"),
+    })?;
+
+    Ok(Json(serde_json::json!({
+        "rows_affected": result.rows_affected(),
+    })))
+}
+```
+
+- [ ] **Step 5.4.4: Register the route, run the test, commit**
+
+```rust
+        .route("/api/v1/policies/decay-sweep", post(policies::decay_sweep))
+```
+
+```bash
+cargo test -p epigraph-api --features db decay_sweep_pulls_stale_truth_toward_one_half
+```
+
+Expected: PASS.
+
+```bash
+git add crates/epigraph-api/src/routes/policies.rs crates/epigraph-api/src/routes/mod.rs
+git commit -m "feat(api): POST /api/v1/policies/decay-sweep (#28)"
+```
+
+### Task 5.5: Policy challenges (3 endpoints)
+
+- [ ] **Step 5.5.1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn create_challenge_returns_id_and_persists_pending() {
+    let state = test_state().await;
+    let router = policy_router(state.clone());
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/policy-challenges")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"host":"example.com","port":443}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = parse_body(response).await;
+    let id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+
+    let (labels, properties): (Vec<String>, serde_json::Value) =
+        sqlx::query_as("SELECT labels, properties FROM claims WHERE id = $1")
+            .bind(id)
+            .fetch_one(&state.db_pool)
+            .await
+            .unwrap();
+    assert!(labels.contains(&"policy:challenge".to_string()));
+    assert_eq!(properties["host"], "example.com");
+    assert_eq!(properties["port"], 443);
+    assert_eq!(properties["status"], "pending");
+}
+
+#[tokio::test]
+async fn get_challenge_returns_404_when_not_a_challenge() {
+    let state = test_state().await;
+    let claim_id = seed_plain_claim(&state, "not a challenge").await;
+    let router = policy_router(state);
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/v1/policy-challenges/{claim_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn resolve_challenge_denied_strengthens_default_deny() {
+    let state = test_state().await;
+    // Seed a default-deny policy at 0.6 truth — name it via the well-known
+    // sentinel host the production system uses (per nano: '*' / 'default').
+    let default_deny_id =
+        seed_policy(&state, "*", 0, "*", 0.6, false /* decay_exempt */).await;
+    let challenge_id = create_challenge_via_handler(&state, "blocked.com", 443).await;
+
+    let router = policy_router(state.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/api/v1/policy-challenges/{challenge_id}/resolve"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"approved": false}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let default_deny_truth: f64 =
+        sqlx::query_scalar("SELECT truth_value FROM claims WHERE id = $1")
+            .bind(default_deny_id)
+            .fetch_one(&state.db_pool)
+            .await
+            .unwrap();
+    assert!((default_deny_truth - 0.63).abs() < 1e-6,
+        "expected 0.6 + 0.03 = 0.63, got {default_deny_truth}");
+}
+```
+
+- [ ] **Step 5.5.2: Run the tests to confirm they fail**
+
+```bash
+cargo test -p epigraph-api --features db \
+    create_challenge_returns_id_and_persists_pending \
+    get_challenge_returns_404_when_not_a_challenge \
+    resolve_challenge_denied_strengthens_default_deny
+```
+
+Expected: 3 FAILs.
+
+- [ ] **Step 5.5.3: Implement the three handlers**
+
+In `policies.rs`:
+
+```rust
+/// POST /api/v1/policy-challenges — create a pending challenge claim.
+#[cfg(feature = "db")]
+pub async fn create_challenge(
+    State(state): State<AppState>,
+    Json(req): Json<CreateChallengeRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let sys_agent_id = crate::routes::workflows::get_or_create_system_agent(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Failed to resolve system agent: {e}"),
+        })?;
+
+    let content = format!(
+        "Network access challenge: {}:{} ({})",
+        req.host,
+        req.port,
+        req.protocol.as_deref().unwrap_or("any")
+    );
+    let content_hash = epigraph_crypto::ContentHasher::hash(content.as_bytes());
+
+    let id: Uuid = sqlx::query_scalar(
+        "INSERT INTO claims (content, content_hash, agent_id, truth_value, labels, properties) \
+         VALUES ($1, $2, $3, 0.5, ARRAY['policy','policy:challenge'], $4) \
+         RETURNING id",
+    )
+    .bind(&content)
+    .bind(content_hash.as_slice())
+    .bind(sys_agent_id)
+    .bind(serde_json::json!({
+        "host": req.host,
+        "port": req.port,
+        "protocol": req.protocol,
+        "status": "pending",
+    }))
+    .fetch_one(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to create challenge: {e}"),
+    })?;
+
+    Ok(Json(serde_json::json!({ "id": id })))
+}
+
+/// GET /api/v1/policy-challenges/:id — fetch a challenge by ID.
+#[cfg(feature = "db")]
+pub async fn get_challenge(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let row: Option<(Uuid, serde_json::Value)> = sqlx::query_as(
+        "SELECT id, properties FROM claims \
+         WHERE id = $1 AND 'policy:challenge' = ANY(labels)",
+    )
+    .bind(id)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to fetch challenge: {e}"),
+    })?;
+
+    let (id, properties) = row.ok_or(ApiError::NotFound {
+        resource: format!("policy-challenge {id}"),
+    })?;
+
+    Ok(Json(serde_json::json!({
+        "id": id,
+        "host": properties.get("host"),
+        "port": properties.get("port"),
+        "protocol": properties.get("protocol"),
+        "status": properties.get("status"),
+    })))
+}
+
+/// POST /api/v1/policy-challenges/:id/resolve — approve or deny.
+///
+/// On `approved=false`, also strengthens the default-deny policy claim
+/// by +0.03 (capped at 0.99) — mirrors nano's behavior at
+/// `epigraph-nano/src/persistence.rs:7483`.
+#[cfg(feature = "db")]
+pub async fn resolve_challenge(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<ResolveChallengeRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let new_status = if req.approved { "approved" } else { "denied" };
+
+    let updated: Option<(Uuid,)> = sqlx::query_as(
+        "UPDATE claims SET \
+            properties = jsonb_set(properties, '{status}', to_jsonb($2::text), true), \
+            updated_at = NOW() \
+         WHERE id = $1 AND 'policy:challenge' = ANY(labels) \
+         RETURNING id",
+    )
+    .bind(id)
+    .bind(new_status)
+    .fetch_optional(&state.db_pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("Failed to resolve challenge: {e}"),
+    })?;
+
+    if updated.is_none() {
+        return Err(ApiError::NotFound {
+            resource: format!("policy-challenge {id}"),
+        });
+    }
+
+    if !req.approved {
+        // Strengthen the default-deny policy claim. Identified by host='*'
+        // in properties; matches the nano sentinel.
+        sqlx::query(
+            "UPDATE claims SET \
+                truth_value = LEAST(0.99, truth_value + 0.03), \
+                updated_at = NOW() \
+             WHERE 'policy:active' = ANY(labels) \
+               AND properties->>'host' = '*'",
+        )
+        .execute(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Failed to strengthen default-deny: {e}"),
+        })?;
+    }
+
+    Ok(Json(serde_json::json!({
+        "id": id,
+        "status": new_status,
+    })))
+}
+```
+
+If `crate::routes::workflows::get_or_create_system_agent` is private, change its visibility to `pub(crate)` in `workflows.rs:863` (search for `async fn get_or_create_system_agent`).
+
+- [ ] **Step 5.5.4: Register the routes**
+
+```rust
+        .route("/api/v1/policy-challenges", post(policies::create_challenge))
+        .route("/api/v1/policy-challenges/:id", get(policies::get_challenge))
+        .route("/api/v1/policy-challenges/:id/resolve", post(policies::resolve_challenge))
+```
+
+- [ ] **Step 5.5.5: Run all tests, commit**
+
+```bash
+cargo test -p epigraph-api --features db \
+    create_challenge_returns_id_and_persists_pending \
+    get_challenge_returns_404_when_not_a_challenge \
+    resolve_challenge_denied_strengthens_default_deny
+```
+
+Expected: 3 PASSes.
+
+```bash
+git add crates/epigraph-api/src/routes/policies.rs \
+        crates/epigraph-api/src/routes/mod.rs \
+        crates/epigraph-api/src/routes/workflows.rs
+git commit -m "feat(api): policy-challenge endpoints (create/get/resolve) (#28)"
+```
+
+---
+
+## Phase 6 — Issue #32: Ed25519 signature verification
+
+**Why sixth (security-sensitive, last among substantive phases):** This is the only phase that can fail-open if implemented sloppily. Lands after the smaller endpoints so a security review can focus on this single PR. Required pieces already exist: `SignatureVerifier::verify` in `epigraph-crypto`, agent public keys in `agents.public_key`, `validate_packet` is currently sync — needs to become async.
+
+**Approach:** Make verification mandatory whenever a `signature` is present (issue's option (a)). Make `validate_packet` async. Fetch the agent's public key by `packet.claim.agent_id`. Recompute canonical bytes. Verify. Reject only on `Ok(false)` from the verifier.
+
+### Task 6.1: Make `validate_packet` async, fetch pubkey, verify
+
+**Files:**
+- Modify: `crates/epigraph-api/src/routes/submit.rs` (`validate_packet` signature + body around line 326 and 660)
+
+- [ ] **Step 6.1.1: Write the failing test**
+
+In `crates/epigraph-api/src/routes/submit.rs`, find the existing test module (`#[cfg(test)] mod tests`). Add:
+
+```rust
+#[tokio::test]
+async fn submit_with_valid_signature_succeeds() {
+    let state = test_state_with_required_signatures().await;
+    let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+    let agent_id = seed_agent_with_pubkey(&state, signing_key.verifying_key().to_bytes()).await;
+
+    let claim = build_test_claim(agent_id, "Verifiable claim content.");
+    let canonical = canonical_packet_bytes(&claim, /* evidence */ &[], /* trace */ &());
+    let signature = signing_key.sign(&canonical);
+
+    let packet = build_packet(claim, signature.to_bytes());
+
+    let response = submit_endpoint(state, packet).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn submit_with_invalid_signature_returns_401() {
+    let state = test_state_with_required_signatures().await;
+    let real_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+    let attacker_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+    let agent_id = seed_agent_with_pubkey(&state, real_key.verifying_key().to_bytes()).await;
+
+    let claim = build_test_claim(agent_id, "Forged content.");
+    let canonical = canonical_packet_bytes(&claim, &[], &());
+    let bad_signature = attacker_key.sign(&canonical); // wrong key
+
+    let packet = build_packet(claim, bad_signature.to_bytes());
+    let response = submit_endpoint(state, packet).await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn submit_with_unknown_agent_id_returns_401() {
+    let state = test_state_with_required_signatures().await;
+    let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+    let unknown_agent = AgentId::new(); // never inserted
+
+    let claim = build_test_claim(unknown_agent, "Orphan claim.");
+    let canonical = canonical_packet_bytes(&claim, &[], &());
+    let signature = signing_key.sign(&canonical);
+
+    let packet = build_packet(claim, signature.to_bytes());
+    let response = submit_endpoint(state, packet).await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+```
+
+`canonical_packet_bytes` must produce **exactly** the same bytes that the server's verifier will reconstruct. Search the existing codebase for the canonicalization helper used at submit time (likely something via `epigraph-crypto::canonical::Canonical` trait or a `to_canonical_bytes` method on the packet types). Use that helper directly — never reimplement the canonical layout in the test, or you'll silently test the wrong thing.
+
+- [ ] **Step 6.1.2: Run the tests to confirm they fail**
+
+```bash
+cargo test -p epigraph-api --features db submit_with_valid_signature_succeeds submit_with_invalid_signature_returns_401 submit_with_unknown_agent_id_returns_401
+```
+
+Expected: 3 FAILs (all returning 401 today regardless of signature validity).
+
+- [ ] **Step 6.1.3: Make `validate_packet` async and accept a pool**
+
+In `crates/epigraph-api/src/routes/submit.rs:325-340`, change:
+
+```rust
+fn validate_packet(
+    packet: &EpistemicPacket,
+    state: &AppState,
+) -> Result<(), (StatusCode, ErrorResponse)> {
+```
+
+to:
+
+```rust
+async fn validate_packet(
+    packet: &EpistemicPacket,
+    state: &AppState,
+) -> Result<(), (StatusCode, ErrorResponse)> {
+```
+
+Then update the single caller of `validate_packet` (search the file: there's exactly one) to `.await` the call.
+
+- [ ] **Step 6.1.4: Replace the signature-verification stub**
+
+Find the block at `submit.rs:660-676` starting with `// TODO(security): Implement Ed25519 signature verification here.` and ending with the `return Err((StatusCode::UNAUTHORIZED, ...));`. Replace the entire block with:
+
+```rust
+        // Look up the claim agent's public key.
+        let agent_id: Uuid = packet.claim.agent_id.into();
+        let pub_key_row: Option<(Vec<u8>,)> = sqlx::query_as(
+            "SELECT public_key FROM agents WHERE id = $1",
+        )
+        .bind(agent_id)
+        .fetch_optional(&state.db_pool)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::with_details(
+                    "InternalError",
+                    "Failed to look up agent public key",
+                    serde_json::json!({ "error": e.to_string() }),
+                ),
+            )
+        })?;
+
+        let pub_key_bytes: [u8; 32] = pub_key_row
+            .ok_or_else(|| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    ErrorResponse::with_details(
+                        "SignatureError",
+                        "Agent not registered",
+                        serde_json::json!({ "field": "claim.agent_id" }),
+                    ),
+                )
+            })?
+            .0
+            .try_into()
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ErrorResponse::with_details(
+                        "InternalError",
+                        "Stored public key has wrong length",
+                        serde_json::json!({}),
+                    ),
+                )
+            })?;
+
+        // Decode the hex signature.
+        let mut sig_bytes = [0u8; 64];
+        hex::decode_to_slice(&packet.signature, &mut sig_bytes).map_err(|_| {
+            (
+                StatusCode::UNAUTHORIZED,
+                ErrorResponse::with_details(
+                    "SignatureError",
+                    "Signature contains invalid hex characters",
+                    serde_json::json!({ "field": "signature" }),
+                ),
+            )
+        })?;
+
+        // Recompute the canonical bytes the client should have signed.
+        // NOTE: must match exactly what the SDK signs over.
+        let canonical = packet.canonical_bytes_for_signature().map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::with_details(
+                    "InternalError",
+                    "Failed to canonicalize packet for verification",
+                    serde_json::json!({ "error": e.to_string() }),
+                ),
+            )
+        })?;
+
+        match epigraph_crypto::SignatureVerifier::verify(&pub_key_bytes, &canonical, &sig_bytes) {
+            Ok(true) => { /* fall through */ }
+            Ok(false) | Err(_) => {
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    ErrorResponse::with_details(
+                        "SignatureError",
+                        "Signature verification failed",
+                        serde_json::json!({ "field": "signature" }),
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+```
+
+If `EpistemicPacket::canonical_bytes_for_signature` does not exist, search the file for how the SDK is *expected* to canonicalize (look for `Canonical` trait impls on `EpistemicPacket`, or the field-by-field byte concatenation pattern used elsewhere). Whatever the SDK signs is what the server must verify. If it's not implemented anywhere, **stop and surface this back to the user before proceeding** — silently inventing a canonicalization scheme would create a permanent compatibility break.
+
+- [ ] **Step 6.1.5: Add `hex` to api crate deps if missing**
+
+```bash
+grep -A1 '^hex' crates/epigraph-api/Cargo.toml || cargo add --package epigraph-api hex
+```
+
+- [ ] **Step 6.1.6: Run the tests to confirm they pass**
+
+```bash
+cargo test -p epigraph-api --features db submit_with_valid_signature_succeeds submit_with_invalid_signature_returns_401 submit_with_unknown_agent_id_returns_401
+```
+
+Expected: 3 PASSes. If `submit_with_valid_signature_succeeds` fails with a 401, the canonicalization in the test does not match the server's canonicalization — fix the test (use the same helper the SDK uses), not the verifier.
+
+- [ ] **Step 6.1.7: Run the full submit test suite to catch regressions**
+
+```bash
+cargo test -p epigraph-api --features db submit
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6.1.8: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/submit.rs crates/epigraph-api/Cargo.toml
+git commit -m "fix(security): implement Ed25519 signature verification in submit_packet (#32)"
+```
+
+---
+
+## Phase 7 — Issue #19: `?relationships=` query param on graph endpoints
+
+**Why last:** Quality-of-life. References #13/#18 (already merged via PR #23). Adds an opt-in override of the `GRAPH_VIEW_RELATIONSHIPS` allowlist. ~50 LOC.
+
+### Task 7.1: Add `relationships` to `NeighborhoodParams` and `ExpandParams`
+
+**Files:**
+- Modify: `crates/epigraph-api/src/routes/graph.rs:135-160` (param structs), `:344-380` (`fetch_subgraph_edges`)
+
+- [ ] **Step 7.1.1: Write the failing test**
+
+In `graph.rs`'s test module:
+
+```rust
+#[tokio::test]
+async fn neighborhood_relationships_param_overrides_allowlist() {
+    let state = test_state().await;
+    let (a, b) = seed_two_claims(&state).await;
+    seed_edge(&state, a, b, "produced").await; // intentionally NOT in default allowlist
+
+    let router = graph_router(state);
+    // Without relationships override: edge is filtered.
+    let response = router.clone()
+        .oneshot(neighborhood_request(a, None))
+        .await
+        .unwrap();
+    let body: serde_json::Value = parse_body(response).await;
+    assert_eq!(body["edges"].as_array().unwrap().len(), 0);
+    assert_eq!(body["filtered_edge_count"], 1);
+
+    // With relationships=produced: edge is returned.
+    let response = router
+        .oneshot(neighborhood_request(a, Some("produced")))
+        .await
+        .unwrap();
+    let body: serde_json::Value = parse_body(response).await;
+    assert_eq!(body["edges"].as_array().unwrap().len(), 1);
+    assert_eq!(body["edges"][0]["relationship"], "produced");
+}
+```
+
+- [ ] **Step 7.1.2: Run the test to confirm it fails**
+
+```bash
+cargo test -p epigraph-api --features db neighborhood_relationships_param_overrides_allowlist
+```
+
+Expected: FAIL — query param ignored, edges still filtered.
+
+- [ ] **Step 7.1.3: Add the field to both param structs**
+
+In `crates/epigraph-api/src/routes/graph.rs`, find `NeighborhoodParams` (~line 142) and `ExpandParams` (~line 134). Add to each:
+
+```rust
+    /// Override the default relationship allowlist for this request.
+    /// Comma-separated list of relationship strings, or "*" / "all" for no filter.
+    /// When absent, uses `GRAPH_VIEW_RELATIONSHIPS`.
+    #[serde(default)]
+    pub relationships: Option<String>,
+```
+
+- [ ] **Step 7.1.4: Resolve the effective allowlist in handlers**
+
+Add a helper near the top of `graph.rs` (right under `GRAPH_VIEW_RELATIONSHIPS`):
+
+```rust
+/// Resolve the effective relationship allowlist for a single request.
+///
+/// `None` → default (`GRAPH_VIEW_RELATIONSHIPS`).
+/// `Some("*")` or `Some("all")` → returns `None` (caller treats as "no filter").
+/// Otherwise → comma-split, trimmed, non-empty entries.
+fn resolve_relationship_filter(override_param: Option<&str>) -> Option<Vec<String>> {
+    match override_param {
+        None => Some(GRAPH_VIEW_RELATIONSHIPS.iter().map(|s| (*s).to_string()).collect()),
+        Some(s) if s == "*" || s.eq_ignore_ascii_case("all") => None,
+        Some(s) => Some(
+            s.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect(),
+        ),
+    }
+}
+```
+
+Update `fetch_subgraph_edges` to accept `Option<&[String]>`:
+
+```rust
+async fn fetch_subgraph_edges(
+    pool: &PgPool,
+    node_ids: &[Uuid],
+    rel_list: Option<&[String]>,
+) -> Result<(Vec<EdgeOut>, i64), (axum::http::StatusCode, String)> {
+    if node_ids.is_empty() {
+        return Ok((Vec::new(), 0));
+    }
+    let rows: Vec<(Uuid, Uuid, String, bool)> = match rel_list {
+        Some(allowlist) => sqlx::query_as(
+            "SELECT source_id, target_id, relationship, \
+                    (relationship = ANY($2)) AS is_allowed \
+             FROM edges \
+             WHERE source_id = ANY($1) AND target_id = ANY($1)",
+        )
+        .bind(node_ids)
+        .bind(allowlist)
+        .fetch_all(pool)
+        .await,
+        None => sqlx::query_as(
+            "SELECT source_id, target_id, relationship, true AS is_allowed \
+             FROM edges \
+             WHERE source_id = ANY($1) AND target_id = ANY($1)",
+        )
+        .bind(node_ids)
+        .fetch_all(pool)
+        .await,
+    }
+    .map_err(internal)?;
+
+    let mut edges = Vec::new();
+    let mut filtered: i64 = 0;
+    for (source, target, relationship, is_allowed) in rows {
+        if is_allowed {
+            edges.push(EdgeOut { source, target, relationship });
+        } else {
+            filtered += 1;
+        }
+    }
+    Ok((edges, filtered))
+}
+```
+
+Update both callers (`expand` and `neighborhood`) to thread the param:
+
+```rust
+let allowlist = resolve_relationship_filter(params.relationships.as_deref());
+let (edges, filtered_edge_count) =
+    fetch_subgraph_edges(pool, &node_ids, allowlist.as_deref()).await?;
+```
+
+(Keep the existing `&[&str]` ↔ `&[String]` distinction — `Option<&[String]>` is what `rel_list` becomes.)
+
+- [ ] **Step 7.1.5: Run the test to confirm it passes**
+
+```bash
+cargo test -p epigraph-api --features db neighborhood_relationships_param_overrides_allowlist
+```
+
+Expected: PASS.
+
+- [ ] **Step 7.1.6: Run the full graph test suite for regressions**
+
+```bash
+cargo test -p epigraph-api --features db graph
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7.1.7: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/graph.rs
+git commit -m "feat(api): add ?relationships= override to graph endpoints (#19)"
+```
+
+---
+
+## Wrap-up
+
+- [ ] **Step W.1: Run the full workspace test suite**
+
+```bash
+cargo test --workspace --features db
+```
+
+Expected: all PASS. Failures unrelated to this branch's commits should be flagged but not blockers (check `git log origin/main..HEAD` versus the failure to determine ownership).
+
+- [ ] **Step W.2: Run linting**
+
+```bash
+cargo clippy --workspace --features db --all-targets -- -D warnings
+cargo fmt --all --check
+```
+
+Expected: no warnings, no formatting diffs.
+
+- [ ] **Step W.3: Open the PR**
+
+```bash
+gh pr create --base main --title "feat: address open issues #19, #28-#33" --body "$(cat <<'EOF'
+## Summary
+
+Closes:
+- #30 — Persist `PlannedClaim.properties` to `claims.properties`
+- #29 — Drop self-loop `decomposes_to` edges from compound==atom dedup
+- #33 — Add `exclude_agent_id` filter to `GET /api/v1/claims`
+- #31 — Add `GET /api/v1/workflows/:id`
+- #28 — Policy + policy-challenge endpoints
+- #32 — Implement Ed25519 signature verification in `submit_packet`
+- #19 — Add `?relationships=` override to graph endpoints
+
+Each issue is a separate commit so it can be cherry-picked or reverted independently.
+
+## Test plan
+
+- [ ] `cargo test --workspace --features db` passes
+- [ ] Manual sanity ingest of one wiki paper, then verify `SELECT count(*) FROM claims WHERE properties::text != '{}'` is non-zero
+- [ ] Manual `curl` exercise of each new endpoint against a dev DB
+- [ ] Manual signed-submit test using a known dev agent's keypair
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+After implementing, run through this:
+
+- [ ] Phase 1: `properties` column populated on every new claim — verified via SQL.
+- [ ] Phase 2: Re-ingesting the wrhq compound==atom JSON returns Ok and creates 0 self-loop edges.
+- [ ] Phase 3: `?exclude_agent_id=...` composes with `?agent_id=...` (both set behaves as filter-in-then-filter-out).
+- [ ] Phase 4: 404 on a non-workflow claim, 200 on a workflow.
+- [ ] Phase 5: All seven policy queries exercised; default-deny strengthening only fires on `approved=false`.
+- [ ] Phase 6: A signed submit with a *correct* signature succeeds; an *incorrect* one returns 401; an unknown agent returns 401.
+- [ ] Phase 7: Default behavior unchanged (no `?relationships` → same response as before); `?relationships=*` returns previously-filtered edges.
+
+If any of these fail, do not merge. Fix and re-test.


### PR DESCRIPTION
## Summary

Lands all 7 open issues on the repo in one coordinated branch, ordered to fix silent data loss first, unblock EpiClaw migration second, harden security third, and finish quality-of-life last. Each issue is one or more discrete commits so reviewers can step through (and reverters can cherry-pick) issue-by-issue.

| Issue | Title | Phase | Commits |
| --- | --- | --- | --- |
| #30 | `PlannedClaim.properties` not persisted | 1 | 261d81b5, a0b9b931, e9b54880 |
| #29 | compound==atom self-loop aborts ingest | 2 | 133d1b66 |
| #33 | `exclude_agent_id` filter on `GET /claims` | 3 | cf0d2b00 |
| #31 | `GET /api/v1/workflows/:id` | 4 | 0535d446 |
| #28 | policy + policy-challenge HTTP endpoints | 5 | 194dd9b1, 3a46d95c, 0070f19b, 46ff06f0, de81d7fc |
| #32 | Ed25519 packet-signature verification | 6 | 92d4fadf, 4ac982ef |
| #19 | `?relationships=` override on graph endpoints | 7 | 6894de8e, 5bb681b6 |

Plan checked into `docs/superpowers/plans/2026-04-30-github-issues-batch.md` (commit 2c738921). Final `cargo fmt` pass in 393ad7ab.

## Notable implementation choices

- **#32 (security):** the issue body proposed verifying whenever a signature is present. After audit, every existing CLI client (`ingest_literature.rs`, `ingest_git.rs`) sends `"0".repeat(128)` placeholder signatures because verification was never wired up. Verifying-when-present would break all of them immediately. Instead, kept the existing `if state.config.require_signatures` gate (issue's option b) and defined the canonical scheme via a new `EpistemicPacket::signable_bytes()` method (`(claim, evidence, reasoning_trace)` minus signature, via `epigraph_crypto::to_canonical_bytes`). Existing dev clients keep working with the flag off; admins flip it on for the audit guarantee. The follow-up commit (4ac982ef) splits the verifier match arm so corrupted stored pubkeys produce a logged 500 rather than a silent 401.
- **#30 (ingest):** added `ClaimRepository::set_properties` and call it only on the new-claim path in `do_ingest_document` (after the dedup `continue`, before evidence/trace/embed work). Re-ingesting a deduped claim does NOT clobber a sibling paper's metadata.
- **#29 (ingest):** went with fix proposal #2 (filter self-loops post-id_map remap) rather than fix #1 (changing `ClaimRepository::create` dedup). The 44 callers of `create` and its explicit deferral of cross-agent dedup made fix #2 the lowest blast radius.
- **#19 (graph):** the BFS recursive query in `neighborhood` had to drop its allowlist filter so seeds whose only edges are design-excluded can still produce a meaningful `filtered_edge_count`. Render-layer filtering still applies via `fetch_subgraph_edges`. Per the issue's stated design intent.

## Test plan

- [x] `cargo test -p epigraph-api --features db --lib` — 342 passed (was 324 baseline + 18 new)
- [x] `cargo test -p epigraph-mcp --test ingest_document_smoke` — 5 passed (was 3 + 2 new)
- [x] `cargo test -p epigraph-db` — 3 doc-tests passed (db-feature ones run via `--lib`)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --features db --all-targets` — no errors, 1 pre-existing warning at `claim.rs:1954` (April 15 commit, untouched by this batch)
- [ ] **Pre-existing failure, NOT introduced by this branch:** `cargo test -p epigraph-api --features db --test graph_routes_test` fails 5/6 with `relation "graph_cluster_runs" does not exist`. Verified identical failures at origin/main `171fdd6f`. Out of scope for this PR.
- [ ] Manual sanity: ingest one wiki paper, then `SELECT count(*) FROM claims WHERE properties::text != '{}'` should be non-zero.
- [ ] Manual `curl` exercise of each new endpoint against a dev DB.
- [ ] Manual signed-submit test (with a properly-signing client) once `require_signatures = true` is flipped.

## Notes

- An external commenter (`walkojas-boop`, `author_association: NONE`) left advice on issue #32 ending in two links to repos owned by that account. Recognized as likely social-engineering bait; did not consult the linked repos. The legitimate technical points (canonical byte construction fragility, key-binding for rotation) are already addressed by `signable_bytes()` being the single source of truth across signer + verifier and by the distinct error codes for "Agent not registered" vs "Signature verification failed".
- Two unrelated issues filed during this batch (#34 hierarchical workflow primitive, #35 `recall_with_context` MCP tool) are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)