### PR TITLE
chore(docs): scrub private deployment specifics from comments

### DIFF
--- a/calibration.toml
+++ b/calibration.toml
@@ -60,9 +60,9 @@ conversational  = 0.3
 # ── Evidence Type Aliases ───────────────────────────────────────────────────
 # Maps the DB's `evidence.evidence_type` enum values to the canonical
 # SciFact-calibration keys above. Without these aliases every lookup against
-# DB-stored evidence falls through to the 0.5 unknown-type default —
-# leaving the 295k+ NULL-source_strength BBAs effectively undiscounted
-# under the auto_wire_ds path. See bug #6 (sheaf stuck) for the symptom.
+# DB-stored evidence falls through to the 0.5 unknown-type default, which
+# leaves any legacy NULL-source_strength BBAs effectively undiscounted under
+# the auto_wire_ds path.
 
 [evidence_type_aliases]
 observation = "empirical"      # direct empirical observation

--- a/crates/epigraph-mcp/tests/source_strength_tests.rs
+++ b/crates/epigraph-mcp/tests/source_strength_tests.rs
@@ -3,7 +3,8 @@
 //! as Shafer's reliability multiplier; conflating it with agent confidence
 //! double-discounts the BBA (the mass shape already encodes confidence).
 //!
-//! Bug #6 (sheaf stuck) was the user-visible symptom of the prior conflation.
+//! Sheaf cohomology stagnation (h1 frozen at the obstruction-rich extreme)
+//! is the visible symptom of the prior conflation.
 
 #[macro_use]
 mod common;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,13 +65,13 @@ in 5–6 h. Read-only against the database.
 ## backfill_source_strength.py
 
 One-shot backfill for `mass_functions.source_strength` rows that
-predate the evidence-type-weighted writer (PR #76). The discount
-path treats NULL as 1.0 (no discount), which is what produced the
-runaway hubs at BetP≈1.0 in bug #6.
+predate the evidence-type-weighted writer. The discount path treats
+NULL as 1.0 (no discount); under undiscounted Dempster combination
+even mid-confidence supporters can drive a target's BetP toward 1.0.
 
 For each NULL row:
 - If the claim has ≥1 evidence row: take the **highest** evidence-type
-  weight from `calibration.toml` (single source of truth, with PR #75's
+  weight from `calibration.toml` (single source of truth, with the
   DB-vocab aliases applied — and a hardcoded fallback if the alias
   section is absent). Best-evidence wins.
 - Otherwise: fall back to the agent-only / `conversational` tier (0.3).

--- a/scripts/backfill_source_strength.py
+++ b/scripts/backfill_source_strength.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 """Backfill `mass_functions.source_strength` for legacy NULL rows.
 
-The 295k pre-2026-04-08 mass-function rows have NULL `source_strength`,
-which the discount path treats as 1.0 (no discount) — undiscounted Dempster
-combination then runs away to BetP≈1.0 with even mid-confidence sources.
-This is bug #6 (sheaf stuck), explained at length in PR #75 and PR #76.
-
-This is **piece 3 of 3**: backfill the legacy NULLs by inferring each row's
-source_strength from its claim's evidence rows.
+Mass-function rows written before the evidence-type-weighted writer landed
+carry NULL `source_strength`. The discount path treats NULL as 1.0
+(no discount), so undiscounted Dempster combination runs away to BetP≈1.0
+with even mid-confidence supporting sources. Backfilling source_strength
+restores Shafer's reliability discount on the legacy rows.
 
 Policy:
   - For each NULL row with ≥1 attached evidence row: take the highest
     evidence-type weight (best-evidence wins) using the calibration map
-    + DB-vocab aliases shipped in PR #75.
-  - For each NULL row with no attached evidence (~82% of NULLs):
+    + DB-vocab aliases.
+  - For each NULL row with no attached evidence on the claim:
     use the conversational / agent-only tier (0.3).
 
 The mapping is loaded from `calibration.toml` at the repo root (single
@@ -24,8 +22,8 @@ Usage:
     python3 scripts/backfill_source_strength.py --execute  # commit
 
 After --execute, run reconcile_sheaf (or wait for the next nightly
-graph-integrity task) to re-aggregate beliefs. Most legacy hubs should
-move down from BetP≈1.0 to a value matching their support distribution.
+graph-integrity task) to re-aggregate beliefs against the new discount
+weights.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Replace specific row counts, hub UUIDs, and private bug-tracker references in script module-docs, README sections, calibration.toml comments, and test headers with generic phrasing. No code or behaviour changes — purely doc/comment scrubbing.

## Files
- `calibration.toml` — drop "295k+" specific count from the alias-section header.
- `scripts/backfill_source_strength.py` — generic module docstring (no specific row counts, no PR cross-refs).
- `scripts/README.md` — generic backfill section.
- `crates/epigraph-mcp/tests/source_strength_tests.rs` — generic header in place of "Bug #6".

## Test plan
- [x] `cargo check -p epigraph-engine -p epigraph-mcp` clean.
- [x] No `cargo fmt --check` or test impact (whitespace-equivalent).