### PR TITLE
fix(ds): store evidence-type weight as source_strength, not agent confidence

### DIFF
--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -183,7 +183,7 @@ pub async fn auto_wire_ds_for_claim(
         &masses_json,
         None,
         Some("auto_wire"),
-        Some(weight), // source_strength = evidence-type reliability
+        Some(weight),  // source_strength = evidence-type reliability
         evidence_type, // evidence_type
     )
     .await

--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -169,7 +169,11 @@ pub async fn auto_wire_ds_for_claim(
         .await
         .map_err(|e| format!("assign_claim: {e}"))?;
 
-    // Store BBA (perspective_id=NULL for auto-wired)
+    // Store BBA (perspective_id=NULL for auto-wired). source_strength is the
+    // evidence-type reliability weight (used as Shafer's reliability discount
+    // at combination time). Agent confidence is already encoded in the BBA's
+    // mass shape (mass = confidence * weight, clamped); using `confidence`
+    // here would double-discount.
     MassFunctionRepository::store_with_perspective(
         pool,
         claim_id,
@@ -179,8 +183,8 @@ pub async fn auto_wire_ds_for_claim(
         &masses_json,
         None,
         Some("auto_wire"),
-        Some(confidence), // source_strength
-        evidence_type,    // evidence_type
+        Some(weight), // source_strength = evidence-type reliability
+        evidence_type, // evidence_type
     )
     .await
     .map_err(|e| format!("store BBA: {e}"))?;
@@ -259,6 +263,9 @@ pub async fn auto_wire_ds_update(
 
     // Store BBA — use evidence_id as perspective_id so each evidence submission
     // gets its own row instead of upsert-overwriting on (claim, frame, agent, NULL).
+    // source_strength = evidence-type reliability weight (used for Shafer
+    // discount at combination time); agent confidence is already in the
+    // BBA mass shape, storing it here too would double-discount.
     MassFunctionRepository::store_with_perspective(
         pool,
         claim_id,
@@ -268,7 +275,7 @@ pub async fn auto_wire_ds_update(
         &masses_json,
         None,
         Some("auto_wire"),
-        Some(confidence),  // source_strength
+        Some(weight),      // source_strength = evidence-type reliability
         evidence_type_str, // evidence_type
     )
     .await
@@ -383,8 +390,8 @@ async fn wire_single_batch_entry(
         &masses_json,
         None,
         Some("auto_wire"),
-        Some(entry.confidence), // source_strength
-        None,                   // evidence_type (not available in batch)
+        Some(entry.weight), // source_strength = evidence-type reliability
+        None,               // evidence_type (not threaded through batch yet)
     )
     .await
     .map_err(|e| format!("store BBA: {e}"))?;

--- a/crates/epigraph-mcp/tests/source_strength_tests.rs
+++ b/crates/epigraph-mcp/tests/source_strength_tests.rs
@@ -1,0 +1,84 @@
+//! Verify auto_wire_ds_update stores source_strength = evidence-type weight
+//! (not the agent confidence). The SciFact discount path uses source_strength
+//! as Shafer's reliability multiplier; conflating it with agent confidence
+//! double-discounts the BBA (the mass shape already encodes confidence).
+//!
+//! Bug #6 (sheaf stuck) was the user-visible symptom of the prior conflation.
+
+#[macro_use]
+mod common;
+
+use epigraph_mcp::tools;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent_and_claim(pool: &PgPool) -> (Uuid, Uuid) {
+    let agent_id = Uuid::new_v4();
+    let claim_id = Uuid::new_v4();
+    // Derive unique public_key + content_hash from the UUIDs so re-runs
+    // against a persistent test DB don't collide on previous fixtures.
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, $2)")
+        .bind(agent_id)
+        .bind(agent_id.as_bytes().repeat(2))
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(claim_id)
+    .bind(format!("source-strength regression {claim_id}"))
+    .bind(claim_id.as_bytes().repeat(2))
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("seed claim");
+    (agent_id, claim_id)
+}
+
+#[tokio::test]
+async fn auto_wire_ds_update_stores_weight_as_source_strength() {
+    let pool = test_pool_or_skip!();
+    let (agent_id, claim_id) = seed_agent_and_claim(&pool).await;
+
+    // Confidence and weight differ so we can tell which one was stored.
+    let confidence = 0.95;
+    let weight = 0.6;
+    let evidence_id = Uuid::new_v4();
+
+    tools::ds_auto::auto_wire_ds_update(
+        &pool,
+        claim_id,
+        agent_id,
+        confidence,
+        weight,
+        true, // supports
+        Some("testimony"),
+        Some(evidence_id),
+    )
+    .await
+    .expect("auto_wire_ds_update");
+
+    let stored: (Option<f64>, Option<String>) = sqlx::query_as(
+        "SELECT source_strength, evidence_type \
+           FROM mass_functions \
+          WHERE claim_id = $1 AND perspective_id = $2",
+    )
+    .bind(claim_id)
+    .bind(evidence_id)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch BBA");
+
+    let stored_strength = stored.0.expect("source_strength must be set");
+    assert!(
+        (stored_strength - weight).abs() < f64::EPSILON,
+        "source_strength should be the evidence-type weight ({weight}), got {stored_strength}"
+    );
+    assert!(
+        (stored_strength - confidence).abs() > 0.01,
+        "source_strength must NOT equal confidence ({confidence}); confidence is encoded in BBA shape"
+    );
+    assert_eq!(stored.1.as_deref(), Some("testimony"));
+}


### PR DESCRIPTION
## Summary
`ds_auto::auto_wire_ds_update` / `auto_wire_ds_for_claim` / `auto_wire_ds_batch` were storing the caller's `confidence` parameter as the BBA's `source_strength`. That conflated two distinct quantities:

- `confidence` — agent's expressed strength on the proposition
- `source_strength` — reliability of the evidence source class (used by Shafer's reliability discount during Dempster combination)

Agent confidence is already encoded in the BBA mass shape (`mass = confidence * weight`, clamped). Storing it again as `source_strength` caused the discount step to re-multiply by it, double-discounting low-confidence agents while leaving the intended evidence-type reliability unenforced.

## Why this matters (bug #6 piece 2)
This contributed directly to **bug #6 (sheaf stuck)**: for the 295k+ NULL-strength legacy rows, the discount step's NULL fallback (1.0) combined with no source_strength signal produced runaway accumulation — 21 mid-confidence supports → BetP=0.997 on the canonical hubs `720a6fce`, `a29c2b65`.

This PR is piece 2 of 3:
1. ✅ #75 — calibration alias bridge (DB vocab → SciFact-calibrated weights)
2. ✅ **this PR** — make new writes set `source_strength = evidence-type weight`
3. ⏭ Backfill the 295k existing NULL `source_strength` rows + `reconcile_sheaf`

## Change
- `auto_wire_ds_update`, `auto_wire_ds_for_claim`, `wire_single_batch_entry`: pass `weight` (not `confidence`) as `source_strength` to `MassFunctionRepository::store_with_perspective`.
- Comments updated to spell out the semantic.

## Test plan
- [x] `tests/source_strength_tests.rs` — calls `auto_wire_ds_update` with distinct confidence (0.95) and weight (0.6); asserts stored `source_strength=0.6` and `evidence_type='testimony'`.
- [x] `cargo build --tests -p epigraph-mcp` clean
- [x] No existing test asserted on the prior (incorrect) semantic, so no behavioural-test churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)