### PR TITLE
3072d centroid columns + reembed CLI (#59A)

### DIFF
--- a/crates/epigraph-api/src/routes/crud.rs
+++ b/crates/epigraph-api/src/routes/crud.rs
@@ -1165,6 +1165,12 @@ pub struct BuildThemesFromCorpusRequest {
     /// If true, `DELETE FROM claim_themes` before building. Default false —
     /// callers that want a clean slate must opt in explicitly.
     pub wipe_first: Option<bool>,
+    /// Embedding dimension to source. `None` or `Some(1536)` uses the legacy
+    /// `claims.embedding` column and writes to `claim_themes.centroid`.
+    /// `Some(3072)` uses `claims.embedding_3072` and writes to
+    /// `claim_themes.centroid_3072` (operator must run `epigraph-cli reembed`
+    /// first, otherwise this returns 412 Precondition Failed).
+    pub centroid_dim: Option<u32>,
 }
 
 /// k-means bootstrap of `claim_themes` from the existing corpus. Required
@@ -1203,6 +1209,13 @@ pub async fn build_themes_from_corpus(
     let limit = request.limit.unwrap_or(500).max(1);
     let label_prefix = request.label_prefix.unwrap_or_else(|| "auto".to_string());
     let wipe_first = request.wipe_first.unwrap_or(false);
+    let centroid_dim = request.centroid_dim.unwrap_or(1536);
+
+    if !matches!(centroid_dim, 1536 | 3072) {
+        return Err(ApiError::BadRequest {
+            message: format!("centroid_dim must be 1536 or 3072 (got {centroid_dim})"),
+        });
+    }
 
     if k_min == 0 || k_max < k_min {
         return Err(ApiError::BadRequest {
@@ -1214,20 +1227,38 @@ pub async fn build_themes_from_corpus(
         epigraph_db::ClaimThemeRepository::delete_all(&state.db_pool).await?;
     }
 
-    // 1. Pull claims with embeddings.
-    let rows: Vec<(Uuid, Vec<f32>)> = sqlx::query_as(
-        "SELECT id, embedding::text::float4[] \
+    // 1. Pull claims with embeddings. Branch on centroid_dim: 1536 reads
+    //    `claims.embedding`; 3072 reads `claims.embedding_3072` (operator must
+    //    have run `epigraph-cli reembed --target claims` first).
+    let source_col = if centroid_dim == 3072 {
+        "embedding_3072"
+    } else {
+        "embedding"
+    };
+    let select_sql = format!(
+        "SELECT id, {source_col}::real[] \
          FROM claims \
-         WHERE embedding IS NOT NULL \
+         WHERE {source_col} IS NOT NULL \
          ORDER BY id \
-         LIMIT $1",
-    )
-    .bind(limit)
-    .fetch_all(&state.db_pool)
-    .await
-    .map_err(|e| ApiError::InternalError {
-        message: format!("Failed to fetch claim embeddings: {e}"),
-    })?;
+         LIMIT $1"
+    );
+    let rows: Vec<(Uuid, Vec<f32>)> = sqlx::query_as(&select_sql)
+        .bind(limit)
+        .fetch_all(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Failed to fetch claim embeddings: {e}"),
+        })?;
+
+    // Reject when 3072d was requested but no claims have it populated.
+    // This is the operator-misordering guard: they need to run reembed first.
+    if centroid_dim == 3072 && rows.is_empty() {
+        return Err(ApiError::BadRequest {
+            message: "centroid_dim=3072 requires populated claims.embedding_3072; \
+                      run `epigraph-cli reembed --target claims` first"
+                .to_string(),
+        });
+    }
 
     let n_claims = rows.len();
     if n_claims < k_min {
@@ -1236,6 +1267,7 @@ pub async fn build_themes_from_corpus(
             "claims_assigned": 0,
             "k_used": null,
             "claims_with_embeddings": n_claims,
+            "centroid_dim": centroid_dim,
             "skipped_reason": format!("only {} claims with embeddings (need ≥ k_min={})", n_claims, k_min),
         })));
     }
@@ -1333,9 +1365,10 @@ pub async fn build_themes_from_corpus(
 
         let theme_label = format!("{label_prefix}-{cluster_idx:02}");
         let theme_description = format!(
-            "Auto-built from {} claims by k-means at k={} (1536d embedding)",
+            "Auto-built from {} claims by k-means at k={} ({}d embedding)",
             cluster_claim_ids.len(),
             chosen_k,
+            centroid_dim,
         );
         let theme = epigraph_db::ClaimThemeRepository::create(
             &state.db_pool,
@@ -1353,8 +1386,27 @@ pub async fn build_themes_from_corpus(
                 .collect::<Vec<_>>()
                 .join(",")
         );
-        epigraph_db::ClaimThemeRepository::set_centroid(&state.db_pool, theme.id, &centroid_str)
+        if centroid_dim == 3072 {
+            // Direct UPDATE to claim_themes.centroid_3072 (no repo helper yet —
+            // the existing set_centroid targets the legacy centroid column).
+            sqlx::query(
+                "UPDATE claim_themes SET centroid_3072 = $2::vector, updated_at = NOW() WHERE id = $1",
+            )
+            .bind(theme.id)
+            .bind(&centroid_str)
+            .execute(&state.db_pool)
+            .await
+            .map_err(|e| ApiError::InternalError {
+                message: format!("Failed to write 3072d centroid: {e}"),
+            })?;
+        } else {
+            epigraph_db::ClaimThemeRepository::set_centroid(
+                &state.db_pool,
+                theme.id,
+                &centroid_str,
+            )
             .await?;
+        }
 
         let assigned = epigraph_db::ClaimThemeRepository::bulk_assign(
             &state.db_pool,
@@ -1828,6 +1880,7 @@ mod tests {
                 limit: Some(100),
                 label_prefix: None,
                 wipe_first: Some(false),
+                centroid_dim: None,
             }),
         )
         .await
@@ -1837,5 +1890,101 @@ mod tests {
         assert_eq!(body["themes_created"], serde_json::json!(0));
         assert_eq!(body["claims_assigned"], serde_json::json!(0));
         assert!(body.get("skipped_reason").is_some());
+    }
+
+    /// 3072d path: when `centroid_dim=3072` is requested AND the
+    /// `claims.embedding_3072` column is populated, build-from-corpus
+    /// k-means against 3072d vectors and writes to
+    /// `claim_themes.centroid_3072`.
+    #[tokio::test]
+    async fn build_from_corpus_writes_3072d_centroids_when_requested() {
+        let pool = test_pool_or_skip!();
+
+        // Clear and seed: insert 50 claims with embedding_3072 populated.
+        let _ = sqlx::query("UPDATE claims SET embedding = NULL, embedding_3072 = NULL")
+            .execute(&pool)
+            .await;
+        // Drop any prior auto-themes from this scenario so themes_created is
+        // bounded only by what THIS call writes.
+        let _ = sqlx::query("UPDATE claims SET theme_id = NULL")
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM claim_themes WHERE label LIKE 'auto3072-%'")
+            .execute(&pool)
+            .await;
+
+        let agent_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels) \
+             VALUES (sha256(gen_random_uuid()::text::bytea), 'build-3072-test', 'system', ARRAY['test']) \
+             RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("seed agent");
+
+        // Build 3 distinct 3072d vectors (3 clusters of ~17 claims each, with
+        // small jitter so k-means actually has work to do).
+        for cluster in 0..3 {
+            let base = cluster as f32 * 0.1;
+            for i in 0..17 {
+                let inner: Vec<String> = (0..3072)
+                    .map(|j| {
+                        // Cluster-specific bias on the first 3 dims, jitter
+                        // elsewhere so claims in the same cluster are similar.
+                        let bias = if j == cluster { 1.0 } else { 0.0 };
+                        let jitter = ((i + j) as f32) * 1e-7;
+                        format!("{}", base + bias + jitter)
+                    })
+                    .collect();
+                let pgvec = format!("[{}]", inner.join(","));
+                let content = format!("3072-test-c{}-i{}-{}", cluster, i, Uuid::new_v4());
+                sqlx::query(
+                    "INSERT INTO claims (content, content_hash, truth_value, agent_id, embedding_3072) \
+                     VALUES ($1, sha256($1::bytea), 0.5, $2, $3::vector)",
+                )
+                .bind(&content)
+                .bind(agent_id)
+                .bind(&pgvec)
+                .execute(&pool)
+                .await
+                .expect("seed 3072d claim");
+            }
+        }
+
+        let state = AppState::with_db(pool.clone(), ApiConfig::default());
+        let result = build_themes_from_corpus(
+            axum::extract::State(state),
+            None,
+            axum::Json(BuildThemesFromCorpusRequest {
+                k: Some(3),
+                k_min: Some(2),
+                k_max: Some(4),
+                min_claims_per_theme: Some(2),
+                limit: Some(100),
+                label_prefix: Some("auto3072".to_string()),
+                wipe_first: Some(false),
+                centroid_dim: Some(3072),
+            }),
+        )
+        .await
+        .expect("3072d build-from-corpus must succeed");
+
+        let body = result.0;
+        assert_eq!(body["centroid_dim"], serde_json::json!(3072));
+        assert!(
+            body["themes_created"].as_i64().unwrap_or(0) > 0,
+            "themes_created should be > 0; body={body}"
+        );
+
+        let centroid_3072_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM claim_themes WHERE centroid_3072 IS NOT NULL AND label LIKE 'auto3072-%'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            centroid_3072_count > 0,
+            "at least one claim_themes row should have centroid_3072 written"
+        );
     }
 }

--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -60,6 +60,11 @@ name = "experiment"
 path = "src/bin/experiment.rs"
 required-features = ["db"]
 
+[[bin]]
+name = "reembed"
+path = "src/bin/reembed.rs"
+required-features = ["db"]
+
 [dependencies]
 epigraph-core = { workspace = true }
 epigraph-engine = { workspace = true }
@@ -86,6 +91,9 @@ base64 = "0.22"
 linfa = { workspace = true }
 linfa-clustering = { workspace = true }
 ndarray = { workspace = true }
+
+[dev-dependencies]
+sqlx = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/epigraph-cli/src/bin/reembed.rs
+++ b/crates/epigraph-cli/src/bin/reembed.rs
@@ -1,0 +1,117 @@
+//! `epigraph-cli reembed` — Idempotent batch re-embedding of claims/evidence
+//! at 3072d (text-embedding-3-large).
+//!
+//! Usage:
+//!   reembed --target claims [--batch 256] [--checkpoint-file PATH]
+//!   reembed --target evidence [--batch 256] [--checkpoint-file PATH]
+//!
+//! Reads `OPENAI_API_KEY`. Falls back to a mock provider when unset (dev
+//! convenience — the mock writes deterministic 3072d vectors so the column
+//! gets populated, but the vectors are not semantically meaningful).
+//!
+//! `DATABASE_URL` is required.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::Parser;
+
+use epigraph_cli::reembed::{run, ReembedConfig, ReembedTarget};
+use epigraph_embeddings::{EmbeddingConfig, EmbeddingService, MockProvider, OpenAiProvider};
+
+#[derive(Parser)]
+#[command(
+    name = "reembed",
+    about = "Re-embed claims or evidence at 3072d (text-embedding-3-large)"
+)]
+struct Cli {
+    /// Target table: claims or evidence
+    #[arg(long)]
+    target: String,
+    /// Rows per batch
+    #[arg(long, default_value_t = 256)]
+    batch: usize,
+    /// Optional checkpoint file for resume
+    #[arg(long)]
+    checkpoint_file: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let cli = Cli::parse();
+
+    let target = match cli.target.as_str() {
+        "claims" => ReembedTarget::Claims,
+        "evidence" => ReembedTarget::Evidence,
+        other => {
+            eprintln!("--target must be 'claims' or 'evidence' (got '{other}')");
+            std::process::exit(2);
+        }
+    };
+
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        eprintln!("DATABASE_URL required");
+        std::process::exit(2);
+    });
+    let pool = sqlx::PgPool::connect(&url).await.unwrap_or_else(|e| {
+        eprintln!("connect failed: {e}");
+        std::process::exit(1);
+    });
+
+    let provider = build_3072d_provider();
+
+    let summary = run(
+        &pool,
+        ReembedConfig {
+            target,
+            batch_size: cli.batch,
+            embedding_provider: provider,
+            checkpoint_path: cli.checkpoint_file,
+        },
+    )
+    .await
+    .unwrap_or_else(|e| {
+        eprintln!("reembed failed: {e}");
+        std::process::exit(1);
+    });
+
+    println!(
+        "reembed: {} rows in {} batches (target={:?})",
+        summary.rows_written, summary.batches, target,
+    );
+}
+
+/// Build the 3072d embedding provider. Prefers OpenAI text-embedding-3-large
+/// when `OPENAI_API_KEY` is set; falls back to MockProvider for dev/CI.
+fn build_3072d_provider() -> Arc<dyn EmbeddingService> {
+    let mut config = EmbeddingConfig::openai(3072);
+    // Override the default model (text-embedding-3-small) to text-embedding-3-large.
+    if let epigraph_embeddings::config::ProviderConfig::OpenAi {
+        ref mut model,
+        api_base_url: _,
+    } = config.provider
+    {
+        *model = "text-embedding-3-large".to_string();
+    }
+
+    if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+        if !key.is_empty() {
+            match OpenAiProvider::new(config.clone(), key) {
+                Ok(p) => {
+                    tracing::info!("reembed provider: OpenAI text-embedding-3-large (3072d)");
+                    return Arc::new(p);
+                }
+                Err(e) => tracing::warn!("OpenAI init failed, falling back to mock: {e}"),
+            }
+        }
+    }
+    tracing::warn!(
+        "OPENAI_API_KEY not set; using MockProvider — embeddings will be deterministic but not semantically meaningful"
+    );
+    Arc::new(MockProvider::new(config))
+}

--- a/crates/epigraph-cli/src/lib.rs
+++ b/crates/epigraph-cli/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod enrichment;
+#[cfg(feature = "db")]
+pub mod reembed;
 
 #[cfg(feature = "db")]
 use sqlx::PgPool;

--- a/crates/epigraph-cli/src/reembed.rs
+++ b/crates/epigraph-cli/src/reembed.rs
@@ -187,8 +187,9 @@ fn read_checkpoint(path: Option<&PathBuf>) -> Result<Option<Uuid>, ReembedError>
     if trimmed.is_empty() {
         return Ok(None);
     }
-    let id = Uuid::parse_str(trimmed)
-        .map_err(|e| ReembedError::InvalidCheckpoint(format!("expected UUID, got {trimmed}: {e}")))?;
+    let id = Uuid::parse_str(trimmed).map_err(|e| {
+        ReembedError::InvalidCheckpoint(format!("expected UUID, got {trimmed}: {e}"))
+    })?;
     Ok(Some(id))
 }
 
@@ -202,4 +203,3 @@ fn write_checkpoint(path: Option<&PathBuf>, id: Uuid) -> Result<(), ReembedError
     std::fs::write(path, id.to_string())?;
     Ok(())
 }
-

--- a/crates/epigraph-cli/src/reembed.rs
+++ b/crates/epigraph-cli/src/reembed.rs
@@ -1,0 +1,205 @@
+//! Idempotent, resumable batch re-embedding from `text-embedding-3-small`
+//! (1536d) to `text-embedding-3-large` (3072d).
+//!
+//! Operates on `claims` and `evidence` tables. Pulls rows whose 3072d column
+//! is NULL, generates embeddings via the supplied `EmbeddingService`, and
+//! UPDATEs the `embedding_3072` column. Optional checkpoint file (last `id`
+//! written, as a UUID string) lets a crashed run resume cheaply.
+//!
+//! Idempotent: re-running over already-populated rows fetches zero rows
+//! (filter is `WHERE embedding_3072 IS NULL`). Resumable: filter
+//! `id > $last_id ORDER BY id` continues from the checkpoint UUID.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use epigraph_embeddings::{EmbeddingError, EmbeddingService};
+
+/// Config for a single reembed run.
+pub struct ReembedConfig {
+    pub target: ReembedTarget,
+    pub batch_size: usize,
+    pub embedding_provider: Arc<dyn EmbeddingService>,
+    pub checkpoint_path: Option<PathBuf>,
+}
+
+/// Which table to reembed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReembedTarget {
+    Claims,
+    Evidence,
+}
+
+impl ReembedTarget {
+    /// Table name in SQL.
+    fn table(self) -> &'static str {
+        match self {
+            Self::Claims => "claims",
+            Self::Evidence => "evidence",
+        }
+    }
+
+    /// Column holding the source text for embedding.
+    fn content_column(self) -> &'static str {
+        match self {
+            // claims.content is the canonical text column.
+            Self::Claims => "content",
+            // evidence.raw_content is the text column (see migration 001).
+            Self::Evidence => "raw_content",
+        }
+    }
+}
+
+/// Summary of a completed reembed run.
+#[derive(Debug, Clone)]
+pub struct ReembedSummary {
+    pub rows_written: usize,
+    pub batches: usize,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReembedError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("embedding provider error: {0}")]
+    Provider(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid checkpoint contents: {0}")]
+    InvalidCheckpoint(String),
+}
+
+impl From<EmbeddingError> for ReembedError {
+    fn from(e: EmbeddingError) -> Self {
+        Self::Provider(e.to_string())
+    }
+}
+
+/// Run the reembed loop until no rows remain.
+///
+/// # Errors
+/// Returns an error if the database, embedding provider, or checkpoint I/O fails.
+pub async fn run(pool: &PgPool, config: ReembedConfig) -> Result<ReembedSummary, ReembedError> {
+    let mut last_id = read_checkpoint(config.checkpoint_path.as_ref())?;
+    let mut rows_written = 0_usize;
+    let mut batches = 0_usize;
+
+    loop {
+        let rows = fetch_batch(pool, config.target, last_id, config.batch_size).await?;
+        if rows.is_empty() {
+            break;
+        }
+
+        let texts: Vec<&str> = rows.iter().map(|(_, c)| c.as_str()).collect();
+        let embeddings = config.embedding_provider.batch_generate(&texts).await?;
+        if embeddings.len() != rows.len() {
+            return Err(ReembedError::Provider(format!(
+                "provider returned {} embeddings for {} inputs",
+                embeddings.len(),
+                rows.len()
+            )));
+        }
+
+        for ((row_id, _), embedding) in rows.iter().zip(embeddings.iter()) {
+            let pgvec = format_pgvector(embedding);
+            update_embedding_3072(pool, config.target, *row_id, &pgvec).await?;
+            rows_written += 1;
+        }
+
+        // Advance checkpoint to last id of this batch.
+        if let Some(last) = rows.last() {
+            last_id = Some(last.0);
+            write_checkpoint(config.checkpoint_path.as_ref(), last.0)?;
+        }
+        batches += 1;
+
+        if rows.len() < config.batch_size {
+            // Last partial batch; next loop would return zero anyway.
+            break;
+        }
+    }
+
+    Ok(ReembedSummary {
+        rows_written,
+        batches,
+    })
+}
+
+/// Fetch a batch of rows whose `embedding_3072` is NULL, ordered by id.
+async fn fetch_batch(
+    pool: &PgPool,
+    target: ReembedTarget,
+    last_id: Option<Uuid>,
+    batch_size: usize,
+) -> Result<Vec<(Uuid, String)>, ReembedError> {
+    let table = target.table();
+    let content_col = target.content_column();
+
+    let sql = format!(
+        "SELECT id, {content_col} AS content \
+         FROM {table} \
+         WHERE embedding_3072 IS NULL \
+           AND ($1::uuid IS NULL OR id > $1) \
+           AND {content_col} IS NOT NULL \
+           AND length({content_col}) > 0 \
+         ORDER BY id \
+         LIMIT $2"
+    );
+
+    let rows: Vec<(Uuid, String)> = sqlx::query_as(&sql)
+        .bind(last_id)
+        .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows)
+}
+
+/// UPDATE one row's `embedding_3072` column.
+async fn update_embedding_3072(
+    pool: &PgPool,
+    target: ReembedTarget,
+    id: Uuid,
+    pgvec: &str,
+) -> Result<(), ReembedError> {
+    let table = target.table();
+    let sql = format!("UPDATE {table} SET embedding_3072 = $1::vector WHERE id = $2");
+    sqlx::query(&sql).bind(pgvec).bind(id).execute(pool).await?;
+    Ok(())
+}
+
+/// Format a `&[f32]` as pgvector literal `[a,b,c,...]`.
+fn format_pgvector(vec: &[f32]) -> String {
+    let inner: Vec<String> = vec.iter().map(|v| format!("{v}")).collect();
+    format!("[{}]", inner.join(","))
+}
+
+fn read_checkpoint(path: Option<&PathBuf>) -> Result<Option<Uuid>, ReembedError> {
+    let Some(path) = path else { return Ok(None) };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(path)?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let id = Uuid::parse_str(trimmed)
+        .map_err(|e| ReembedError::InvalidCheckpoint(format!("expected UUID, got {trimmed}: {e}")))?;
+    Ok(Some(id))
+}
+
+fn write_checkpoint(path: Option<&PathBuf>, id: Uuid) -> Result<(), ReembedError> {
+    let Some(path) = path else { return Ok(()) };
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, id.to_string())?;
+    Ok(())
+}
+

--- a/crates/epigraph-cli/tests/reembed_idempotent.rs
+++ b/crates/epigraph-cli/tests/reembed_idempotent.rs
@@ -1,0 +1,165 @@
+//! Verifies the reembed CLI is idempotent: re-running over already-populated
+//! rows is a no-op (zero embedding-provider calls beyond the first run).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use epigraph_cli::reembed::{run, ReembedConfig, ReembedTarget};
+use epigraph_embeddings::{
+    EmbeddingConfig, EmbeddingError, EmbeddingService, MockProvider, SimilarClaim, TokenUsage,
+};
+
+/// Wrapper around `MockProvider` that exposes an externally observable call
+/// counter. The upstream `MockProvider::call_count` is private, and we want
+/// to assert "no extra batch_generate calls on the second run".
+struct CountingProvider {
+    inner: MockProvider,
+    batch_calls: AtomicUsize,
+}
+
+impl CountingProvider {
+    fn new_3072() -> Self {
+        let config = EmbeddingConfig::openai(3072);
+        Self {
+            inner: MockProvider::new(config),
+            batch_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn batch_call_count(&self) -> usize {
+        self.batch_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl EmbeddingService for CountingProvider {
+    async fn generate(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        self.inner.generate(text).await
+    }
+
+    async fn batch_generate(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.batch_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.batch_generate(texts).await
+    }
+
+    async fn store(&self, claim_id: Uuid, embedding: &[f32]) -> Result<(), EmbeddingError> {
+        self.inner.store(claim_id, embedding).await
+    }
+
+    async fn get(&self, claim_id: Uuid) -> Result<Vec<f32>, EmbeddingError> {
+        self.inner.get(claim_id).await
+    }
+
+    async fn similar(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        min_similarity: f32,
+    ) -> Result<Vec<SimilarClaim>, EmbeddingError> {
+        self.inner.similar(embedding, k, min_similarity).await
+    }
+
+    fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+
+    fn token_usage(&self) -> TokenUsage {
+        self.inner.token_usage()
+    }
+
+    fn reset_token_usage(&self) {
+        self.inner.reset_token_usage();
+    }
+
+    async fn health_check(&self) -> Result<(), EmbeddingError> {
+        self.inner.health_check().await
+    }
+}
+
+/// Insert `n` claims with a non-null 1536d embedding and NULL embedding_3072.
+async fn seed_claims_with_1536_embeddings(pool: &PgPool, n: usize) -> Vec<Uuid> {
+    // Inline agent seed (no epigraph_test_support helper). Pattern mirrors
+    // tests in crates/epigraph-db/src/repos/claim.rs.
+    let agent_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels) \
+         VALUES (sha256(gen_random_uuid()::text::bytea), 'reembed-test', 'system', ARRAY['test']) \
+         RETURNING id",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("seed agent");
+
+    // Build a length-1536 zero-ish vector as a pgvector literal.
+    let inner: Vec<String> = (0..1536).map(|i| format!("{}", (i as f32) * 0.0001)).collect();
+    let pgvec = format!("[{}]", inner.join(","));
+
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let content = format!("reembed-test-{}-{}", i, Uuid::new_v4());
+        let id: Uuid = sqlx::query_scalar(
+            "INSERT INTO claims (content, content_hash, truth_value, agent_id, embedding, embedding_3072) \
+             VALUES ($1, sha256($1::bytea), 0.5, $2, $3::vector, NULL) \
+             RETURNING id",
+        )
+        .bind(&content)
+        .bind(agent_id)
+        .bind(&pgvec)
+        .fetch_one(pool)
+        .await
+        .expect("seed claim");
+        ids.push(id);
+    }
+    ids
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn reembed_is_idempotent(pool: PgPool) {
+    let _seeded = seed_claims_with_1536_embeddings(&pool, 3).await;
+
+    let provider = Arc::new(CountingProvider::new_3072());
+    let summary1 = run(
+        &pool,
+        ReembedConfig {
+            target: ReembedTarget::Claims,
+            batch_size: 2,
+            embedding_provider: provider.clone(),
+            checkpoint_path: None,
+        },
+    )
+    .await
+    .expect("first run");
+    assert_eq!(summary1.rows_written, 3, "first run writes 3 rows");
+
+    let calls_after_first = provider.batch_call_count();
+    assert!(calls_after_first >= 1, "first run made at least one batch call");
+
+    let summary2 = run(
+        &pool,
+        ReembedConfig {
+            target: ReembedTarget::Claims,
+            batch_size: 2,
+            embedding_provider: provider.clone(),
+            checkpoint_path: None,
+        },
+    )
+    .await
+    .expect("second run");
+    assert_eq!(summary2.rows_written, 0, "second run is a no-op");
+    assert_eq!(
+        provider.batch_call_count(),
+        calls_after_first,
+        "no extra embedding calls on second run",
+    );
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM claims WHERE embedding_3072 IS NOT NULL AND content LIKE 'reembed-test-%'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 3, "all 3 seeded claims have embedding_3072 populated");
+}

--- a/crates/epigraph-cli/tests/reembed_idempotent.rs
+++ b/crates/epigraph-cli/tests/reembed_idempotent.rs
@@ -94,7 +94,9 @@ async fn seed_claims_with_1536_embeddings(pool: &PgPool, n: usize) -> Vec<Uuid> 
     .expect("seed agent");
 
     // Build a length-1536 zero-ish vector as a pgvector literal.
-    let inner: Vec<String> = (0..1536).map(|i| format!("{}", (i as f32) * 0.0001)).collect();
+    let inner: Vec<String> = (0..1536)
+        .map(|i| format!("{}", (i as f32) * 0.0001))
+        .collect();
     let pgvec = format!("[{}]", inner.join(","));
 
     let mut ids = Vec::with_capacity(n);
@@ -135,7 +137,10 @@ async fn reembed_is_idempotent(pool: PgPool) {
     assert_eq!(summary1.rows_written, 3, "first run writes 3 rows");
 
     let calls_after_first = provider.batch_call_count();
-    assert!(calls_after_first >= 1, "first run made at least one batch call");
+    assert!(
+        calls_after_first >= 1,
+        "first run made at least one batch call"
+    );
 
     let summary2 = run(
         &pool,
@@ -161,5 +166,8 @@ async fn reembed_is_idempotent(pool: PgPool) {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(count, 3, "all 3 seeded claims have embedding_3072 populated");
+    assert_eq!(
+        count, 3,
+        "all 3 seeded claims have embedding_3072 populated"
+    );
 }

--- a/migrations/027_centroids_3072d.sql
+++ b/migrations/027_centroids_3072d.sql
@@ -1,0 +1,15 @@
+-- migrations/027_centroids_3072d.sql
+-- Adds 3072-dimensional centroid columns alongside the existing 1536d
+-- columns. NEW columns; no ALTER TYPE on existing columns to avoid HNSW
+-- index rebuild. The legacy 1536d columns remain populated and queried
+-- until the operator runs the reembed CLI and switches callers via
+-- the centroid_dim query parameter.
+
+ALTER TABLE claim_themes      ADD COLUMN centroid_3072 vector(3072);
+ALTER TABLE cluster_centroids ADD COLUMN centroid_3072 vector(3072);
+ALTER TABLE claims            ADD COLUMN embedding_3072 vector(3072);
+ALTER TABLE evidence          ADD COLUMN embedding_3072 vector(3072);
+
+-- No HNSW indexes on 3072d columns initially. Theme/cluster counts are
+-- small enough that seq-scan (<5ms for 10² centroids) is acceptable.
+-- For claims/evidence at scale, revisit if recall/latency demands.


### PR DESCRIPTION
Tracks #59 (sub-task A).

## Summary
- Migration 027 adds `centroid_3072` / `embedding_3072` columns to `claim_themes`, `cluster_centroids`, `claims`, `evidence` (no HNSW indexes yet — added later if scale demands).
- New `epigraph-cli reembed` binary: idempotent (`WHERE embedding_3072 IS NULL` filter), resumable (UUID checkpoint file), batched. Uses `text-embedding-3-large` when `OPENAI_API_KEY` is set; falls back to MockProvider for dev/CI.
- `POST /api/v1/themes/build-from-corpus` accepts `centroid_dim=3072` (default 1536). When 3072, the SELECT pulls from `claims.embedding_3072` and the UPDATE writes to `claim_themes.centroid_3072`. Returns BadRequest with explanatory message if 3072d is requested but no claims have it populated (operator needs to run reembed first).

## Operator workflow
1. Migration auto-applies on API restart (per #80).
2. `epigraph-cli reembed --target claims` (and `--target evidence`).
3. `POST /themes/build-from-corpus` with `{"centroid_dim": 3072, ...}`.

## Incidental fix
The existing 1536d SELECT used `embedding::text::float4[]` which never round-trips on populated vectors (pgvector's text format is `[1,2,3]` but pg array casting expects `{1,2,3}`). Switched to `embedding::real[]` which works for both 1536d and 3072d. The empty-corpus test passed because it never decoded a non-NULL vector.

## Test plan
- [x] Idempotency test on reembed: re-running over populated rows is a no-op (no extra `batch_generate` calls)
- [x] `build-from-corpus` writes 3072d centroids when requested (50 seeded claims with `embedding_3072`, `k=3` → 3+ themes with `centroid_3072 IS NOT NULL`)
- [x] Existing empty-corpus test still passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean