### PR TITLE
Ingest common helpers + edge-case tests (#43)

### DIFF
--- a/crates/epigraph-ingest/src/builder.rs
+++ b/crates/epigraph-ingest/src/builder.rs
@@ -2,5 +2,6 @@
 //! builder lives in `workflow::builder`. Re-exports here keep existing
 //! `epigraph_ingest::build_ingest_plan` callers compiling.
 
+pub use crate::common::paths::normalize_claim_path;
 pub use crate::common::plan::{IngestPlan, PlannedClaim, PlannedEdge};
-pub use crate::document::builder::{build_ingest_plan, normalize_claim_path};
+pub use crate::document::builder::build_ingest_plan;

--- a/crates/epigraph-ingest/src/common/edges.rs
+++ b/crates/epigraph-ingest/src/common/edges.rs
@@ -1,0 +1,35 @@
+//! Edge helpers shared by the document and workflow walkers.
+//!
+//! These were previously duplicated verbatim in `document/builder.rs` and
+//! `workflow/builder.rs`. Centralizing them here keeps the two walkers in
+//! lockstep and gives the executor crate a single import surface.
+
+use uuid::Uuid;
+
+use crate::common::plan::PlannedEdge;
+use crate::common::schema::ThesisDerivation;
+
+/// String representation of a `ThesisDerivation` enum, used as an edge property.
+#[must_use]
+pub const fn thesis_derivation_str(td: &ThesisDerivation) -> &'static str {
+    match td {
+        ThesisDerivation::TopDown => "TopDown",
+        ThesisDerivation::BottomUp => "BottomUp",
+    }
+}
+
+/// Build a `decomposes_to` edge between two claim nodes. Used for parent →
+/// child relationships in the hierarchy (thesis → section, section →
+/// paragraph, paragraph → atom; or workflow root → phase, phase → step,
+/// step → operation).
+#[must_use]
+pub fn decomposes_edge(source_id: Uuid, target_id: Uuid) -> PlannedEdge {
+    PlannedEdge {
+        source_id,
+        source_type: "claim".to_string(),
+        target_id,
+        target_type: "claim".to_string(),
+        relationship: "decomposes_to".to_string(),
+        properties: serde_json::json!({}),
+    }
+}

--- a/crates/epigraph-ingest/src/common/mod.rs
+++ b/crates/epigraph-ingest/src/common/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod edges;
 pub mod ids;
+pub mod paths;
 pub mod plan;
 pub mod schema;
 pub mod walker;

--- a/crates/epigraph-ingest/src/common/mod.rs
+++ b/crates/epigraph-ingest/src/common/mod.rs
@@ -2,6 +2,7 @@
 //! walker, ID derivation namespaces, and plan types live here. Document-
 //! and workflow-specific schemas wrap them in `document::` and `workflow::`.
 
+pub mod edges;
 pub mod ids;
 pub mod plan;
 pub mod schema;

--- a/crates/epigraph-ingest/src/common/paths.rs
+++ b/crates/epigraph-ingest/src/common/paths.rs
@@ -1,0 +1,33 @@
+//! Path-string helpers shared by the document and workflow walkers.
+//!
+//! `normalize_claim_path` previously lived in `document/builder.rs` and was
+//! imported cross-module by `workflow/builder.rs`. It is logic-agnostic to
+//! either artifact type, so it belongs here.
+
+/// Convert slash-delimited paths from extraction ("sections/0/paragraphs/1/atoms/2")
+/// to the bracket-dot notation used by path_index ("sections[0].paragraphs[1].atoms[2]").
+/// Passes through paths that are already in bracket-dot format unchanged.
+#[must_use]
+pub fn normalize_claim_path(path: &str) -> String {
+    if path.contains('[') {
+        return path.to_string();
+    }
+    let parts: Vec<&str> = path.split('/').collect();
+    let mut result = String::new();
+    let mut i = 0;
+    while i < parts.len() {
+        if i > 0 {
+            result.push('.');
+        }
+        result.push_str(parts[i]);
+        if i + 1 < parts.len() && parts[i + 1].parse::<usize>().is_ok() {
+            result.push('[');
+            result.push_str(parts[i + 1]);
+            result.push(']');
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    result
+}

--- a/crates/epigraph-ingest/src/document/builder.rs
+++ b/crates/epigraph-ingest/src/document/builder.rs
@@ -7,36 +7,9 @@ use uuid::Uuid;
 
 use crate::common::edges::{decomposes_edge, thesis_derivation_str};
 use crate::common::ids::{atom_id, compound_claim_id, content_hash};
+use crate::common::paths::normalize_claim_path;
 use crate::common::plan::{IngestPlan, PlannedClaim, PlannedEdge};
 use crate::document::schema::{DocumentExtraction, Paragraph, SourceType};
-
-/// Convert slash-delimited paths from extraction ("sections/0/paragraphs/1/atoms/2")
-/// to the bracket-dot notation used by path_index ("sections[0].paragraphs[1].atoms[2]").
-/// Passes through paths that are already in bracket-dot format unchanged.
-#[must_use]
-pub fn normalize_claim_path(path: &str) -> String {
-    if path.contains('[') {
-        return path.to_string();
-    }
-    let parts: Vec<&str> = path.split('/').collect();
-    let mut result = String::new();
-    let mut i = 0;
-    while i < parts.len() {
-        if i > 0 {
-            result.push('.');
-        }
-        result.push_str(parts[i]);
-        if i + 1 < parts.len() && parts[i + 1].parse::<usize>().is_ok() {
-            result.push('[');
-            result.push_str(parts[i + 1]);
-            result.push(']');
-            i += 2;
-            continue;
-        }
-        i += 1;
-    }
-    result
-}
 
 const fn source_type_str(st: &SourceType) -> &'static str {
     match st {

--- a/crates/epigraph-ingest/src/document/builder.rs
+++ b/crates/epigraph-ingest/src/document/builder.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use crate::common::edges::{decomposes_edge, thesis_derivation_str};
 use crate::common::ids::{atom_id, compound_claim_id, content_hash};
 use crate::common::plan::{IngestPlan, PlannedClaim, PlannedEdge};
-use crate::common::schema::ThesisDerivation;
 use crate::document::schema::{DocumentExtraction, Paragraph, SourceType};
 
 /// Convert slash-delimited paths from extraction ("sections/0/paragraphs/1/atoms/2")
@@ -47,24 +47,6 @@ const fn source_type_str(st: &SourceType) -> &'static str {
         SourceType::Transcript => "Transcript",
         SourceType::Legal => "Legal",
         SourceType::Tabular => "Tabular",
-    }
-}
-
-const fn thesis_derivation_str(td: &ThesisDerivation) -> &'static str {
-    match td {
-        ThesisDerivation::TopDown => "TopDown",
-        ThesisDerivation::BottomUp => "BottomUp",
-    }
-}
-
-fn decomposes_edge(source_id: Uuid, target_id: Uuid) -> PlannedEdge {
-    PlannedEdge {
-        source_id,
-        source_type: "claim".to_string(),
-        target_id,
-        target_type: "claim".to_string(),
-        relationship: "decomposes_to".to_string(),
-        properties: serde_json::json!({}),
     }
 }
 

--- a/crates/epigraph-ingest/src/lib.rs
+++ b/crates/epigraph-ingest/src/lib.rs
@@ -706,8 +706,7 @@ mod tests {
         }"#;
 
         let plan_with = crate::workflow::build_ingest_plan(&make_workflow(json_with_parent));
-        let plan_without =
-            crate::workflow::build_ingest_plan(&make_workflow(json_without_parent));
+        let plan_without = crate::workflow::build_ingest_plan(&make_workflow(json_without_parent));
 
         // Workflow root claim (the thesis, level 0) should exist and be
         // derived from the variant's canonical_name, not the parent's.

--- a/crates/epigraph-ingest/src/lib.rs
+++ b/crates/epigraph-ingest/src/lib.rs
@@ -585,4 +585,173 @@ mod tests {
             "compound nodes must NOT converge across workflows with different canonical_name"
         );
     }
+
+    #[test]
+    fn test_workflow_build_plan_no_thesis() {
+        // Symmetric to test_build_plan_no_thesis on the document side: a workflow
+        // with thesis: null should produce zero level-0 claims and zero
+        // thesis-derived decomposes_to edges (i.e. nothing at the thesis→phase
+        // step). All other phase/step structure should still be planned.
+        let json = r#"{
+            "source": {"canonical_name": "no-thesis-wf", "goal": "G", "authors": []},
+            "thesis": null,
+            "thesis_derivation": "BottomUp",
+            "phases": [{
+                "title": "P1",
+                "summary": "Phase summary",
+                "steps": [{
+                    "compound": "Compound step",
+                    "operations": ["op-text"],
+                    "generality": [1],
+                    "confidence": 0.8
+                }]
+            }],
+            "relationships": []
+        }"#;
+
+        let plan = crate::workflow::build_ingest_plan(&make_workflow(json));
+
+        let level0 = plan.claims.iter().filter(|c| c.level == 0).count();
+        assert_eq!(level0, 0, "no thesis → no level-0 claim");
+
+        // Phase/step/operation should still exist: 1 phase + 1 step + 1 op.
+        assert_eq!(
+            plan.claims.len(),
+            3,
+            "0 thesis + 1 phase + 1 step + 1 op = 3 claims"
+        );
+
+        // decomposes_to edges should NOT include thesis→phase: only
+        // phase→step and step→op.
+        let decompose_count = plan
+            .edges
+            .iter()
+            .filter(|e| e.relationship == "decomposes_to")
+            .count();
+        assert_eq!(decompose_count, 2, "phase->step, step->op (no thesis edge)");
+    }
+
+    #[test]
+    fn test_workflow_phases_without_steps() {
+        // A workflow with phases but each phase has zero steps. This exercises
+        // the empty-children path that the existing `phase_follows` test only
+        // touches incidentally. Asserts the planner emits L1 phase claims but
+        // no L2 step claims, no L3 operation claims, and no step_follows edges.
+        let json = r#"{
+            "source": {"canonical_name": "empty-phases", "goal": "G", "authors": []},
+            "thesis": "Top-level thesis",
+            "phases": [
+                {"title": "P1", "summary": "First phase", "steps": []},
+                {"title": "P2", "summary": "Second phase", "steps": []}
+            ],
+            "relationships": []
+        }"#;
+
+        let plan = crate::workflow::build_ingest_plan(&make_workflow(json));
+
+        let level1 = plan.claims.iter().filter(|c| c.level == 1).count();
+        let level2 = plan.claims.iter().filter(|c| c.level == 2).count();
+        let level3 = plan.claims.iter().filter(|c| c.level == 3).count();
+        assert_eq!(level1, 2, "two phases as level-1 claims");
+        assert_eq!(level2, 0, "no steps → no level-2 claims");
+        assert_eq!(level3, 0, "no operations → no level-3 claims");
+
+        let step_follows = plan
+            .edges
+            .iter()
+            .filter(|e| e.relationship == "step_follows")
+            .count();
+        assert_eq!(step_follows, 0, "no steps → no step_follows edges");
+    }
+
+    #[test]
+    fn test_workflow_with_parent_canonical_name() {
+        // The planner does NOT consume `parent_canonical_name` — the
+        // `variant_of` edge between this workflow and its parent is the
+        // executor's responsibility (emitted by epigraph-mcp::tools::workflow_ingest
+        // once the workflow row is created). This test pins that contract:
+        //   1. Plans built from the same variant with vs without
+        //      `parent_canonical_name` set produce identical hierarchical
+        //      claim IDs (proves the planner ignores parent for ID derivation).
+        //   2. No `variant_of` edge appears in the plan output.
+        let json_with_parent = r#"{
+            "source": {
+                "canonical_name": "variant_v2",
+                "goal": "G",
+                "parent_canonical_name": "parent_workflow_v1",
+                "authors": []
+            },
+            "thesis": "Variant thesis",
+            "phases": [{
+                "title": "P1",
+                "summary": "Phase summary",
+                "steps": []
+            }],
+            "relationships": []
+        }"#;
+
+        let json_without_parent = r#"{
+            "source": {
+                "canonical_name": "variant_v2",
+                "goal": "G",
+                "authors": []
+            },
+            "thesis": "Variant thesis",
+            "phases": [{
+                "title": "P1",
+                "summary": "Phase summary",
+                "steps": []
+            }],
+            "relationships": []
+        }"#;
+
+        let plan_with = crate::workflow::build_ingest_plan(&make_workflow(json_with_parent));
+        let plan_without =
+            crate::workflow::build_ingest_plan(&make_workflow(json_without_parent));
+
+        // Workflow root claim (the thesis, level 0) should exist and be
+        // derived from the variant's canonical_name, not the parent's.
+        let thesis_with = plan_with
+            .claims
+            .iter()
+            .find(|c| c.level == 0)
+            .expect("variant has thesis");
+        let thesis_without = plan_without
+            .claims
+            .iter()
+            .find(|c| c.level == 0)
+            .expect("variant has thesis");
+        assert_eq!(
+            thesis_with.id, thesis_without.id,
+            "thesis ID derives from variant canonical_name; parent_canonical_name must not affect it"
+        );
+
+        // L1 phase claim IDs should also match (further proof the parent is
+        // not folded into the compound seed).
+        let phase_with = plan_with
+            .claims
+            .iter()
+            .find(|c| c.level == 1)
+            .expect("variant has phase");
+        let phase_without = plan_without
+            .claims
+            .iter()
+            .find(|c| c.level == 1)
+            .expect("variant has phase");
+        assert_eq!(
+            phase_with.id, phase_without.id,
+            "phase ID derives from variant canonical_name; parent_canonical_name must not affect it"
+        );
+
+        // Planner must NOT emit a variant_of edge — that's the executor's job.
+        let variant_of_count = plan_with
+            .edges
+            .iter()
+            .filter(|e| e.relationship == "variant_of")
+            .count();
+        assert_eq!(
+            variant_of_count, 0,
+            "planner must not emit variant_of; that's the executor's responsibility"
+        );
+    }
 }

--- a/crates/epigraph-ingest/src/workflow/builder.rs
+++ b/crates/epigraph-ingest/src/workflow/builder.rs
@@ -7,29 +7,11 @@ use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use crate::common::edges::{decomposes_edge, thesis_derivation_str};
 use crate::common::ids::{atom_id, compound_claim_id, content_hash, workflow_root_id};
 use crate::common::plan::{IngestPlan, PlannedClaim, PlannedEdge};
-use crate::common::schema::ThesisDerivation;
 use crate::document::builder::normalize_claim_path;
 use crate::workflow::schema::WorkflowExtraction;
-
-const fn thesis_derivation_str(td: &ThesisDerivation) -> &'static str {
-    match td {
-        ThesisDerivation::TopDown => "TopDown",
-        ThesisDerivation::BottomUp => "BottomUp",
-    }
-}
-
-fn decomposes_edge(source_id: Uuid, target_id: Uuid) -> PlannedEdge {
-    PlannedEdge {
-        source_id,
-        source_type: "claim".to_string(),
-        target_id,
-        target_type: "claim".to_string(),
-        relationship: "decomposes_to".to_string(),
-        properties: serde_json::json!({}),
-    }
-}
 
 /// Walk a `WorkflowExtraction` tree and produce a flat list of operations.
 ///

--- a/crates/epigraph-ingest/src/workflow/builder.rs
+++ b/crates/epigraph-ingest/src/workflow/builder.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 
 use crate::common::edges::{decomposes_edge, thesis_derivation_str};
 use crate::common::ids::{atom_id, compound_claim_id, content_hash, workflow_root_id};
+use crate::common::paths::normalize_claim_path;
 use crate::common::plan::{IngestPlan, PlannedClaim, PlannedEdge};
-use crate::document::builder::normalize_claim_path;
 use crate::workflow::schema::WorkflowExtraction;
 
 /// Walk a `WorkflowExtraction` tree and produce a flat list of operations.


### PR DESCRIPTION
Closes #43.

## Summary
- Hoist `decomposes_edge`, `thesis_derivation_str` → `epigraph-ingest::common::edges`
- Hoist `normalize_claim_path` → `epigraph-ingest::common::paths`
- Add 3 edge-case tests for the workflow walker symmetric to existing document coverage

No behavior change; pure refactor + test additions. Prep work for the executor-crate hoist (#44).

## Test plan
- [x] cargo test -p epigraph-ingest