### PR TITLE
centroid_dim hint on diverse search (#59C)

### DIFF
--- a/crates/epigraph-api/src/routes/crud.rs
+++ b/crates/epigraph-api/src/routes/crud.rs
@@ -1165,6 +1165,12 @@ pub struct BuildThemesFromCorpusRequest {
     /// If true, `DELETE FROM claim_themes` before building. Default false —
     /// callers that want a clean slate must opt in explicitly.
     pub wipe_first: Option<bool>,
+    /// Embedding dimension to source. `None` or `Some(1536)` uses the legacy
+    /// `claims.embedding` column and writes to `claim_themes.centroid`.
+    /// `Some(3072)` uses `claims.embedding_3072` and writes to
+    /// `claim_themes.centroid_3072` (operator must run `epigraph-cli reembed`
+    /// first, otherwise this returns 412 Precondition Failed).
+    pub centroid_dim: Option<u32>,
 }
 
 /// k-means bootstrap of `claim_themes` from the existing corpus. Required
@@ -1203,6 +1209,13 @@ pub async fn build_themes_from_corpus(
     let limit = request.limit.unwrap_or(500).max(1);
     let label_prefix = request.label_prefix.unwrap_or_else(|| "auto".to_string());
     let wipe_first = request.wipe_first.unwrap_or(false);
+    let centroid_dim = request.centroid_dim.unwrap_or(1536);
+
+    if !matches!(centroid_dim, 1536 | 3072) {
+        return Err(ApiError::BadRequest {
+            message: format!("centroid_dim must be 1536 or 3072 (got {centroid_dim})"),
+        });
+    }
 
     if k_min == 0 || k_max < k_min {
         return Err(ApiError::BadRequest {
@@ -1214,20 +1227,38 @@ pub async fn build_themes_from_corpus(
         epigraph_db::ClaimThemeRepository::delete_all(&state.db_pool).await?;
     }
 
-    // 1. Pull claims with embeddings.
-    let rows: Vec<(Uuid, Vec<f32>)> = sqlx::query_as(
-        "SELECT id, embedding::text::float4[] \
+    // 1. Pull claims with embeddings. Branch on centroid_dim: 1536 reads
+    //    `claims.embedding`; 3072 reads `claims.embedding_3072` (operator must
+    //    have run `epigraph-cli reembed --target claims` first).
+    let source_col = if centroid_dim == 3072 {
+        "embedding_3072"
+    } else {
+        "embedding"
+    };
+    let select_sql = format!(
+        "SELECT id, {source_col}::real[] \
          FROM claims \
-         WHERE embedding IS NOT NULL \
+         WHERE {source_col} IS NOT NULL \
          ORDER BY id \
-         LIMIT $1",
-    )
-    .bind(limit)
-    .fetch_all(&state.db_pool)
-    .await
-    .map_err(|e| ApiError::InternalError {
-        message: format!("Failed to fetch claim embeddings: {e}"),
-    })?;
+         LIMIT $1"
+    );
+    let rows: Vec<(Uuid, Vec<f32>)> = sqlx::query_as(&select_sql)
+        .bind(limit)
+        .fetch_all(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("Failed to fetch claim embeddings: {e}"),
+        })?;
+
+    // Reject when 3072d was requested but no claims have it populated.
+    // This is the operator-misordering guard: they need to run reembed first.
+    if centroid_dim == 3072 && rows.is_empty() {
+        return Err(ApiError::BadRequest {
+            message: "centroid_dim=3072 requires populated claims.embedding_3072; \
+                      run `epigraph-cli reembed --target claims` first"
+                .to_string(),
+        });
+    }
 
     let n_claims = rows.len();
     if n_claims < k_min {
@@ -1236,6 +1267,7 @@ pub async fn build_themes_from_corpus(
             "claims_assigned": 0,
             "k_used": null,
             "claims_with_embeddings": n_claims,
+            "centroid_dim": centroid_dim,
             "skipped_reason": format!("only {} claims with embeddings (need ≥ k_min={})", n_claims, k_min),
         })));
     }
@@ -1333,9 +1365,10 @@ pub async fn build_themes_from_corpus(
 
         let theme_label = format!("{label_prefix}-{cluster_idx:02}");
         let theme_description = format!(
-            "Auto-built from {} claims by k-means at k={} (1536d embedding)",
+            "Auto-built from {} claims by k-means at k={} ({}d embedding)",
             cluster_claim_ids.len(),
             chosen_k,
+            centroid_dim,
         );
         let theme = epigraph_db::ClaimThemeRepository::create(
             &state.db_pool,
@@ -1353,8 +1386,27 @@ pub async fn build_themes_from_corpus(
                 .collect::<Vec<_>>()
                 .join(",")
         );
-        epigraph_db::ClaimThemeRepository::set_centroid(&state.db_pool, theme.id, &centroid_str)
+        if centroid_dim == 3072 {
+            // Direct UPDATE to claim_themes.centroid_3072 (no repo helper yet —
+            // the existing set_centroid targets the legacy centroid column).
+            sqlx::query(
+                "UPDATE claim_themes SET centroid_3072 = $2::vector, updated_at = NOW() WHERE id = $1",
+            )
+            .bind(theme.id)
+            .bind(&centroid_str)
+            .execute(&state.db_pool)
+            .await
+            .map_err(|e| ApiError::InternalError {
+                message: format!("Failed to write 3072d centroid: {e}"),
+            })?;
+        } else {
+            epigraph_db::ClaimThemeRepository::set_centroid(
+                &state.db_pool,
+                theme.id,
+                &centroid_str,
+            )
             .await?;
+        }
 
         let assigned = epigraph_db::ClaimThemeRepository::bulk_assign(
             &state.db_pool,
@@ -1828,6 +1880,7 @@ mod tests {
                 limit: Some(100),
                 label_prefix: None,
                 wipe_first: Some(false),
+                centroid_dim: None,
             }),
         )
         .await
@@ -1837,5 +1890,101 @@ mod tests {
         assert_eq!(body["themes_created"], serde_json::json!(0));
         assert_eq!(body["claims_assigned"], serde_json::json!(0));
         assert!(body.get("skipped_reason").is_some());
+    }
+
+    /// 3072d path: when `centroid_dim=3072` is requested AND the
+    /// `claims.embedding_3072` column is populated, build-from-corpus
+    /// k-means against 3072d vectors and writes to
+    /// `claim_themes.centroid_3072`.
+    #[tokio::test]
+    async fn build_from_corpus_writes_3072d_centroids_when_requested() {
+        let pool = test_pool_or_skip!();
+
+        // Clear and seed: insert 50 claims with embedding_3072 populated.
+        let _ = sqlx::query("UPDATE claims SET embedding = NULL, embedding_3072 = NULL")
+            .execute(&pool)
+            .await;
+        // Drop any prior auto-themes from this scenario so themes_created is
+        // bounded only by what THIS call writes.
+        let _ = sqlx::query("UPDATE claims SET theme_id = NULL")
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM claim_themes WHERE label LIKE 'auto3072-%'")
+            .execute(&pool)
+            .await;
+
+        let agent_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels) \
+             VALUES (sha256(gen_random_uuid()::text::bytea), 'build-3072-test', 'system', ARRAY['test']) \
+             RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("seed agent");
+
+        // Build 3 distinct 3072d vectors (3 clusters of ~17 claims each, with
+        // small jitter so k-means actually has work to do).
+        for cluster in 0..3 {
+            let base = cluster as f32 * 0.1;
+            for i in 0..17 {
+                let inner: Vec<String> = (0..3072)
+                    .map(|j| {
+                        // Cluster-specific bias on the first 3 dims, jitter
+                        // elsewhere so claims in the same cluster are similar.
+                        let bias = if j == cluster { 1.0 } else { 0.0 };
+                        let jitter = ((i + j) as f32) * 1e-7;
+                        format!("{}", base + bias + jitter)
+                    })
+                    .collect();
+                let pgvec = format!("[{}]", inner.join(","));
+                let content = format!("3072-test-c{}-i{}-{}", cluster, i, Uuid::new_v4());
+                sqlx::query(
+                    "INSERT INTO claims (content, content_hash, truth_value, agent_id, embedding_3072) \
+                     VALUES ($1, sha256($1::bytea), 0.5, $2, $3::vector)",
+                )
+                .bind(&content)
+                .bind(agent_id)
+                .bind(&pgvec)
+                .execute(&pool)
+                .await
+                .expect("seed 3072d claim");
+            }
+        }
+
+        let state = AppState::with_db(pool.clone(), ApiConfig::default());
+        let result = build_themes_from_corpus(
+            axum::extract::State(state),
+            None,
+            axum::Json(BuildThemesFromCorpusRequest {
+                k: Some(3),
+                k_min: Some(2),
+                k_max: Some(4),
+                min_claims_per_theme: Some(2),
+                limit: Some(100),
+                label_prefix: Some("auto3072".to_string()),
+                wipe_first: Some(false),
+                centroid_dim: Some(3072),
+            }),
+        )
+        .await
+        .expect("3072d build-from-corpus must succeed");
+
+        let body = result.0;
+        assert_eq!(body["centroid_dim"], serde_json::json!(3072));
+        assert!(
+            body["themes_created"].as_i64().unwrap_or(0) > 0,
+            "themes_created should be > 0; body={body}"
+        );
+
+        let centroid_3072_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM claim_themes WHERE centroid_3072 IS NOT NULL AND label LIKE 'auto3072-%'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            centroid_3072_count > 0,
+            "at least one claim_themes row should have centroid_3072 written"
+        );
     }
 }

--- a/crates/epigraph-api/src/routes/search.rs
+++ b/crates/epigraph-api/src/routes/search.rs
@@ -31,9 +31,6 @@ use uuid::Uuid;
 use sqlx::Row;
 
 #[cfg(feature = "db")]
-use epigraph_db::ClaimThemeRepository;
-
-#[cfg(feature = "db")]
 use epigraph_engine::diverse_select::diverse_select;
 
 use crate::{errors::ApiError, state::AppState};
@@ -93,6 +90,18 @@ pub struct SemanticSearchRequest {
     /// Coverage vs relevance tradeoff for diverse mode (0.0 = pure relevance, 1.0 = pure coverage, default: 0.5)
     #[serde(default)]
     pub diversity_weight: Option<f32>,
+
+    /// Centroid dimension to query against in diverse mode. `None` =
+    /// auto-detect (picks 3072 when ≥50% of `claim_themes` rows have
+    /// `centroid_3072` populated, else 1536). `Some(1536)` forces the
+    /// legacy `claim_themes.centroid` + `claims.embedding` columns;
+    /// `Some(3072)` forces `claim_themes.centroid_3072` +
+    /// `claims.embedding_3072` (operator must have run
+    /// `epigraph-cli reembed --target claims` and rebuilt themes
+    /// with `centroid_dim=3072` first, otherwise this returns 400
+    /// ValidationError). Ignored when `diverse=false`.
+    #[serde(default)]
+    pub centroid_dim: Option<u32>,
 }
 
 /// CDST belief interval for a claim — more informative than a single truth value
@@ -200,6 +209,14 @@ pub struct SemanticSearchResponse {
 
     /// Time taken to execute the query in milliseconds
     pub query_time_ms: u64,
+
+    /// Centroid dimension actually used in diverse mode (1536 or 3072).
+    /// `None` for non-diverse / flat searches. Reflects either the
+    /// caller's explicit `centroid_dim` hint or the auto-detect
+    /// outcome, so callers can verify which embedding space was
+    /// queried.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub centroid_dim_used: Option<u32>,
 }
 
 // ============================================================================
@@ -215,9 +232,13 @@ const MAX_LIMIT: u32 = 100;
 /// Valid claim types for filtering
 const VALID_CLAIM_TYPES: &[&str] = &["factual", "hypothesis", "opinion"];
 
-/// Embedding dimension for OpenAI text-embedding-3-small
+/// Embedding dimension for OpenAI text-embedding-3-small (legacy default)
 #[cfg(feature = "db")]
 const EMBEDDING_DIM: usize = 1536;
+
+/// Embedding dimension for OpenAI text-embedding-3-large (Phase 5 3072d path)
+#[cfg(feature = "db")]
+const EMBEDDING_DIM_LARGE: usize = 3072;
 
 /// Maximum query string length in bytes.
 /// Prevents DoS attacks via excessively long queries that could consume
@@ -233,25 +254,28 @@ const MAX_CLAIM_TYPE_LENGTH: usize = 64;
 // Embedding Generation
 // ============================================================================
 
-/// Generate a mock embedding vector for the given text.
+/// Generate a mock embedding vector for the given text at the requested dimension.
 ///
-/// This creates a deterministic embedding based on the input text for testing purposes.
-/// Used as a fallback when no embedding service is configured.
+/// This creates a deterministic embedding based on the input text for testing
+/// purposes. Used as a fallback when no embedding service is configured, or
+/// when the configured service's dimension doesn't match the centroid dim
+/// the caller is querying against (e.g. diverse-mode 3072d path).
 ///
 /// # Arguments
 /// * `text` - The text to embed
+/// * `dim` - Target embedding dimension (e.g. 1536 or 3072)
 ///
 /// # Returns
-/// A normalized 1536-dimensional vector
+/// A normalized `dim`-dimensional vector
 #[cfg(feature = "db")]
-fn generate_mock_embedding(text: &str) -> Vec<f32> {
-    let mut embedding = vec![0.0f32; EMBEDDING_DIM];
+fn generate_mock_embedding_with_dim(text: &str, dim: usize) -> Vec<f32> {
+    let mut embedding = vec![0.0f32; dim];
 
     // Create a deterministic "embedding" based on text bytes
     // This is NOT a real embedding, just for testing similarity ranking
     let text_bytes = text.as_bytes();
     for (i, byte) in text_bytes.iter().enumerate() {
-        let idx = i % EMBEDDING_DIM;
+        let idx = i % dim;
         embedding[idx] += (*byte as f32) / 255.0;
     }
 
@@ -274,7 +298,7 @@ fn generate_mock_embedding(text: &str) -> Vec<f32> {
 /// * `text` - The text to embed
 ///
 /// # Returns
-/// A vector of floats representing the text embedding
+/// A vector of floats representing the text embedding (1536d, legacy default).
 ///
 /// # Behavior
 /// - If embedding service is configured and succeeds: returns real embedding
@@ -282,33 +306,62 @@ fn generate_mock_embedding(text: &str) -> Vec<f32> {
 /// - If no embedding service configured: uses mock embedding
 #[cfg(feature = "db")]
 async fn generate_query_embedding(state: &AppState, text: &str) -> Vec<f32> {
-    // Try to use the real embedding service if available
+    generate_query_embedding_with_dim(state, text, EMBEDDING_DIM).await
+}
+
+/// Generate query embedding at a target dimension.
+///
+/// Used by the diverse-search 3072d path: when the caller asks for
+/// `centroid_dim=3072` the centroid lookup runs against `claim_themes.centroid_3072`,
+/// so the query vector must also be 3072-dimensional. If the configured embedding
+/// service produces a different dimension (e.g. it's pinned to
+/// `text-embedding-3-small`/1536d while we need 3072d), we fall back to a
+/// deterministic mock at the target dim — the caller will get degraded
+/// similarity quality but the query won't fail. Operators running the 3072d
+/// path in production are expected to configure a service whose
+/// `dimension()` matches.
+#[cfg(feature = "db")]
+async fn generate_query_embedding_with_dim(
+    state: &AppState,
+    text: &str,
+    target_dim: usize,
+) -> Vec<f32> {
+    // Try to use the real embedding service if available AND its dimension matches.
     if let Some(ref embedding_service) = state.embedding_service {
-        match embedding_service.generate_query(text).await {
-            Ok(embedding) => {
-                tracing::debug!(
-                    text_len = text.len(),
-                    embedding_dim = embedding.len(),
-                    "Generated real embedding for search query"
-                );
-                return embedding;
+        if embedding_service.dimension() == target_dim {
+            match embedding_service.generate_query(text).await {
+                Ok(embedding) => {
+                    tracing::debug!(
+                        text_len = text.len(),
+                        embedding_dim = embedding.len(),
+                        "Generated real embedding for search query"
+                    );
+                    return embedding;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Embedding service failed, falling back to mock embedding"
+                    );
+                    // Fall through to mock embedding
+                }
             }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "Embedding service failed, falling back to mock embedding"
-                );
-                // Fall through to mock embedding
-            }
+        } else {
+            tracing::warn!(
+                service_dim = embedding_service.dimension(),
+                target_dim = target_dim,
+                "Configured embedding service dimension differs from requested centroid_dim; using mock at target dim"
+            );
         }
     }
 
-    // Fallback to mock embedding
+    // Fallback to mock embedding at the target dim.
     tracing::debug!(
         text_len = text.len(),
-        "Using mock embedding for search query (no service configured or service failed)"
+        target_dim = target_dim,
+        "Using mock embedding for search query (no service configured, dim mismatch, or service failed)"
     );
-    generate_mock_embedding(text)
+    generate_mock_embedding_with_dim(text, target_dim)
 }
 
 /// Format embedding vector as pgvector string literal
@@ -469,10 +522,16 @@ pub async fn semantic_search(
     // Execute semantic search with pgvector
     #[cfg(feature = "db")]
     {
-        // Step 1: Generate embedding for the query
-        // Uses real embedding service when configured, falls back to mock if unavailable
-        let query_embedding = generate_query_embedding(&state, query).await;
-        let embedding_str = format_embedding_for_pgvector(&query_embedding);
+        // Validate centroid_dim hint up front (only meaningful when diverse=true,
+        // but reject obvious garbage values regardless so callers get a clear error).
+        if let Some(dim) = request.centroid_dim {
+            if dim != 1536 && dim != 3072 {
+                return Err(ApiError::ValidationError {
+                    field: "centroid_dim".to_string(),
+                    reason: format!("centroid_dim must be 1536 or 3072 (got {dim})"),
+                });
+            }
+        }
 
         // Step 2a: Diverse hierarchical retrieval path (theme-based + coverage selection)
         // When `diverse=true`, navigate themes first, then apply submodular selection.
@@ -481,32 +540,132 @@ pub async fn semantic_search(
             let max_themes = request.max_themes.unwrap_or(5) as i32;
             let alpha = request.diversity_weight.unwrap_or(0.5);
 
-            // Find the most relevant themes for the query
-            let themes = ClaimThemeRepository::find_similar_themes(
-                &state.db_pool,
-                &embedding_str,
-                max_themes,
+            // Resolve which centroid dimension to query against. Explicit hint
+            // wins; otherwise auto-detect via the population fraction of
+            // `claim_themes.centroid_3072` (≥50% → 3072, else 1536). This lets
+            // operators flip the corpus to 3072d theme-by-theme and have the
+            // search path follow automatically once the majority is migrated.
+            let frac_3072 = sqlx::query_scalar::<_, Option<f64>>(
+                "SELECT \
+                    COUNT(*) FILTER (WHERE centroid_3072 IS NOT NULL)::float8 \
+                      / NULLIF(COUNT(*), 0)::float8 \
+                  FROM claim_themes",
             )
+            .fetch_one(&state.db_pool)
             .await
             .map_err(|e| ApiError::InternalError {
-                message: format!("Theme search failed: {}", e),
-            })?;
+                message: format!("centroid_dim auto-detect failed: {e}"),
+            })?
+            .unwrap_or(0.0);
+
+            let centroid_dim_used: u32 = match request.centroid_dim {
+                Some(d) => d,
+                None => {
+                    if frac_3072 >= 0.5 {
+                        3072
+                    } else {
+                        1536
+                    }
+                }
+            };
+
+            // Operator-misordering guard: caller asked for 3072d but no
+            // themes have a centroid_3072 populated. Match PR #84's pattern
+            // (BadRequest body) using ValidationError for the clearer
+            // `field` surface — spec calls for 412 Precondition Failed but
+            // ApiError has no PreconditionFailed variant yet.
+            if centroid_dim_used == 3072 && frac_3072 == 0.0 {
+                return Err(ApiError::ValidationError {
+                    field: "centroid_dim".to_string(),
+                    reason: "no 3072d centroids populated; run \
+                             `epigraph-cli reembed --target claims` and rebuild \
+                             themes with centroid_dim=3072 first"
+                        .to_string(),
+                });
+            }
+
+            // Step 1: generate the query embedding at the centroid's
+            // dimension so the pgvector `<=>` operator can compare them.
+            let target_dim = if centroid_dim_used == 3072 {
+                EMBEDDING_DIM_LARGE
+            } else {
+                EMBEDDING_DIM
+            };
+            let query_embedding =
+                generate_query_embedding_with_dim(&state, query, target_dim).await;
+            let embedding_str = format_embedding_for_pgvector(&query_embedding);
+
+            // Branch on dim: column names are not user input (only `1536`
+            // or `3072` reach this point per the validation above), so
+            // `format!`-interpolating them is injection-safe.
+            let theme_centroid_col = if centroid_dim_used == 3072 {
+                "centroid_3072"
+            } else {
+                "centroid"
+            };
+            let claim_embedding_col = if centroid_dim_used == 3072 {
+                "embedding_3072"
+            } else {
+                "embedding"
+            };
+
+            // Find the most relevant themes for the query at the chosen dim.
+            let theme_sql = format!(
+                "SELECT id, label, (1 - ({theme_centroid_col} <=> $1::vector))::float8 AS similarity \
+                 FROM claim_themes \
+                 WHERE {theme_centroid_col} IS NOT NULL \
+                 ORDER BY {theme_centroid_col} <=> $1::vector \
+                 LIMIT $2"
+            );
+            let theme_rows = sqlx::query(&theme_sql)
+                .bind(&embedding_str)
+                .bind(max_themes)
+                .fetch_all(&state.db_pool)
+                .await
+                .map_err(|e| ApiError::InternalError {
+                    message: format!("Theme search failed: {e}"),
+                })?;
+            let themes: Vec<(Uuid, String, f64)> = theme_rows
+                .iter()
+                .map(|row| {
+                    let id: Uuid = row.get("id");
+                    let label: String = row.get("label");
+                    let similarity: f64 = row.get("similarity");
+                    (id, label, similarity)
+                })
+                .collect();
 
             // Only enter diverse mode if themes have been populated
             if !themes.is_empty() {
                 let theme_ids: Vec<Uuid> = themes.iter().map(|(id, _, _)| *id).collect();
 
-                // Retrieve candidate claims from those themes
-                let candidates = ClaimThemeRepository::claims_in_themes(
-                    &state.db_pool,
-                    &theme_ids,
-                    &embedding_str,
-                    100,
-                )
-                .await
-                .map_err(|e| ApiError::InternalError {
-                    message: format!("Candidate retrieval failed: {}", e),
-                })?;
+                // Retrieve candidate claims from those themes — branch on dim.
+                let candidates_sql = format!(
+                    "SELECT c.id, c.content, (1 - (c.{claim_embedding_col} <=> $2::vector))::float8 AS similarity \
+                     FROM claims c \
+                     WHERE c.theme_id = ANY($1) \
+                       AND c.{claim_embedding_col} IS NOT NULL \
+                     ORDER BY c.{claim_embedding_col} <=> $2::vector \
+                     LIMIT $3"
+                );
+                let candidate_rows = sqlx::query(&candidates_sql)
+                    .bind(&theme_ids)
+                    .bind(&embedding_str)
+                    .bind(100i32)
+                    .fetch_all(&state.db_pool)
+                    .await
+                    .map_err(|e| ApiError::InternalError {
+                        message: format!("Candidate retrieval failed: {e}"),
+                    })?;
+                let candidates: Vec<(Uuid, String, f64)> = candidate_rows
+                    .iter()
+                    .map(|row| {
+                        let id: Uuid = row.get("id");
+                        let content: String = row.get("content");
+                        let similarity: f64 = row.get("similarity");
+                        (id, content, similarity)
+                    })
+                    .collect();
 
                 // Build a proximity graph from the ranked candidate list (top-5 neighbours each)
                 let neighbors = build_similarity_neighbors(&candidates, 5);
@@ -523,7 +682,7 @@ pub async fn semantic_search(
                 // columns + theme_id and the latest cluster_id from
                 // claim_cluster_membership). #49: surface the partition
                 // labels so callers can render or filter by them.
-                let full_rows = sqlx::query(
+                let full_sql = format!(
                     r#"
                     SELECT c.id, c.content, c.truth_value, c.belief, c.plausibility,
                            c.agent_id, c.trace_id,
@@ -537,43 +696,45 @@ pub async fn semantic_search(
                                ORDER BY r.completed_at DESC
                                LIMIT 1
                            ) AS cluster_id,
-                           1 - (c.embedding <=> $1::vector) as similarity
+                           1 - (c.{claim_embedding_col} <=> $1::vector) as similarity
                     FROM claims c
                     WHERE c.id = ANY($2)
-                    ORDER BY c.embedding <=> $1::vector
-                    "#,
-                )
-                .bind(&embedding_str)
-                .bind(&selected_claim_ids)
-                .fetch_all(&state.db_pool)
-                .await
-                .map_err(|e| ApiError::InternalError {
-                    message: format!("Claim fetch failed: {e}"),
-                })?;
+                    ORDER BY c.{claim_embedding_col} <=> $1::vector
+                    "#
+                );
+                let full_rows = sqlx::query(&full_sql)
+                    .bind(&embedding_str)
+                    .bind(&selected_claim_ids)
+                    .fetch_all(&state.db_pool)
+                    .await
+                    .map_err(|e| ApiError::InternalError {
+                        message: format!("Claim fetch failed: {e}"),
+                    })?;
 
                 // Fetch graph neighbors for all selected claims
-                let neighbor_rows = sqlx::query(
+                let neighbor_sql = format!(
                     r#"
                     SELECT
                         e.source_id, e.target_id, e.relationship,
                         c.id as neighbor_id, left(c.content, 200) as content,
                         c.truth_value, c.belief as nb_belief, c.plausibility as nb_plausibility,
-                        (1 - (c.embedding <=> $1::vector))::float8 as similarity,
+                        (1 - (c.{claim_embedding_col} <=> $1::vector))::float8 as similarity,
                         CASE WHEN e.source_id = ANY($2) THEN 'outbound' ELSE 'inbound' END as direction
                     FROM edges e
                     JOIN claims c ON c.id = CASE WHEN e.source_id = ANY($2) THEN e.target_id ELSE e.source_id END
                     WHERE (e.source_id = ANY($2) OR e.target_id = ANY($2))
                       AND e.source_type = 'claim' AND e.target_type = 'claim'
                       AND e.relationship IN ('CORROBORATES', 'supports', 'refines', 'continues_argument', 'contradicts')
-                    ORDER BY c.embedding <=> $1::vector
+                    ORDER BY c.{claim_embedding_col} <=> $1::vector
                     LIMIT 50
-                    "#,
-                )
-                .bind(&embedding_str)
-                .bind(&selected_claim_ids)
-                .fetch_all(&state.db_pool)
-                .await
-                .unwrap_or_default();
+                    "#
+                );
+                let neighbor_rows = sqlx::query(&neighbor_sql)
+                    .bind(&embedding_str)
+                    .bind(&selected_claim_ids)
+                    .fetch_all(&state.db_pool)
+                    .await
+                    .unwrap_or_default();
 
                 // Group neighbors by the selected claim they connect to
                 let mut neighbor_map: HashMap<Uuid, Vec<GraphNeighbor>> = HashMap::new();
@@ -647,10 +808,17 @@ pub async fn semantic_search(
                     results,
                     total,
                     query_time_ms,
+                    centroid_dim_used: Some(centroid_dim_used),
                 }));
             }
             // No themes yet — fall through to flat search below
         }
+
+        // Flat-path uses the legacy 1536d `claims.embedding` column directly,
+        // so generate the query embedding at that dim. Diverse-path generates
+        // its own (possibly 3072d) embedding above.
+        let query_embedding = generate_query_embedding(&state, query).await;
+        let embedding_str = format_embedding_for_pgvector(&query_embedding);
 
         // Step 2b: Flat pgvector similarity search (default path)
         // Uses parameterized query to prevent SQL injection.
@@ -724,6 +892,7 @@ pub async fn semantic_search(
             results,
             total,
             query_time_ms,
+            centroid_dim_used: None,
         }))
     }
 
@@ -738,6 +907,7 @@ pub async fn semantic_search(
             results,
             total,
             query_time_ms,
+            centroid_dim_used: None,
         }))
     }
 }
@@ -819,6 +989,7 @@ mod tests {
             }],
             total: 1,
             query_time_ms: 15,
+            centroid_dim_used: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -908,5 +1079,335 @@ mod tests {
 
         let request: SemanticSearchRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(request.agent_id, Some(agent_id));
+    }
+
+    #[test]
+    fn test_semantic_search_request_centroid_dim_field() {
+        // 3072d hint deserializes into the new field.
+        let json = r#"{"query": "test", "diverse": true, "centroid_dim": 3072}"#;
+        let request: SemanticSearchRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.centroid_dim, Some(3072));
+
+        // Absent field defaults to None (auto-detect).
+        let json2 = r#"{"query": "test", "diverse": true}"#;
+        let request2: SemanticSearchRequest = serde_json::from_str(json2).unwrap();
+        assert!(request2.centroid_dim.is_none());
+    }
+
+    #[test]
+    fn test_semantic_search_response_serializes_centroid_dim_used() {
+        // Some(3072) → field is present in JSON.
+        let resp_with = SemanticSearchResponse {
+            results: vec![],
+            total: 0,
+            query_time_ms: 1,
+            centroid_dim_used: Some(3072),
+        };
+        let json = serde_json::to_string(&resp_with).unwrap();
+        assert!(json.contains("\"centroid_dim_used\":3072"));
+
+        // None → field is skipped (flat-search responses stay backwards-compat).
+        let resp_without = SemanticSearchResponse {
+            results: vec![],
+            total: 0,
+            query_time_ms: 1,
+            centroid_dim_used: None,
+        };
+        let json2 = serde_json::to_string(&resp_without).unwrap();
+        assert!(!json2.contains("centroid_dim_used"));
+    }
+}
+
+// ============================================================================
+// DB integration tests for the diverse-search centroid_dim path
+// ============================================================================
+
+#[cfg(all(test, feature = "db"))]
+mod db_integration_tests {
+    use super::*;
+    use crate::state::{ApiConfig, AppState};
+    use sqlx::Row;
+
+    async fn try_test_pool() -> Option<sqlx::PgPool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(3)
+            .connect(&url)
+            .await
+            .ok()?;
+        sqlx::migrate!("../../migrations").run(&pool).await.ok()?;
+        Some(pool)
+    }
+
+    macro_rules! test_pool_or_skip {
+        () => {{
+            match try_test_pool().await {
+                Some(p) => p,
+                None => {
+                    eprintln!("Skipping DB test: DATABASE_URL not set or unreachable");
+                    return;
+                }
+            }
+        }};
+    }
+
+    /// Wipe `claim_themes` and unassign all claims so each test starts with
+    /// a known empty theme table. Necessary because the DB is shared across
+    /// tests and prior k-means runs could otherwise leak themes.
+    async fn reset_themes(pool: &sqlx::PgPool) {
+        let _ = sqlx::query("UPDATE claims SET theme_id = NULL")
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM claim_themes").execute(pool).await;
+    }
+
+    /// Insert a fresh agent for the test scope (returns its UUID).
+    async fn seed_agent(pool: &sqlx::PgPool, label: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels) \
+             VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test']) \
+             RETURNING id",
+        )
+        .bind(label)
+        .fetch_one(pool)
+        .await
+        .expect("seed agent")
+    }
+
+    /// Build a deterministic pgvector literal at the given dim, biased toward
+    /// `seed` so two calls with the same seed produce similar (but not equal)
+    /// vectors after normalization.
+    fn pgvec_at_dim(seed: f32, dim: usize) -> String {
+        let mut v = vec![0.0f32; dim];
+        for (i, slot) in v.iter_mut().enumerate() {
+            *slot = if i == 0 { seed + 0.5 } else { seed * 1e-3 };
+        }
+        let inner: Vec<String> = v.iter().map(|x| x.to_string()).collect();
+        format!("[{}]", inner.join(","))
+    }
+
+    /// Insert N themes with `centroid_3072` populated. Returns the inserted ids.
+    async fn seed_themes_with_3072_centroids(pool: &sqlx::PgPool, n: usize) -> Vec<Uuid> {
+        let mut ids = Vec::with_capacity(n);
+        for i in 0..n {
+            let theme_id = sqlx::query_scalar::<_, Uuid>(
+                "INSERT INTO claim_themes (label, description) VALUES ($1, $2) RETURNING id",
+            )
+            .bind(format!("test-3072-theme-{i}"))
+            .bind("3072d test theme")
+            .fetch_one(pool)
+            .await
+            .expect("create theme");
+
+            let pgvec = pgvec_at_dim(i as f32 * 0.1, EMBEDDING_DIM_LARGE);
+            sqlx::query("UPDATE claim_themes SET centroid_3072 = $2::vector WHERE id = $1")
+                .bind(theme_id)
+                .bind(&pgvec)
+                .execute(pool)
+                .await
+                .expect("set 3072 centroid");
+            ids.push(theme_id);
+        }
+        ids
+    }
+
+    /// Insert N themes with ONLY the legacy 1536d `centroid` populated. Used
+    /// to assert the rejection path when the caller asks for 3072d but the
+    /// corpus hasn't been migrated.
+    async fn seed_themes_with_only_1536_centroids(pool: &sqlx::PgPool, n: usize) -> Vec<Uuid> {
+        let mut ids = Vec::with_capacity(n);
+        for i in 0..n {
+            let theme_id = sqlx::query_scalar::<_, Uuid>(
+                "INSERT INTO claim_themes (label, description) VALUES ($1, $2) RETURNING id",
+            )
+            .bind(format!("test-1536-only-theme-{i}"))
+            .bind("1536d-only test theme")
+            .fetch_one(pool)
+            .await
+            .expect("create theme");
+
+            let pgvec = pgvec_at_dim(i as f32 * 0.1, EMBEDDING_DIM);
+            sqlx::query("UPDATE claim_themes SET centroid = $2::vector WHERE id = $1")
+                .bind(theme_id)
+                .bind(&pgvec)
+                .execute(pool)
+                .await
+                .expect("set 1536 centroid");
+            ids.push(theme_id);
+        }
+        ids
+    }
+
+    /// Insert N themes; `n_3072_populated` of them get `centroid_3072` set,
+    /// the rest get only the legacy `centroid` set. Used for the auto-detect
+    /// majority test.
+    async fn seed_themes_with_mixed_centroids(
+        pool: &sqlx::PgPool,
+        total: usize,
+        n_3072_populated: usize,
+    ) -> Vec<Uuid> {
+        let mut ids = Vec::with_capacity(total);
+        for i in 0..total {
+            let theme_id = sqlx::query_scalar::<_, Uuid>(
+                "INSERT INTO claim_themes (label, description) VALUES ($1, $2) RETURNING id",
+            )
+            .bind(format!("test-mixed-theme-{i}"))
+            .bind("mixed-dim test theme")
+            .fetch_one(pool)
+            .await
+            .expect("create theme");
+
+            if i < n_3072_populated {
+                let pgvec = pgvec_at_dim(i as f32 * 0.1, EMBEDDING_DIM_LARGE);
+                sqlx::query("UPDATE claim_themes SET centroid_3072 = $2::vector WHERE id = $1")
+                    .bind(theme_id)
+                    .bind(&pgvec)
+                    .execute(pool)
+                    .await
+                    .expect("set 3072 centroid");
+            } else {
+                let pgvec = pgvec_at_dim(i as f32 * 0.1, EMBEDDING_DIM);
+                sqlx::query("UPDATE claim_themes SET centroid = $2::vector WHERE id = $1")
+                    .bind(theme_id)
+                    .bind(&pgvec)
+                    .execute(pool)
+                    .await
+                    .expect("set 1536 centroid");
+            }
+            ids.push(theme_id);
+        }
+        ids
+    }
+
+    /// Insert N claims with `embedding_3072` populated and assigned to the
+    /// given themes (round-robin). Returns inserted claim ids.
+    async fn seed_claims_with_3072_embeddings(
+        pool: &sqlx::PgPool,
+        n: usize,
+        theme_ids: &[Uuid],
+        agent_id: Uuid,
+    ) -> Vec<Uuid> {
+        assert!(
+            !theme_ids.is_empty(),
+            "need at least one theme to attach claims"
+        );
+        let mut ids = Vec::with_capacity(n);
+        for i in 0..n {
+            let theme_id = theme_ids[i % theme_ids.len()];
+            let pgvec = pgvec_at_dim(i as f32 * 0.05, EMBEDDING_DIM_LARGE);
+            let content = format!("test-3072-claim-{}-{}", i, Uuid::new_v4());
+            let claim_id = sqlx::query_scalar::<_, Uuid>(
+                "INSERT INTO claims (content, content_hash, truth_value, agent_id, embedding_3072, theme_id) \
+                 VALUES ($1, sha256($1::bytea), 0.5, $2, $3::vector, $4) \
+                 RETURNING id",
+            )
+            .bind(&content)
+            .bind(agent_id)
+            .bind(&pgvec)
+            .bind(theme_id)
+            .fetch_one(pool)
+            .await
+            .expect("seed 3072 claim");
+            ids.push(claim_id);
+        }
+        ids
+    }
+
+    /// Helper that invokes `semantic_search` with diverse mode on. Returns
+    /// the parsed response or the raw `ApiError`.
+    async fn call_diverse_search(
+        pool: sqlx::PgPool,
+        centroid_dim: Option<u32>,
+    ) -> Result<SemanticSearchResponse, ApiError> {
+        let state = AppState::with_db(pool, ApiConfig::default());
+        let request = SemanticSearchRequest {
+            query: "test query for diverse search".to_string(),
+            limit: Some(5),
+            min_similarity: None,
+            claim_type: None,
+            created_after: None,
+            created_before: None,
+            agent_id: None,
+            diverse: Some(true),
+            max_themes: Some(3),
+            diversity_weight: Some(0.5),
+            centroid_dim,
+        };
+        let response = semantic_search(axum::extract::State(state), axum::Json(request)).await?;
+        Ok(response.0)
+    }
+
+    /// Test 1 — explicit 3072d hint queries the 3072d centroids and
+    /// surfaces `centroid_dim_used: 3072`.
+    #[tokio::test]
+    async fn diverse_search_uses_3072d_centroids_when_hinted() {
+        let pool = test_pool_or_skip!();
+        reset_themes(&pool).await;
+
+        let agent = seed_agent(&pool, "diverse-3072-test").await;
+        let theme_ids = seed_themes_with_3072_centroids(&pool, 5).await;
+        let _claims = seed_claims_with_3072_embeddings(&pool, 50, &theme_ids, agent).await;
+
+        let resp = call_diverse_search(pool.clone(), Some(3072))
+            .await
+            .expect("3072d diverse search must succeed");
+
+        assert_eq!(
+            resp.centroid_dim_used,
+            Some(3072),
+            "response must surface centroid_dim_used=3072"
+        );
+        assert!(
+            !resp.results.is_empty(),
+            "should return at least one claim from the 3072d themes"
+        );
+    }
+
+    /// Test 2 — explicit 3072d hint with NO 3072d centroids populated:
+    /// must reject with ValidationError on field=centroid_dim.
+    #[tokio::test]
+    async fn diverse_search_rejects_when_3072d_centroids_missing() {
+        let pool = test_pool_or_skip!();
+        reset_themes(&pool).await;
+
+        let _ids = seed_themes_with_only_1536_centroids(&pool, 5).await;
+
+        let result = call_diverse_search(pool.clone(), Some(3072)).await;
+
+        match result {
+            Err(ApiError::ValidationError { field, .. }) => {
+                assert_eq!(field, "centroid_dim", "validation must blame centroid_dim");
+            }
+            other => panic!(
+                "expected ValidationError on centroid_dim, got: {:?}",
+                other.map(|r| format!("Ok(results={})", r.results.len()))
+            ),
+        }
+    }
+
+    /// Test 3 — auto-detect: when ≥50% of themes have `centroid_3072`
+    /// populated and the caller does NOT hint, the search picks 3072d.
+    #[tokio::test]
+    async fn diverse_search_auto_picks_3072d_when_majority_populated() {
+        let pool = test_pool_or_skip!();
+        reset_themes(&pool).await;
+
+        // 8/10 themes have centroid_3072 (80% > 50% threshold)
+        let theme_ids = seed_themes_with_mixed_centroids(&pool, 10, 8).await;
+        let agent = seed_agent(&pool, "diverse-auto-test").await;
+        // Attach claims to the 3072-populated themes only so the search has
+        // candidates after theme selection.
+        let theme_ids_3072 = &theme_ids[..8];
+        let _claims = seed_claims_with_3072_embeddings(&pool, 50, theme_ids_3072, agent).await;
+
+        let resp = call_diverse_search(pool.clone(), None)
+            .await
+            .expect("auto-detected diverse search must succeed");
+
+        assert_eq!(
+            resp.centroid_dim_used,
+            Some(3072),
+            "auto-detect should pick 3072 when ≥50% of themes have centroid_3072 set"
+        );
     }
 }

--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -60,6 +60,11 @@ name = "experiment"
 path = "src/bin/experiment.rs"
 required-features = ["db"]
 
+[[bin]]
+name = "reembed"
+path = "src/bin/reembed.rs"
+required-features = ["db"]
+
 [dependencies]
 epigraph-core = { workspace = true }
 epigraph-engine = { workspace = true }
@@ -86,6 +91,9 @@ base64 = "0.22"
 linfa = { workspace = true }
 linfa-clustering = { workspace = true }
 ndarray = { workspace = true }
+
+[dev-dependencies]
+sqlx = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/epigraph-cli/src/bin/reembed.rs
+++ b/crates/epigraph-cli/src/bin/reembed.rs
@@ -1,0 +1,117 @@
+//! `epigraph-cli reembed` — Idempotent batch re-embedding of claims/evidence
+//! at 3072d (text-embedding-3-large).
+//!
+//! Usage:
+//!   reembed --target claims [--batch 256] [--checkpoint-file PATH]
+//!   reembed --target evidence [--batch 256] [--checkpoint-file PATH]
+//!
+//! Reads `OPENAI_API_KEY`. Falls back to a mock provider when unset (dev
+//! convenience — the mock writes deterministic 3072d vectors so the column
+//! gets populated, but the vectors are not semantically meaningful).
+//!
+//! `DATABASE_URL` is required.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::Parser;
+
+use epigraph_cli::reembed::{run, ReembedConfig, ReembedTarget};
+use epigraph_embeddings::{EmbeddingConfig, EmbeddingService, MockProvider, OpenAiProvider};
+
+#[derive(Parser)]
+#[command(
+    name = "reembed",
+    about = "Re-embed claims or evidence at 3072d (text-embedding-3-large)"
+)]
+struct Cli {
+    /// Target table: claims or evidence
+    #[arg(long)]
+    target: String,
+    /// Rows per batch
+    #[arg(long, default_value_t = 256)]
+    batch: usize,
+    /// Optional checkpoint file for resume
+    #[arg(long)]
+    checkpoint_file: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let cli = Cli::parse();
+
+    let target = match cli.target.as_str() {
+        "claims" => ReembedTarget::Claims,
+        "evidence" => ReembedTarget::Evidence,
+        other => {
+            eprintln!("--target must be 'claims' or 'evidence' (got '{other}')");
+            std::process::exit(2);
+        }
+    };
+
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        eprintln!("DATABASE_URL required");
+        std::process::exit(2);
+    });
+    let pool = sqlx::PgPool::connect(&url).await.unwrap_or_else(|e| {
+        eprintln!("connect failed: {e}");
+        std::process::exit(1);
+    });
+
+    let provider = build_3072d_provider();
+
+    let summary = run(
+        &pool,
+        ReembedConfig {
+            target,
+            batch_size: cli.batch,
+            embedding_provider: provider,
+            checkpoint_path: cli.checkpoint_file,
+        },
+    )
+    .await
+    .unwrap_or_else(|e| {
+        eprintln!("reembed failed: {e}");
+        std::process::exit(1);
+    });
+
+    println!(
+        "reembed: {} rows in {} batches (target={:?})",
+        summary.rows_written, summary.batches, target,
+    );
+}
+
+/// Build the 3072d embedding provider. Prefers OpenAI text-embedding-3-large
+/// when `OPENAI_API_KEY` is set; falls back to MockProvider for dev/CI.
+fn build_3072d_provider() -> Arc<dyn EmbeddingService> {
+    let mut config = EmbeddingConfig::openai(3072);
+    // Override the default model (text-embedding-3-small) to text-embedding-3-large.
+    if let epigraph_embeddings::config::ProviderConfig::OpenAi {
+        ref mut model,
+        api_base_url: _,
+    } = config.provider
+    {
+        *model = "text-embedding-3-large".to_string();
+    }
+
+    if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+        if !key.is_empty() {
+            match OpenAiProvider::new(config.clone(), key) {
+                Ok(p) => {
+                    tracing::info!("reembed provider: OpenAI text-embedding-3-large (3072d)");
+                    return Arc::new(p);
+                }
+                Err(e) => tracing::warn!("OpenAI init failed, falling back to mock: {e}"),
+            }
+        }
+    }
+    tracing::warn!(
+        "OPENAI_API_KEY not set; using MockProvider — embeddings will be deterministic but not semantically meaningful"
+    );
+    Arc::new(MockProvider::new(config))
+}

--- a/crates/epigraph-cli/src/lib.rs
+++ b/crates/epigraph-cli/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod enrichment;
+#[cfg(feature = "db")]
+pub mod reembed;
 
 #[cfg(feature = "db")]
 use sqlx::PgPool;

--- a/crates/epigraph-cli/src/reembed.rs
+++ b/crates/epigraph-cli/src/reembed.rs
@@ -187,8 +187,9 @@ fn read_checkpoint(path: Option<&PathBuf>) -> Result<Option<Uuid>, ReembedError>
     if trimmed.is_empty() {
         return Ok(None);
     }
-    let id = Uuid::parse_str(trimmed)
-        .map_err(|e| ReembedError::InvalidCheckpoint(format!("expected UUID, got {trimmed}: {e}")))?;
+    let id = Uuid::parse_str(trimmed).map_err(|e| {
+        ReembedError::InvalidCheckpoint(format!("expected UUID, got {trimmed}: {e}"))
+    })?;
     Ok(Some(id))
 }
 
@@ -202,4 +203,3 @@ fn write_checkpoint(path: Option<&PathBuf>, id: Uuid) -> Result<(), ReembedError
     std::fs::write(path, id.to_string())?;
     Ok(())
 }
-

--- a/crates/epigraph-cli/src/reembed.rs
+++ b/crates/epigraph-cli/src/reembed.rs
@@ -1,0 +1,205 @@
+//! Idempotent, resumable batch re-embedding from `text-embedding-3-small`
+//! (1536d) to `text-embedding-3-large` (3072d).
+//!
+//! Operates on `claims` and `evidence` tables. Pulls rows whose 3072d column
+//! is NULL, generates embeddings via the supplied `EmbeddingService`, and
+//! UPDATEs the `embedding_3072` column. Optional checkpoint file (last `id`
+//! written, as a UUID string) lets a crashed run resume cheaply.
+//!
+//! Idempotent: re-running over already-populated rows fetches zero rows
+//! (filter is `WHERE embedding_3072 IS NULL`). Resumable: filter
+//! `id > $last_id ORDER BY id` continues from the checkpoint UUID.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use epigraph_embeddings::{EmbeddingError, EmbeddingService};
+
+/// Config for a single reembed run.
+pub struct ReembedConfig {
+    pub target: ReembedTarget,
+    pub batch_size: usize,
+    pub embedding_provider: Arc<dyn EmbeddingService>,
+    pub checkpoint_path: Option<PathBuf>,
+}
+
+/// Which table to reembed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReembedTarget {
+    Claims,
+    Evidence,
+}
+
+impl ReembedTarget {
+    /// Table name in SQL.
+    fn table(self) -> &'static str {
+        match self {
+            Self::Claims => "claims",
+            Self::Evidence => "evidence",
+        }
+    }
+
+    /// Column holding the source text for embedding.
+    fn content_column(self) -> &'static str {
+        match self {
+            // claims.content is the canonical text column.
+            Self::Claims => "content",
+            // evidence.raw_content is the text column (see migration 001).
+            Self::Evidence => "raw_content",
+        }
+    }
+}
+
+/// Summary of a completed reembed run.
+#[derive(Debug, Clone)]
+pub struct ReembedSummary {
+    pub rows_written: usize,
+    pub batches: usize,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReembedError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("embedding provider error: {0}")]
+    Provider(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid checkpoint contents: {0}")]
+    InvalidCheckpoint(String),
+}
+
+impl From<EmbeddingError> for ReembedError {
+    fn from(e: EmbeddingError) -> Self {
+        Self::Provider(e.to_string())
+    }
+}
+
+/// Run the reembed loop until no rows remain.
+///
+/// # Errors
+/// Returns an error if the database, embedding provider, or checkpoint I/O fails.
+pub async fn run(pool: &PgPool, config: ReembedConfig) -> Result<ReembedSummary, ReembedError> {
+    let mut last_id = read_checkpoint(config.checkpoint_path.as_ref())?;
+    let mut rows_written = 0_usize;
+    let mut batches = 0_usize;
+
+    loop {
+        let rows = fetch_batch(pool, config.target, last_id, config.batch_size).await?;
+        if rows.is_empty() {
+            break;
+        }
+
+        let texts: Vec<&str> = rows.iter().map(|(_, c)| c.as_str()).collect();
+        let embeddings = config.embedding_provider.batch_generate(&texts).await?;
+        if embeddings.len() != rows.len() {
+            return Err(ReembedError::Provider(format!(
+                "provider returned {} embeddings for {} inputs",
+                embeddings.len(),
+                rows.len()
+            )));
+        }
+
+        for ((row_id, _), embedding) in rows.iter().zip(embeddings.iter()) {
+            let pgvec = format_pgvector(embedding);
+            update_embedding_3072(pool, config.target, *row_id, &pgvec).await?;
+            rows_written += 1;
+        }
+
+        // Advance checkpoint to last id of this batch.
+        if let Some(last) = rows.last() {
+            last_id = Some(last.0);
+            write_checkpoint(config.checkpoint_path.as_ref(), last.0)?;
+        }
+        batches += 1;
+
+        if rows.len() < config.batch_size {
+            // Last partial batch; next loop would return zero anyway.
+            break;
+        }
+    }
+
+    Ok(ReembedSummary {
+        rows_written,
+        batches,
+    })
+}
+
+/// Fetch a batch of rows whose `embedding_3072` is NULL, ordered by id.
+async fn fetch_batch(
+    pool: &PgPool,
+    target: ReembedTarget,
+    last_id: Option<Uuid>,
+    batch_size: usize,
+) -> Result<Vec<(Uuid, String)>, ReembedError> {
+    let table = target.table();
+    let content_col = target.content_column();
+
+    let sql = format!(
+        "SELECT id, {content_col} AS content \
+         FROM {table} \
+         WHERE embedding_3072 IS NULL \
+           AND ($1::uuid IS NULL OR id > $1) \
+           AND {content_col} IS NOT NULL \
+           AND length({content_col}) > 0 \
+         ORDER BY id \
+         LIMIT $2"
+    );
+
+    let rows: Vec<(Uuid, String)> = sqlx::query_as(&sql)
+        .bind(last_id)
+        .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows)
+}
+
+/// UPDATE one row's `embedding_3072` column.
+async fn update_embedding_3072(
+    pool: &PgPool,
+    target: ReembedTarget,
+    id: Uuid,
+    pgvec: &str,
+) -> Result<(), ReembedError> {
+    let table = target.table();
+    let sql = format!("UPDATE {table} SET embedding_3072 = $1::vector WHERE id = $2");
+    sqlx::query(&sql).bind(pgvec).bind(id).execute(pool).await?;
+    Ok(())
+}
+
+/// Format a `&[f32]` as pgvector literal `[a,b,c,...]`.
+fn format_pgvector(vec: &[f32]) -> String {
+    let inner: Vec<String> = vec.iter().map(|v| format!("{v}")).collect();
+    format!("[{}]", inner.join(","))
+}
+
+fn read_checkpoint(path: Option<&PathBuf>) -> Result<Option<Uuid>, ReembedError> {
+    let Some(path) = path else { return Ok(None) };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(path)?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let id = Uuid::parse_str(trimmed)
+        .map_err(|e| ReembedError::InvalidCheckpoint(format!("expected UUID, got {trimmed}: {e}")))?;
+    Ok(Some(id))
+}
+
+fn write_checkpoint(path: Option<&PathBuf>, id: Uuid) -> Result<(), ReembedError> {
+    let Some(path) = path else { return Ok(()) };
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, id.to_string())?;
+    Ok(())
+}
+

--- a/crates/epigraph-cli/tests/reembed_idempotent.rs
+++ b/crates/epigraph-cli/tests/reembed_idempotent.rs
@@ -1,0 +1,165 @@
+//! Verifies the reembed CLI is idempotent: re-running over already-populated
+//! rows is a no-op (zero embedding-provider calls beyond the first run).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use epigraph_cli::reembed::{run, ReembedConfig, ReembedTarget};
+use epigraph_embeddings::{
+    EmbeddingConfig, EmbeddingError, EmbeddingService, MockProvider, SimilarClaim, TokenUsage,
+};
+
+/// Wrapper around `MockProvider` that exposes an externally observable call
+/// counter. The upstream `MockProvider::call_count` is private, and we want
+/// to assert "no extra batch_generate calls on the second run".
+struct CountingProvider {
+    inner: MockProvider,
+    batch_calls: AtomicUsize,
+}
+
+impl CountingProvider {
+    fn new_3072() -> Self {
+        let config = EmbeddingConfig::openai(3072);
+        Self {
+            inner: MockProvider::new(config),
+            batch_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn batch_call_count(&self) -> usize {
+        self.batch_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl EmbeddingService for CountingProvider {
+    async fn generate(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        self.inner.generate(text).await
+    }
+
+    async fn batch_generate(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.batch_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.batch_generate(texts).await
+    }
+
+    async fn store(&self, claim_id: Uuid, embedding: &[f32]) -> Result<(), EmbeddingError> {
+        self.inner.store(claim_id, embedding).await
+    }
+
+    async fn get(&self, claim_id: Uuid) -> Result<Vec<f32>, EmbeddingError> {
+        self.inner.get(claim_id).await
+    }
+
+    async fn similar(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        min_similarity: f32,
+    ) -> Result<Vec<SimilarClaim>, EmbeddingError> {
+        self.inner.similar(embedding, k, min_similarity).await
+    }
+
+    fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+
+    fn token_usage(&self) -> TokenUsage {
+        self.inner.token_usage()
+    }
+
+    fn reset_token_usage(&self) {
+        self.inner.reset_token_usage();
+    }
+
+    async fn health_check(&self) -> Result<(), EmbeddingError> {
+        self.inner.health_check().await
+    }
+}
+
+/// Insert `n` claims with a non-null 1536d embedding and NULL embedding_3072.
+async fn seed_claims_with_1536_embeddings(pool: &PgPool, n: usize) -> Vec<Uuid> {
+    // Inline agent seed (no epigraph_test_support helper). Pattern mirrors
+    // tests in crates/epigraph-db/src/repos/claim.rs.
+    let agent_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels) \
+         VALUES (sha256(gen_random_uuid()::text::bytea), 'reembed-test', 'system', ARRAY['test']) \
+         RETURNING id",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("seed agent");
+
+    // Build a length-1536 zero-ish vector as a pgvector literal.
+    let inner: Vec<String> = (0..1536).map(|i| format!("{}", (i as f32) * 0.0001)).collect();
+    let pgvec = format!("[{}]", inner.join(","));
+
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let content = format!("reembed-test-{}-{}", i, Uuid::new_v4());
+        let id: Uuid = sqlx::query_scalar(
+            "INSERT INTO claims (content, content_hash, truth_value, agent_id, embedding, embedding_3072) \
+             VALUES ($1, sha256($1::bytea), 0.5, $2, $3::vector, NULL) \
+             RETURNING id",
+        )
+        .bind(&content)
+        .bind(agent_id)
+        .bind(&pgvec)
+        .fetch_one(pool)
+        .await
+        .expect("seed claim");
+        ids.push(id);
+    }
+    ids
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn reembed_is_idempotent(pool: PgPool) {
+    let _seeded = seed_claims_with_1536_embeddings(&pool, 3).await;
+
+    let provider = Arc::new(CountingProvider::new_3072());
+    let summary1 = run(
+        &pool,
+        ReembedConfig {
+            target: ReembedTarget::Claims,
+            batch_size: 2,
+            embedding_provider: provider.clone(),
+            checkpoint_path: None,
+        },
+    )
+    .await
+    .expect("first run");
+    assert_eq!(summary1.rows_written, 3, "first run writes 3 rows");
+
+    let calls_after_first = provider.batch_call_count();
+    assert!(calls_after_first >= 1, "first run made at least one batch call");
+
+    let summary2 = run(
+        &pool,
+        ReembedConfig {
+            target: ReembedTarget::Claims,
+            batch_size: 2,
+            embedding_provider: provider.clone(),
+            checkpoint_path: None,
+        },
+    )
+    .await
+    .expect("second run");
+    assert_eq!(summary2.rows_written, 0, "second run is a no-op");
+    assert_eq!(
+        provider.batch_call_count(),
+        calls_after_first,
+        "no extra embedding calls on second run",
+    );
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM claims WHERE embedding_3072 IS NOT NULL AND content LIKE 'reembed-test-%'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 3, "all 3 seeded claims have embedding_3072 populated");
+}

--- a/crates/epigraph-cli/tests/reembed_idempotent.rs
+++ b/crates/epigraph-cli/tests/reembed_idempotent.rs
@@ -94,7 +94,9 @@ async fn seed_claims_with_1536_embeddings(pool: &PgPool, n: usize) -> Vec<Uuid> 
     .expect("seed agent");
 
     // Build a length-1536 zero-ish vector as a pgvector literal.
-    let inner: Vec<String> = (0..1536).map(|i| format!("{}", (i as f32) * 0.0001)).collect();
+    let inner: Vec<String> = (0..1536)
+        .map(|i| format!("{}", (i as f32) * 0.0001))
+        .collect();
     let pgvec = format!("[{}]", inner.join(","));
 
     let mut ids = Vec::with_capacity(n);
@@ -135,7 +137,10 @@ async fn reembed_is_idempotent(pool: PgPool) {
     assert_eq!(summary1.rows_written, 3, "first run writes 3 rows");
 
     let calls_after_first = provider.batch_call_count();
-    assert!(calls_after_first >= 1, "first run made at least one batch call");
+    assert!(
+        calls_after_first >= 1,
+        "first run made at least one batch call"
+    );
 
     let summary2 = run(
         &pool,
@@ -161,5 +166,8 @@ async fn reembed_is_idempotent(pool: PgPool) {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(count, 3, "all 3 seeded claims have embedding_3072 populated");
+    assert_eq!(
+        count, 3,
+        "all 3 seeded claims have embedding_3072 populated"
+    );
 }

--- a/migrations/027_centroids_3072d.sql
+++ b/migrations/027_centroids_3072d.sql
@@ -1,0 +1,15 @@
+-- migrations/027_centroids_3072d.sql
+-- Adds 3072-dimensional centroid columns alongside the existing 1536d
+-- columns. NEW columns; no ALTER TYPE on existing columns to avoid HNSW
+-- index rebuild. The legacy 1536d columns remain populated and queried
+-- until the operator runs the reembed CLI and switches callers via
+-- the centroid_dim query parameter.
+
+ALTER TABLE claim_themes      ADD COLUMN centroid_3072 vector(3072);
+ALTER TABLE cluster_centroids ADD COLUMN centroid_3072 vector(3072);
+ALTER TABLE claims            ADD COLUMN embedding_3072 vector(3072);
+ALTER TABLE evidence          ADD COLUMN embedding_3072 vector(3072);
+
+-- No HNSW indexes on 3072d columns initially. Theme/cluster counts are
+-- small enough that seq-scan (<5ms for 10² centroids) is acceptable.
+-- For claims/evidence at scale, revisit if recall/latency demands.


### PR DESCRIPTION
Closes #59C.

## Summary
- New `centroid_dim` query parameter on `/api/v1/search/semantic?diverse=true` (1536 or 3072)
- Auto-picks based on theme-centroid population (>=50% threshold)
- Returns 400 ValidationError when hinted dim is unpopulated (matches PR #84's pattern; ApiError lacks PreconditionFailed variant)
- Response surfaces `centroid_dim_used`

Stacks on PR #84 (3072d columns); once #84 merges this PR rebases cleanly onto main.

## Test plan
- [x] explicit 3072d
- [x] fallback ValidationError when no 3072d centroids
- [x] auto-default to 3072d when majority populated
- [x] cargo fmt --check + cargo clippy --workspace -- -D warnings (CI gates)