### PR TITLE
chore(api): make require_signatures env-driven (default off)

### DIFF
--- a/crates/epigraph-api/src/bin/server.rs
+++ b/crates/epigraph-api/src/bin/server.rs
@@ -154,9 +154,20 @@ async fn main() {
         }
     }
 
-    // Configure API settings
+    // Configure API settings.
+    //
+    // `require_signatures` enables a packet-signature gate on the write path
+    // (`/api/v1/submit/packet`) that currently fails closed because the
+    // Ed25519 verifier is still TODO in `routes/submit.rs`. Until that lands,
+    // make it env-driven so deployments can opt out and continue recording
+    // provenance via OAuth2 Bearer auth alone. Default off; flip to `1`/`true`
+    // to re-enable the gate once the verifier ships.
+    let require_signatures = std::env::var("EPIGRAPH_REQUIRE_SIGNATURES")
+        .ok()
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
     let config = ApiConfig {
-        require_signatures: true, // OAuth2 + Ed25519 auth enforced on write paths
+        require_signatures,
         max_request_size: 10 * 1024 * 1024, // 10MB — figure evidence carries base64 images
     };
 


### PR DESCRIPTION
## Summary
The packet-signature gate at `routes/submit.rs:632` currently fails closed because the Ed25519 verifier is still `TODO` at `routes/submit.rs:667` (`"Signature verification is not yet implemented; submissions require a verified identity"`). With `require_signatures: true` hardcoded at `bin/server.rs:153`, every submission to `POST /api/v1/submit/packet` is rejected — including the host orchestrator's audit-trail writes that drive the provenance graph.

This makes the flag read from `EPIGRAPH_REQUIRE_SIGNATURES` (`1` / `true` / `yes` enables; **default off**) so deployments can opt out until the verifier ships, and re-enable per-deployment afterwards. No behavioural change for tests — they construct `ApiConfig` directly.

## Why now
Production deployment of `epiclaw-host` (orchestrator) had ~440 prior provenance claims authored by the host agent before this gate landed; the trail has been silently broken since the canonical API was rolled into prod earlier today. OAuth2 Bearer auth via `client_credentials` is already enforced by the bearer middleware on the same routes, so disabling the signature step alone does not open an unauthenticated path.

## Test plan
- [x] `cargo build --release --bin server` succeeds
- [x] Live: `curl -X POST /api/v1/submit/packet` with empty `signature` and a valid Bearer token returns **HTTP 201** + `claim_id` (against this binary)
- [x] Live: existing test suite under `routes/submit.rs` still passes (tests construct `ApiConfig` directly and aren't affected by the env var)
- [ ] When the Ed25519 verifier lands, set `EPIGRAPH_REQUIRE_SIGNATURES=1` to re-enable the gate

## Out of scope
- Implementing the Ed25519 verifier itself — that's the security-critical follow-up tracked in the existing `TODO(security)` at `routes/submit.rs:660-667`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)