### PR TITLE
feat(mcp): expose hierarchical workflow tools (ingest/search/outcome)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,7 @@ name = "epigraph-ingest"
 version = "0.3.0"
 dependencies = [
  "blake3",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/epigraph-ingest/Cargo.toml
+++ b/crates/epigraph-ingest/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+schemars = { workspace = true }
 uuid = { workspace = true, features = ["v4", "v5"] }
 thiserror = { workspace = true }
 blake3 = "1"  # High-performance hashing for content-addressed atom IDs

--- a/crates/epigraph-ingest/src/common/schema.rs
+++ b/crates/epigraph-ingest/src/common/schema.rs
@@ -1,10 +1,11 @@
 //! Schema types shared across `document::` and `workflow::` artifact kinds.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// An author with affiliations and roles. Workflows can be authored by humans,
 /// LLMs, or external systems — same shape as document authors.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AuthorEntry {
     pub name: String,
     #[serde(default)]
@@ -16,7 +17,7 @@ pub struct AuthorEntry {
 /// A relationship between two claims identified by path. Workflow steps can
 /// support / contradict / refute each other across phases just like document
 /// atoms can across paragraphs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ClaimRelationship {
     pub source_path: String,
     pub target_path: String,
@@ -28,7 +29,7 @@ pub struct ClaimRelationship {
 }
 
 /// Whether the thesis was derived top-down or bottom-up.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub enum ThesisDerivation {
     #[default]
     TopDown,

--- a/crates/epigraph-ingest/src/workflow/schema.rs
+++ b/crates/epigraph-ingest/src/workflow/schema.rs
@@ -3,13 +3,14 @@
 //! names (phases/steps/operations) and workflow-specific source metadata
 //! (canonical_name, generation, parent_canonical_name).
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::common::schema::{AuthorEntry, ClaimRelationship, ThesisDerivation};
 use crate::document::schema::default_confidence;
 
 /// Top-level extraction result from a workflow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WorkflowExtraction {
     pub source: WorkflowSource,
     #[serde(default)]
@@ -23,7 +24,7 @@ pub struct WorkflowExtraction {
 }
 
 /// Metadata about the workflow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WorkflowSource {
     /// Required slug; drives the deterministic root ID.
     pub canonical_name: String,
@@ -44,7 +45,7 @@ pub struct WorkflowSource {
 }
 
 /// A phase within a workflow (analog of `document::schema::Section`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Phase {
     pub title: String,
     #[serde(default)]
@@ -56,7 +57,7 @@ pub struct Phase {
 /// A step within a phase (analog of `document::schema::Paragraph`).
 /// Paper-specific fields (methodology, evidence_type, page, instruments_used,
 /// reagents_involved, conditions) are intentionally absent.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Step {
     pub compound: String,
     #[serde(default)]

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -319,6 +319,45 @@ impl EpiGraphMcpFull {
         tools::workflows::deprecate_workflow(self, params).await
     }
 
+    // ── Hierarchical Workflows (3 tools) ──
+    //
+    // Counterparts to the flat `store_workflow` family above. These operate
+    // on the `workflows` table where every step is a claim node connected
+    // via `executes` edges, so each step accrues evidence and Darwinian
+    // variants independently of its workflow root.
+
+    #[tool(
+        description = "Ingest a hierarchical WorkflowExtraction: persists thesis → phases → steps → operation atoms as claim nodes, writes `executes` edges from the workflow root to every planned claim, and resolves author identities. Idempotent: re-ingesting the same canonical_name+generation is a no-op."
+    )]
+    async fn ingest_workflow(
+        &self,
+        Parameters(params): Parameters<IngestWorkflowParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::workflow_ingest::ingest_workflow(self, params).await
+    }
+
+    #[tool(
+        description = "Search hierarchical workflows by free-text over goal and canonical_name (ILIKE). Returns rows from the `workflows` table — distinct from `find_workflow` which searches flat workflow claims."
+    )]
+    async fn find_workflow_hierarchical(
+        &self,
+        Parameters(params): Parameters<FindWorkflowHierarchicalParams>,
+    ) -> Result<CallToolResult, McpError> {
+        tools::workflow_hierarchical::find_workflow_hierarchical(self, params).await
+    }
+
+    #[tool(
+        description = "Record an outcome for a hierarchical workflow run. Updates rolling counters in workflows.metadata (use_count, success_count, failure_count, avg_variance) and writes one behavioral_executions row per step_execution with step_claim_id resolved from the workflow's `executes` edges in plan order. Use `report_workflow_outcome` instead for flat workflow claims."
+    )]
+    async fn report_hierarchical_outcome(
+        &self,
+        Parameters(params): Parameters<ReportHierarchicalOutcomeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::workflow_hierarchical::report_hierarchical_outcome(self, params).await
+    }
+
     // ── Graph (2 tools) ──
 
     #[tool(

--- a/crates/epigraph-mcp/src/tools/mod.rs
+++ b/crates/epigraph-mcp/src/tools/mod.rs
@@ -12,5 +12,6 @@ pub mod perspectives;
 pub mod provenance;
 pub mod rdf;
 pub mod sheaf;
+pub mod workflow_hierarchical;
 pub mod workflow_ingest;
 pub mod workflows;

--- a/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
@@ -1,0 +1,358 @@
+//! Hierarchical workflow query and outcome tools.
+//!
+//! Companions to `workflow_ingest::do_ingest_workflow`. These operate on the
+//! `workflows` table (hierarchical roots) — distinct from the legacy flat
+//! workflow claims handled in `workflows.rs`.
+//!
+//! - `find_workflow_hierarchical` — ILIKE search over goal/canonical_name.
+//! - `report_hierarchical_outcome` — updates `workflows.metadata` counters
+//!   and writes per-step `behavioral_executions` rows with `step_claim_id`
+//!   resolved from the workflow's `executes` edges in plan order.
+//!
+//! Mirrors the API routes
+//! `GET /api/v1/workflows/hierarchical/search` and
+//! `POST /api/v1/workflows/hierarchical/:id/outcome`.
+
+use rmcp::model::*;
+use uuid::Uuid;
+
+use crate::errors::{internal_error, McpError};
+use crate::server::EpiGraphMcpFull;
+use crate::types::{
+    FindWorkflowHierarchicalParams, HierarchicalStepExecution, ReportHierarchicalOutcomeParams,
+};
+
+fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(value).map_err(internal_error)?,
+    )]))
+}
+
+fn invalid_uuid(field: &'static str) -> McpError {
+    McpError {
+        code: rmcp::model::ErrorCode::INVALID_PARAMS,
+        message: std::borrow::Cow::Owned(format!("invalid UUID for `{field}`")),
+        data: None,
+    }
+}
+
+fn not_found(workflow_id: Uuid) -> McpError {
+    McpError {
+        code: rmcp::model::ErrorCode::INVALID_PARAMS,
+        message: std::borrow::Cow::Owned(format!(
+            "no hierarchical workflow with id {workflow_id} (use ingest_workflow first, or check whether this is a flat workflow)"
+        )),
+        data: None,
+    }
+}
+
+// ── find_workflow_hierarchical ─────────────────────────────────────────────
+
+pub async fn find_workflow_hierarchical(
+    server: &EpiGraphMcpFull,
+    params: FindWorkflowHierarchicalParams,
+) -> Result<CallToolResult, McpError> {
+    let limit = params.limit.unwrap_or(10).clamp(1, 50);
+    let rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
+        &server.pool,
+        &params.query,
+        limit,
+    )
+    .await
+    .map_err(internal_error)?;
+
+    let workflows: Vec<serde_json::Value> = rows
+        .into_iter()
+        .map(|r| {
+            serde_json::json!({
+                "workflow_id": r.id,
+                "canonical_name": r.canonical_name,
+                "generation": r.generation,
+                "goal": r.goal,
+                "parent_id": r.parent_id,
+                "metadata": r.metadata,
+                "created_at": r.created_at,
+            })
+        })
+        .collect();
+
+    success_json(&serde_json::json!({
+        "workflows": workflows,
+        "total": workflows.len(),
+    }))
+}
+
+// ── report_hierarchical_outcome ────────────────────────────────────────────
+
+pub async fn report_hierarchical_outcome(
+    server: &EpiGraphMcpFull,
+    params: ReportHierarchicalOutcomeParams,
+) -> Result<CallToolResult, McpError> {
+    let workflow_id =
+        Uuid::parse_str(&params.workflow_id).map_err(|_| invalid_uuid("workflow_id"))?;
+
+    do_report_hierarchical_outcome_via_pool(
+        &server.pool,
+        workflow_id,
+        params.success,
+        &params.step_executions,
+        params.quality,
+        params.goal_text.as_deref(),
+    )
+    .await
+}
+
+/// Pool-only outcome reporting for hierarchical workflows. Updates
+/// `workflows.metadata` rolling counters and writes per-step
+/// `behavioral_executions` rows with `step_claim_id` resolved from the
+/// workflow's `executes` edges (level=2 claims, in plan order).
+pub async fn do_report_hierarchical_outcome_via_pool(
+    pool: &sqlx::PgPool,
+    workflow_id: Uuid,
+    success: bool,
+    step_executions: &[HierarchicalStepExecution],
+    quality: Option<f64>,
+    goal_text: Option<&str>,
+) -> Result<CallToolResult, McpError> {
+    // 1. Confirm hierarchical workflow exists.
+    let row: Option<(serde_json::Value,)> =
+        sqlx::query_as("SELECT metadata FROM workflows WHERE id = $1")
+            .bind(workflow_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(internal_error)?;
+    let mut metadata = match row {
+        Some((m,)) => m,
+        None => return Err(not_found(workflow_id)),
+    };
+
+    // 2. Compute deltas.
+    let variance = if step_executions.is_empty() {
+        0.0
+    } else {
+        let dev = step_executions.iter().filter(|s| s.deviated).count();
+        dev as f64 / step_executions.len() as f64
+    };
+    let quality = quality.unwrap_or(if success { 1.0 } else { 0.0 });
+
+    // 3. Update rolling counters in metadata.
+    let use_count = metadata
+        .get("use_count")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0)
+        + 1;
+    let success_count = metadata
+        .get("success_count")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0)
+        + i64::from(success);
+    let failure_count = metadata
+        .get("failure_count")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0)
+        + i64::from(!success);
+    let prev_avg_var = metadata
+        .get("avg_variance")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0);
+    let avg_variance = if use_count > 0 {
+        (prev_avg_var * (use_count - 1) as f64 + variance) / use_count as f64
+    } else {
+        variance
+    };
+    metadata["use_count"] = serde_json::json!(use_count);
+    metadata["success_count"] = serde_json::json!(success_count);
+    metadata["failure_count"] = serde_json::json!(failure_count);
+    metadata["avg_variance"] = serde_json::json!(avg_variance);
+
+    sqlx::query("UPDATE workflows SET metadata = $1 WHERE id = $2")
+        .bind(&metadata)
+        .bind(workflow_id)
+        .execute(pool)
+        .await
+        .map_err(internal_error)?;
+
+    // 4. Resolve step_index → step_claim_id via this workflow's `executes`
+    //    edges, restricted to level=2 (steps), in plan/insertion order.
+    let step_claim_rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT c.id \
+         FROM edges e \
+         JOIN claims c ON c.id = e.target_id \
+         WHERE e.source_id = $1 AND e.relationship = 'executes' AND (c.properties->>'level')::int = 2 \
+         ORDER BY e.created_at ASC, c.id ASC",
+    )
+    .bind(workflow_id)
+    .fetch_all(pool)
+    .await
+    .map_err(internal_error)?;
+    let step_claim_ids: Vec<Uuid> = step_claim_rows.into_iter().map(|(id,)| id).collect();
+
+    // 5. Per-step behavioral_executions rows. Single timestamp groups them.
+    let report_ts = chrono::Utc::now();
+    let goal_text_owned = goal_text.unwrap_or("hierarchical").to_string();
+    let mut written = 0_usize;
+    for step_exec in step_executions {
+        let step_claim_id = step_claim_ids.get(step_exec.step_index).copied();
+        if step_claim_id.is_none() && !step_claim_ids.is_empty() {
+            tracing::warn!(
+                workflow_id = %workflow_id,
+                step_index = step_exec.step_index,
+                known_steps = step_claim_ids.len(),
+                "step_index out of range; behavioral_executions row will have NULL step_claim_id"
+            );
+        }
+        let step_beliefs = serde_json::json!({
+            "deviated": step_exec.deviated,
+            "deviation_reason": step_exec.deviation_reason,
+        });
+        let row = epigraph_db::BehavioralExecutionRow {
+            id: Uuid::new_v4(),
+            workflow_id,
+            goal_text: goal_text_owned.clone(),
+            success,
+            step_beliefs,
+            tool_pattern: vec![step_exec.planned.clone()],
+            quality: Some(quality),
+            deviation_count: i32::from(step_exec.deviated),
+            total_steps: 1,
+            created_at: report_ts,
+            step_claim_id,
+        };
+        if let Err(e) = epigraph_db::BehavioralExecutionRepository::create(pool, row, None).await {
+            tracing::warn!(workflow_id = %workflow_id, "behavioral_executions write failed: {e}");
+            continue;
+        }
+        written += 1;
+    }
+
+    success_json(&serde_json::json!({
+        "workflow_id": workflow_id,
+        "use_count": use_count,
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "avg_variance": avg_variance,
+        "variance": variance,
+        "step_executions_written": written,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::workflow_ingest::do_ingest_workflow_via_pool;
+    use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowSource};
+    use epigraph_ingest::workflow::WorkflowExtraction;
+
+    fn extraction(canonical_name: &str) -> WorkflowExtraction {
+        WorkflowExtraction {
+            source: WorkflowSource {
+                canonical_name: canonical_name.to_string(),
+                goal: "Validate hierarchical outcome reporting".to_string(),
+                generation: 0,
+                parent_canonical_name: None,
+                authors: vec![],
+                expected_outcome: None,
+                tags: vec![],
+                metadata: serde_json::json!({}),
+            },
+            thesis: Some("This workflow validates outcome reporting".to_string()),
+            thesis_derivation: epigraph_ingest::common::schema::ThesisDerivation::TopDown,
+            phases: vec![Phase {
+                title: "Phase 1".to_string(),
+                summary: "Single phase".to_string(),
+                steps: vec![
+                    Step {
+                        compound: "Step A".to_string(),
+                        rationale: String::new(),
+                        operations: vec!["op a1".to_string()],
+                        generality: vec![1],
+                        confidence: 0.9,
+                    },
+                    Step {
+                        compound: "Step B".to_string(),
+                        rationale: String::new(),
+                        operations: vec!["op b1".to_string()],
+                        generality: vec![1],
+                        confidence: 0.9,
+                    },
+                ],
+            }],
+            relationships: vec![],
+        }
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn report_outcome_updates_counters_and_writes_step_rows(pool: sqlx::PgPool) {
+        let ext = extraction("test-outcome-counters");
+        let ingest = do_ingest_workflow_via_pool(&pool, &ext).await.unwrap();
+        let workflow_id = Uuid::parse_str(&ingest.workflow_id).unwrap();
+
+        let steps = vec![
+            HierarchicalStepExecution {
+                step_index: 0,
+                planned: "Step A".to_string(),
+                actual: "Step A — done".to_string(),
+                deviated: false,
+                deviation_reason: None,
+            },
+            HierarchicalStepExecution {
+                step_index: 1,
+                planned: "Step B".to_string(),
+                actual: "Step B — pivoted".to_string(),
+                deviated: true,
+                deviation_reason: Some("blocked".to_string()),
+            },
+        ];
+
+        do_report_hierarchical_outcome_via_pool(
+            &pool,
+            workflow_id,
+            true,
+            &steps,
+            None,
+            Some("smoke run"),
+        )
+        .await
+        .expect("outcome must succeed");
+
+        let (metadata,): (serde_json::Value,) =
+            sqlx::query_as("SELECT metadata FROM workflows WHERE id = $1")
+                .bind(workflow_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(metadata["use_count"].as_i64(), Some(1));
+        assert_eq!(metadata["success_count"].as_i64(), Some(1));
+        assert_eq!(metadata["failure_count"].as_i64(), Some(0));
+
+        let exec_count: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM behavioral_executions WHERE workflow_id = $1")
+                .bind(workflow_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(exec_count, 2, "one row per step_execution");
+
+        let with_step_claim: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM behavioral_executions \
+             WHERE workflow_id = $1 AND step_claim_id IS NOT NULL",
+        )
+        .bind(workflow_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            with_step_claim, 2,
+            "every step_execution must resolve to a step claim node"
+        );
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn report_outcome_404s_for_unknown_workflow(pool: sqlx::PgPool) {
+        let bogus = Uuid::new_v4();
+        let err = do_report_hierarchical_outcome_via_pool(&pool, bogus, true, &[], None, None)
+            .await
+            .expect_err("unknown workflow id must error");
+        assert!(err.message.contains("no hierarchical workflow"));
+    }
+}

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 use crate::errors::{internal_error, McpError};
 use crate::server::EpiGraphMcpFull;
+use crate::types::IngestWorkflowParams;
 
 use epigraph_core::{AgentId, TruthValue};
 use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, WorkflowRepository};
@@ -259,6 +260,14 @@ pub async fn do_ingest_workflow(
 ) -> Result<CallToolResult, McpError> {
     let response = do_ingest_workflow_via_pool(&server.pool, extraction).await?;
     success_json(&response)
+}
+
+/// Param-driven MCP tool entry point. Thin wrapper over `do_ingest_workflow`.
+pub async fn ingest_workflow(
+    server: &EpiGraphMcpFull,
+    params: IngestWorkflowParams,
+) -> Result<CallToolResult, McpError> {
+    do_ingest_workflow(server, &params.extraction).await
 }
 
 // ── Internal helper ────────────────────────────────────────────────────────

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -367,6 +367,83 @@ pub struct DeprecateWorkflowParams {
     pub cascade: Option<bool>,
 }
 
+// ── Hierarchical Workflows ──
+//
+// The flat `StoreWorkflowParams` above models steps as plain strings on a
+// single root claim. The hierarchical primitive (issue #34) lands every
+// step as its own claim node connected to a `workflows` row via `executes`
+// edges, so each step accrues evidence and Darwinian variants independently.
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IngestWorkflowParams {
+    #[schemars(
+        description = "Hierarchical workflow extraction: source (canonical_name, goal, generation, authors, tags, metadata), thesis, thesis_derivation, phases (each with title/summary/steps where each step has compound, rationale, operations, generality, confidence), and relationships."
+    )]
+    pub extraction: epigraph_ingest::workflow::WorkflowExtraction,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindWorkflowHierarchicalParams {
+    #[schemars(
+        description = "Free-text search over hierarchical workflow goal and canonical_name (ILIKE)."
+    )]
+    pub query: String,
+
+    #[schemars(description = "Maximum number of workflows to return (default 10, max 50).")]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HierarchicalStepExecution {
+    #[schemars(
+        description = "Zero-based index of the step in the workflow's plan order (matches `executes`-edge ordering at level=2)."
+    )]
+    pub step_index: usize,
+
+    #[schemars(description = "What the workflow plan said to do for this step.")]
+    pub planned: String,
+
+    #[schemars(description = "What you actually did.")]
+    pub actual: String,
+
+    #[schemars(description = "true if the actual execution differed from the plan.")]
+    pub deviated: bool,
+
+    #[schemars(description = "Reason for deviation (if deviated is true).")]
+    pub deviation_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReportHierarchicalOutcomeParams {
+    #[schemars(
+        description = "UUID of the hierarchical workflow root (a row in the `workflows` table, not a flat workflow claim)."
+    )]
+    pub workflow_id: String,
+
+    #[schemars(description = "true if the workflow succeeded, false if it failed.")]
+    pub success: bool,
+
+    #[schemars(
+        description = "Per-step execution log. Each step_index is resolved to the step's claim node via `executes` edges so per-step evidence accrues."
+    )]
+    pub step_executions: Vec<HierarchicalStepExecution>,
+
+    #[schemars(
+        description = "Summary of what happened (e.g. 'Completed in 45s, all checks passed')."
+    )]
+    pub outcome_details: String,
+
+    #[schemars(
+        description = "Execution quality 0.0-1.0 (default: 1.0 if success, 0.0 if failure)."
+    )]
+    pub quality: Option<f64>,
+
+    #[schemars(
+        description = "Your specific goal for this run. More specific goal text improves future affinity matching."
+    )]
+    pub goal_text: Option<String>,
+}
+
 // ── Graph ──
 
 #[derive(Debug, Deserialize, JsonSchema)]


### PR DESCRIPTION
## Summary

PR #55 (issue #34) landed the hierarchical workflow primitive at the DB and API layers — every step becomes its own claim node connected to a `workflows` row via `executes` edges, so per-step evidence and Darwinian variants accrue independently. The MCP face still showed only the legacy flat-string `store_workflow` family, leaving agents unable to drive the new primitive.

This PR adds three MCP tools wrapping logic that already existed in `tools/workflow_ingest.rs` and the API routes:

- **`ingest_workflow`** — wraps `do_ingest_workflow` (idempotent persist of thesis → phases → steps → operation atoms with `executes` edges).
- **`find_workflow_hierarchical`** — ILIKE search over the `workflows` table (counterpart to `find_workflow` for flat workflows).
- **`report_hierarchical_outcome`** — updates rolling counters on `workflows.metadata` (`use_count`, `success_count`, `failure_count`, `avg_variance`) and writes per-step `behavioral_executions` rows with `step_claim_id` resolved from `executes` edges in plan order.

To pass `WorkflowExtraction` directly as a typed param (rather than a stringly-typed JSON `Value` with no schema signal for the calling LLM), `JsonSchema` is derived on the workflow ingest schema types and `schemars` is added as a dependency of `epigraph-ingest`.

## Test plan

- [x] `cargo build --release -p epigraph-mcp` clean
- [x] `cargo fmt` + `cargo clippy --release` clean for `epigraph-mcp` and `epigraph-ingest`
- [x] New `report_outcome_updates_counters_and_writes_step_rows` integration test in `workflow_hierarchical.rs::tests` (exercises ingest → outcome round-trip with two steps; asserts metadata counters and per-step `step_claim_id` resolution)
- [x] New `report_outcome_404s_for_unknown_workflow` test (asserts not-found error path)
- [x] End-to-end smoke against the live DB via stdio MCP transport:
  - [x] `ingest_workflow` → 5 claims, 5 `executes` edges, 4 relationships; re-ingest returns `already_ingested: true`
  - [x] `find_workflow_hierarchical` → returns the freshly ingested workflow
  - [x] `report_hierarchical_outcome` → `use_count=1`, `success_count=1`, 1 `behavioral_executions` row written
- [x] `tools/list` shows all three new tools alongside the legacy flat-workflow tools (no displacement)

## Notes

- No changes to existing tools or DB schema — purely additive on the MCP surface.
- `improve_workflow` (root-level variant_of) is intentionally not duplicated for hierarchical workflows here; per-step variant_of would be a separate `improve_step` tool, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)