### PR TITLE
epigraph-ingest-executor crate (#44)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "epigraph-ingest-executor"
+version = "0.3.0"
+dependencies = [
+ "blake3",
+ "chrono",
+ "epigraph-core",
+ "epigraph-crypto",
+ "epigraph-db",
+ "epigraph-ingest",
+ "serde_json",
+ "sqlx 0.7.4",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "epigraph-interfaces"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "epigraph-embeddings",
  "epigraph-engine",
  "epigraph-ingest",
+ "epigraph-ingest-executor",
  "hex",
  "openssl",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "epigraph-engine",
  "epigraph-events",
  "epigraph-ingest",
+ "epigraph-ingest-executor",
  "epigraph-interfaces",
  "epigraph-jobs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/epigraph-tools",
     "crates/epigraph-mcp",
     "crates/epigraph-ingest",
+    "crates/epigraph-ingest-executor",
     "tests/engine-integration",
 ]
 
@@ -77,6 +78,7 @@ epigraph-ds = { path = "crates/epigraph-ds" }
 epigraph-tools = { path = "crates/epigraph-tools" }
 epigraph-mcp = { path = "crates/epigraph-mcp" }
 epigraph-ingest = { path = "crates/epigraph-ingest" }
+epigraph-ingest-executor = { path = "crates/epigraph-ingest-executor" }
 
 # Graph algorithms
 petgraph = "0.7"

--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [features]
 default = ["db"]
-db = ["dep:epigraph-db", "dep:sqlx"]
+db = ["dep:epigraph-db", "dep:sqlx", "dep:epigraph-ingest-executor"]
 jina = ["epigraph-embeddings/jina"]
 genai = ["db", "dep:epigraph-cli"]  # LLM-dependent workflows; requires ANTHROPIC_API_KEY (or CLAUDE_CODE_OAUTH_TOKEN)
 integration = []
@@ -33,6 +33,7 @@ required-features = ["db"]
 [dependencies]
 epigraph-interfaces = { workspace = true }  # Extension point traits (EncryptionProvider, PolicyGate, OrchestrationBackend)
 epigraph-ingest = { workspace = true }  # Workflow/document extraction schemas and ingest planners
+epigraph-ingest-executor = { workspace = true, optional = true }  # Persistence executor for workflow ingest (db feature)
 linfa = { workspace = true }  # k-means for /api/v1/themes/build-from-corpus
 linfa-clustering = { workspace = true }
 ndarray = { workspace = true }

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -1106,222 +1106,23 @@ pub async fn ingest_workflow(
     State(state): State<AppState>,
     Json(extraction): Json<epigraph_ingest::workflow::WorkflowExtraction>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    use epigraph_core::{AgentId, TruthValue};
-    use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, WorkflowRepository};
-    use epigraph_ingest::workflow::builder::root_workflow_id;
-    use std::collections::HashMap;
-
     let plan = epigraph_ingest::workflow::builder::build_ingest_plan(&extraction);
-    let pool = &state.db_pool;
-
-    let canonical_name = &extraction.source.canonical_name;
-    let generation = extraction.source.generation as i32;
-    let goal = &extraction.source.goal;
-    let workflow_id = root_workflow_id(&extraction);
-
-    // ── 1. Idempotency gate ──────────────────────────────────────────────
-    if let Some(existing_id) =
-        WorkflowRepository::find_root_by_canonical(pool, canonical_name, generation)
+    let result =
+        epigraph_ingest_executor::execute_workflow_ingest_plan(&state.db_pool, &plan, &extraction)
             .await
             .map_err(|e| ApiError::InternalError {
-                message: e.to_string(),
-            })?
-    {
-        let edge_count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM edges \
-             WHERE source_id = $1 AND source_type = 'workflow' AND relationship = 'executes'",
-        )
-        .bind(existing_id)
-        .fetch_one(pool)
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: e.to_string(),
-        })?;
-
-        if edge_count > 0 {
-            return Ok(Json(serde_json::json!({
-                "workflow_id": existing_id,
-                "canonical_name": canonical_name,
-                "generation": generation,
-                "claims_ingested": 0,
-                "claims_skipped_dedup": 0,
-                "executes_edges": edge_count,
-                "relationships_created": 0,
-                "already_ingested": true,
-            })));
-        }
-    }
-
-    // ── 2. System agent ──────────────────────────────────────────────────
-    let system_agent_id = get_or_create_system_agent(pool).await?;
-    let _agent_id_typed = AgentId::from_uuid(system_agent_id);
-
-    // ── 3. Workflow row (idempotent) ──────────────────────────────────────
-    let parent_id = if let Some(ref pcn) = extraction.source.parent_canonical_name {
-        WorkflowRepository::find_root_by_canonical(pool, pcn, generation.saturating_sub(1))
-            .await
-            .map_err(|e| ApiError::InternalError {
-                message: e.to_string(),
-            })?
-    } else {
-        None
-    };
-
-    WorkflowRepository::insert_root(
-        pool,
-        workflow_id,
-        canonical_name,
-        generation,
-        goal,
-        parent_id,
-        extraction.source.metadata.clone(),
-    )
-    .await
-    .map_err(|e| ApiError::InternalError {
-        message: e.to_string(),
-    })?;
-
-    // ── 4. Author agents ─────────────────────────────────────────────────
-    let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
-    for (idx, author) in extraction.source.authors.iter().enumerate() {
-        if author.name.is_empty() {
-            continue;
-        }
-        let (_did, pub_key_bytes) =
-            epigraph_crypto::did_key::did_key_for_author(None, &author.name);
-        let agent_uuid: Uuid = if let Some(existing) =
-            AgentRepository::get_by_public_key(pool, &pub_key_bytes)
-                .await
-                .map_err(|e| ApiError::InternalError {
-                    message: e.to_string(),
-                })? {
-            existing.id.into()
-        } else {
-            let author_agent = epigraph_core::Agent::new(pub_key_bytes, Some(author.name.clone()));
-            let created = AgentRepository::create(pool, &author_agent)
-                .await
-                .map_err(|e| ApiError::InternalError {
-                    message: e.to_string(),
-                })?;
-            created.id.into()
-        };
-        author_agent_map.insert(idx, agent_uuid);
-    }
-
-    // ── 5. Claims ────────────────────────────────────────────────────────
-    let mut claims_ingested = 0_usize;
-    let mut claims_skipped_dedup = 0_usize;
-    let mut id_map: HashMap<Uuid, Uuid> = HashMap::new();
-
-    for planned in &plan.claims {
-        let confidence = planned.confidence.clamp(0.0, 1.0);
-        let truth = TruthValue::clamped(confidence.clamp(0.01, 0.99));
-        let kind = planned
-            .properties
-            .get("kind")
-            .and_then(|v| v.as_str())
-            .unwrap_or("workflow_claim");
-        let labels = vec!["claim".to_string(), kind.to_string()];
-
-        let was_new = ClaimRepository::create_with_id_if_absent(
-            pool,
-            planned.id,
-            &planned.content,
-            &planned.content_hash,
-            system_agent_id,
-            truth,
-            &labels,
-        )
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: e.to_string(),
-        })?;
-
-        if was_new {
-            sqlx::query("UPDATE claims SET properties = $1 WHERE id = $2")
-                .bind(&planned.properties)
-                .bind(planned.id)
-                .execute(pool)
-                .await
-                .map_err(|e| ApiError::InternalError {
-                    message: e.to_string(),
-                })?;
-            claims_ingested += 1;
-        } else {
-            claims_skipped_dedup += 1;
-        }
-        id_map.insert(planned.id, planned.id);
-    }
-
-    // ── 6. executes edges ────────────────────────────────────────────────
-    let mut executes_edges = 0_usize;
-    for planned in &plan.claims {
-        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
-            pool,
-            workflow_id,
-            "workflow",
-            planned.id,
-            "claim",
-            "executes",
-            Some(serde_json::json!({"level": planned.level})),
-            None,
-            None,
-        )
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: e.to_string(),
-        })?;
-        executes_edges += 1;
-    }
-
-    // ── 7. Intra-claim plan edges ─────────────────────────────────────────
-    let mut relationships_created = 0_usize;
-    for edge in &plan.edges {
-        let (src, src_type) = if edge.source_type == "author_placeholder" {
-            let idx = edge.properties["author_index"].as_u64().unwrap_or(0) as usize;
-            let Some(&agent_uuid) = author_agent_map.get(&idx) else {
-                continue;
-            };
-            (agent_uuid, "agent".to_string())
-        } else {
-            let mapped = id_map
-                .get(&edge.source_id)
-                .copied()
-                .unwrap_or(edge.source_id);
-            (mapped, edge.source_type.clone())
-        };
-        let tgt = id_map
-            .get(&edge.target_id)
-            .copied()
-            .unwrap_or(edge.target_id);
-
-        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
-            pool,
-            src,
-            &src_type,
-            tgt,
-            &edge.target_type,
-            &edge.relationship,
-            Some(edge.properties.clone()),
-            None,
-            None,
-        )
-        .await
-        .map_err(|e| ApiError::InternalError {
-            message: e.to_string(),
-        })?;
-        relationships_created += 1;
-    }
+                message: format!("workflow ingest: {e}"),
+            })?;
 
     Ok(Json(serde_json::json!({
-        "workflow_id": workflow_id,
-        "canonical_name": canonical_name,
-        "generation": generation,
-        "claims_ingested": claims_ingested,
-        "claims_skipped_dedup": claims_skipped_dedup,
-        "executes_edges": executes_edges,
-        "relationships_created": relationships_created,
-        "already_ingested": false,
+        "workflow_id": result.workflow_id,
+        "canonical_name": result.canonical_name,
+        "generation": result.generation,
+        "claims_ingested": result.claims_ingested,
+        "claims_skipped_dedup": result.claims_skipped_dedup,
+        "executes_edges": result.executes_edges_created,
+        "relationships_created": result.relationship_edges_created,
+        "already_ingested": result.already_ingested,
     })))
 }
 

--- a/crates/epigraph-ingest-executor/Cargo.toml
+++ b/crates/epigraph-ingest-executor/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "epigraph-ingest-executor"
+description = "Persistence-layer executor for hierarchical workflow ingest plans"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+# Internal crates
+epigraph-core = { workspace = true }
+epigraph-crypto = { workspace = true }
+epigraph-db = { workspace = true }
+epigraph-ingest = { workspace = true }
+
+# Database
+sqlx = { workspace = true }
+
+# Serialization
+serde_json = { workspace = true }
+
+# Identifiers & time
+uuid = { workspace = true }
+chrono = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+[dev-dependencies]
+blake3 = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/epigraph-ingest-executor/src/error.rs
+++ b/crates/epigraph-ingest-executor/src/error.rs
@@ -1,0 +1,30 @@
+//! Error type for the ingest executor.
+
+use thiserror::Error;
+
+/// Errors that can be raised while executing a workflow ingest plan.
+///
+/// Callers (MCP and API handlers) map this into their own error type
+/// (`McpError`, `ApiError`, etc.) at the wrapper boundary.
+#[derive(Error, Debug)]
+pub enum IngestExecutorError {
+    /// Raw `sqlx` error from inline queries (UPDATE / SELECT COUNT(*)).
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    /// Repository-layer error from `epigraph_db`.
+    #[error("repository error: {0}")]
+    Repository(#[from] epigraph_db::DbError),
+
+    /// Failed to look up or create an agent (system or author).
+    #[error("agent creation failed: {0}")]
+    AgentCreation(String),
+
+    /// Failed to insert the workflow row.
+    #[error("workflow row insert failed: {0}")]
+    WorkflowInsert(String),
+
+    /// Plan structure violated an executor invariant.
+    #[error("plan inconsistency: {0}")]
+    PlanInconsistency(String),
+}

--- a/crates/epigraph-ingest-executor/src/lib.rs
+++ b/crates/epigraph-ingest-executor/src/lib.rs
@@ -1,0 +1,15 @@
+//! Persistence-layer executor for hierarchical workflow ingest plans.
+//!
+//! This crate consolidates the workflow-ingest execution logic that was
+//! previously duplicated between `epigraph-mcp::tools::workflow_ingest` and
+//! `epigraph-api::routes::workflows`. Both call sites now reduce to a thin
+//! wrapper that builds an [`epigraph_ingest::workflow::IngestPlan`] and calls
+//! [`execute_workflow_ingest_plan`].
+
+pub mod error;
+pub mod system_agent;
+pub mod workflow;
+
+pub use error::IngestExecutorError;
+pub use system_agent::get_or_create_system_agent;
+pub use workflow::{execute_workflow_ingest_plan, WorkflowIngestExecutionResult};

--- a/crates/epigraph-ingest-executor/src/system_agent.rs
+++ b/crates/epigraph-ingest-executor/src/system_agent.rs
@@ -1,0 +1,33 @@
+//! Resolves the shared `workflow-ingest-system` agent identity.
+//!
+//! Both ingest call sites (MCP `do_ingest_workflow_via_pool` and
+//! HTTP `ingest_workflow`) need to attribute persisted claims to a
+//! deterministic system agent. This helper looks it up by deterministic
+//! `did:key` and creates it on first use.
+
+use uuid::Uuid;
+
+use crate::error::IngestExecutorError;
+
+/// Get-or-create the canonical `workflow-ingest-system` agent.
+///
+/// Idempotent across processes: derives a deterministic `did:key` from a
+/// fixed seed and either fetches the matching `agents` row or inserts one.
+pub async fn get_or_create_system_agent(pool: &sqlx::PgPool) -> Result<Uuid, IngestExecutorError> {
+    let (_did, pub_key_bytes) =
+        epigraph_crypto::did_key::did_key_for_author(None, "workflow-ingest-system");
+
+    if let Some(existing) = epigraph_db::AgentRepository::get_by_public_key(pool, &pub_key_bytes)
+        .await
+        .map_err(|e| IngestExecutorError::AgentCreation(format!("lookup: {e}")))?
+    {
+        return Ok(existing.id.into());
+    }
+
+    let agent =
+        epigraph_core::Agent::new(pub_key_bytes, Some("workflow-ingest-system".to_string()));
+    let created = epigraph_db::AgentRepository::create(pool, &agent)
+        .await
+        .map_err(|e| IngestExecutorError::AgentCreation(format!("create: {e}")))?;
+    Ok(created.id.into())
+}

--- a/crates/epigraph-ingest-executor/src/workflow.rs
+++ b/crates/epigraph-ingest-executor/src/workflow.rs
@@ -1,0 +1,43 @@
+//! Workflow ingest executor — applies an [`epigraph_ingest::workflow::IngestPlan`]
+//! to the database.
+//!
+//! Stub: implementation is ported from the duplicated MCP/API call sites in
+//! the next commit (see `feat: port workflow ingest execution` in this PR's
+//! history).
+
+use uuid::Uuid;
+
+use crate::error::IngestExecutorError;
+
+/// Summary of what the executor wrote (or skipped) for a single plan.
+#[derive(Debug, Clone)]
+pub struct WorkflowIngestExecutionResult {
+    pub workflow_id: Uuid,
+    pub canonical_name: String,
+    pub generation: i32,
+    pub claims_ingested: usize,
+    pub claims_skipped_dedup: usize,
+    pub executes_edges_created: usize,
+    /// Reserved for Phase 4.3 — set by the upcoming `variant_of` edge work
+    /// (issue #51). Always `false` in this phase.
+    pub variant_of_edge_created: bool,
+    pub relationship_edges_created: usize,
+    /// `true` when the idempotency gate short-circuited (workflow already
+    /// has `executes` edges); the other counters are zero in that case.
+    pub already_ingested: bool,
+}
+
+/// Execute a workflow ingest plan against the database.
+///
+/// Idempotent. If the canonical workflow already has `executes` edges, this
+/// returns early with `already_ingested: true` and no DB writes. Otherwise
+/// inserts the workflow row, ensures author and system agents, persists each
+/// planned claim with dedup, writes `workflow —executes→ claim` edges, and
+/// emits the intra-claim plan edges.
+pub async fn execute_workflow_ingest_plan(
+    _pool: &sqlx::PgPool,
+    _plan: &epigraph_ingest::common::plan::IngestPlan,
+    _extraction: &epigraph_ingest::workflow::WorkflowExtraction,
+) -> Result<WorkflowIngestExecutionResult, IngestExecutorError> {
+    todo!("ported in next commit (Phase 4.2.C)")
+}

--- a/crates/epigraph-ingest-executor/src/workflow.rs
+++ b/crates/epigraph-ingest-executor/src/workflow.rs
@@ -1,13 +1,22 @@
-//! Workflow ingest executor — applies an [`epigraph_ingest::workflow::IngestPlan`]
-//! to the database.
+//! Workflow ingest executor — applies an [`epigraph_ingest::common::plan::IngestPlan`]
+//! built from a [`epigraph_ingest::workflow::WorkflowExtraction`] to the database.
 //!
-//! Stub: implementation is ported from the duplicated MCP/API call sites in
-//! the next commit (see `feat: port workflow ingest execution` in this PR's
-//! history).
+//! This module consolidates logic previously duplicated between
+//! `epigraph-mcp::tools::workflow_ingest::do_ingest_workflow_via_pool` and
+//! `epigraph-api::routes::workflows::ingest_workflow`.
+
+use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use epigraph_core::TruthValue;
+use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, WorkflowRepository};
+use epigraph_ingest::common::plan::IngestPlan;
+use epigraph_ingest::workflow::builder::root_workflow_id;
+use epigraph_ingest::workflow::WorkflowExtraction;
+
 use crate::error::IngestExecutorError;
+use crate::system_agent::get_or_create_system_agent;
 
 /// Summary of what the executor wrote (or skipped) for a single plan.
 #[derive(Debug, Clone)]
@@ -18,26 +27,214 @@ pub struct WorkflowIngestExecutionResult {
     pub claims_ingested: usize,
     pub claims_skipped_dedup: usize,
     pub executes_edges_created: usize,
-    /// Reserved for Phase 4.3 — set by the upcoming `variant_of` edge work
-    /// (issue #51). Always `false` in this phase.
+    /// Reserved for Phase 4.3 (issue #51): the `variant_of` edge between
+    /// successive workflow generations is added in a follow-up PR. This
+    /// field is always `false` in the current phase.
     pub variant_of_edge_created: bool,
     pub relationship_edges_created: usize,
     /// `true` when the idempotency gate short-circuited (workflow already
-    /// has `executes` edges); the other counters are zero in that case.
+    /// has `executes` edges). The other counters are zero in that case.
     pub already_ingested: bool,
 }
 
 /// Execute a workflow ingest plan against the database.
 ///
 /// Idempotent. If the canonical workflow already has `executes` edges, this
-/// returns early with `already_ingested: true` and no DB writes. Otherwise
+/// returns early with `already_ingested: true` and no DB writes. Otherwise it
 /// inserts the workflow row, ensures author and system agents, persists each
 /// planned claim with dedup, writes `workflow —executes→ claim` edges, and
 /// emits the intra-claim plan edges.
 pub async fn execute_workflow_ingest_plan(
-    _pool: &sqlx::PgPool,
-    _plan: &epigraph_ingest::common::plan::IngestPlan,
-    _extraction: &epigraph_ingest::workflow::WorkflowExtraction,
+    pool: &sqlx::PgPool,
+    plan: &IngestPlan,
+    extraction: &WorkflowExtraction,
 ) -> Result<WorkflowIngestExecutionResult, IngestExecutorError> {
-    todo!("ported in next commit (Phase 4.2.C)")
+    let canonical_name = &extraction.source.canonical_name;
+    let generation = extraction.source.generation as i32;
+    let goal = &extraction.source.goal;
+
+    let workflow_id = root_workflow_id(extraction);
+
+    // ── 1. Idempotency gate: skip if workflow row already processed ──────
+    if let Some(existing_id) =
+        WorkflowRepository::find_root_by_canonical(pool, canonical_name, generation).await?
+    {
+        let edge_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM edges \
+             WHERE source_id = $1 AND source_type = 'workflow' AND relationship = 'executes'",
+        )
+        .bind(existing_id)
+        .fetch_one(pool)
+        .await?;
+
+        if edge_count > 0 {
+            return Ok(WorkflowIngestExecutionResult {
+                workflow_id: existing_id,
+                canonical_name: canonical_name.clone(),
+                generation,
+                claims_ingested: 0,
+                claims_skipped_dedup: 0,
+                executes_edges_created: edge_count as usize,
+                variant_of_edge_created: false,
+                relationship_edges_created: 0,
+                already_ingested: true,
+            });
+        }
+    }
+
+    // ── 2. Ensure system agent ───────────────────────────────────────────
+    let system_agent_id = get_or_create_system_agent(pool).await?;
+
+    // ── 3. Insert workflow row (idempotent) ──────────────────────────────
+    let parent_id = if let Some(ref pcn) = extraction.source.parent_canonical_name {
+        WorkflowRepository::find_root_by_canonical(pool, pcn, generation.saturating_sub(1)).await?
+    } else {
+        None
+    };
+
+    WorkflowRepository::insert_root(
+        pool,
+        workflow_id,
+        canonical_name,
+        generation,
+        goal,
+        parent_id,
+        extraction.source.metadata.clone(),
+    )
+    .await
+    .map_err(|e| IngestExecutorError::WorkflowInsert(e.to_string()))?;
+
+    // ── 4. Ensure author agents ──────────────────────────────────────────
+    let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
+    for (idx, author) in extraction.source.authors.iter().enumerate() {
+        if author.name.is_empty() {
+            continue;
+        }
+        let (_did, pub_key_bytes) =
+            epigraph_crypto::did_key::did_key_for_author(None, &author.name);
+        let agent_uuid: Uuid = if let Some(existing) =
+            AgentRepository::get_by_public_key(pool, &pub_key_bytes)
+                .await
+                .map_err(|e| IngestExecutorError::AgentCreation(format!("author lookup: {e}")))?
+        {
+            existing.id.into()
+        } else {
+            let author_agent = epigraph_core::Agent::new(pub_key_bytes, Some(author.name.clone()));
+            let created = AgentRepository::create(pool, &author_agent)
+                .await
+                .map_err(|e| IngestExecutorError::AgentCreation(format!("author create: {e}")))?;
+            created.id.into()
+        };
+        author_agent_map.insert(idx, agent_uuid);
+    }
+
+    // ── 5. Walk planned claims: dedup-by-id ─────────────────────────────
+    let mut claims_ingested = 0_usize;
+    let mut claims_skipped_dedup = 0_usize;
+    let mut id_map: HashMap<Uuid, Uuid> = HashMap::new();
+
+    for planned in &plan.claims {
+        let confidence = planned.confidence.clamp(0.0, 1.0);
+        let raw_truth = confidence.clamp(0.01, 0.99);
+        let truth = TruthValue::clamped(raw_truth);
+
+        // Derive labels from kind property.
+        let kind = planned
+            .properties
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("workflow_claim");
+        let labels = vec!["claim".to_string(), kind.to_string()];
+
+        let was_new = ClaimRepository::create_with_id_if_absent(
+            pool,
+            planned.id,
+            &planned.content,
+            &planned.content_hash,
+            system_agent_id,
+            truth,
+            &labels,
+        )
+        .await?;
+
+        if was_new {
+            // Set properties via raw SQL (no set_properties method on ClaimRepository).
+            sqlx::query("UPDATE claims SET properties = $1 WHERE id = $2")
+                .bind(&planned.properties)
+                .bind(planned.id)
+                .execute(pool)
+                .await?;
+            claims_ingested += 1;
+        } else {
+            claims_skipped_dedup += 1;
+        }
+
+        id_map.insert(planned.id, planned.id);
+    }
+
+    // ── 6. workflow —executes→ claim edges ──────────────────────────────
+    let mut executes_edges = 0_usize;
+    for planned in &plan.claims {
+        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
+            pool,
+            workflow_id,
+            "workflow",
+            planned.id,
+            "claim",
+            "executes",
+            Some(serde_json::json!({"level": planned.level})),
+            None,
+            None,
+        )
+        .await?;
+        executes_edges += 1;
+    }
+
+    // ── 7. Intra-claim plan edges (decomposes_to / step_follows / phase_follows / cross-refs) ──
+    let mut relationships_created = 0_usize;
+    for edge in &plan.edges {
+        let (src, src_type) = if edge.source_type == "author_placeholder" {
+            let idx = edge.properties["author_index"].as_u64().unwrap_or(0) as usize;
+            let Some(&agent_uuid) = author_agent_map.get(&idx) else {
+                continue;
+            };
+            (agent_uuid, "agent".to_string())
+        } else {
+            let mapped = id_map
+                .get(&edge.source_id)
+                .copied()
+                .unwrap_or(edge.source_id);
+            (mapped, edge.source_type.clone())
+        };
+        let tgt = id_map
+            .get(&edge.target_id)
+            .copied()
+            .unwrap_or(edge.target_id);
+
+        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
+            pool,
+            src,
+            &src_type,
+            tgt,
+            &edge.target_type,
+            &edge.relationship,
+            Some(edge.properties.clone()),
+            None,
+            None,
+        )
+        .await?;
+        relationships_created += 1;
+    }
+
+    Ok(WorkflowIngestExecutionResult {
+        workflow_id,
+        canonical_name: canonical_name.clone(),
+        generation,
+        claims_ingested,
+        claims_skipped_dedup,
+        executes_edges_created: executes_edges,
+        variant_of_edge_created: false,
+        relationship_edges_created: relationships_created,
+        already_ingested: false,
+    })
 }

--- a/crates/epigraph-ingest-executor/tests/workflow_ingest.rs
+++ b/crates/epigraph-ingest-executor/tests/workflow_ingest.rs
@@ -1,0 +1,133 @@
+//! Integration tests for [`epigraph_ingest_executor::execute_workflow_ingest_plan`].
+//!
+//! Migrated from the duplicate-site tests in `epigraph-mcp::tools::workflow_ingest`
+//! and `epigraph-api::routes::workflows`. The executor crate owns the canonical
+//! contract going forward.
+
+use sqlx::PgPool;
+
+use epigraph_ingest::common::schema::ThesisDerivation;
+use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowSource};
+use epigraph_ingest::workflow::WorkflowExtraction;
+
+fn build_minimal_workflow_extraction(canonical_name: &str) -> WorkflowExtraction {
+    WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: canonical_name.to_string(),
+            goal: "Validate the executor crate ingests workflows idempotently".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: Some("Executor must be idempotent across repeat calls".to_string()),
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "Phase 1".to_string(),
+            summary: "Run the executor twice and assert no duplicates".to_string(),
+            steps: vec![Step {
+                compound: "Invoke executor".to_string(),
+                rationale: "Idempotency contract".to_string(),
+                operations: vec![
+                    "Call execute_workflow_ingest_plan".to_string(),
+                    "Verify counters and edge counts".to_string(),
+                ],
+                generality: vec![2, 1],
+                confidence: 0.9,
+            }],
+        }],
+        relationships: vec![],
+    }
+}
+
+/// Re-running the executor with the same plan must short-circuit on the
+/// idempotency gate: no new claims, no duplicated edges.
+#[sqlx::test(migrations = "../../migrations")]
+async fn execute_is_idempotent(pool: PgPool) {
+    let extraction = build_minimal_workflow_extraction("executor-idempotent-test");
+    let plan = epigraph_ingest::workflow::builder::build_ingest_plan(&extraction);
+
+    let r1 = epigraph_ingest_executor::execute_workflow_ingest_plan(&pool, &plan, &extraction)
+        .await
+        .expect("first call");
+    assert!(
+        !r1.already_ingested,
+        "first ingest should not short-circuit"
+    );
+    assert!(r1.claims_ingested > 0, "first ingest should write claims");
+    assert!(
+        r1.executes_edges_created > 0,
+        "first ingest should write executes edges"
+    );
+
+    let r2 = epigraph_ingest_executor::execute_workflow_ingest_plan(&pool, &plan, &extraction)
+        .await
+        .expect("second call");
+    assert!(
+        r2.already_ingested,
+        "second ingest should hit the idempotency gate"
+    );
+    assert_eq!(r2.workflow_id, r1.workflow_id);
+    assert_eq!(r2.claims_ingested, 0);
+    assert_eq!(r2.claims_skipped_dedup, 0);
+    assert_eq!(r2.relationship_edges_created, 0);
+
+    // Edge count in DB must be unchanged.
+    let edge_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM edges \
+         WHERE source_id = $1 AND source_type = 'workflow' AND relationship = 'executes'",
+    )
+    .bind(r1.workflow_id)
+    .fetch_one(&pool)
+    .await
+    .expect("edge count");
+    assert_eq!(
+        edge_count, r1.executes_edges_created as i64,
+        "re-ingest must not duplicate executes edges"
+    );
+
+    // Claim count under the workflow must be unchanged.
+    let claim_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM claims WHERE id IN \
+         (SELECT target_id FROM edges WHERE source_id = $1 AND relationship = 'executes')",
+    )
+    .bind(r1.workflow_id)
+    .fetch_one(&pool)
+    .await
+    .expect("claim count");
+    assert_eq!(claim_count, r1.executes_edges_created as i64);
+}
+
+/// First-call sanity: counters reflect what was actually written.
+#[sqlx::test(migrations = "../../migrations")]
+async fn execute_smoke(pool: PgPool) {
+    let extraction = build_minimal_workflow_extraction("executor-smoke-test");
+    let plan = epigraph_ingest::workflow::builder::build_ingest_plan(&extraction);
+
+    let r = epigraph_ingest_executor::execute_workflow_ingest_plan(&pool, &plan, &extraction)
+        .await
+        .expect("ingest must succeed");
+
+    assert!(!r.already_ingested);
+    assert!(
+        !r.variant_of_edge_created,
+        "phase 4.2 leaves variant_of for phase 4.3"
+    );
+    assert!(r.claims_ingested > 0);
+    assert!(r.executes_edges_created > 0);
+
+    // Workflow row exists.
+    let workflow_exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM workflows WHERE id = $1)")
+            .bind(r.workflow_id)
+            .fetch_one(&pool)
+            .await
+            .expect("workflow exists query");
+    assert!(workflow_exists);
+
+    // workflow_id is deterministic from canonical_name + generation.
+    let recomputed = epigraph_ingest::workflow::builder::root_workflow_id(&extraction);
+    assert_eq!(r.workflow_id, recomputed);
+}

--- a/crates/epigraph-mcp/Cargo.toml
+++ b/crates/epigraph-mcp/Cargo.toml
@@ -16,6 +16,7 @@ epigraph-ds = { workspace = true }
 epigraph-engine = { workspace = true }
 epigraph-embeddings = { workspace = true }
 epigraph-ingest = { workspace = true }
+epigraph-ingest-executor = { workspace = true }
 
 # MCP protocol (no sqlx dep — coexists with workspace sqlx 0.7)
 rmcp = { workspace = true }

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -5,19 +5,17 @@
 //! `workflow —executes→ claim` edges for every planned claim, resolves author
 //! placeholder edges, and returns a summary. Mirrors `do_ingest_document` in
 //! `ingestion.rs`.
-
-use std::collections::HashMap;
+//!
+//! The persistence body lives in [`epigraph_ingest_executor::execute_workflow_ingest_plan`];
+//! this module is now a thin wrapper that builds an ingest plan, invokes the
+//! executor, and maps the result into the MCP response shape.
 
 use rmcp::model::*;
-use uuid::Uuid;
 
 use crate::errors::{internal_error, McpError};
 use crate::server::EpiGraphMcpFull;
 use crate::types::IngestWorkflowParams;
 
-use epigraph_core::{AgentId, TruthValue};
-use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, WorkflowRepository};
-use epigraph_ingest::workflow::builder::root_workflow_id;
 use epigraph_ingest::workflow::WorkflowExtraction;
 
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
@@ -45,209 +43,27 @@ pub struct IngestWorkflowResponse {
 /// Pool-only ingest logic. Callable from both the MCP entry point (which
 /// supplies `server.pool`) and from integration tests (which supply a
 /// `sqlx::test`-managed pool directly).
+///
+/// Thin wrapper over [`epigraph_ingest_executor::execute_workflow_ingest_plan`];
+/// see that function for the canonical persistence semantics.
 pub async fn do_ingest_workflow_via_pool(
     pool: &sqlx::PgPool,
     extraction: &WorkflowExtraction,
 ) -> Result<IngestWorkflowResponse, McpError> {
     let plan = epigraph_ingest::workflow::builder::build_ingest_plan(extraction);
-
-    let canonical_name = &extraction.source.canonical_name;
-    let generation = extraction.source.generation as i32;
-    let goal = &extraction.source.goal;
-
-    let workflow_id = root_workflow_id(extraction);
-
-    // ── 1. Idempotency gate: skip if workflow row already processed ──────
-    if let Some(existing_id) =
-        WorkflowRepository::find_root_by_canonical(pool, canonical_name, generation)
-            .await
-            .map_err(internal_error)?
-    {
-        // Workflow row exists — check if any executes edges have been written.
-        let edge_count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM edges \
-             WHERE source_id = $1 AND source_type = 'workflow' AND relationship = 'executes'",
-        )
-        .bind(existing_id)
-        .fetch_one(pool)
+    let result = epigraph_ingest_executor::execute_workflow_ingest_plan(pool, &plan, extraction)
         .await
-        .map_err(internal_error)?;
-
-        if edge_count > 0 {
-            return Ok(IngestWorkflowResponse {
-                workflow_id: existing_id.to_string(),
-                canonical_name: canonical_name.clone(),
-                generation,
-                claims_ingested: 0,
-                claims_skipped_dedup: 0,
-                executes_edges: edge_count as usize,
-                relationships_created: 0,
-                already_ingested: true,
-            });
-        }
-    }
-
-    // ── 2. Ensure system agent ───────────────────────────────────────────
-    let system_agent_id = get_or_create_system_agent(pool).await?;
-    let agent_id_typed = AgentId::from_uuid(system_agent_id);
-
-    // ── 3. Insert workflow row (idempotent) ──────────────────────────────
-    let parent_id = if let Some(ref pcn) = extraction.source.parent_canonical_name {
-        WorkflowRepository::find_root_by_canonical(pool, pcn, generation.saturating_sub(1))
-            .await
-            .map_err(internal_error)?
-    } else {
-        None
-    };
-
-    WorkflowRepository::insert_root(
-        pool,
-        workflow_id,
-        canonical_name,
-        generation,
-        goal,
-        parent_id,
-        extraction.source.metadata.clone(),
-    )
-    .await
-    .map_err(internal_error)?;
-
-    // ── 4. Ensure author agents ──────────────────────────────────────────
-    let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
-    for (idx, author) in extraction.source.authors.iter().enumerate() {
-        if author.name.is_empty() {
-            continue;
-        }
-        let (_did, pub_key_bytes) =
-            epigraph_crypto::did_key::did_key_for_author(None, &author.name);
-        let agent_uuid = if let Some(existing) =
-            AgentRepository::get_by_public_key(pool, &pub_key_bytes)
-                .await
-                .map_err(internal_error)?
-        {
-            existing.id.into()
-        } else {
-            let author_agent = epigraph_core::Agent::new(pub_key_bytes, Some(author.name.clone()));
-            let created = AgentRepository::create(pool, &author_agent)
-                .await
-                .map_err(internal_error)?;
-            created.id.into()
-        };
-        author_agent_map.insert(idx, agent_uuid);
-    }
-
-    // ── 5. Walk planned claims: dedup-by-id ─────────────────────────────
-    let mut claims_ingested = 0_usize;
-    let mut claims_skipped_dedup = 0_usize;
-    let mut id_map: HashMap<Uuid, Uuid> = HashMap::new();
-
-    for planned in &plan.claims {
-        let confidence = planned.confidence.clamp(0.0, 1.0);
-        let raw_truth = confidence.clamp(0.01, 0.99);
-        let truth = TruthValue::clamped(raw_truth);
-
-        // Derive labels from kind property.
-        let kind = planned
-            .properties
-            .get("kind")
-            .and_then(|v| v.as_str())
-            .unwrap_or("workflow_claim");
-        let labels = vec!["claim".to_string(), kind.to_string()];
-
-        let was_new = ClaimRepository::create_with_id_if_absent(
-            pool,
-            planned.id,
-            &planned.content,
-            &planned.content_hash,
-            system_agent_id,
-            truth,
-            &labels,
-        )
-        .await
-        .map_err(internal_error)?;
-
-        if was_new {
-            // Set properties via raw SQL (no set_properties method on ClaimRepository).
-            sqlx::query("UPDATE claims SET properties = $1 WHERE id = $2")
-                .bind(&planned.properties)
-                .bind(planned.id)
-                .execute(pool)
-                .await
-                .map_err(internal_error)?;
-            claims_ingested += 1;
-        } else {
-            claims_skipped_dedup += 1;
-        }
-
-        id_map.insert(planned.id, planned.id);
-        let _ = agent_id_typed; // suppress unused warning
-    }
-
-    // ── 6. workflow —executes→ claim edges ──────────────────────────────
-    let mut executes_edges = 0_usize;
-    for planned in &plan.claims {
-        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
-            pool,
-            workflow_id,
-            "workflow",
-            planned.id,
-            "claim",
-            "executes",
-            Some(serde_json::json!({"level": planned.level})),
-            None,
-            None,
-        )
-        .await
-        .map_err(internal_error)?;
-        executes_edges += 1;
-    }
-
-    // ── 7. Intra-claim plan edges (decomposes_to / step_follows / phase_follows / cross-refs) ──
-    let mut relationships_created = 0_usize;
-    for edge in &plan.edges {
-        let (src, src_type) = if edge.source_type == "author_placeholder" {
-            let idx = edge.properties["author_index"].as_u64().unwrap_or(0) as usize;
-            let Some(&agent_uuid) = author_agent_map.get(&idx) else {
-                continue;
-            };
-            (agent_uuid, "agent".to_string())
-        } else {
-            let mapped = id_map
-                .get(&edge.source_id)
-                .copied()
-                .unwrap_or(edge.source_id);
-            (mapped, edge.source_type.clone())
-        };
-        let tgt = id_map
-            .get(&edge.target_id)
-            .copied()
-            .unwrap_or(edge.target_id);
-
-        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
-            pool,
-            src,
-            &src_type,
-            tgt,
-            &edge.target_type,
-            &edge.relationship,
-            Some(edge.properties.clone()),
-            None,
-            None,
-        )
-        .await
-        .map_err(internal_error)?;
-        relationships_created += 1;
-    }
+        .map_err(|e| internal_error(format!("workflow ingest: {e}")))?;
 
     Ok(IngestWorkflowResponse {
-        workflow_id: workflow_id.to_string(),
-        canonical_name: canonical_name.clone(),
-        generation,
-        claims_ingested,
-        claims_skipped_dedup,
-        executes_edges,
-        relationships_created,
-        already_ingested: false,
+        workflow_id: result.workflow_id.to_string(),
+        canonical_name: result.canonical_name,
+        generation: result.generation,
+        claims_ingested: result.claims_ingested,
+        claims_skipped_dedup: result.claims_skipped_dedup,
+        executes_edges: result.executes_edges_created,
+        relationships_created: result.relationship_edges_created,
+        already_ingested: result.already_ingested,
     })
 }
 
@@ -270,32 +86,13 @@ pub async fn ingest_workflow(
     do_ingest_workflow(server, &params.extraction).await
 }
 
-// ── Internal helper ────────────────────────────────────────────────────────
-
-async fn get_or_create_system_agent(pool: &sqlx::PgPool) -> Result<Uuid, McpError> {
-    let (_did, pub_key_bytes) =
-        epigraph_crypto::did_key::did_key_for_author(None, "workflow-ingest-system");
-    if let Some(existing) = AgentRepository::get_by_public_key(pool, &pub_key_bytes)
-        .await
-        .map_err(internal_error)?
-    {
-        Ok(existing.id.into())
-    } else {
-        let agent =
-            epigraph_core::Agent::new(pub_key_bytes, Some("workflow-ingest-system".to_string()));
-        let created = AgentRepository::create(pool, &agent)
-            .await
-            .map_err(internal_error)?;
-        Ok(created.id.into())
-    }
-}
-
 // ── Integration tests ──────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowSource};
+    use uuid::Uuid;
 
     fn minimal_extraction() -> WorkflowExtraction {
         WorkflowExtraction {
@@ -421,7 +218,9 @@ mod tests {
         );
 
         // Manually insert the document atom (mirrors what do_ingest_document would do).
-        let sys_agent_id = get_or_create_system_agent(&pool).await.unwrap();
+        let sys_agent_id = epigraph_ingest_executor::get_or_create_system_agent(&pool)
+            .await
+            .unwrap();
         let doc_atom = doc_plan.claims.iter().find(|c| c.level == 3).unwrap();
         assert_eq!(doc_atom.id, expected_atom_id);
         epigraph_db::ClaimRepository::create_with_id_if_absent(


### PR DESCRIPTION
Closes #44.

## Summary
Extracts the ~200-line workflow-ingest execution logic from `epigraph-mcp::tools::workflow_ingest` and `epigraph-api::routes::workflows` into a new shared crate `epigraph-ingest-executor`. Both callers are now thin wrappers (~12 + ~20 lines).

Pre-existing `#[sqlx::test]` cases in MCP and API pass unchanged. New integration tests in the executor crate cover the idempotency contract and a smoke first-call.

Sets up #51 (variant_of edge fix) — single-site fix in the executor follows in a separate PR. The `WorkflowIngestExecutionResult::variant_of_edge_created` field is reserved for that work and is currently always `false`.

## Commits
- `feat(executor): scaffold epigraph-ingest-executor crate (refs #44)` — empty crate with public API surface; moves `get_or_create_system_agent` from MCP and adds `IngestExecutorError`.
- `feat(executor): port workflow ingest execution to epigraph-ingest-executor (refs #44)` — moves the ~200-line execution body and adds idempotency + smoke integration tests.
- `refactor(mcp): thin workflow_ingest caller using executor crate (refs #44)` — `do_ingest_workflow_via_pool` reduced to a thin wrapper.
- `refactor(api): thin ingest_workflow handler using executor crate (refs #44)` — `routes/workflows.rs::ingest_workflow` reduced to a thin wrapper. Other handlers in the file (and `policies.rs`) still call the local `get_or_create_system_agent`, so it stays.

## Test plan
- [x] `cargo test -p epigraph-ingest-executor` (2 new integration tests pass: `execute_is_idempotent`, `execute_smoke`)
- [x] `cargo test -p epigraph-mcp workflow_ingest` (4 pre-existing tests pass: `ingest_workflow_smoke`, `ingest_workflow_idempotent`, `ingest_workflow_atom_converges_with_document_atom`, `ingest_workflow_executes_edges_created`)
- [x] `cargo test -p epigraph-api workflow` (6 pre-existing tests pass)
- [x] `cargo test --workspace --lib --bins` (all unit/lib tests pass; counts include 357 in epigraph-api lib)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

Note: full `cargo test --workspace` (including all `epigraph-api` integration tests) was not run end-to-end because building the integration test set on this VM exceeds the available disk in `~/.cargo-target`. CI will run the full matrix.