### PR TITLE
feat(calibration): bridge DB evidence-type vocab to SciFact-calibrated weights

### DIFF
--- a/calibration.toml
+++ b/calibration.toml
@@ -57,6 +57,20 @@ testimonial     = 0.6
 circumstantial  = 0.4
 conversational  = 0.3
 
+# ── Evidence Type Aliases ───────────────────────────────────────────────────
+# Maps the DB's `evidence.evidence_type` enum values to the canonical
+# SciFact-calibration keys above. Without these aliases every lookup against
+# DB-stored evidence falls through to the 0.5 unknown-type default —
+# leaving the 295k+ NULL-source_strength BBAs effectively undiscounted
+# under the auto_wire_ds path. See bug #6 (sheaf stuck) for the symptom.
+
+[evidence_type_aliases]
+observation = "empirical"      # direct empirical observation
+computation = "statistical"    # computational / statistical analysis
+document    = "logical"        # claim asserted in a document
+reference   = "logical"        # citation to another claim/source
+testimony   = "testimonial"    # explicit agent testimony
+
 # ── Section Tier Weights ────────────────────────────────────────────────────
 # Fraction of informative mass retained (rest shifted to theta).
 

--- a/crates/epigraph-engine/src/calibration.rs
+++ b/crates/epigraph-engine/src/calibration.rs
@@ -37,6 +37,12 @@ pub struct CalibrationConfig {
     /// Evidence type → weight multiplier.
     pub evidence_type_weights: HashMap<String, f64>,
 
+    /// Alias → canonical evidence-type key. Bridges the DB's
+    /// `evidence.evidence_type` vocabulary onto the SciFact-calibrated
+    /// canonical keys in `evidence_type_weights`.
+    #[serde(default)]
+    pub evidence_type_aliases: HashMap<String, String>,
+
     /// Section tier → retention fraction (rest shifted to theta).
     pub section_tier_weights: HashMap<String, f64>,
 
@@ -123,9 +129,22 @@ impl CalibrationConfig {
     }
 
     /// Look up evidence type weight. Returns 0.5 for unknown types.
+    ///
+    /// Resolution order:
+    /// 1. Direct match against `evidence_type_weights` (canonical keys)
+    /// 2. Alias lookup → canonical → `evidence_type_weights`
+    /// 3. Fallback to 0.5
     pub fn get_evidence_type_weight(&self, evidence_type: &str) -> f64 {
         let key = evidence_type.to_lowercase();
-        self.evidence_type_weights.get(&key).copied().unwrap_or(0.5)
+        if let Some(&w) = self.evidence_type_weights.get(&key) {
+            return w;
+        }
+        if let Some(canonical) = self.evidence_type_aliases.get(&key) {
+            if let Some(&w) = self.evidence_type_weights.get(canonical) {
+                return w;
+            }
+        }
+        0.5
     }
 
     /// Look up section tier weight. Returns 1.0 for unknown sections (no discount).
@@ -278,6 +297,40 @@ mod tests {
 
         // Unknown type → 0.5
         assert!((cfg.get_evidence_type_weight("alien_telepathy") - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_evidence_type_aliases_resolve_to_canonical_weights() {
+        let cfg = load_config();
+
+        // DB-vocab values that should resolve via the alias table.
+        assert!(
+            (cfg.get_evidence_type_weight("observation") - 1.0).abs() < f64::EPSILON,
+            "observation → empirical (1.0)"
+        );
+        assert!(
+            (cfg.get_evidence_type_weight("computation") - 0.9).abs() < f64::EPSILON,
+            "computation → statistical (0.9)"
+        );
+        assert!(
+            (cfg.get_evidence_type_weight("document") - 0.85).abs() < f64::EPSILON,
+            "document → logical (0.85)"
+        );
+        assert!(
+            (cfg.get_evidence_type_weight("reference") - 0.85).abs() < f64::EPSILON,
+            "reference → logical (0.85)"
+        );
+        assert!(
+            (cfg.get_evidence_type_weight("testimony") - 0.6).abs() < f64::EPSILON,
+            "testimony → testimonial (0.6)"
+        );
+    }
+
+    #[test]
+    fn test_evidence_type_alias_is_case_insensitive() {
+        let cfg = load_config();
+        assert!((cfg.get_evidence_type_weight("OBSERVATION") - 1.0).abs() < f64::EPSILON);
+        assert!((cfg.get_evidence_type_weight("Reference") - 0.85).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The DB's `evidence.evidence_type` enum (`observation` / `computation` / `document` / `reference` / `testimony`) doesn't match the SciFact-calibrated weight table's vocabulary (`empirical` / `statistical` / `logical` / `testimonial` / etc.). Every lookup against DB-stored evidence has been falling through `get_evidence_type_weight`'s 0.5 unknown-default, so the calibrated weights have effectively been dead code for those rows.

Add `[evidence_type_aliases]` in `calibration.toml`. Update `get_evidence_type_weight` to fall through aliases before defaulting.

## Mapping
| DB type | Canonical | Weight |
|--|--|--|
| observation | empirical | 1.0 |
| computation | statistical | 0.9 |
| document | logical | 0.85 |
| reference | logical | 0.85 |
| testimony | testimonial | 0.6 |

## Test plan
- [x] `cargo test -p epigraph-engine calibration::` clean (15/15, including 2 new alias tests)
- [x] Case-insensitive alias resolution covered
- [x] Existing tests untouched (alias path is purely additive)