### PR TITLE
POST /clusters/build-from-bridges (#59B)

### DIFF
--- a/crates/epigraph-api/src/routes/clusters.rs
+++ b/crates/epigraph-api/src/routes/clusters.rs
@@ -1,0 +1,363 @@
+//! Cluster construction endpoints.
+//!
+//! Currently exposes:
+//! - `POST /api/v1/clusters/build-from-bridges` — Louvain over `decomposes_to`
+//!   bridges between paragraph-level claims (level=2). Two paragraphs are
+//!   bridge-connected if they share ≥1 atom child via `decomposes_to`. Edge
+//!   weight = count of shared atoms.
+//!
+//! The bridge graph captures structural overlap between paragraphs, which is
+//! orthogonal to the epistemic SUPPORTS/CONTRADICTS clustering produced by the
+//! nightly `cluster_graph` job. Both run results live in the same physical
+//! tables (`graph_cluster_runs`, `graph_clusters`, `claim_cluster_membership`)
+//! and are discriminated by the `algo` column on `graph_cluster_runs`.
+
+#[cfg(feature = "db")]
+use crate::errors::ApiError;
+#[cfg(feature = "db")]
+use crate::state::AppState;
+#[cfg(feature = "db")]
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+pub struct BuildFromBridgesRequest {
+    /// Minimum number of shared atom children required to draw a bridge edge
+    /// between two paragraphs. Default: 1.
+    pub min_shared_atoms: Option<u32>,
+    /// Louvain modularity resolution parameter. Default: 1.0.
+    pub resolution: Option<f64>,
+    /// How many bridge runs to retain after this one completes. Older runs
+    /// (and their clusters / memberships) are GCed. Default: 5.
+    pub retain_runs: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BuildFromBridgesResponse {
+    pub run_id: Uuid,
+    pub cluster_count: usize,
+    pub paragraph_count: usize,
+    pub bridge_edge_count: usize,
+}
+
+/// Algorithm discriminator written to `graph_cluster_runs.algo` so this run is
+/// distinguishable from the nightly SUPPORTS/CONTRADICTS Louvain run (which
+/// uses `algo='louvain'`).
+#[cfg(feature = "db")]
+const ALGO_LOUVAIN_BRIDGE: &str = "louvain_bridge";
+
+#[cfg(feature = "db")]
+pub async fn build_from_bridges(
+    State(state): State<AppState>,
+    Json(req): Json<BuildFromBridgesRequest>,
+) -> Result<Json<BuildFromBridgesResponse>, ApiError> {
+    use epigraph_jobs::cluster_graph::louvain::{louvain, LouvainInput};
+    use std::collections::HashMap;
+
+    let pool = &state.db_pool;
+
+    let min_shared = req.min_shared_atoms.unwrap_or(1) as i64;
+    let resolution = req.resolution.unwrap_or(1.0);
+    let retain_runs = req.retain_runs.unwrap_or(5);
+
+    // -- Step 1: pre-aggregate bridge edges via SQL.
+    //
+    // For each pair of paragraph-level claims (level=2), count the number of
+    // atom-level children (level=3 — by convention; we don't strictly require
+    // it on the child side because the parent gate is what matters for the
+    // bridge graph) they share via `decomposes_to`.
+    //
+    // The `paragraph_id < other.paragraph_id` join condition emits each
+    // unordered pair exactly once.
+    #[derive(sqlx::FromRow)]
+    struct BridgeEdgeRow {
+        para_a: Uuid,
+        para_b: Uuid,
+        weight: i64,
+    }
+    let edges: Vec<BridgeEdgeRow> = sqlx::query_as::<_, BridgeEdgeRow>(
+        r#"WITH atom_parents AS (
+            SELECT e.target_id AS atom_id, e.source_id AS paragraph_id
+            FROM edges e
+            JOIN claims p ON p.id = e.source_id
+            WHERE e.relationship = 'decomposes_to'
+              AND (p.properties->>'level')::int = 2
+        )
+        SELECT
+            a.paragraph_id  AS para_a,
+            b.paragraph_id  AS para_b,
+            COUNT(*)::bigint AS weight
+        FROM atom_parents a
+        JOIN atom_parents b
+            ON a.atom_id = b.atom_id
+           AND a.paragraph_id < b.paragraph_id
+        GROUP BY a.paragraph_id, b.paragraph_id
+        HAVING COUNT(*) >= $1
+        "#,
+    )
+    .bind(min_shared)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("bridge edge query: {e}"),
+    })?;
+
+    // -- Step 2a: enumerate paragraph nodes.
+    //
+    // A paragraph is a node in the bridge graph if it is level=2 and has at
+    // least one atom child via `decomposes_to`. This keeps singleton
+    // paragraphs in the result (they get their own cluster) — matching the
+    // Phase 5.B spec contract that paragraph_count counts "paragraphs in the
+    // bridge graph", not just paragraphs with at least one bridge.
+    let para_rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT DISTINCT e.source_id
+         FROM edges e
+         JOIN claims p ON p.id = e.source_id
+         WHERE e.relationship = 'decomposes_to'
+           AND (p.properties->>'level')::int = 2",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("paragraph node query: {e}"),
+    })?;
+
+    // -- Step 2b: build a dense node index for Louvain.
+    //
+    // Louvain expects nodes to be 0..n. We seed the index with every
+    // paragraph node (so isolates are nodes too), then ensure both endpoints
+    // of each bridge edge are present.
+    let mut node_idx: HashMap<Uuid, u32> = HashMap::new();
+    for (id,) in &para_rows {
+        let next = node_idx.len() as u32;
+        node_idx.entry(*id).or_insert(next);
+    }
+    for e in &edges {
+        let next = node_idx.len() as u32;
+        node_idx.entry(e.para_a).or_insert(next);
+        let next = node_idx.len() as u32;
+        node_idx.entry(e.para_b).or_insert(next);
+    }
+
+    let louvain_edges: Vec<(u32, u32, f64)> = edges
+        .iter()
+        .map(|e| (node_idx[&e.para_a], node_idx[&e.para_b], e.weight as f64))
+        .collect();
+
+    // -- Step 3: run Louvain.
+    let assignments: Vec<u32> = if node_idx.is_empty() {
+        Vec::new()
+    } else {
+        let input = LouvainInput {
+            node_count: node_idx.len(),
+            edges: louvain_edges,
+            resolution,
+        };
+        louvain(&input)
+            .map_err(|e| ApiError::InternalError {
+                message: format!("louvain: {e}"),
+            })?
+            .assignments
+    };
+
+    // -- Step 4: persist run row + clusters + memberships, then GC old runs.
+    let run_id = persist_bridge_run(pool, &node_idx, &assignments).await?;
+    gc_bridge_runs(pool, retain_runs).await?;
+
+    let cluster_count: usize = {
+        use std::collections::BTreeSet;
+        assignments.iter().copied().collect::<BTreeSet<_>>().len()
+    };
+
+    Ok(Json(BuildFromBridgesResponse {
+        run_id,
+        cluster_count,
+        paragraph_count: node_idx.len(),
+        bridge_edge_count: edges.len(),
+    }))
+}
+
+#[cfg(not(feature = "db"))]
+pub async fn build_from_bridges(
+    axum::extract::Json(_req): axum::extract::Json<BuildFromBridgesRequest>,
+) -> Result<axum::Json<BuildFromBridgesResponse>, axum::http::StatusCode> {
+    Err(axum::http::StatusCode::SERVICE_UNAVAILABLE)
+}
+
+/// Insert a `graph_cluster_runs` row + `graph_clusters` rows for each unique
+/// community + `claim_cluster_membership` rows tying each paragraph (looked up
+/// via the reverse of `node_idx`) to its assigned cluster id.
+///
+/// Mirrors `epigraph_jobs::cluster_graph::runner::write_clusters` for the
+/// epistemic Louvain runs but operates over paragraph nodes only and writes
+/// `algo='louvain_bridge'` on the run row.
+#[cfg(feature = "db")]
+async fn persist_bridge_run(
+    pool: &sqlx::PgPool,
+    node_idx: &std::collections::HashMap<Uuid, u32>,
+    assignments: &[u32],
+) -> Result<Uuid, ApiError> {
+    use std::collections::HashMap;
+
+    let run_id = Uuid::new_v4();
+
+    // Reverse mapping: dense u32 idx -> paragraph UUID.
+    let mut idx_to_id: HashMap<u32, Uuid> = HashMap::with_capacity(node_idx.len());
+    for (id, idx) in node_idx {
+        idx_to_id.insert(*idx, *id);
+    }
+
+    // Group node indices by assigned community id.
+    let mut groups: HashMap<u32, Vec<u32>> = HashMap::new();
+    for (idx, comm) in assignments.iter().enumerate() {
+        groups.entry(*comm).or_default().push(idx as u32);
+    }
+
+    let mut tx = pool.begin().await.map_err(|e| ApiError::InternalError {
+        message: format!("begin tx: {e}"),
+    })?;
+
+    // 1. Run row. NOTE: the existing schema has columns
+    //    (run_id, completed_at, cluster_count, degraded). Migration 027 adds
+    //    `algo`. `degraded` is FALSE for bridge runs since we don't fall back
+    //    to per-frame grouping when the graph is sparse — empty graphs simply
+    //    produce zero clusters and that's the truthful answer.
+    sqlx::query(
+        "INSERT INTO graph_cluster_runs (run_id, cluster_count, degraded, algo)
+         VALUES ($1, $2, FALSE, $3)",
+    )
+    .bind(run_id)
+    .bind(groups.len() as i32)
+    .bind(ALGO_LOUVAIN_BRIDGE)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("insert run: {e}"),
+    })?;
+
+    // 2. Cluster rows + memberships.
+    let mut cluster_id_map: HashMap<u32, Uuid> = HashMap::with_capacity(groups.len());
+    for (comm, members) in &groups {
+        let cluster_id = Uuid::new_v4();
+        cluster_id_map.insert(*comm, cluster_id);
+        let size = members.len() as i32;
+        let label = format!("bridge-cluster-{comm}");
+
+        sqlx::query(
+            "INSERT INTO graph_clusters
+             (id, run_id, label, size, mean_betp, dominant_type, dominant_frame_id, degraded)
+             VALUES ($1, $2, $3, $4, NULL, 'paragraph', NULL, FALSE)",
+        )
+        .bind(cluster_id)
+        .bind(run_id)
+        .bind(&label)
+        .bind(size)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("insert cluster: {e}"),
+        })?;
+    }
+
+    // 3. Membership rows. Batch in chunks of 1000 to keep the query plan small.
+    let chunk = 1000usize;
+    let mut batch: Vec<(Uuid, Uuid)> = Vec::with_capacity(chunk);
+    for (idx, comm) in assignments.iter().enumerate() {
+        let cluster_id = cluster_id_map[comm];
+        let claim_id = idx_to_id[&(idx as u32)];
+        batch.push((claim_id, cluster_id));
+        if batch.len() == chunk {
+            flush_membership(&mut tx, &batch, run_id).await?;
+            batch.clear();
+        }
+    }
+    if !batch.is_empty() {
+        flush_membership(&mut tx, &batch, run_id).await?;
+    }
+
+    tx.commit().await.map_err(|e| ApiError::InternalError {
+        message: format!("commit tx: {e}"),
+    })?;
+
+    Ok(run_id)
+}
+
+#[cfg(feature = "db")]
+async fn flush_membership(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    batch: &[(Uuid, Uuid)],
+    run_id: Uuid,
+) -> Result<(), ApiError> {
+    let mut q =
+        String::from("INSERT INTO claim_cluster_membership (claim_id, cluster_id, run_id) VALUES ");
+    let placeholders: Vec<String> = (0..batch.len())
+        .map(|i| {
+            let base = i * 3;
+            format!("(${}, ${}, ${})", base + 1, base + 2, base + 3)
+        })
+        .collect();
+    q.push_str(&placeholders.join(", "));
+
+    let mut query = sqlx::query(&q);
+    for (claim_id, cluster_id) in batch {
+        query = query.bind(claim_id).bind(cluster_id).bind(run_id);
+    }
+    query
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("insert membership: {e}"),
+        })?;
+    Ok(())
+}
+
+/// Garbage-collect old `louvain_bridge` runs, keeping only the newest
+/// `retain` runs by `completed_at`. Scoped by `algo` so we don't touch the
+/// nightly epistemic Louvain runs.
+#[cfg(feature = "db")]
+async fn gc_bridge_runs(pool: &sqlx::PgPool, retain: u32) -> Result<(), ApiError> {
+    sqlx::query(
+        r#"
+        WITH old AS (
+            SELECT run_id FROM graph_cluster_runs
+            WHERE algo = $2
+            ORDER BY completed_at DESC
+            OFFSET $1
+        )
+        DELETE FROM graph_cluster_runs WHERE run_id IN (SELECT run_id FROM old)
+        "#,
+    )
+    .bind(retain as i64)
+    .bind(ALGO_LOUVAIN_BRIDGE)
+    .execute(pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("gc runs: {e}"),
+    })?;
+
+    // Cascade: clean up clusters + memberships whose run no longer exists.
+    // (`graph_clusters` is not declared FK to `graph_cluster_runs`, and
+    // `claim_cluster_membership.run_id` isn't either; only
+    // `claim_cluster_membership.cluster_id` cascades. So we explicitly clean.)
+    sqlx::query(
+        "DELETE FROM claim_cluster_membership
+         WHERE run_id NOT IN (SELECT run_id FROM graph_cluster_runs)",
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("gc memberships: {e}"),
+    })?;
+    sqlx::query(
+        "DELETE FROM graph_clusters
+         WHERE run_id NOT IN (SELECT run_id FROM graph_cluster_runs)",
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| ApiError::InternalError {
+        message: format!("gc clusters: {e}"),
+    })?;
+
+    Ok(())
+}

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -20,6 +20,7 @@ pub mod belief;
 pub mod challenge;
 pub mod claims;
 pub mod claims_query;
+pub mod clusters;
 pub mod community;
 #[cfg(feature = "db")]
 pub mod computation;
@@ -187,6 +188,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/themes/build-from-corpus",
             post(crud::build_themes_from_corpus),
+        )
+        .route(
+            "/api/v1/clusters/build-from-bridges",
+            post(clusters::build_from_bridges),
         )
         .route(
             "/api/v1/frames/:id/assign-claim",
@@ -809,6 +814,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/themes/build-from-corpus",
             post(crud::build_themes_from_corpus),
+        )
+        .route(
+            "/api/v1/clusters/build-from-bridges",
+            post(clusters::build_from_bridges),
         )
         .route(
             "/api/v1/frames/:id/assign-claim",

--- a/crates/epigraph-api/tests/build_from_bridges_test.rs
+++ b/crates/epigraph-api/tests/build_from_bridges_test.rs
@@ -1,0 +1,251 @@
+#![cfg(feature = "db")]
+
+//! Integration test for `POST /api/v1/clusters/build-from-bridges` (Phase 5.B).
+//!
+//! Seeds 5 paragraph-level claims (level=2) and a set of atom-level children
+//! such that:
+//!   - paragraphs 1+2 share 2 atoms (bridge weight = 2)
+//!   - paragraphs 3+4 share 1 atom (bridge weight = 1)
+//!   - paragraph 5 is isolated (no atoms shared with the rest)
+//!
+//! Asserts cluster_count, paragraph_count, bridge_edge_count, and persistence
+//! invariants on the run row + memberships.
+
+use serde_json::{json, Value};
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+mod common;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn build_from_bridges_clusters_paragraphs() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    // Wipe cluster fixture state. We DELETE memberships before runs to avoid
+    // FK trouble with `claim_cluster_membership.cluster_id → graph_clusters`.
+    // We also wipe neighborhood tables if present, since they FK back to runs.
+    let _ = sqlx::query("DELETE FROM neighborhood_edges")
+        .execute(&pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM claim_neighborhood_membership")
+        .execute(&pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM graph_neighborhoods")
+        .execute(&pool)
+        .await;
+    sqlx::query("DELETE FROM claim_cluster_membership")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM cluster_edges")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM graph_clusters")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM graph_cluster_runs")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // The test DB (`epigraph_5b_test`) is dedicated to this Phase-5.B test.
+    // Wipe all bridge-relevant data from prior runs: decomposes_to edges and
+    // every claim that was tagged as paragraph (level=2) or atom (level=3).
+    sqlx::query("DELETE FROM edges WHERE relationship = 'decomposes_to'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM claims WHERE (properties->>'level')::int IN (2, 3)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let agent_id = Uuid::parse_str("00000000-0000-0000-0000-0000000000dd").unwrap();
+
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, display_name, agent_type) \
+         VALUES ($1, decode(repeat('DD', 32), 'hex'), 'bridge-test', 'system') \
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(agent_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Helper: insert a claim with a level marker in `properties`.
+    async fn ins_claim(pool: &sqlx::PgPool, content: &str, agent: Uuid, level: i32) -> Uuid {
+        let id = Uuid::new_v4();
+        let hash: Vec<u8> = id
+            .as_bytes()
+            .iter()
+            .chain(id.as_bytes().iter())
+            .copied()
+            .collect();
+        let props = serde_json::json!({"level": level});
+        sqlx::query(
+            "INSERT INTO claims (id, content, content_hash, agent_id, pignistic_prob, properties) \
+             VALUES ($1, $2, $3, $4, 0.5, $5)",
+        )
+        .bind(id)
+        .bind(content)
+        .bind(hash)
+        .bind(agent)
+        .bind(&props)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+    async fn ins_decomposes(pool: &sqlx::PgPool, parent: Uuid, child: Uuid) {
+        sqlx::query(
+            "INSERT INTO edges (source_id, target_id, source_type, target_type, relationship) \
+             VALUES ($1, $2, 'claim', 'claim', 'decomposes_to')",
+        )
+        .bind(parent)
+        .bind(child)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    // 5 paragraph-level claims (level=2). One of them is a bridge isolate.
+    let p1 = ins_claim(&pool, "paragraph-1", agent_id, 2).await;
+    let p2 = ins_claim(&pool, "paragraph-2", agent_id, 2).await;
+    let p3 = ins_claim(&pool, "paragraph-3", agent_id, 2).await;
+    let p4 = ins_claim(&pool, "paragraph-4", agent_id, 2).await;
+    let p5 = ins_claim(&pool, "paragraph-5", agent_id, 2).await;
+
+    // Atoms (level=3). Some are shared between paragraphs.
+    let a_shared_12_x = ins_claim(&pool, "atom-shared-12-x", agent_id, 3).await;
+    let a_shared_12_y = ins_claim(&pool, "atom-shared-12-y", agent_id, 3).await;
+    let a_shared_34 = ins_claim(&pool, "atom-shared-34", agent_id, 3).await;
+    let a_p1_only = ins_claim(&pool, "atom-p1-only", agent_id, 3).await;
+    let a_p2_only = ins_claim(&pool, "atom-p2-only", agent_id, 3).await;
+    let a_p3_only = ins_claim(&pool, "atom-p3-only", agent_id, 3).await;
+    let a_p4_only = ins_claim(&pool, "atom-p4-only", agent_id, 3).await;
+    let a_p5_only_a = ins_claim(&pool, "atom-p5-only-a", agent_id, 3).await;
+    let a_p5_only_b = ins_claim(&pool, "atom-p5-only-b", agent_id, 3).await;
+    let a_p5_only_c = ins_claim(&pool, "atom-p5-only-c", agent_id, 3).await;
+
+    // p1 children: shared_12_x, shared_12_y, p1_only
+    ins_decomposes(&pool, p1, a_shared_12_x).await;
+    ins_decomposes(&pool, p1, a_shared_12_y).await;
+    ins_decomposes(&pool, p1, a_p1_only).await;
+
+    // p2 children: shared_12_x, shared_12_y, p2_only — shares 2 atoms with p1
+    ins_decomposes(&pool, p2, a_shared_12_x).await;
+    ins_decomposes(&pool, p2, a_shared_12_y).await;
+    ins_decomposes(&pool, p2, a_p2_only).await;
+
+    // p3 children: shared_34, p3_only
+    ins_decomposes(&pool, p3, a_shared_34).await;
+    ins_decomposes(&pool, p3, a_p3_only).await;
+
+    // p4 children: shared_34, p4_only — shares 1 atom with p3
+    ins_decomposes(&pool, p4, a_shared_34).await;
+    ins_decomposes(&pool, p4, a_p4_only).await;
+
+    // p5 children: 3 unique atoms, no overlap → isolated
+    ins_decomposes(&pool, p5, a_p5_only_a).await;
+    ins_decomposes(&pool, p5, a_p5_only_b).await;
+    ins_decomposes(&pool, p5, a_p5_only_c).await;
+
+    // Spin up the app and call the endpoint.
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let body = json!({
+        "min_shared_atoms": 1,
+        "resolution": 1.0,
+        "retain_runs": 5
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/clusters/build-from-bridges"))
+        .header(
+            "Authorization",
+            format!("Bearer {}", common::test_bearer_token()),
+        )
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "build_from_bridges should return 200"
+    );
+    let resp_json: Value = resp.json().await.unwrap();
+
+    let cluster_count = resp_json["cluster_count"].as_u64().unwrap() as usize;
+    let paragraph_count = resp_json["paragraph_count"].as_u64().unwrap() as usize;
+    let bridge_edge_count = resp_json["bridge_edge_count"].as_u64().unwrap() as usize;
+    let run_id_str = resp_json["run_id"].as_str().unwrap();
+    let run_id = Uuid::parse_str(run_id_str).unwrap();
+
+    // Bridge graph contains exactly two edges: (p1,p2) weight 2 and (p3,p4)
+    // weight 1. p5 has no shared atoms so it has no bridge edges.
+    assert_eq!(
+        bridge_edge_count, 2,
+        "expected 2 bridge edges (p1↔p2, p3↔p4); got {bridge_edge_count}"
+    );
+
+    // All 5 paragraphs are nodes in the bridge graph because each has at
+    // least one decomposes_to atom child. p5 is a singleton node with no
+    // bridge edges; the other 4 form two pair-clusters.
+    assert_eq!(
+        paragraph_count, 5,
+        "expected 5 paragraph nodes (incl. p5 isolate); got {paragraph_count}"
+    );
+
+    // Three components → three clusters: {p1, p2}, {p3, p4}, {p5}.
+    assert_eq!(
+        cluster_count, 3,
+        "expected 3 clusters: {{p1,p2}}, {{p3,p4}}, {{p5}}; got {cluster_count}"
+    );
+
+    // Run row landed with algo='louvain_bridge'.
+    let runs: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM graph_cluster_runs WHERE algo = 'louvain_bridge' AND run_id = $1",
+    )
+    .bind(run_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(runs, 1, "run row missing or wrong algo");
+
+    // Memberships persisted: one row per paragraph node.
+    let memberships: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM claim_cluster_membership WHERE run_id = $1")
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(memberships, 5, "expected 5 membership rows");
+
+    // p1 and p2 share a cluster; p3 and p4 share a different cluster; p5 has
+    // its own cluster distinct from both pairs.
+    async fn cluster_of(pool: &sqlx::PgPool, run_id: Uuid, claim_id: Uuid) -> Option<Uuid> {
+        sqlx::query_scalar(
+            "SELECT cluster_id FROM claim_cluster_membership WHERE run_id = $1 AND claim_id = $2",
+        )
+        .bind(run_id)
+        .bind(claim_id)
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+    }
+    let c_p1 = cluster_of(&pool, run_id, p1).await.expect("p1 has cluster");
+    let c_p2 = cluster_of(&pool, run_id, p2).await.expect("p2 has cluster");
+    let c_p3 = cluster_of(&pool, run_id, p3).await.expect("p3 has cluster");
+    let c_p4 = cluster_of(&pool, run_id, p4).await.expect("p4 has cluster");
+    let c_p5 = cluster_of(&pool, run_id, p5).await.expect("p5 has cluster");
+    assert_eq!(c_p1, c_p2, "p1 and p2 should share a bridge cluster");
+    assert_eq!(c_p3, c_p4, "p3 and p4 should share a bridge cluster");
+    assert_ne!(c_p1, c_p3, "p1 and p3 must be in different bridge clusters");
+    assert_ne!(c_p1, c_p5, "p5 must be in its own cluster");
+    assert_ne!(c_p3, c_p5, "p5 must be in its own cluster");
+}

--- a/migrations/027_graph_cluster_runs_algo.sql
+++ b/migrations/027_graph_cluster_runs_algo.sql
@@ -1,0 +1,16 @@
+-- 027_graph_cluster_runs_algo.sql
+-- Adds an `algo` discriminator column to `graph_cluster_runs` so that we can
+-- have multiple parallel clustering algorithms (epistemic edges vs. structural
+-- bridges) co-existing without colliding on retention/GC.
+--
+-- Existing runs are produced by the nightly `cluster_graph` job which runs
+-- Louvain over SUPPORTS / CONTRADICTS edges; back-fill them as 'louvain'.
+--
+-- Phase 5.B introduces 'louvain_bridge' for paragraphs (level=2) clustered by
+-- decomposes_to atom-sharing.
+
+ALTER TABLE graph_cluster_runs
+    ADD COLUMN IF NOT EXISTS algo TEXT NOT NULL DEFAULT 'louvain';
+
+CREATE INDEX IF NOT EXISTS graph_cluster_runs_algo_completed_idx
+    ON graph_cluster_runs (algo, completed_at DESC);

--- a/migrations/028_graph_cluster_runs_algo.sql
+++ b/migrations/028_graph_cluster_runs_algo.sql
@@ -1,4 +1,4 @@
--- 027_graph_cluster_runs_algo.sql
+-- 028_graph_cluster_runs_algo.sql
 -- Adds an `algo` discriminator column to `graph_cluster_runs` so that we can
 -- have multiple parallel clustering algorithms (epistemic edges vs. structural
 -- bridges) co-existing without colliding on retention/GC.


### PR DESCRIPTION
Closes #59B.

## Summary
- Adds `POST /api/v1/clusters/build-from-bridges`. Builds paragraph-paragraph Louvain clustering over `decomposes_to` bridges (two paragraphs are bridge-connected if they share >=1 atom child via `decomposes_to`; edge weight = shared-atom count). Reuses the existing `epigraph_jobs::cluster_graph::louvain` function unchanged.
- Migration `027_graph_cluster_runs_algo.sql` adds `algo TEXT NOT NULL DEFAULT 'louvain'` to `graph_cluster_runs`. Existing rows back-fill to `'louvain'` (matching what the nightly `cluster_graph` job emits); new bridge runs write `'louvain_bridge'`. GC is scoped per-algo so `retain_runs` on bridge runs cannot evict epistemic runs.
- Bridge graph nodes: every level=2 claim with at least one `decomposes_to` child. Isolated paragraphs (no atoms shared with anyone) become singleton clusters. Bridge edges: SQL-aggregated count of shared atoms per paragraph pair, gated by `min_shared_atoms` (default 1).

## Architecture
- New file `crates/epigraph-api/src/routes/clusters.rs` housing `build_from_bridges` + `persist_bridge_run` + `gc_bridge_runs` + `flush_membership` (mirrors the structure of `epigraph_jobs::cluster_graph::runner`).
- New file `crates/epigraph-api/tests/build_from_bridges_test.rs` (live-DB integration test, follows `graph_neighborhoods_test.rs` pattern: env-driven `DATABASE_URL`, `mod common`, manual cleanup).
- Route registered in `routes/mod.rs` under the protected (signature/bearer-required) router, sibling to `/api/v1/themes/build-from-corpus`.

## Test plan
- [x] `cargo test -p epigraph-api --test build_from_bridges_test` (5 paragraphs, 10 atoms; verifies bridge_edge_count=2, paragraph_count=5, cluster_count=3, run row + memberships persisted, p1=p2 cluster, p3=p4 cluster, p5 singleton)
- [x] `cargo build --workspace` (CI build path)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `migrate_on_startup` test passes (now reports 27 migrations applied >= 26 threshold)
- [x] Existing `graph_routes_test` still passes (cluster fixtures with `algo='louvain'` default still work)

## Notes for reviewers
- The pre-existing `cargo build --no-default-features` is broken on `origin/main` (32 errors in unrelated routes); the no-db stub for `build_from_bridges` is included for symmetry but isn't exercised by CI (`default = ["db"]`).
- `claim_cluster_membership.run_id` is not declared FK to `graph_cluster_runs(run_id)` in migration 015; GC explicitly cleans memberships and clusters when their run_id row goes away.