### PR TITLE
fix(db): cascade_delete_edges triggers on tasks/events/workflows (#39)

### DIFF
--- a/crates/epigraph-db/Cargo.toml
+++ b/crates/epigraph-db/Cargo.toml
@@ -33,3 +33,7 @@ path = "tests/lineage_tests.rs"
 [[test]]
 name = "batch_operations_tests"
 path = "tests/batch_operations_tests.rs"
+
+[[test]]
+name = "cascade_delete_tests"
+path = "tests/cascade_delete_tests.rs"

--- a/crates/epigraph-db/tests/cascade_delete_tests.rs
+++ b/crates/epigraph-db/tests/cascade_delete_tests.rs
@@ -43,12 +43,11 @@ async fn deleting_task_cascades_to_edges(pool: PgPool) -> sqlx::Result<()> {
     .execute(&pool)
     .await?;
 
-    let edges_before: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
-    )
-    .bind(task_id)
-    .fetch_one(&pool)
-    .await?;
+    let edges_before: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1")
+            .bind(task_id)
+            .fetch_one(&pool)
+            .await?;
     assert_eq!(edges_before, 1, "edge should exist before delete");
 
     sqlx::query("DELETE FROM tasks WHERE id = $1")
@@ -56,13 +55,15 @@ async fn deleting_task_cascades_to_edges(pool: PgPool) -> sqlx::Result<()> {
         .execute(&pool)
         .await?;
 
-    let edges_after: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
-    )
-    .bind(task_id)
-    .fetch_one(&pool)
-    .await?;
-    assert_eq!(edges_after, 0, "cascade trigger should have removed orphan edges");
+    let edges_after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1")
+            .bind(task_id)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(
+        edges_after, 0,
+        "cascade trigger should have removed orphan edges"
+    );
 
     Ok(())
 }
@@ -109,12 +110,11 @@ async fn deleting_event_cascades_to_edges(pool: PgPool) -> sqlx::Result<()> {
         .execute(&pool)
         .await?;
 
-    let edges_after: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
-    )
-    .bind(event_id)
-    .fetch_one(&pool)
-    .await?;
+    let edges_after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1")
+            .bind(event_id)
+            .fetch_one(&pool)
+            .await?;
     assert_eq!(edges_after, 0);
 
     Ok(())
@@ -162,12 +162,11 @@ async fn deleting_workflow_cascades_to_edges(pool: PgPool) -> sqlx::Result<()> {
         .execute(&pool)
         .await?;
 
-    let edges_after: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
-    )
-    .bind(workflow_id)
-    .fetch_one(&pool)
-    .await?;
+    let edges_after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1")
+            .bind(workflow_id)
+            .fetch_one(&pool)
+            .await?;
     assert_eq!(edges_after, 0);
 
     Ok(())

--- a/crates/epigraph-db/tests/cascade_delete_tests.rs
+++ b/crates/epigraph-db/tests/cascade_delete_tests.rs
@@ -1,0 +1,174 @@
+// crates/epigraph-db/tests/cascade_delete_tests.rs
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn deleting_task_cascades_to_edges(pool: PgPool) -> sqlx::Result<()> {
+    let task_id = Uuid::new_v4();
+    let claim_id = Uuid::new_v4();
+    let agent_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO agents (id, public_key) \
+         VALUES ($1, decode(repeat('00', 32), 'hex'))",
+    )
+    .bind(agent_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id) \
+         VALUES ($1, 'cascade-test-claim', decode(repeat('11', 32), 'hex'), $2)",
+    )
+    .bind(claim_id)
+    .bind(agent_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO tasks (id, description, task_type) \
+         VALUES ($1, 'cascade-test', 'cascade-test')",
+    )
+    .bind(task_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'task', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(task_id)
+    .bind(claim_id)
+    .execute(&pool)
+    .await?;
+
+    let edges_before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
+    )
+    .bind(task_id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edges_before, 1, "edge should exist before delete");
+
+    sqlx::query("DELETE FROM tasks WHERE id = $1")
+        .bind(task_id)
+        .execute(&pool)
+        .await?;
+
+    let edges_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
+    )
+    .bind(task_id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edges_after, 0, "cascade trigger should have removed orphan edges");
+
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn deleting_event_cascades_to_edges(pool: PgPool) -> sqlx::Result<()> {
+    let event_id = Uuid::new_v4();
+    let claim_id = Uuid::new_v4();
+    let agent_id = Uuid::new_v4();
+
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode(repeat('00', 32), 'hex'))")
+        .bind(agent_id)
+        .execute(&pool)
+        .await?;
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id) \
+         VALUES ($1, 'cascade-test-claim', decode(repeat('22', 32), 'hex'), $2)",
+    )
+    .bind(claim_id)
+    .bind(agent_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO events (id, event_type, graph_version) \
+         VALUES ($1, 'cascade-test', 0)",
+    )
+    .bind(event_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'event', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(event_id)
+    .bind(claim_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query("DELETE FROM events WHERE id = $1")
+        .bind(event_id)
+        .execute(&pool)
+        .await?;
+
+    let edges_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
+    )
+    .bind(event_id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edges_after, 0);
+
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn deleting_workflow_cascades_to_edges(pool: PgPool) -> sqlx::Result<()> {
+    let workflow_id = Uuid::new_v4();
+    let claim_id = Uuid::new_v4();
+    let agent_id = Uuid::new_v4();
+
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode(repeat('00', 32), 'hex'))")
+        .bind(agent_id)
+        .execute(&pool)
+        .await?;
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id) \
+         VALUES ($1, 'cascade-test-claim', decode(repeat('33', 32), 'hex'), $2)",
+    )
+    .bind(claim_id)
+    .bind(agent_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO workflows (id, canonical_name, goal) \
+         VALUES ($1, 'cascade-test', 'cascade-test')",
+    )
+    .bind(workflow_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'workflow', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(workflow_id)
+    .bind(claim_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query("DELETE FROM workflows WHERE id = $1")
+        .bind(workflow_id)
+        .execute(&pool)
+        .await?;
+
+    let edges_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 OR target_id = $1",
+    )
+    .bind(workflow_id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edges_after, 0);
+
+    Ok(())
+}

--- a/migrations/024_cascade_delete_edges_backfill.sql
+++ b/migrations/024_cascade_delete_edges_backfill.sql
@@ -1,0 +1,45 @@
+-- Migration 024: backfill cascade_delete_edges triggers
+--
+-- The cascade_delete_edges trigger function exists since migration 001 and is
+-- wired to claims, papers, agents, evidence, analyses, reasoning_traces (and
+-- experiments + experiment_results since 023). Three entity tables that
+-- participate in edges (tasks, events, workflows) lack the trigger, leaving
+-- orphan edges when rows are deleted. This migration closes that gap.
+--
+-- All trigger creations are guarded by IF NOT EXISTS-equivalent pg_trigger
+-- checks so the migration is idempotent on any DB that may have had partial
+-- backfills applied directly.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'tasks_cascade_edges'
+          AND tgrelid = 'tasks'::regclass
+    ) THEN
+        CREATE TRIGGER tasks_cascade_edges
+            BEFORE DELETE ON tasks
+            FOR EACH ROW EXECUTE FUNCTION cascade_delete_edges('task');
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'events_cascade_edges'
+          AND tgrelid = 'events'::regclass
+    ) THEN
+        CREATE TRIGGER events_cascade_edges
+            BEFORE DELETE ON events
+            FOR EACH ROW EXECUTE FUNCTION cascade_delete_edges('event');
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'workflows_cascade_edges'
+          AND tgrelid = 'workflows'::regclass
+    ) THEN
+        CREATE TRIGGER workflows_cascade_edges
+            BEFORE DELETE ON workflows
+            FOR EACH ROW EXECUTE FUNCTION cascade_delete_edges('workflow');
+    END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary

Adds `BEFORE DELETE` cascade_delete_edges triggers on `tasks`, `events`, and `workflows` — closes the gap identified in #39. Brings these three tables into agreement with the existing convention used by `claims`, `papers`, `agents`, `evidence`, `analyses`, `reasoning_traces` (since migration 001) and `experiments`, `experiment_results` (since migration 023).

Without these triggers, deleting a row in any of the three tables left orphan rows in `edges`. The trigger function (`cascade_delete_edges`) already exists; this migration just wires it up to the three tables that were missing it.

## Test plan

- [x] **TDD red**: `crates/epigraph-db/tests/cascade_delete_tests.rs` adds 3 `#[sqlx::test(migrations = "../../migrations")]`-isolated tests asserting orphan-edges removal on row delete. Without migration 024, all three FAIL with `edges_after = 1`.
- [x] **TDD green**: After migration 024 lands, all 3 tests PASS.
- [x] **Workspace**: `cargo test --workspace --no-fail-fast -- --test-threads=1` → 2469 passed, 0 failed (Plan A baseline + 3 new cascade tests).
- [x] **fmt**: `cargo fmt --all -- --check` clean.
- [x] **clippy**: `cargo clippy --workspace -- -D warnings` clean.
- [x] **E2E against dev DB**: `INSERT entity → INSERT edge → DELETE entity → assert edge gone` for tasks, events, workflows. All three cascades fire correctly. Migration applied directly via `psql -f` (idempotent DDL).

## Migration shape

`migrations/024_cascade_delete_edges_backfill.sql` — 45 lines, single `DO $$ ... $$;` block with three `IF NOT EXISTS (SELECT 1 FROM pg_trigger ...)` guards. Idempotent on partial-state DBs.

Closes #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)