### PR TITLE
fix(db): consolidate validate_edge_reference + add missing entity branches (#40, #41)

### DIFF
--- a/crates/epigraph-db/Cargo.toml
+++ b/crates/epigraph-db/Cargo.toml
@@ -37,3 +37,7 @@ path = "tests/batch_operations_tests.rs"
 [[test]]
 name = "cascade_delete_tests"
 path = "tests/cascade_delete_tests.rs"
+
+[[test]]
+name = "edge_validation_tests"
+path = "tests/edge_validation_tests.rs"

--- a/crates/epigraph-db/tests/edge_validation_tests.rs
+++ b/crates/epigraph-db/tests/edge_validation_tests.rs
@@ -1,0 +1,193 @@
+// crates/epigraph-db/tests/edge_validation_tests.rs
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn validate_edge_reference_has_one_overload(pool: PgPool) -> sqlx::Result<()> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pg_proc WHERE proname = 'validate_edge_reference'",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(
+        count, 1,
+        "expected exactly one validate_edge_reference overload, found {count}"
+    );
+    Ok(())
+}
+
+async fn seed_agent_and_claim(
+    pool: &PgPool,
+    agent_byte: u8,
+    claim_byte: u8,
+) -> sqlx::Result<(Uuid, Uuid)> {
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(agent_id)
+        .bind(format!("{:02x}", agent_byte).repeat(32))
+        .execute(pool)
+        .await?;
+
+    let claim_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id) \
+         VALUES ($1, 'cleanup-test', decode($2, 'hex'), $3)",
+    )
+    .bind(claim_id)
+    .bind(format!("{:02x}", claim_byte).repeat(32))
+    .bind(agent_id)
+    .execute(pool)
+    .await?;
+
+    Ok((agent_id, claim_id))
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn perspective_edge_with_valid_fk_succeeds(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xA1, 0x41).await?;
+    let perspective_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO perspectives (id, name) VALUES ($1, 'cleanup-test')")
+        .bind(perspective_id)
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'perspective', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(perspective_id)
+    .bind(claim_id)
+    .execute(&pool)
+    .await?;
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn community_edge_with_valid_fk_succeeds(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xA2, 0x42).await?;
+    let community_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO communities (id, name) VALUES ($1, 'cleanup-test')")
+        .bind(community_id)
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'community', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(community_id)
+    .bind(claim_id)
+    .execute(&pool)
+    .await?;
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn context_edge_with_valid_fk_succeeds(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xA3, 0x43).await?;
+    let context_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO contexts (id, name, context_type) \
+         VALUES ($1, 'cleanup-test', 'cleanup-test')",
+    )
+    .bind(context_id)
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'context', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(context_id)
+    .bind(claim_id)
+    .execute(&pool)
+    .await?;
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn frame_edge_with_valid_fk_succeeds(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xA4, 0x44).await?;
+    let frame_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO frames (id, name, hypotheses) \
+         VALUES ($1, 'cleanup-test', ARRAY['h1','h2']::text[])",
+    )
+    .bind(frame_id)
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'frame', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(frame_id)
+    .bind(claim_id)
+    .execute(&pool)
+    .await?;
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn perspective_edge_with_bogus_uuid_fails(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xB1, 0x51).await?;
+    let bogus = Uuid::new_v4();
+    let result = sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'perspective', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(bogus)
+    .bind(claim_id)
+    .execute(&pool)
+    .await;
+    assert!(
+        result.is_err(),
+        "edge with non-existent perspective should be rejected"
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn community_edge_with_bogus_uuid_fails(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xB2, 0x52).await?;
+    let bogus = Uuid::new_v4();
+    let result = sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'community', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(bogus)
+    .bind(claim_id)
+    .execute(&pool)
+    .await;
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn context_edge_with_bogus_uuid_fails(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xB3, 0x53).await?;
+    let bogus = Uuid::new_v4();
+    let result = sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'context', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(bogus)
+    .bind(claim_id)
+    .execute(&pool)
+    .await;
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn frame_edge_with_bogus_uuid_fails(pool: PgPool) -> sqlx::Result<()> {
+    let (_, claim_id) = seed_agent_and_claim(&pool, 0xB4, 0x54).await?;
+    let bogus = Uuid::new_v4();
+    let result = sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'frame', $2, 'claim', 'TEST_EDGE')",
+    )
+    .bind(bogus)
+    .bind(claim_id)
+    .execute(&pool)
+    .await;
+    assert!(result.is_err());
+    Ok(())
+}

--- a/migrations/025_validate_edge_reference_cleanup.sql
+++ b/migrations/025_validate_edge_reference_cleanup.sql
@@ -1,0 +1,44 @@
+-- Migration 025: validate_edge_reference cleanup
+--
+-- Two cleanups in one:
+--   1. Drop the unused (text, uuid) overload — only (uuid, varchar) is invoked
+--      from trigger_validate_edge_refs and from any Rust callsite (#41).
+--   2. Add the missing perspective / community / context / frame branches so
+--      the function aligns with the edges_entity_types_valid CHECK constraint
+--      (#40).
+--
+-- Drops a function used by zero callers; idempotent on a DB where the function
+-- has already been removed (DROP FUNCTION IF EXISTS).
+
+DROP FUNCTION IF EXISTS validate_edge_reference(text, uuid);
+
+CREATE OR REPLACE FUNCTION validate_edge_reference(entity_id UUID, entity_type CHARACTER VARYING)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN CASE entity_type
+        WHEN 'claim'              THEN EXISTS (SELECT 1 FROM claims WHERE id = entity_id)
+        WHEN 'agent'              THEN EXISTS (SELECT 1 FROM agents WHERE id = entity_id)
+        WHEN 'evidence'           THEN EXISTS (SELECT 1 FROM evidence WHERE id = entity_id)
+        WHEN 'trace'              THEN EXISTS (SELECT 1 FROM reasoning_traces WHERE id = entity_id)
+        WHEN 'paper'              THEN EXISTS (SELECT 1 FROM papers WHERE id = entity_id)
+        WHEN 'analysis'           THEN EXISTS (SELECT 1 FROM analyses WHERE id = entity_id)
+        WHEN 'activity'           THEN EXISTS (SELECT 1 FROM activities WHERE id = entity_id)
+        WHEN 'source_artifact'    THEN EXISTS (SELECT 1 FROM source_artifacts WHERE id = entity_id)
+        WHEN 'span'               THEN EXISTS (SELECT 1 FROM agent_spans WHERE id = entity_id)
+        WHEN 'entity'             THEN EXISTS (SELECT 1 FROM entities WHERE id = entity_id)
+        WHEN 'task'               THEN EXISTS (SELECT 1 FROM tasks WHERE id = entity_id)
+        WHEN 'event'              THEN EXISTS (SELECT 1 FROM events WHERE id = entity_id)
+        WHEN 'experiment'         THEN EXISTS (SELECT 1 FROM experiments WHERE id = entity_id)
+        WHEN 'experiment_result'  THEN EXISTS (SELECT 1 FROM experiment_results WHERE id = entity_id)
+        WHEN 'workflow'           THEN EXISTS (SELECT 1 FROM workflows WHERE id = entity_id)
+        WHEN 'perspective'        THEN EXISTS (SELECT 1 FROM perspectives WHERE id = entity_id)
+        WHEN 'community'          THEN EXISTS (SELECT 1 FROM communities WHERE id = entity_id)
+        WHEN 'context'            THEN EXISTS (SELECT 1 FROM contexts WHERE id = entity_id)
+        WHEN 'frame'              THEN EXISTS (SELECT 1 FROM frames WHERE id = entity_id)
+        WHEN 'node'               THEN TRUE
+        ELSE FALSE
+    END;
+END;
+$$;


### PR DESCRIPTION
## Summary

Two related schema fixes in one migration that close the `validate_edge_reference` cleanup cluster.

- **#41** — Drop the unused `validate_edge_reference(text, uuid)` overload. The trigger `edges_validate_refs` and zero Rust call-sites all use `(uuid, varchar)`. Halves the maintenance burden — every future entity-type addition now only touches one function body. This is **Path A** from #41 (drop one overload). Path B (metadata-table-driven dispatch) is a deeper refactor deferred until justified.
- **#40** — Add `WHEN` branches for `perspective`, `community`, `context`, `frame` to the kept overload. The `edges_entity_types_valid` CHECK admitted them, but the function fell through to `ELSE FALSE` so legitimate edges of those types were silently rejected by the trigger.

## Test plan

- [x] **TDD red**: 9 new tests in `crates/epigraph-db/tests/edge_validation_tests.rs` — 1 overload-count + 4 valid-FK + 4 bogus-UUID. Without migration 025: 5 fail (overload-count + 4 valid-FK), 4 pass coincidentally (bogus-UUID — function rejects everything in red state).
- [x] **TDD green**: After migration 025, all 9 PASS — including the bogus-UUID tests for the right reason (the new `WHEN` branches return FALSE because the row doesn't exist, not because of `ELSE FALSE`).
- [x] **Workspace**: 2478 passed, 0 failed (+9 new tests vs. Plan B's 2469 baseline).
- [x] **fmt** + **clippy**: clean.
- [x] **E2E against dev DB**: applied migration 025 directly via `psql -f`, then INSERTed perspective/community/context/frame entities and edges → all 4 INSERTs succeed (would have failed in red state). Negative test with a bogus UUID → correctly rejected with "Edge source references nonexistent perspective". `pg_proc` overload count: 1 (was 2).

## Migration shape

`migrations/025_validate_edge_reference_cleanup.sql` — 44 lines: `DROP FUNCTION IF EXISTS validate_edge_reference(text, uuid);` then `CREATE OR REPLACE FUNCTION` for the kept overload with all 20 CASE arms (15 preserved + 4 new + `node` + `ELSE FALSE`).

Closes #40.
Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)