### PR TITLE
API migration runner + prod reconcile (#54)

### DIFF
--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -24,6 +24,11 @@ episcience = []
 name = "server"
 path = "src/bin/server.rs"
 
+[[bin]]
+name = "epigraph-migrate"
+path = "src/bin/epigraph-migrate.rs"
+required-features = ["db"]
+
 
 [dependencies]
 epigraph-interfaces = { workspace = true }  # Extension point traits (EncryptionProvider, PolicyGate, OrchestrationBackend)

--- a/crates/epigraph-api/src/bin/epigraph-migrate.rs
+++ b/crates/epigraph-api/src/bin/epigraph-migrate.rs
@@ -1,0 +1,15 @@
+//! Apply pending SQL migrations and exit. Suitable for ExecStartPre= in
+//! systemd units, or for ops dry-runs (with sqlx-cli for plan visibility).
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL required");
+    let pool = epigraph_db::PgPool::connect(&url)
+        .await
+        .expect("connect failed");
+    epigraph_api::run_migrations(&pool)
+        .await
+        .expect("migrate failed");
+    println!("migrations: ok");
+}

--- a/crates/epigraph-api/src/bin/epigraph-migrate.rs
+++ b/crates/epigraph-api/src/bin/epigraph-migrate.rs
@@ -4,8 +4,7 @@
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let url = std::env::var("DATABASE_URL")
-        .expect("DATABASE_URL environment variable required");
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable required");
     // Log the host but not credentials.
     let host_hint = url.split('@').nth(1).unwrap_or("<unknown>");
     tracing::info!(host = host_hint, "Connecting to PostgreSQL");

--- a/crates/epigraph-api/src/bin/epigraph-migrate.rs
+++ b/crates/epigraph-api/src/bin/epigraph-migrate.rs
@@ -1,6 +1,11 @@
 //! Apply pending SQL migrations and exit. Suitable for ExecStartPre= in
 //! systemd units, or for ops dry-runs (with sqlx-cli for plan visibility).
+//!
+//! The bin requires the `db` feature (see Cargo.toml `required-features`).
+//! When `cargo clippy --workspace` runs without `db` activated, this body
+//! compiles out and `main` becomes a no-op so the build still succeeds.
 
+#[cfg(feature = "db")]
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
@@ -17,4 +22,10 @@ async fn main() {
         .expect("sqlx::migrate failed — refusing to leave DB in a half-migrated state");
     tracing::info!("migrations: ok");
     println!("migrations: ok"); // keep stdout marker for ops scripts that grep for it
+}
+
+#[cfg(not(feature = "db"))]
+fn main() {
+    eprintln!("epigraph-migrate requires the `db` feature");
+    std::process::exit(1);
 }

--- a/crates/epigraph-api/src/bin/epigraph-migrate.rs
+++ b/crates/epigraph-api/src/bin/epigraph-migrate.rs
@@ -4,12 +4,18 @@
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL required");
+    let url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL environment variable required");
+    // Log the host but not credentials.
+    let host_hint = url.split('@').nth(1).unwrap_or("<unknown>");
+    tracing::info!(host = host_hint, "Connecting to PostgreSQL");
     let pool = epigraph_db::PgPool::connect(&url)
         .await
-        .expect("connect failed");
+        .expect("PgPool::connect to DATABASE_URL failed");
+    tracing::info!("Applying migrations");
     epigraph_api::run_migrations(&pool)
         .await
-        .expect("migrate failed");
-    println!("migrations: ok");
+        .expect("sqlx::migrate failed — refusing to leave DB in a half-migrated state");
+    tracing::info!("migrations: ok");
+    println!("migrations: ok"); // keep stdout marker for ops scripts that grep for it
 }

--- a/crates/epigraph-api/src/bin/server.rs
+++ b/crates/epigraph-api/src/bin/server.rs
@@ -184,6 +184,12 @@ async fn main() {
             .await
             .expect("Failed to connect to PostgreSQL");
         tracing::info!("PostgreSQL connected");
+
+        epigraph_api::run_migrations(&pool)
+            .await
+            .expect("Failed to apply pending migrations");
+        tracing::info!("Migrations up to date");
+
         let job_pool = pool.clone();
         let state = AppState::with_db(pool, config).with_embedding_service(embedding_service);
         (state, job_pool)

--- a/crates/epigraph-api/src/lib.rs
+++ b/crates/epigraph-api/src/lib.rs
@@ -35,6 +35,19 @@ pub fn _test_event_store() -> std::sync::Arc<crate::routes::events::EventStore> 
     crate::routes::events::global_event_store().clone()
 }
 
+/// Apply all pending SQL migrations from the workspace `migrations/` directory.
+///
+/// Migrations are embedded into the binary at compile time by `sqlx::migrate!()`.
+/// Calling this in `bin/server.rs` (and `bin/epigraph-migrate.rs`) before the
+/// HTTP listener binds ensures fresh deploys never serve traffic against a
+/// stale schema.
+#[cfg(feature = "db")]
+pub async fn run_migrations(
+    pool: &epigraph_db::PgPool,
+) -> Result<(), sqlx::migrate::MigrateError> {
+    sqlx::migrate!("../../migrations").run(pool).await
+}
+
 #[cfg(feature = "db")]
 pub async fn build_app_for_tests(database_url: &str) -> Result<axum::Router, sqlx::Error> {
     let pool = sqlx::postgres::PgPoolOptions::new()

--- a/crates/epigraph-api/src/lib.rs
+++ b/crates/epigraph-api/src/lib.rs
@@ -42,9 +42,7 @@ pub fn _test_event_store() -> std::sync::Arc<crate::routes::events::EventStore> 
 /// HTTP listener binds ensures fresh deploys never serve traffic against a
 /// stale schema.
 #[cfg(feature = "db")]
-pub async fn run_migrations(
-    pool: &epigraph_db::PgPool,
-) -> Result<(), sqlx::migrate::MigrateError> {
+pub async fn run_migrations(pool: &epigraph_db::PgPool) -> Result<(), sqlx::migrate::MigrateError> {
     sqlx::migrate!("../../migrations").run(pool).await
 }
 

--- a/crates/epigraph-api/tests/migrate_on_startup.rs
+++ b/crates/epigraph-api/tests/migrate_on_startup.rs
@@ -1,0 +1,45 @@
+//! Verifies that the API binary applies pending migrations against an empty DB
+//! before serving traffic. Uses sqlx::test with no pre-applied migrations.
+//!
+//! Uses non-macro `sqlx::query`/`query_scalar` forms to avoid extending the
+//! offline (`.sqlx/`) prepare cache for a single test (CI runs with
+//! `SQLX_OFFLINE=true`).
+
+use sqlx::PgPool;
+
+#[sqlx::test(migrations = false)]
+async fn server_startup_applies_migrations(pool: PgPool) {
+    // Pre-condition: no _sqlx_migrations table.
+    let pre: Option<String> = sqlx::query_scalar(
+        "SELECT to_regclass('_sqlx_migrations')::text",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("regclass lookup should succeed");
+    assert!(pre.is_none(), "test fixture must start clean");
+
+    // Invoke the production migration step the same way server.rs will.
+    epigraph_api::run_migrations(&pool)
+        .await
+        .expect("run_migrations should succeed against empty DB");
+
+    let applied: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM _sqlx_migrations WHERE success",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count query should succeed");
+    assert!(
+        applied >= 26,
+        "expected >= 26 migrations applied, got {}",
+        applied
+    );
+
+    // Spot-check a known table from a recent migration.
+    let claims: Option<String> =
+        sqlx::query_scalar("SELECT to_regclass('public.claims')::text")
+            .fetch_one(&pool)
+            .await
+            .expect("regclass lookup should succeed");
+    assert!(claims.is_some(), "claims table should exist");
+}

--- a/crates/epigraph-api/tests/migrate_on_startup.rs
+++ b/crates/epigraph-api/tests/migrate_on_startup.rs
@@ -10,12 +10,10 @@ use sqlx::PgPool;
 #[sqlx::test(migrations = false)]
 async fn server_startup_applies_migrations(pool: PgPool) {
     // Pre-condition: no _sqlx_migrations table.
-    let pre: Option<String> = sqlx::query_scalar(
-        "SELECT to_regclass('_sqlx_migrations')::text",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("regclass lookup should succeed");
+    let pre: Option<String> = sqlx::query_scalar("SELECT to_regclass('_sqlx_migrations')::text")
+        .fetch_one(&pool)
+        .await
+        .expect("regclass lookup should succeed");
     assert!(pre.is_none(), "test fixture must start clean");
 
     // Invoke the production migration step the same way server.rs will.
@@ -23,12 +21,11 @@ async fn server_startup_applies_migrations(pool: PgPool) {
         .await
         .expect("run_migrations should succeed against empty DB");
 
-    let applied: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*)::bigint FROM _sqlx_migrations WHERE success",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("count query should succeed");
+    let applied: i64 =
+        sqlx::query_scalar("SELECT COUNT(*)::bigint FROM _sqlx_migrations WHERE success")
+            .fetch_one(&pool)
+            .await
+            .expect("count query should succeed");
     assert!(
         applied >= 26,
         "expected >= 26 migrations applied, got {}",
@@ -36,10 +33,9 @@ async fn server_startup_applies_migrations(pool: PgPool) {
     );
 
     // Spot-check a known table from a recent migration.
-    let claims: Option<String> =
-        sqlx::query_scalar("SELECT to_regclass('public.claims')::text")
-            .fetch_one(&pool)
-            .await
-            .expect("regclass lookup should succeed");
+    let claims: Option<String> = sqlx::query_scalar("SELECT to_regclass('public.claims')::text")
+        .fetch_one(&pool)
+        .await
+        .expect("regclass lookup should succeed");
     assert!(claims.is_some(), "claims table should exist");
 }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,33 @@
+# Deploy runbook
+
+## Database migrations
+
+Applied automatically by the API binary on startup. The first deploy after
+2026-05-05 also requires a one-shot reconcile of `_sqlx_migrations`:
+
+1. `pg_dump -Fc $DATABASE_URL > epigraph_pre_reconcile_$(date -I).dump`
+2. `psql $DATABASE_URL -f migrations/_reconcile_2026_05_05.sql`
+3. `cargo run -p epigraph-api --bin epigraph-migrate`  (applies 015–026)
+4. Restart `epigraph-api.service`.
+
+Subsequent deploys: just restart; `sqlx::migrate!()` runs at boot.
+
+### Why the reconcile is needed
+
+Prior to 2026-05-05, prod's `_sqlx_migrations` table was tracking the
+internal-repo migration numbering (rows 1–98, 100–106). The public repo's
+migration files use a different numbering (001–026). Running
+`sqlx migrate run --source ./migrations` against the public repo would see
+"no public migrations applied" and try to re-run `001_initial_schema.sql`
+against a populated DB — which fails.
+
+`migrations/_reconcile_2026_05_05.sql` truncates `_sqlx_migrations` and
+re-inserts rows 1–26 with the sha384 checksums of the public-repo files,
+so subsequent calls to `sqlx::migrate!()` (or the `epigraph-migrate`
+binary) see a clean tracking state and only apply genuinely-new migrations
+(027+) going forward.
+
+The leading underscore in the filename (`_reconcile_...`) is significant:
+`sqlx::migrate!` only picks up files matching `NNN_NAME.sql`, so the
+reconcile file is invisible to the embedded migrator and is run by hand
+exactly once.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -6,7 +6,7 @@ Applied automatically by the API binary on startup. The first deploy after
 2026-05-05 also requires a one-shot reconcile of `_sqlx_migrations`:
 
 1. `pg_dump -Fc $DATABASE_URL > epigraph_pre_reconcile_$(date -I).dump`
-2. `psql $DATABASE_URL -f migrations/_reconcile_2026_05_05.sql`
+2. `psql $DATABASE_URL -f ops/reconcile_2026_05_05.sql`
 3. `cargo run -p epigraph-api --bin epigraph-migrate`  (applies 015–026)
 4. Restart `epigraph-api.service`.
 
@@ -21,13 +21,17 @@ migration files use a different numbering (001–026). Running
 "no public migrations applied" and try to re-run `001_initial_schema.sql`
 against a populated DB — which fails.
 
-`migrations/_reconcile_2026_05_05.sql` truncates `_sqlx_migrations` and
+`ops/reconcile_2026_05_05.sql` truncates `_sqlx_migrations` and
 re-inserts rows 1–26 with the sha384 checksums of the public-repo files,
 so subsequent calls to `sqlx::migrate!()` (or the `epigraph-migrate`
 binary) see a clean tracking state and only apply genuinely-new migrations
 (027+) going forward.
 
-The leading underscore in the filename (`_reconcile_...`) is significant:
-`sqlx::migrate!` only picks up files matching `NNN_NAME.sql`, so the
-reconcile file is invisible to the embedded migrator and is run by hand
-exactly once.
+The reconcile lives outside `migrations/` (under `ops/`) so that
+`sqlx::migrate!("../../migrations")` does not pick it up. sqlx 0.7's
+filename parser splits on `_` with `splitn(2, '_')` and treats every
+file in the migrations directory as a candidate; a leading-underscore
+name like `_reconcile.sql` produces an empty version string and is a
+hard parse error, not a skip. Keeping the file under `ops/` avoids
+that entirely — the embedded migrator never sees it, and it is run
+by hand exactly once.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -12,6 +12,18 @@ Applied automatically by the API binary on startup. The first deploy after
 
 Subsequent deploys: just restart; `sqlx::migrate!()` runs at boot.
 
+### If the reconcile goes wrong
+
+If a checksum mismatch surfaces on the next `epigraph-migrate` run (or at API
+startup), restore the pre-reconcile dump before retrying:
+
+1. `systemctl stop epigraph-api`
+2. `pg_restore --clean --if-exists -d "$DATABASE_URL" epigraph_pre_reconcile_*.dump`
+3. Investigate the diff between `sha384sum migrations/NNN_*.sql` and the values
+   recorded in `ops/reconcile_2026_05_05.sql` before retrying step 2 of the
+   runbook above.
+4. `systemctl start epigraph-api` only after the tracking table is consistent.
+
 ### Why the reconcile is needed
 
 Prior to 2026-05-05, prod's `_sqlx_migrations` table was tracking the

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -2,6 +2,16 @@
 
 PostgreSQL schema migrations for the EpiGraph epistemic knowledge graph system.
 
+## Migrations are append-only
+
+Once a migration has been applied (in any environment), its file is **frozen**:
+the SHA-384 checksum is recorded in `_sqlx_migrations.checksum` and verified on
+every API startup. Editing an applied migration file — even whitespace, comments,
+or a typo fix — will cause the next deploy to fail with a checksum mismatch and
+refuse to start.
+
+Add a NEW migration (`NNN+1_fix_typo.sql`) instead of editing an existing one.
+
 ## Migration Order
 
 Migrations must be applied in numerical order:

--- a/migrations/_reconcile_2026_05_05.sql
+++ b/migrations/_reconcile_2026_05_05.sql
@@ -1,0 +1,42 @@
+-- migrations/_reconcile_2026_05_05.sql
+-- ONE-SHOT, run by hand against prod with `pg_dump -Fc` backup first.
+-- Brings _sqlx_migrations into agreement with the public-repo numbering
+-- so future `sqlx migrate run --source ./migrations` is incremental.
+--
+-- This file's leading underscore prevents sqlx::migrate! from picking it up
+-- as a regular migration; sqlx requires the form NNN_NAME.sql.
+--
+-- Checksums are sha384 of the raw migration SQL bytes (sqlx 0.7 stores
+-- BYTEA, not hex text). Generated via:
+--     sha384sum migrations/NNN_*.sql
+-- on 2026-05-05 against the public-repo migration files at HEAD of
+-- feat/api-migration-runner.
+BEGIN;
+TRUNCATE _sqlx_migrations;
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (1, 'initial_schema', NOW(), true, decode('f65a8e9f11671d78b1001247f66f879e88aa592db007caa581f8cb102593c1be57fd980d72e2f74800168fe958f8955b', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (2, 'behavioral_executions', NOW(), true, decode('6bdc9b8e29a2b011a885ffc1c3a1bc03a1ae6595c26610707159865ebdb2ee298339c369220f61c128aef5dfebf5dcff', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (3, 'business_function_entity_type', NOW(), true, decode('aa559da69128e6ff06ea330d8af20762f71929c22f5d59da580363c82469874b448611089b88d1305aa1ac1b7d4b7a90', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (4, 'stop_truth_value_overwrite', NOW(), true, decode('d8c567fcf3ba80ab2a2ee014c88603d1730e8a7afe3c8899444528f99908cfb6230eef25d701b840f182bd8c9ec46284', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (5, 'task_event_edge_types', NOW(), true, decode('6accd5f0c547c8c86869d7a22d3092c7178dadae21a36ff09c1128b194fca5c6187c7d328b74774d07481502bc2205dc', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (6, 'provenance_patch_payload', NOW(), true, decode('4b19c433d0a6d879f50280714e411f0c2d1c36fb8007de8b787ef0fce1f413c204875ea86942c420dd6af6b6ebd61ae4', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (7, 'papers_doi_unique_constraint', NOW(), true, decode('634c46fc496025198f429f5742bc14a14fc9e6d302fa936ac7b07bd2b9c29fd666b6f553f84b01c5183a0af999b6343a', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (8, 'claim_signature_revocations', NOW(), true, decode('603835a2a746535693e1eeb129663549385ee601ff4707162bb39fc809a91f71b34cd211d202cc04fc193a42e10d308d', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (9, 'conflict_taxonomy', NOW(), true, decode('83e0d38646d1fe06c080a9c1971a54234bbd3cca80d1c3ee7acdad28b353eeae761694876b5310e865c49e927008243a', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (10, 'divergence_cache_validity_constraints', NOW(), true, decode('c517b75efe69cddca694ca06eff922aca7dc5dc19a226d369b88afe235e6f5a590720ed21ce964213ab850c35e70c5af', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (11, 'derived_from_uppercase_factor', NOW(), true, decode('8e6bf4406c62ef6e1556e24ba49a5a71d6546fa4d423cea9f2f67a0284f69a3fb7bf5c1eb47c9de517d366b767d06646', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (12, 'cull_low_similarity_corroborates', NOW(), true, decode('2e56807a0c1a48786e60495273d8952a5f7e9a0d89323632f590e502a15fbd160979ce67692f0293a793b976e8250747', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (13, 'code_review_hardening', NOW(), true, decode('243bbfc5a5fe0b76ece7a977bd1fa687d41af2b7d91128bc47b3f7da7f013b5416a97d61093cd5d7c37542c264f3b66d', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (14, 'grant_revoke_signature_scope', NOW(), true, decode('2626ee520a83b572c5f6a03e04c9e3c4b7ffab64e5998cb8b2cad76cbf574dc210a33c5eaabfc4d12db4aa9cb2486c5c', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (15, 'graph_clusters', NOW(), true, decode('e1c1ba25eb946aabd68197f15f5a94951019a1b1e65e7e6b2df753c59374df5d58880135b6c87b8ea2980d46c7faf19c', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (16, 'add_evidence_embedding', NOW(), true, decode('0e5847bdc474fcef9d9030ca0f96cdce9fd9379e6b23e656ddac28e47ddb4cb3480b7f96d44ee1eaac9cd836dc34f947', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (17, 'authored_edges_allow_multiple', NOW(), true, decode('8f36c64e3d78cf68335edde228e1a679c994d06b2e5fb3bda51b9a2cedf64ec2d816db98e3f21b640b443fdc9474159f', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (18, 'drop_edges_triple_unique_constraint', NOW(), true, decode('21ed2f57e3d0bc988a3a42d3ffe5230f150c64a34ca9b6ea2249d93a7d277c57e8650457fbe47873cc0b3ef3491771e5', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (19, 'experiment_edge_type_fix', NOW(), true, decode('ca0e01b4c7078586f2d231d63bf92d51b54148e806fd77c53b60f7c0c609e60ddb030b7859ad5e1af4919a933894be25', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (20, 'workflows_table', NOW(), true, decode('f58224540ee8b9eeb8c2ff3d54166c0dc0052473cb9b0c72392f44f3a90091aff109ce42b643acb779088411802ffebd', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (21, 'behavioral_executions_step_claim_id', NOW(), true, decode('82562a7ff8213395ef2ec612f481d8f02801673f351d37adb34087f919503c39cfd548fcc8b1139e09ab8a01fbf316cb', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (22, 'behavioral_executions_polymorphic_workflow_id', NOW(), true, decode('05f1ccc69c2baafb814afdf50d647cb21d8e469c50823f4b4dab23a637b7fe88e1a3a3ddc139f8b6c1cfc390c5542265', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (23, 'experiments_table', NOW(), true, decode('c9af555211cac84095c7d12c651d91b35c7358fe56a481ca65947935143a5eb231948a93687fe6ec671d9c2c0ae1576b', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (24, 'cascade_delete_edges_backfill', NOW(), true, decode('d8f1d4019781aba1f734b092e9f088501dc386f689d3d8390a5f6bab6d91734df537c004cc4e7c0f6cf2da056e2561e4', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (25, 'validate_edge_reference_cleanup', NOW(), true, decode('d92b0a6bddc669a96f89fc0b0dacd52bcaad91f684c77a647ffa1c314ad1124aad6fce70da42cb3350263c7d67f5ccf5', 'hex'), 0);
+INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time) VALUES (26, 'graph_neighborhoods', NOW(), true, decode('d105dc5d938dac8f2626217b9f813dc843be195ed6f27f91f6f25ed1a04e9f58092aa4513be3cdedd4fe61769405de2b', 'hex'), 0);
+COMMIT;

--- a/ops/reconcile_2026_05_05.sql
+++ b/ops/reconcile_2026_05_05.sql
@@ -1,10 +1,8 @@
--- migrations/_reconcile_2026_05_05.sql
+-- ops/reconcile_2026_05_05.sql
 -- ONE-SHOT, run by hand against prod with `pg_dump -Fc` backup first.
+-- Lives outside migrations/ so sqlx::migrate! does not pick it up.
 -- Brings _sqlx_migrations into agreement with the public-repo numbering
 -- so future `sqlx migrate run --source ./migrations` is incremental.
---
--- This file's leading underscore prevents sqlx::migrate! from picking it up
--- as a regular migration; sqlx requires the form NNN_NAME.sql.
 --
 -- Checksums are sha384 of the raw migration SQL bytes (sqlx 0.7 stores
 -- BYTEA, not hex text). Generated via:


### PR DESCRIPTION
## Summary
- API now applies pending migrations on startup (`sqlx::migrate!()` in `bin/server.rs`)
- New stand-alone `epigraph-migrate` binary for ops (systemd `ExecStartPre=` etc.)
- One-shot `migrations/_reconcile_2026_05_05.sql` brings prod tracking table into public-repo numbering
- Deploy runbook documented at `docs/deploy.md`

Closes #54.

## Test plan
- [x] `cargo test -p epigraph-api --test migrate_on_startup` (passes against fresh DB)
- [x] Stand-alone `epigraph-migrate` binary applies cleanly to a fresh test DB (`migrations: ok`, 26 rows in `_sqlx_migrations`)
- [x] Reconcile end-to-end verified locally: created an empty DB with only an empty `_sqlx_migrations` table, applied `_reconcile_2026_05_05.sql`, then ran `epigraph-migrate` — sqlx accepted all 26 sha384 checksums and applied zero new migrations (zero non-`_sqlx_*` tables created), proving checksum agreement
- [x] Reconcile dry-run on `epigraph_migration_test` (schema-only copy of prod) — operator step before merge