### PR TITLE
Cross-component bridge sweep CLI (#53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "chrono",
  "clap",
  "csv",
  "dotenvy",

--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -37,6 +37,16 @@ path = "src/bin/rerank_bridges.rs"
 required-features = ["genai"]
 
 [[bin]]
+name = "bridge_component"
+path = "src/bin/bridge_component.rs"
+required-features = ["genai"]
+
+[[bin]]
+name = "bridge_sweep"
+path = "src/bin/bridge_sweep.rs"
+required-features = ["genai"]
+
+[[bin]]
 name = "dekg"
 path = "src/bin/dekg.rs"
 

--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -101,6 +101,7 @@ base64 = "0.22"
 linfa = { workspace = true }
 linfa-clustering = { workspace = true }
 ndarray = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }

--- a/crates/epigraph-cli/src/bin/bridge_component.rs
+++ b/crates/epigraph-cli/src/bin/bridge_component.rs
@@ -3,9 +3,12 @@
 //!
 //! See docs/superpowers/specs/2026-05-05-cross-component-bridge-sweep-design.md.
 
-#![allow(dead_code)] // Filled in by Phase 7 Task 4.
-
+use sqlx::PgPool;
 use uuid::Uuid;
+
+use epigraph_cli::bridge::candidates::{build_candidate_table, drop_candidate_table};
+use epigraph_cli::bridge::components::{compute_components, ComponentSummary};
+use epigraph_cli::rerank::{rerank_candidates_table, RerankConfig};
 
 const USAGE: &str = r#"
 bridge-component — bridge a single disconnected component into the giant CC
@@ -14,16 +17,17 @@ USAGE:
   bridge-component <component-id> [OPTIONS]
 
 OPTIONS:
-  --target <ID>              Target component (default: giant)
-  --min-similarity <FLOAT>   Cosine similarity threshold [default: 0.50]
-  --top-k <N>                Per-source-atom top-K matches [default: 50]
+  --target <ID>              Target component (default: giant — largest by size)
+  --min-similarity <FLOAT>   Cosine threshold [default: 0.50]
+  --top-k <N>                Per-source-atom [default: 50]
   --batch-size <N>           Pairs per LLM call [default: 10]
   --provider <NAME>          LLM provider [default: claude-cli]
   --model <NAME>             Model override
   --dry-run                  Default. Reports candidates + LLM eval; creates no edges.
   --apply                    Commit edges (overrides --dry-run).
   --keep-tables              Don't drop the temp candidates table on exit.
-  --report-out <PATH>        Write JSON report to file (else stdout)
+  --report-out <PATH>        JSON report path (else stdout)
+  --limit <N>                Cap LLM evaluations
   -h, --help                 Show this message
 "#;
 
@@ -39,15 +43,331 @@ struct Args {
     apply: bool,
     keep_tables: bool,
     report_out: Option<String>,
+    limit: Option<i64>,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let argv: Vec<String> = std::env::args().collect();
+        let mut positional: Vec<String> = vec![];
+
+        let mut min_similarity = 0.50;
+        let mut top_k = 50_u32;
+        let mut batch_size = 10_usize;
+        let mut provider = "claude-cli".to_string();
+        let mut model = None;
+        let mut apply = false;
+        let mut keep_tables = false;
+        let mut target = None;
+        let mut report_out = None;
+        let mut limit = None;
+
+        let mut i = 1;
+        while i < argv.len() {
+            match argv[i].as_str() {
+                "-h" | "--help" => {
+                    println!("{USAGE}");
+                    std::process::exit(0);
+                }
+                "--target" => {
+                    i += 1;
+                    target = Some(parse_uuid(&argv, i, "--target")?);
+                }
+                "--min-similarity" => {
+                    i += 1;
+                    min_similarity = parse_f64(&argv, i, "--min-similarity")?;
+                }
+                "--top-k" => {
+                    i += 1;
+                    top_k = parse_u32(&argv, i, "--top-k")?;
+                }
+                "--batch-size" => {
+                    i += 1;
+                    batch_size = parse_usize(&argv, i, "--batch-size")?;
+                }
+                "--provider" => {
+                    i += 1;
+                    provider = parse_string(&argv, i, "--provider")?;
+                }
+                "--model" => {
+                    i += 1;
+                    model = Some(parse_string(&argv, i, "--model")?);
+                }
+                "--dry-run" => { /* default */ }
+                "--apply" => {
+                    apply = true;
+                }
+                "--keep-tables" => {
+                    keep_tables = true;
+                }
+                "--report-out" => {
+                    i += 1;
+                    report_out = Some(parse_string(&argv, i, "--report-out")?);
+                }
+                "--limit" => {
+                    i += 1;
+                    limit = Some(parse_i64(&argv, i, "--limit")?);
+                }
+                arg if arg.starts_with("--") => {
+                    return Err(format!("Unknown flag: {arg}\n{USAGE}"));
+                }
+                arg => positional.push(arg.to_string()),
+            }
+            i += 1;
+        }
+
+        let component_id = match positional.as_slice() {
+            [s] => Uuid::parse_str(s).map_err(|_| format!("invalid <component-id> UUID: {s}"))?,
+            _ => {
+                return Err(format!(
+                    "expected exactly one <component-id>; got {}\n{USAGE}",
+                    positional.len()
+                ))
+            }
+        };
+
+        Ok(Args {
+            component_id,
+            target,
+            min_similarity,
+            top_k,
+            batch_size,
+            provider,
+            model,
+            apply,
+            keep_tables,
+            report_out,
+            limit,
+        })
+    }
+}
+
+fn parse_uuid(argv: &[String], i: usize, name: &str) -> Result<Uuid, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    Uuid::parse_str(v).map_err(|_| format!("{name} expects a UUID, got: {v}"))
+}
+fn parse_f64(argv: &[String], i: usize, name: &str) -> Result<f64, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<f64>()
+        .map_err(|_| format!("{name} expects a float, got: {v}"))
+}
+fn parse_u32(argv: &[String], i: usize, name: &str) -> Result<u32, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<u32>()
+        .map_err(|_| format!("{name} expects a u32, got: {v}"))
+}
+fn parse_usize(argv: &[String], i: usize, name: &str) -> Result<usize, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<usize>()
+        .map_err(|_| format!("{name} expects a usize, got: {v}"))
+}
+fn parse_i64(argv: &[String], i: usize, name: &str) -> Result<i64, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<i64>()
+        .map_err(|_| format!("{name} expects an integer, got: {v}"))
+}
+fn parse_string(argv: &[String], i: usize, name: &str) -> Result<String, String> {
+    argv.get(i)
+        .ok_or_else(|| format!("{name} requires a value"))
+        .cloned()
+}
+
+fn locate_component(components: &[ComponentSummary], target: &Uuid) -> Option<usize> {
+    components
+        .iter()
+        .position(|c| c.component_id == *target || c.claim_ids.contains(target))
+}
+
+async fn level3_atoms_in_component(
+    pool: &PgPool,
+    component: &ComponentSummary,
+) -> Result<Vec<Uuid>, sqlx::Error> {
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM claims WHERE id = ANY($1) AND (properties->>'level')::int = 3 AND embedding IS NOT NULL",
+    )
+    .bind(&component.claim_ids)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
 #[tokio::main]
 async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    if args.iter().any(|a| a == "-h" || a == "--help") {
-        println!("{USAGE}");
-        return;
+    dotenvy::dotenv().ok();
+
+    let args = match Args::parse() {
+        Ok(a) => a,
+        Err(msg) => {
+            eprintln!("{msg}");
+            std::process::exit(1);
+        }
+    };
+
+    let database_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        eprintln!("ERROR: DATABASE_URL must be set");
+        std::process::exit(1);
+    });
+
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("ERROR: Failed to connect to PostgreSQL: {e}");
+            std::process::exit(1);
+        });
+
+    let started = std::time::Instant::now();
+    let summary = run_pipeline(&pool, &args).await;
+
+    let report = match summary {
+        Ok(r) => r,
+        Err(msg) => {
+            eprintln!("ERROR: {msg}");
+            std::process::exit(1);
+        }
+    };
+
+    let json = serde_json::to_string_pretty(&report).expect("report serialization");
+    if let Some(ref path) = args.report_out {
+        std::fs::write(path, &json).unwrap_or_else(|e| {
+            eprintln!("ERROR: Failed to write report to {path}: {e}");
+            std::process::exit(1);
+        });
+        eprintln!("Wrote report to {path}");
+    } else {
+        println!("{json}");
     }
-    eprintln!("bridge-component: stub (Phase 7 Task 4 will fill this in)");
-    std::process::exit(1);
+
+    let elapsed = started.elapsed();
+    eprintln!("Done in {:.2}s", elapsed.as_secs_f64());
+}
+
+#[derive(serde::Serialize)]
+struct Report {
+    component_id: Uuid,
+    target_component_id: Uuid,
+    component_size: usize,
+    target_size: usize,
+    candidates_table: String,
+    candidates_count: usize,
+    rerank: Option<RerankReport>,
+    duration_ms: u128,
+    apply: bool,
+}
+
+#[derive(serde::Serialize)]
+struct RerankReport {
+    candidates_evaluated: usize,
+    llm_accepted: usize,
+    edges_created: usize,
+    duration_ms: u128,
+}
+
+async fn run_pipeline(pool: &PgPool, args: &Args) -> Result<Report, String> {
+    let started = std::time::Instant::now();
+
+    let components = compute_components(pool)
+        .await
+        .map_err(|e| format!("compute_components: {e}"))?;
+    if components.is_empty() {
+        return Err("no claims in graph".to_string());
+    }
+
+    // Default target = giant = largest component (compute_components returns
+    // sorted by size descending).
+    let target_id = match args.target {
+        Some(t) => t,
+        None => components.first().expect("non-empty").component_id,
+    };
+
+    let component_idx = locate_component(&components, &args.component_id)
+        .ok_or_else(|| format!("component not found: {}", args.component_id))?;
+    let target_idx = locate_component(&components, &target_id)
+        .ok_or_else(|| format!("target component not found: {target_id}"))?;
+    if component_idx == target_idx {
+        return Err(format!(
+            "component {} IS the target {} — nothing to bridge",
+            args.component_id, target_id,
+        ));
+    }
+
+    let component = &components[component_idx];
+    let target = &components[target_idx];
+
+    let source_atoms = level3_atoms_in_component(pool, component)
+        .await
+        .map_err(|e| format!("source atoms: {e}"))?;
+    let target_atoms = level3_atoms_in_component(pool, target)
+        .await
+        .map_err(|e| format!("target atoms: {e}"))?;
+
+    if source_atoms.is_empty() {
+        return Err("source component has no level-3 atoms with embeddings".to_string());
+    }
+    if target_atoms.is_empty() {
+        return Err("target component has no level-3 atoms with embeddings".to_string());
+    }
+
+    let table_name = format!("bridge_sweep_{}_candidates", Uuid::new_v4().simple());
+
+    let candidates_count = build_candidate_table(
+        pool,
+        &table_name,
+        &source_atoms,
+        &target_atoms,
+        args.min_similarity,
+        args.top_k,
+    )
+    .await
+    .map_err(|e| format!("build_candidate_table: {e}"))?;
+
+    let rerank = if candidates_count > 0 {
+        let config = RerankConfig {
+            min_similarity: args.min_similarity,
+            batch_size: args.batch_size,
+            provider: args.provider.clone(),
+            model: args.model.clone(),
+            dry_run: !args.apply,
+            limit: args.limit,
+            verbose: false, // bridge_component owns its own progress logging
+        };
+        match rerank_candidates_table(pool, &table_name, &config).await {
+            Ok(s) => Some(RerankReport {
+                candidates_evaluated: s.candidates_evaluated,
+                llm_accepted: s.llm_accepted,
+                edges_created: s.edges_created,
+                duration_ms: s.duration_ms,
+            }),
+            Err(e) => return Err(format!("rerank: {e}")),
+        }
+    } else {
+        None
+    };
+
+    if !args.keep_tables {
+        let _ = drop_candidate_table(pool, &table_name).await; // best-effort
+    }
+
+    Ok(Report {
+        component_id: component.component_id,
+        target_component_id: target.component_id,
+        component_size: component.size,
+        target_size: target.size,
+        candidates_table: table_name,
+        candidates_count,
+        rerank,
+        duration_ms: started.elapsed().as_millis(),
+        apply: args.apply,
+    })
 }

--- a/crates/epigraph-cli/src/bin/bridge_component.rs
+++ b/crates/epigraph-cli/src/bin/bridge_component.rs
@@ -1,0 +1,53 @@
+//! `bridge_component` — bridge a single disconnected component into the
+//! giant connected component via LLM-validated semantic edges.
+//!
+//! See docs/superpowers/specs/2026-05-05-cross-component-bridge-sweep-design.md.
+
+#![allow(dead_code)] // Filled in by Phase 7 Task 4.
+
+use uuid::Uuid;
+
+const USAGE: &str = r#"
+bridge-component — bridge a single disconnected component into the giant CC
+
+USAGE:
+  bridge-component <component-id> [OPTIONS]
+
+OPTIONS:
+  --target <ID>              Target component (default: giant)
+  --min-similarity <FLOAT>   Cosine similarity threshold [default: 0.50]
+  --top-k <N>                Per-source-atom top-K matches [default: 50]
+  --batch-size <N>           Pairs per LLM call [default: 10]
+  --provider <NAME>          LLM provider [default: claude-cli]
+  --model <NAME>             Model override
+  --dry-run                  Default. Reports candidates + LLM eval; creates no edges.
+  --apply                    Commit edges (overrides --dry-run).
+  --keep-tables              Don't drop the temp candidates table on exit.
+  --report-out <PATH>        Write JSON report to file (else stdout)
+  -h, --help                 Show this message
+"#;
+
+#[derive(Debug)]
+struct Args {
+    component_id: Uuid,
+    target: Option<Uuid>,
+    min_similarity: f64,
+    top_k: u32,
+    batch_size: usize,
+    provider: String,
+    model: Option<String>,
+    apply: bool,
+    keep_tables: bool,
+    report_out: Option<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        println!("{USAGE}");
+        return;
+    }
+    eprintln!("bridge-component: stub (Phase 7 Task 4 will fill this in)");
+    std::process::exit(1);
+}

--- a/crates/epigraph-cli/src/bin/bridge_sweep.rs
+++ b/crates/epigraph-cli/src/bin/bridge_sweep.rs
@@ -1,11 +1,19 @@
 //! `bridge_sweep` — bridge multiple disconnected components into the
 //! giant connected component, with spine-destination report.
 //!
+//! Pipeline parallels `bridge_component` but iterates a set of source
+//! components and emits one combined JSON report. Per-component errors are
+//! captured into the report and do not abort the sweep.
+//!
 //! See docs/superpowers/specs/2026-05-05-cross-component-bridge-sweep-design.md.
 
-#![allow(dead_code)] // Filled in by Phase 7 Task 5.
-
+use sqlx::PgPool;
 use uuid::Uuid;
+
+use epigraph_cli::bridge::candidates::{build_candidate_table, drop_candidate_table};
+use epigraph_cli::bridge::components::{compute_components, ComponentSummary};
+use epigraph_cli::bridge::spine::{compute_spine_destination, SpineUmbrella};
+use epigraph_cli::rerank::{rerank_candidates_table, RerankConfig};
 
 const USAGE: &str = r#"
 bridge-sweep — bridge multiple disconnected components into the giant CC
@@ -14,10 +22,10 @@ USAGE:
   bridge-sweep [--components <UUID,UUID,...> | --all] [OPTIONS]
 
 OPTIONS:
-  --components <LIST>        Explicit component UUIDs (mutually exclusive with --all)
-  --all                      Sweep all components ≥ --min-component-size
-  --min-component-size <N>   Only used with --all [default: 30]
-  --target <ID>              Target component (default: giant)
+  --components <LIST>        Explicit component UUIDs (mutex with --all)
+  --all                      Sweep all components ≥ --min-component-size, excluding target
+  --min-component-size <N>   Only with --all [default: 30]
+  --target <ID>              Target component (default: giant — largest)
   --min-similarity <FLOAT>   [default: 0.50]
   --top-k <N>                Per-source-atom [default: 50]
   --batch-size <N>           [default: 10]
@@ -27,14 +35,17 @@ OPTIONS:
   --apply                    Commit edges (overrides --dry-run).
   --keep-tables              Don't drop temp candidate tables on exit.
   --report-out <PATH>        JSON report path (else stdout).
+  --limit <N>                Per-component LLM evaluation cap.
   -h, --help
 "#;
 
 #[derive(Debug)]
 struct Args {
-    components: Option<Vec<Uuid>>, // None when --all is set
+    /// Explicit set of component UUIDs to bridge. Mutually exclusive with `all`.
+    components: Option<Vec<Uuid>>,
+    /// Sweep all components ≥ `min_component_size`, excluding the target.
     all: bool,
-    min_component_size: u32,
+    min_component_size: usize,
     target: Option<Uuid>,
     min_similarity: f64,
     top_k: u32,
@@ -44,15 +55,546 @@ struct Args {
     apply: bool,
     keep_tables: bool,
     report_out: Option<String>,
+    limit: Option<i64>,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let argv: Vec<String> = std::env::args().collect();
+
+        let mut components: Option<Vec<Uuid>> = None;
+        let mut all = false;
+        let mut min_component_size = 30_usize;
+        let mut target: Option<Uuid> = None;
+        let mut min_similarity = 0.50_f64;
+        let mut top_k = 50_u32;
+        let mut batch_size = 10_usize;
+        let mut provider = "claude-cli".to_string();
+        let mut model: Option<String> = None;
+        let mut apply = false;
+        let mut keep_tables = false;
+        let mut report_out: Option<String> = None;
+        let mut limit: Option<i64> = None;
+
+        let mut i = 1;
+        while i < argv.len() {
+            match argv[i].as_str() {
+                "-h" | "--help" => {
+                    println!("{USAGE}");
+                    std::process::exit(0);
+                }
+                "--components" => {
+                    i += 1;
+                    let v = argv
+                        .get(i)
+                        .ok_or_else(|| "--components requires a value".to_string())?;
+                    let parsed: Result<Vec<Uuid>, _> = v
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(Uuid::parse_str)
+                        .collect();
+                    let ids = parsed.map_err(|e| {
+                        format!("--components expects comma-separated UUIDs; parse error: {e}")
+                    })?;
+                    if ids.is_empty() {
+                        return Err("--components requires at least one UUID".into());
+                    }
+                    components = Some(ids);
+                }
+                "--all" => {
+                    all = true;
+                }
+                "--min-component-size" => {
+                    i += 1;
+                    min_component_size = parse_usize(&argv, i, "--min-component-size")?;
+                }
+                "--target" => {
+                    i += 1;
+                    target = Some(parse_uuid(&argv, i, "--target")?);
+                }
+                "--min-similarity" => {
+                    i += 1;
+                    min_similarity = parse_f64(&argv, i, "--min-similarity")?;
+                }
+                "--top-k" => {
+                    i += 1;
+                    top_k = parse_u32(&argv, i, "--top-k")?;
+                }
+                "--batch-size" => {
+                    i += 1;
+                    batch_size = parse_usize(&argv, i, "--batch-size")?;
+                }
+                "--provider" => {
+                    i += 1;
+                    provider = parse_string(&argv, i, "--provider")?;
+                }
+                "--model" => {
+                    i += 1;
+                    model = Some(parse_string(&argv, i, "--model")?);
+                }
+                "--dry-run" => { /* default */ }
+                "--apply" => {
+                    apply = true;
+                }
+                "--keep-tables" => {
+                    keep_tables = true;
+                }
+                "--report-out" => {
+                    i += 1;
+                    report_out = Some(parse_string(&argv, i, "--report-out")?);
+                }
+                "--limit" => {
+                    i += 1;
+                    limit = Some(parse_i64(&argv, i, "--limit")?);
+                }
+                arg if arg.starts_with("--") => {
+                    return Err(format!("Unknown flag: {arg}\n{USAGE}"));
+                }
+                arg => {
+                    return Err(format!("Unexpected positional argument: {arg}\n{USAGE}"));
+                }
+            }
+            i += 1;
+        }
+
+        // Mutex / required.
+        match (components.is_some(), all) {
+            (true, true) => {
+                return Err("--components and --all are mutually exclusive\n".to_string() + USAGE)
+            }
+            (false, false) => {
+                return Err("must specify --components <LIST> or --all\n".to_string() + USAGE)
+            }
+            _ => {}
+        }
+
+        Ok(Args {
+            components,
+            all,
+            min_component_size,
+            target,
+            min_similarity,
+            top_k,
+            batch_size,
+            provider,
+            model,
+            apply,
+            keep_tables,
+            report_out,
+            limit,
+        })
+    }
+}
+
+fn parse_uuid(argv: &[String], i: usize, name: &str) -> Result<Uuid, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    Uuid::parse_str(v).map_err(|_| format!("{name} expects a UUID, got: {v}"))
+}
+fn parse_f64(argv: &[String], i: usize, name: &str) -> Result<f64, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<f64>()
+        .map_err(|_| format!("{name} expects a float, got: {v}"))
+}
+fn parse_u32(argv: &[String], i: usize, name: &str) -> Result<u32, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<u32>()
+        .map_err(|_| format!("{name} expects a u32, got: {v}"))
+}
+fn parse_usize(argv: &[String], i: usize, name: &str) -> Result<usize, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<usize>()
+        .map_err(|_| format!("{name} expects a usize, got: {v}"))
+}
+fn parse_i64(argv: &[String], i: usize, name: &str) -> Result<i64, String> {
+    let v = argv
+        .get(i)
+        .ok_or_else(|| format!("{name} requires a value"))?;
+    v.parse::<i64>()
+        .map_err(|_| format!("{name} expects an integer, got: {v}"))
+}
+fn parse_string(argv: &[String], i: usize, name: &str) -> Result<String, String> {
+    argv.get(i)
+        .ok_or_else(|| format!("{name} requires a value"))
+        .cloned()
+}
+
+fn locate_component(components: &[ComponentSummary], target: &Uuid) -> Option<usize> {
+    components
+        .iter()
+        .position(|c| c.component_id == *target || c.claim_ids.contains(target))
+}
+
+async fn level3_atoms_in_component(
+    pool: &PgPool,
+    component: &ComponentSummary,
+) -> Result<Vec<Uuid>, sqlx::Error> {
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM claims WHERE id = ANY($1) AND (properties->>'level')::int = 3 AND embedding IS NOT NULL",
+    )
+    .bind(&component.claim_ids)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
 #[tokio::main]
 async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    if args.iter().any(|a| a == "-h" || a == "--help") {
-        println!("{USAGE}");
-        return;
+    dotenvy::dotenv().ok();
+
+    let args = match Args::parse() {
+        Ok(a) => a,
+        Err(msg) => {
+            eprintln!("{msg}");
+            std::process::exit(1);
+        }
+    };
+
+    let database_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        eprintln!("ERROR: DATABASE_URL must be set");
+        std::process::exit(1);
+    });
+
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("ERROR: Failed to connect to PostgreSQL: {e}");
+            std::process::exit(1);
+        });
+
+    let started = std::time::Instant::now();
+    let report_result = run_sweep(&pool, &args).await;
+
+    let report = match report_result {
+        Ok(r) => r,
+        Err(msg) => {
+            eprintln!("ERROR: {msg}");
+            std::process::exit(1);
+        }
+    };
+
+    let json = serde_json::to_string_pretty(&report).expect("report serialization");
+    if let Some(ref path) = args.report_out {
+        std::fs::write(path, &json).unwrap_or_else(|e| {
+            eprintln!("ERROR: Failed to write report to {path}: {e}");
+            std::process::exit(1);
+        });
+        eprintln!("Wrote report to {path}");
+    } else {
+        println!("{json}");
     }
-    eprintln!("bridge-sweep: stub (Phase 7 Task 5 will fill this in)");
-    std::process::exit(1);
+
+    let elapsed = started.elapsed();
+    eprintln!(
+        "Done in {:.2}s ({} components processed)",
+        elapsed.as_secs_f64(),
+        report.components.len()
+    );
+}
+
+#[derive(serde::Serialize)]
+struct SweepReport {
+    sweep_id: Uuid,
+    started_at: String,
+    target_component_id: Uuid,
+    target_size: usize,
+    apply: bool,
+    config: SweepConfigSummary,
+    components: Vec<ComponentReport>,
+    duration_ms: u128,
+}
+
+#[derive(serde::Serialize)]
+struct SweepConfigSummary {
+    min_similarity: f64,
+    top_k: u32,
+    min_component_size: u32,
+    provider: String,
+    model: Option<String>,
+    limit: Option<i64>,
+}
+
+#[derive(serde::Serialize)]
+struct ComponentReport {
+    component_id: Uuid,
+    size: usize,
+    candidates_table: String,
+    candidates_count: usize,
+    spine_top_umbrellas: Vec<SpineUmbrella>,
+    rerank: Option<RerankReport>,
+    error: Option<String>,
+    duration_ms: u128,
+}
+
+#[derive(serde::Serialize)]
+struct RerankReport {
+    candidates_evaluated: usize,
+    llm_accepted: usize,
+    edges_created: usize,
+    duration_ms: u128,
+}
+
+async fn run_sweep(pool: &PgPool, args: &Args) -> Result<SweepReport, String> {
+    let started = std::time::Instant::now();
+    let started_at = chrono::Utc::now().to_rfc3339();
+    let sweep_id = Uuid::new_v4();
+
+    let components = compute_components(pool)
+        .await
+        .map_err(|e| format!("compute_components: {e}"))?;
+    if components.is_empty() {
+        return Err("no claims in graph".to_string());
+    }
+
+    // Default target = giant = first (compute_components returns sorted desc by size).
+    let target_id = match args.target {
+        Some(t) => t,
+        None => components.first().expect("non-empty").component_id,
+    };
+    let target_idx = locate_component(&components, &target_id)
+        .ok_or_else(|| format!("target component not found: {target_id}"))?;
+    let target = &components[target_idx];
+
+    // Resolve sweep set.
+    let sweep_indices: Vec<usize> = if args.all {
+        components
+            .iter()
+            .enumerate()
+            .filter(|(idx, c)| *idx != target_idx && c.size >= args.min_component_size)
+            .map(|(idx, _)| idx)
+            .collect()
+    } else {
+        // --components: each UUID must locate a component; error if any fail.
+        let ids = args
+            .components
+            .as_ref()
+            .expect("Args::parse enforces components|all");
+        let mut out = Vec::with_capacity(ids.len());
+        for id in ids {
+            let idx = locate_component(&components, id)
+                .ok_or_else(|| format!("component not found: {id}"))?;
+            // Defensive: skip self-bridges. A duplicate inside --components is
+            // accepted but only processed once below.
+            if idx != target_idx && !out.contains(&idx) {
+                out.push(idx);
+            }
+        }
+        out
+    };
+
+    let total = sweep_indices.len();
+    let mut component_reports: Vec<ComponentReport> = Vec::with_capacity(total);
+
+    for (n, &comp_idx) in sweep_indices.iter().enumerate() {
+        let component = &components[comp_idx];
+        let table_name = format!(
+            "bridge_sweep_{}_c{}_candidates",
+            sweep_id.simple(),
+            comp_idx
+        );
+        let comp_started = std::time::Instant::now();
+
+        eprintln!(
+            "[{n}/{total}] component {} (size={}) → table={}",
+            component.component_id,
+            component.size,
+            table_name,
+            n = n + 1,
+            total = total,
+        );
+
+        let block =
+            process_component(pool, args, component, target, &table_name, comp_started).await;
+        component_reports.push(block);
+    }
+
+    Ok(SweepReport {
+        sweep_id,
+        started_at,
+        target_component_id: target.component_id,
+        target_size: target.size,
+        apply: args.apply,
+        config: SweepConfigSummary {
+            min_similarity: args.min_similarity,
+            top_k: args.top_k,
+            min_component_size: args.min_component_size as u32,
+            provider: args.provider.clone(),
+            model: args.model.clone(),
+            limit: args.limit,
+        },
+        components: component_reports,
+        duration_ms: started.elapsed().as_millis(),
+    })
+}
+
+/// Run the candidate-build → spine → rerank pipeline for one component.
+/// Errors are captured into `ComponentReport.error` so the sweep continues.
+async fn process_component(
+    pool: &PgPool,
+    args: &Args,
+    component: &ComponentSummary,
+    target: &ComponentSummary,
+    table_name: &str,
+    started: std::time::Instant,
+) -> ComponentReport {
+    // Step 1: pull source / target atoms.
+    let source_atoms = match level3_atoms_in_component(pool, component).await {
+        Ok(v) if v.is_empty() => {
+            return ComponentReport {
+                component_id: component.component_id,
+                size: component.size,
+                candidates_table: table_name.to_string(),
+                candidates_count: 0,
+                spine_top_umbrellas: Vec::new(),
+                rerank: None,
+                error: Some("source component has no level-3 atoms with embeddings".into()),
+                duration_ms: started.elapsed().as_millis(),
+            }
+        }
+        Ok(v) => v,
+        Err(e) => {
+            return ComponentReport {
+                component_id: component.component_id,
+                size: component.size,
+                candidates_table: table_name.to_string(),
+                candidates_count: 0,
+                spine_top_umbrellas: Vec::new(),
+                rerank: None,
+                error: Some(format!("source atoms: {e}")),
+                duration_ms: started.elapsed().as_millis(),
+            }
+        }
+    };
+
+    let target_atoms = match level3_atoms_in_component(pool, target).await {
+        Ok(v) if v.is_empty() => {
+            return ComponentReport {
+                component_id: component.component_id,
+                size: component.size,
+                candidates_table: table_name.to_string(),
+                candidates_count: 0,
+                spine_top_umbrellas: Vec::new(),
+                rerank: None,
+                error: Some("target component has no level-3 atoms with embeddings".into()),
+                duration_ms: started.elapsed().as_millis(),
+            }
+        }
+        Ok(v) => v,
+        Err(e) => {
+            return ComponentReport {
+                component_id: component.component_id,
+                size: component.size,
+                candidates_table: table_name.to_string(),
+                candidates_count: 0,
+                spine_top_umbrellas: Vec::new(),
+                rerank: None,
+                error: Some(format!("target atoms: {e}")),
+                duration_ms: started.elapsed().as_millis(),
+            }
+        }
+    };
+
+    // Step 2: build candidate table.
+    let candidates_count = match build_candidate_table(
+        pool,
+        table_name,
+        &source_atoms,
+        &target_atoms,
+        args.min_similarity,
+        args.top_k,
+    )
+    .await
+    {
+        Ok(n) => n,
+        Err(e) => {
+            return ComponentReport {
+                component_id: component.component_id,
+                size: component.size,
+                candidates_table: table_name.to_string(),
+                candidates_count: 0,
+                spine_top_umbrellas: Vec::new(),
+                rerank: None,
+                error: Some(format!("build_candidate_table: {e}")),
+                duration_ms: started.elapsed().as_millis(),
+            }
+        }
+    };
+
+    // Step 3: spine BEFORE the LLM step (graph-health diagnostic).
+    let spine = match compute_spine_destination(pool, table_name, 5).await {
+        Ok(v) => v,
+        Err(e) => {
+            // Record the error but continue to the rerank step — spine is a
+            // diagnostic, not a precondition.
+            eprintln!(
+                "WARN: compute_spine_destination for {} failed: {e}",
+                component.component_id
+            );
+            Vec::new()
+        }
+    };
+
+    // Step 4: rerank if there are candidates.
+    let rerank = if candidates_count > 0 {
+        let config = RerankConfig {
+            min_similarity: args.min_similarity,
+            batch_size: args.batch_size,
+            provider: args.provider.clone(),
+            model: args.model.clone(),
+            dry_run: !args.apply,
+            limit: args.limit,
+            verbose: false,
+        };
+        match rerank_candidates_table(pool, table_name, &config).await {
+            Ok(s) => Some(RerankReport {
+                candidates_evaluated: s.candidates_evaluated,
+                llm_accepted: s.llm_accepted,
+                edges_created: s.edges_created,
+                duration_ms: s.duration_ms,
+            }),
+            Err(e) => {
+                if !args.keep_tables {
+                    let _ = drop_candidate_table(pool, table_name).await;
+                }
+                return ComponentReport {
+                    component_id: component.component_id,
+                    size: component.size,
+                    candidates_table: table_name.to_string(),
+                    candidates_count,
+                    spine_top_umbrellas: spine,
+                    rerank: None,
+                    error: Some(format!("rerank: {e}")),
+                    duration_ms: started.elapsed().as_millis(),
+                };
+            }
+        }
+    } else {
+        None
+    };
+
+    // Step 5: drop temp table unless --keep-tables.
+    if !args.keep_tables {
+        let _ = drop_candidate_table(pool, table_name).await; // best-effort
+    }
+
+    ComponentReport {
+        component_id: component.component_id,
+        size: component.size,
+        candidates_table: table_name.to_string(),
+        candidates_count,
+        spine_top_umbrellas: spine,
+        rerank,
+        error: None,
+        duration_ms: started.elapsed().as_millis(),
+    }
 }

--- a/crates/epigraph-cli/src/bin/bridge_sweep.rs
+++ b/crates/epigraph-cli/src/bin/bridge_sweep.rs
@@ -1,0 +1,58 @@
+//! `bridge_sweep` — bridge multiple disconnected components into the
+//! giant connected component, with spine-destination report.
+//!
+//! See docs/superpowers/specs/2026-05-05-cross-component-bridge-sweep-design.md.
+
+#![allow(dead_code)] // Filled in by Phase 7 Task 5.
+
+use uuid::Uuid;
+
+const USAGE: &str = r#"
+bridge-sweep — bridge multiple disconnected components into the giant CC
+
+USAGE:
+  bridge-sweep [--components <UUID,UUID,...> | --all] [OPTIONS]
+
+OPTIONS:
+  --components <LIST>        Explicit component UUIDs (mutually exclusive with --all)
+  --all                      Sweep all components ≥ --min-component-size
+  --min-component-size <N>   Only used with --all [default: 30]
+  --target <ID>              Target component (default: giant)
+  --min-similarity <FLOAT>   [default: 0.50]
+  --top-k <N>                Per-source-atom [default: 50]
+  --batch-size <N>           [default: 10]
+  --provider <NAME>          [default: claude-cli]
+  --model <NAME>             Model override
+  --dry-run                  Default.
+  --apply                    Commit edges (overrides --dry-run).
+  --keep-tables              Don't drop temp candidate tables on exit.
+  --report-out <PATH>        JSON report path (else stdout).
+  -h, --help
+"#;
+
+#[derive(Debug)]
+struct Args {
+    components: Option<Vec<Uuid>>, // None when --all is set
+    all: bool,
+    min_component_size: u32,
+    target: Option<Uuid>,
+    min_similarity: f64,
+    top_k: u32,
+    batch_size: usize,
+    provider: String,
+    model: Option<String>,
+    apply: bool,
+    keep_tables: bool,
+    report_out: Option<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        println!("{USAGE}");
+        return;
+    }
+    eprintln!("bridge-sweep: stub (Phase 7 Task 5 will fill this in)");
+    std::process::exit(1);
+}

--- a/crates/epigraph-cli/src/bin/rerank_bridges.rs
+++ b/crates/epigraph-cli/src/bin/rerank_bridges.rs
@@ -14,15 +14,22 @@
 //!   --dry-run
 //! ```
 //!
+//! Two operating modes:
+//! - **Global join (default):** scan every claim pair above `--min-similarity`,
+//!   optionally filtered by `--source-filter` / `--target-filter`.
+//! - **Candidates table (`--candidates-table NAME`):** read pre-populated pairs
+//!   from a `(source_id uuid, target_id uuid)` table — used by `bridge_component`
+//!   and `bridge_sweep` to avoid the O(N²) global join.
+//!
 //! # Feature gate
 //!
 //! Requires the `genai` feature (implies `db`). Will not compile without it.
 //! Requires `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` at runtime
 //! unless `--provider mock`. Prefers OAuth when both are set.
 
-use epigraph_cli::enrichment::llm_client::{create_llm_client, LlmClient, LlmError};
-use serde::Deserialize;
-use uuid::Uuid;
+use epigraph_cli::rerank::{
+    rerank_candidates_table, rerank_global_join, RerankConfig, RerankSummary,
+};
 
 // =============================================================================
 // USAGE
@@ -40,6 +47,9 @@ OPTIONS:
   --batch-size <N>           Pairs per LLM call [default: 10]
   --source-filter <SQL>      WHERE fragment for source claims (alias: c1)
   --target-filter <SQL>      WHERE fragment for target claims (alias: c2)
+  --candidates-table <NAME>  Read pairs from a caller-supplied table with
+                             (source_id, target_id) columns. Mutually exclusive
+                             with --source-filter / --target-filter.
   --provider <NAME>          LLM provider: anthropic or mock [default: anthropic]
   --model <NAME>             Model override [default: ENRICHMENT_MODEL or claude-haiku-4-5-20251001]
   -n, --dry-run              Evaluate and report, don't create edges
@@ -59,6 +69,9 @@ EXAMPLES:
 
   # Live run with mock provider (no API key needed)
   rerank_bridges --provider mock --dry-run
+
+  # Drive from a candidates table populated by bridge_component
+  rerank_bridges --candidates-table cross_component_candidates --dry-run
 "#;
 
 // =============================================================================
@@ -72,6 +85,7 @@ struct Args {
     batch_size: usize,
     source_filter: Option<String>,
     target_filter: Option<String>,
+    candidates_table: Option<String>,
     provider: String,
     model: Option<String>,
     dry_run: bool,
@@ -80,12 +94,16 @@ struct Args {
 impl Args {
     fn parse() -> Result<Self, String> {
         let args: Vec<String> = std::env::args().collect();
+        Self::parse_from(&args)
+    }
 
+    fn parse_from(args: &[String]) -> Result<Self, String> {
         let mut min_similarity = 0.40;
         let mut limit = None;
         let mut batch_size = 10;
         let mut source_filter = None;
         let mut target_filter = None;
+        let mut candidates_table = None;
         let mut provider = "anthropic".to_string();
         let mut model = None;
         let mut dry_run = false;
@@ -139,6 +157,14 @@ impl Args {
                             .clone(),
                     );
                 }
+                "--candidates-table" => {
+                    i += 1;
+                    candidates_table = Some(
+                        args.get(i)
+                            .ok_or("--candidates-table requires a table name")?
+                            .clone(),
+                    );
+                }
                 "--provider" => {
                     i += 1;
                     provider = args
@@ -163,343 +189,37 @@ impl Args {
             i += 1;
         }
 
+        if candidates_table.is_some() && (source_filter.is_some() || target_filter.is_some()) {
+            return Err(
+                "--candidates-table is mutually exclusive with --source-filter / --target-filter"
+                    .to_string(),
+            );
+        }
+
         Ok(Self {
             min_similarity,
             limit,
             batch_size,
             source_filter,
             target_filter,
+            candidates_table,
             provider,
             model,
             dry_run,
         })
     }
-}
 
-// =============================================================================
-// DATA TYPES
-// =============================================================================
-
-#[derive(Debug, Clone)]
-struct CandidatePair {
-    source_id: Uuid,
-    target_id: Uuid,
-    source_content: String,
-    target_content: String,
-    source_doi: Option<String>,
-    target_doi: Option<String>,
-    similarity: f64,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct ValidationResult {
-    pair_index: usize,
-    valid: bool,
-    relationship: Option<String>,
-    strength: Option<f64>,
-    rationale: String,
-}
-
-const VALID_RELATIONSHIPS: &[&str] = &[
-    "supports",
-    "contradicts",
-    "derives_from",
-    "refines",
-    "analogous",
-];
-
-// =============================================================================
-// DATABASE QUERIES
-// =============================================================================
-
-/// Build and execute the candidate discovery query.
-///
-/// Finds claim pairs above the similarity threshold that don't already
-/// have edges between them. Optional source/target filters restrict
-/// which claims participate.
-async fn find_candidates(
-    pool: &sqlx::PgPool,
-    args: &Args,
-) -> Result<Vec<CandidatePair>, Box<dyn std::error::Error>> {
-    // Build query with optional filters injected as structural SQL
-    let source_clause = args
-        .source_filter
-        .as_ref()
-        .map_or(String::new(), |f| format!("AND {f}"));
-    let target_clause = args
-        .target_filter
-        .as_ref()
-        .map_or(String::new(), |f| format!("AND {f}"));
-    let limit_clause = args
-        .limit
-        .map_or("LIMIT 10000".to_string(), |n| format!("LIMIT {n}"));
-
-    let query = format!(
-        r#"
-        SELECT
-            c1.id AS source_id,
-            c1.content AS source_content,
-            c1.properties->>'paper_doi' AS source_doi,
-            c2.id AS target_id,
-            c2.content AS target_content,
-            c2.properties->>'paper_doi' AS target_doi,
-            (1 - (c1.embedding <=> c2.embedding))::float8 AS similarity
-        FROM claims c1
-        JOIN claims c2 ON c2.id > c1.id
-        WHERE c1.embedding IS NOT NULL
-          AND c2.embedding IS NOT NULL
-          AND (1 - (c1.embedding <=> c2.embedding)) >= $1
-          AND NOT EXISTS (
-              SELECT 1 FROM edges e
-              WHERE (e.source_id = c1.id AND e.target_id = c2.id)
-                 OR (e.source_id = c2.id AND e.target_id = c1.id)
-          )
-          {source_clause}
-          {target_clause}
-        ORDER BY similarity DESC
-        {limit_clause}
-        "#
-    );
-
-    let rows = sqlx::query_as::<
-        _,
-        (
-            Uuid,
-            String,
-            Option<String>,
-            Uuid,
-            String,
-            Option<String>,
-            f64,
-        ),
-    >(&query)
-    .bind(args.min_similarity)
-    .fetch_all(pool)
-    .await?;
-
-    Ok(rows
-        .into_iter()
-        .map(
-            |(
-                source_id,
-                source_content,
-                source_doi,
-                target_id,
-                target_content,
-                target_doi,
-                similarity,
-            )| {
-                CandidatePair {
-                    source_id,
-                    target_id,
-                    source_content,
-                    target_content,
-                    source_doi,
-                    target_doi,
-                    similarity,
-                }
-            },
-        )
-        .collect())
-}
-
-/// Check if an edge already exists between two claims (either direction).
-async fn edge_exists(
-    pool: &sqlx::PgPool,
-    a: Uuid,
-    b: Uuid,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    let row = sqlx::query_scalar::<_, i64>(
-        r#"
-        SELECT COUNT(*) FROM edges
-        WHERE source_type = 'claim' AND target_type = 'claim'
-          AND ((source_id = $1 AND target_id = $2)
-            OR (source_id = $2 AND target_id = $1))
-        "#,
-    )
-    .bind(a)
-    .bind(b)
-    .fetch_one(pool)
-    .await?;
-
-    Ok(row > 0)
-}
-
-/// Create a validated edge in the edges table.
-async fn create_edge(
-    pool: &sqlx::PgPool,
-    pair: &CandidatePair,
-    result: &ValidationResult,
-    model_name: &str,
-) -> Result<Uuid, Box<dyn std::error::Error>> {
-    let properties = serde_json::json!({
-        "strength": result.strength.unwrap_or(0.5),
-        "cosine_similarity": pair.similarity,
-        "validation_method": "llm_rerank",
-        "validation_model": model_name,
-        "rationale": result.rationale,
-        "source_doi": pair.source_doi,
-        "target_doi": pair.target_doi,
-        "source": "rerank_bridges",
-    });
-
-    let relationship = result.relationship.as_deref().unwrap_or("analogous");
-
-    let row = sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO edges (source_id, source_type, target_id, target_type, relationship, properties)
-        VALUES ($1, 'claim', $2, 'claim', $3, $4)
-        RETURNING id
-        "#,
-    )
-    .bind(pair.source_id)
-    .bind(pair.target_id)
-    .bind(relationship)
-    .bind(properties)
-    .fetch_one(pool)
-    .await?;
-
-    Ok(row)
-}
-
-// =============================================================================
-// LLM PROMPT
-// =============================================================================
-
-/// Build the validation prompt for a batch of candidate pairs.
-fn build_validation_prompt(pairs: &[CandidatePair]) -> String {
-    let mut pairs_text = String::new();
-    for (i, pair) in pairs.iter().enumerate() {
-        let src_doi = pair.source_doi.as_deref().unwrap_or("unknown");
-        let tgt_doi = pair.target_doi.as_deref().unwrap_or("unknown");
-        // Truncate content to keep prompt manageable
-        let src = truncate(&pair.source_content, 300);
-        let tgt = truncate(&pair.target_content, 300);
-        pairs_text.push_str(&format!(
-            "Pair {i} (cosine similarity: {:.4}):\n  Source [{src_doi}]: \"{src}\"\n  Target [{tgt_doi}]: \"{tgt}\"\n\n",
-            pair.similarity
-        ));
-    }
-
-    format!(
-        r#"You are a scientific relationship validator for an epistemic knowledge graph.
-You evaluate whether pairs of scientific claims have a genuine scientific
-relationship, or if their high embedding similarity is merely vocabulary overlap.
-
-## CRITICAL DISTINCTION
-
-GENUINE relationship: Claim A's truth or methodology meaningfully bears on Claim B.
-One claim provides evidence, theoretical basis, or specific application of the other.
-
-FALSE POSITIVE (reject): Both claims use the same terms (e.g., "octahedral",
-"geometry", "lattice") but in unrelated scientific contexts. Example:
-Crystal Field Theory (d-orbital splitting in transition metal complexes) vs
-DNA origami (octahedral nanostructure shape) — shared word "octahedral", zero mechanistic link.
-
-## Candidate Pairs
-
-{pairs_text}
-## Relationship Types
-
-- supports: A provides evidence or theoretical basis for B
-- contradicts: A provides evidence undermining B
-- derives_from: A is a logical consequence or application of B
-- refines: A adds precision or qualifies B
-- analogous: genuinely parallel phenomena in related domains
-
-## Rules
-
-1. REJECT pairs where the ONLY connection is shared vocabulary in different contexts
-2. A relationship must be defensible in a peer-reviewed context
-3. If uncertain, REJECT — false negatives are preferable to false positives
-4. Strength range: 0.3 to 1.0 (for accepted pairs)
-5. Rationale must name the SPECIFIC scientific mechanism connecting the claims
-
-## Output
-
-Return a JSON array with one object per pair:
-- pair_index: integer (0-based)
-- valid: boolean
-- relationship: string or null (supports/contradicts/derives_from/refines/analogous)
-- strength: number or null (0.3 to 1.0)
-- rationale: string (explain the specific scientific connection or why it's a false positive)
-
-Return ONLY the JSON array. Include an entry for EVERY pair."#
-    )
-}
-
-/// Truncate a string to `max_len` characters, appending "..." if truncated.
-fn truncate(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        let end = s
-            .char_indices()
-            .nth(max_len)
-            .map_or(s.len(), |(idx, _)| idx);
-        format!("{}...", &s[..end])
-    }
-}
-
-// =============================================================================
-// LLM RESPONSE PARSING
-// =============================================================================
-
-/// Parse and validate the LLM's JSON response into `ValidationResult`s.
-fn parse_validation_response(json: &serde_json::Value, batch_size: usize) -> Vec<ValidationResult> {
-    let arr = match json.as_array() {
-        Some(a) => a,
-        None => {
-            eprintln!("  WARNING: LLM response is not a JSON array");
-            return Vec::new();
+    fn to_config(&self) -> RerankConfig {
+        RerankConfig {
+            min_similarity: self.min_similarity,
+            batch_size: self.batch_size,
+            provider: self.provider.clone(),
+            model: self.model.clone(),
+            dry_run: self.dry_run,
+            limit: self.limit,
+            verbose: true,
         }
-    };
-
-    let mut results = Vec::new();
-    for item in arr {
-        let parsed: ValidationResult = match serde_json::from_value(item.clone()) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("  WARNING: Failed to parse validation item: {e}");
-                continue;
-            }
-        };
-
-        // Bounds check
-        if parsed.pair_index >= batch_size {
-            eprintln!(
-                "  WARNING: pair_index {} out of bounds (batch size {})",
-                parsed.pair_index, batch_size
-            );
-            continue;
-        }
-
-        // Validate accepted pairs
-        if parsed.valid {
-            if let Some(ref rel) = parsed.relationship {
-                if !VALID_RELATIONSHIPS.contains(&rel.as_str()) {
-                    eprintln!(
-                        "  WARNING: pair {}: invalid relationship '{}', skipping",
-                        parsed.pair_index, rel
-                    );
-                    continue;
-                }
-            }
-            if let Some(strength) = parsed.strength {
-                if !(0.3..=1.0).contains(&strength) {
-                    eprintln!(
-                        "  WARNING: pair {}: strength {:.2} out of [0.3, 1.0], skipping",
-                        parsed.pair_index, strength
-                    );
-                    continue;
-                }
-            }
-        }
-
-        results.push(parsed);
     }
-
-    results
 }
 
 // =============================================================================
@@ -518,7 +238,8 @@ async fn main() {
         }
     };
 
-    // If --model was specified, set ENRICHMENT_MODEL for the LLM client factory
+    // If --model was specified, set ENRICHMENT_MODEL for the LLM client factory.
+    // (The factory reads from env, not parameters — keep the indirection at the bin layer.)
     if let Some(ref model) = args.model {
         std::env::set_var("ENRICHMENT_MODEL", model);
     }
@@ -546,6 +267,9 @@ async fn main() {
     if let Some(ref f) = args.target_filter {
         println!("Target filter:  {f}");
     }
+    if let Some(ref t) = args.candidates_table {
+        println!("Candidates:     table {t}");
+    }
     println!();
 
     // Connect to PostgreSQL
@@ -564,172 +288,73 @@ async fn main() {
             std::process::exit(1);
         });
 
-    // Initialize LLM client
-    let llm: Box<dyn LlmClient> = match create_llm_client(&args.provider) {
-        Ok(c) => {
-            println!("LLM model:      {}", c.model_name());
-            c
-        }
-        Err(e) => {
-            eprintln!("ERROR: Failed to create LLM client: {e}");
-            std::process::exit(1);
-        }
-    };
+    let config = args.to_config();
 
-    // Step 1: Find candidate pairs
     println!("\nFinding candidate pairs...");
-    let candidates = match find_candidates(&pool, &args).await {
-        Ok(c) => c,
+    let summary_result = if let Some(table) = args.candidates_table.as_deref() {
+        rerank_candidates_table(&pool, table, &config).await
+    } else {
+        rerank_global_join(
+            &pool,
+            args.source_filter.as_deref(),
+            args.target_filter.as_deref(),
+            &config,
+        )
+        .await
+    };
+
+    let summary = match summary_result {
+        Ok(s) => s,
         Err(e) => {
-            eprintln!("ERROR: Candidate discovery query failed: {e}");
+            eprintln!("ERROR: Rerank failed: {e}");
             std::process::exit(1);
         }
     };
 
-    if candidates.is_empty() {
+    print_summary(&summary, args.dry_run);
+}
+
+// =============================================================================
+// SUMMARY OUTPUT
+// =============================================================================
+
+fn print_summary(summary: &RerankSummary, dry_run: bool) {
+    if summary.candidates_evaluated == 0 {
         println!("No candidate pairs found above threshold. Nothing to do.");
         return;
     }
 
-    // Similarity distribution
-    let avg_sim: f64 =
-        candidates.iter().map(|c| c.similarity).sum::<f64>() / candidates.len() as f64;
-    let max_sim = candidates
-        .iter()
-        .map(|c| c.similarity)
-        .fold(0.0_f64, f64::max);
-    let min_sim = candidates
-        .iter()
-        .map(|c| c.similarity)
-        .fold(1.0_f64, f64::min);
-
-    println!(
-        "Found {} candidate pairs (sim: {min_sim:.4} — {max_sim:.4}, avg: {avg_sim:.4})",
-        candidates.len()
-    );
-
-    // Step 2: Process in batches
-    let num_batches = candidates.len().div_ceil(args.batch_size);
-    let mut total_accepted = 0_usize;
-    let mut total_rejected = 0_usize;
-    let mut total_edges_created = 0_usize;
-    let mut total_errors = 0_usize;
-
-    for (batch_idx, batch) in candidates.chunks(args.batch_size).enumerate() {
-        println!(
-            "\n--- Batch {}/{} ({} pairs) ---",
-            batch_idx + 1,
-            num_batches,
-            batch.len()
-        );
-
-        let prompt = build_validation_prompt(batch);
-
-        // Call LLM (with 1 retry on rate limit)
-        let json = match call_llm_with_retry(&*llm, &prompt).await {
-            Ok(j) => j,
-            Err(e) => {
-                eprintln!("  ERROR calling LLM: {e}");
-                total_errors += batch.len();
-                continue;
-            }
-        };
-
-        let results = parse_validation_response(&json, batch.len());
-
-        for result in &results {
-            let pair = &batch[result.pair_index];
-
-            if result.valid {
-                total_accepted += 1;
-                let rel = result.relationship.as_deref().unwrap_or("analogous");
-                let str_val = result.strength.unwrap_or(0.5);
-                let rationale_preview: String = result.rationale.chars().take(80).collect();
-
-                println!(
-                    "  ACCEPT pair {} (sim={:.3}): {} --[{}({:.2})]--> {} | {}",
-                    result.pair_index,
-                    pair.similarity,
-                    &pair.source_id.to_string()[..8],
-                    rel,
-                    str_val,
-                    &pair.target_id.to_string()[..8],
-                    rationale_preview
-                );
-
-                if !args.dry_run {
-                    // Idempotency check
-                    match edge_exists(&pool, pair.source_id, pair.target_id).await {
-                        Ok(true) => {
-                            println!("    (edge already exists, skipping)");
-                        }
-                        Ok(false) => {
-                            match create_edge(&pool, pair, result, llm.model_name()).await {
-                                Ok(edge_id) => {
-                                    total_edges_created += 1;
-                                    println!("    Created edge {edge_id}");
-                                }
-                                Err(e) => {
-                                    total_errors += 1;
-                                    eprintln!("    ERROR creating edge: {e}");
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            total_errors += 1;
-                            eprintln!("    ERROR checking edge existence: {e}");
-                        }
-                    }
-                }
-            } else {
-                total_rejected += 1;
-                let rationale_preview: String = result.rationale.chars().take(100).collect();
-                println!(
-                    "  REJECT pair {} (sim={:.3}): {}",
-                    result.pair_index, pair.similarity, rationale_preview
-                );
-            }
-        }
-
-        // Count pairs the LLM didn't return results for
-        let responded_indices: std::collections::HashSet<usize> =
-            results.iter().map(|r| r.pair_index).collect();
-        for i in 0..batch.len() {
-            if !responded_indices.contains(&i) {
-                eprintln!("  WARNING: LLM did not return a result for pair {i}");
-                total_errors += 1;
-            }
-        }
-    }
-
-    // Summary
     println!("\n=== Re-Ranking Complete ===");
-    println!("Candidates evaluated: {}", candidates.len());
-    println!("Accepted:             {total_accepted}");
-    println!("Rejected:             {total_rejected}");
-    if args.dry_run {
+    println!("Candidates evaluated: {}", summary.candidates_evaluated);
+    println!("Accepted:             {}", summary.llm_accepted);
+    println!("Rejected:             {}", summary.llm_rejected);
+    if dry_run {
         println!("Dry run — no edges created");
     } else {
-        println!("Edges created:        {total_edges_created}");
+        println!("Edges created:        {}", summary.edges_created);
     }
-    if total_errors > 0 {
-        println!("Errors:               {total_errors}");
+    if summary.errors > 0 {
+        println!("Errors:               {}", summary.errors);
     }
-}
+    println!("Duration:             {} ms", summary.duration_ms);
 
-/// Call the LLM with one retry on rate limit.
-async fn call_llm_with_retry(
-    llm: &dyn LlmClient,
-    prompt: &str,
-) -> Result<serde_json::Value, LlmError> {
-    match llm.complete_json(prompt).await {
-        Ok(v) => Ok(v),
-        Err(LlmError::RateLimited { retry_after_secs }) => {
-            eprintln!("  Rate limited, waiting {retry_after_secs}s before retry...");
-            tokio::time::sleep(std::time::Duration::from_secs(retry_after_secs)).await;
-            llm.complete_json(prompt).await
+    if !summary.relationship_counts.is_empty() {
+        println!("\nRelationship breakdown:");
+        let mut entries: Vec<_> = summary.relationship_counts.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+        for (rel, n) in entries {
+            println!("  {rel:<14} {n}");
         }
-        Err(e) => Err(e),
+    }
+
+    if let Some(ref pair) = summary.sample_contradiction {
+        println!("\nSample contradiction (first encountered):");
+        println!(
+            "  {} <-> {} (sim={:.3})",
+            &pair.source_id.to_string()[..8],
+            &pair.target_id.to_string()[..8],
+            pair.similarity
+        );
     }
 }
 
@@ -741,95 +366,11 @@ async fn call_llm_with_retry(
 mod tests {
     use super::*;
 
-    // ── Arg parsing ─────────────────────────────────────────────────────
-
     fn parse_args(args: &[&str]) -> Result<Args, String> {
         let full: Vec<String> = std::iter::once("rerank_bridges".to_string())
             .chain(args.iter().map(|s| (*s).to_string()))
             .collect();
-
-        // Temporarily override std::env::args by using our own parser
-        // Since Args::parse reads std::env::args, we test the individual logic instead
-        let mut min_similarity = 0.40;
-        let mut limit = None;
-        let mut batch_size = 10;
-        let mut source_filter = None;
-        let mut target_filter = None;
-        let mut provider = "anthropic".to_string();
-        let mut model = None;
-        let mut dry_run = false;
-
-        let mut i = 1;
-        while i < full.len() {
-            match full[i].as_str() {
-                "--min-similarity" => {
-                    i += 1;
-                    let val = full.get(i).ok_or("--min-similarity requires a number")?;
-                    min_similarity = val
-                        .parse::<f64>()
-                        .map_err(|_| format!("--min-similarity must be a number, got: {val}"))?;
-                    if !(0.0..=1.0).contains(&min_similarity) {
-                        return Err(format!(
-                            "--min-similarity must be in [0.0, 1.0], got: {min_similarity}"
-                        ));
-                    }
-                }
-                "--limit" => {
-                    i += 1;
-                    let val = full.get(i).ok_or("--limit requires a number")?;
-                    limit =
-                        Some(val.parse::<i64>().map_err(|_| {
-                            format!("--limit must be a positive integer, got: {val}")
-                        })?);
-                }
-                "--batch-size" => {
-                    i += 1;
-                    let val = full.get(i).ok_or("--batch-size requires a number")?;
-                    batch_size = val.parse::<usize>().map_err(|_| {
-                        format!("--batch-size must be a positive integer, got: {val}")
-                    })?;
-                }
-                "--source-filter" => {
-                    i += 1;
-                    source_filter = Some(
-                        full.get(i)
-                            .ok_or("--source-filter requires a value")?
-                            .clone(),
-                    );
-                }
-                "--target-filter" => {
-                    i += 1;
-                    target_filter = Some(
-                        full.get(i)
-                            .ok_or("--target-filter requires a value")?
-                            .clone(),
-                    );
-                }
-                "--provider" => {
-                    i += 1;
-                    provider = full.get(i).ok_or("--provider requires a value")?.clone();
-                }
-                "--model" => {
-                    i += 1;
-                    model = Some(full.get(i).ok_or("--model requires a value")?.clone());
-                }
-                "--dry-run" | "-n" => dry_run = true,
-                "--help" | "-h" => return Err(USAGE.to_string()),
-                other => return Err(format!("Unknown argument: {other}")),
-            }
-            i += 1;
-        }
-
-        Ok(Args {
-            min_similarity,
-            limit,
-            batch_size,
-            source_filter,
-            target_filter,
-            provider,
-            model,
-            dry_run,
-        })
+        Args::parse_from(&full)
     }
 
     #[test]
@@ -842,6 +383,7 @@ mod tests {
         assert!(args.limit.is_none());
         assert!(args.source_filter.is_none());
         assert!(args.target_filter.is_none());
+        assert!(args.candidates_table.is_none());
     }
 
     #[test]
@@ -914,292 +456,60 @@ mod tests {
         assert!(result.unwrap_err().contains("rerank_bridges"));
     }
 
-    // ── Prompt building ─────────────────────────────────────────────────
-
-    fn make_pair(src: &str, tgt: &str, sim: f64) -> CandidatePair {
-        CandidatePair {
-            source_id: Uuid::new_v4(),
-            target_id: Uuid::new_v4(),
-            source_content: src.to_string(),
-            target_content: tgt.to_string(),
-            source_doi: Some("paper/123".to_string()),
-            target_doi: Some("textbook/chem".to_string()),
-            similarity: sim,
-        }
-    }
-
     #[test]
-    fn test_build_prompt_contains_pairs() {
-        let pairs = vec![
-            make_pair(
-                "DNA nanoengine driven by chemical energy",
-                "DNA is a polymer of four nucleotides",
-                0.51,
-            ),
-            make_pair(
-                "CO on Cu(111) occupies on-top sites",
-                "Crystal field theory explains d-orbital splitting",
-                0.49,
-            ),
-        ];
-
-        let prompt = build_validation_prompt(&pairs);
-
-        assert!(prompt.contains("Pair 0"));
-        assert!(prompt.contains("Pair 1"));
-        assert!(prompt.contains("DNA nanoengine"));
-        assert!(prompt.contains("CO on Cu(111)"));
-        assert!(prompt.contains("0.5100"));
-        assert!(prompt.contains("0.4900"));
-    }
-
-    #[test]
-    fn test_build_prompt_includes_rejection_criteria() {
-        let pairs = vec![make_pair("a", "b", 0.5)];
-        let prompt = build_validation_prompt(&pairs);
-
-        assert!(prompt.contains("FALSE POSITIVE"));
-        assert!(prompt.contains("Crystal Field"));
-        assert!(prompt.contains("vocabulary overlap"));
-        assert!(prompt.contains("REJECT"));
-        assert!(prompt.contains("peer-reviewed"));
-    }
-
-    #[test]
-    fn test_build_prompt_includes_all_relationship_types() {
-        let pairs = vec![make_pair("a", "b", 0.5)];
-        let prompt = build_validation_prompt(&pairs);
-
-        for rel in VALID_RELATIONSHIPS {
-            assert!(
-                prompt.contains(rel),
-                "Prompt missing relationship type: {rel}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_build_prompt_truncates_long_content() {
-        let long_content = "A".repeat(500);
-        let pairs = vec![make_pair(&long_content, "short", 0.5)];
-        let prompt = build_validation_prompt(&pairs);
-
-        // Should be truncated to 300 chars + "..."
-        assert!(!prompt.contains(&"A".repeat(400)));
-        assert!(prompt.contains("..."));
-    }
-
-    // ── Response parsing ────────────────────────────────────────────────
-
-    #[test]
-    fn test_parse_response_accepted() {
-        let json = serde_json::json!([
-            {
-                "pair_index": 0,
-                "valid": true,
-                "relationship": "supports",
-                "strength": 0.75,
-                "rationale": "DNA origami uses DNA polymer structure"
-            }
-        ]);
-
-        let results = parse_validation_response(&json, 1);
-        assert_eq!(results.len(), 1);
-        assert!(results[0].valid);
-        assert_eq!(results[0].relationship.as_deref(), Some("supports"));
-        assert!((results[0].strength.unwrap() - 0.75).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_parse_response_rejected() {
-        let json = serde_json::json!([
-            {
-                "pair_index": 0,
-                "valid": false,
-                "relationship": null,
-                "strength": null,
-                "rationale": "Vocabulary overlap: both use 'octahedral' in different contexts"
-            }
-        ]);
-
-        let results = parse_validation_response(&json, 1);
-        assert_eq!(results.len(), 1);
-        assert!(!results[0].valid);
-        assert!(results[0].relationship.is_none());
-        assert!(results[0].strength.is_none());
-    }
-
-    #[test]
-    fn test_parse_response_mixed() {
-        let json = serde_json::json!([
-            {
-                "pair_index": 0,
-                "valid": true,
-                "relationship": "derives_from",
-                "strength": 0.6,
-                "rationale": "EUV photon energy relates to photoelectric effect"
-            },
-            {
-                "pair_index": 1,
-                "valid": false,
-                "relationship": null,
-                "strength": null,
-                "rationale": "No genuine link between CFT and DNA lattice"
-            }
-        ]);
-
-        let results = parse_validation_response(&json, 2);
-        assert_eq!(results.len(), 2);
-        assert!(results[0].valid);
-        assert!(!results[1].valid);
-    }
-
-    #[test]
-    fn test_parse_response_invalid_relationship() {
-        let json = serde_json::json!([
-            {
-                "pair_index": 0,
-                "valid": true,
-                "relationship": "causes",
-                "strength": 0.7,
-                "rationale": "some reason"
-            }
-        ]);
-
-        let results = parse_validation_response(&json, 1);
-        assert!(
-            results.is_empty(),
-            "Invalid relationship type should be rejected"
+    fn test_args_candidates_table_accepted() {
+        let args = parse_args(&["--candidates-table", "bridge_test_candidates"]).unwrap();
+        assert_eq!(
+            args.candidates_table.as_deref(),
+            Some("bridge_test_candidates")
         );
+        assert!(args.source_filter.is_none());
     }
 
     #[test]
-    fn test_parse_response_strength_too_low() {
-        let json = serde_json::json!([
-            {
-                "pair_index": 0,
-                "valid": true,
-                "relationship": "supports",
-                "strength": 0.1,
-                "rationale": "weak connection"
-            }
+    fn test_args_candidates_table_rejects_with_source_filter() {
+        let result = parse_args(&[
+            "--candidates-table",
+            "t",
+            "--source-filter",
+            "c1.id IS NOT NULL",
         ]);
-
-        let results = parse_validation_response(&json, 1);
-        assert!(results.is_empty(), "Strength < 0.3 should be rejected");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("mutually exclusive"));
     }
 
     #[test]
-    fn test_parse_response_strength_too_high() {
-        let json = serde_json::json!([
-            {
-                "pair_index": 0,
-                "valid": true,
-                "relationship": "supports",
-                "strength": 1.5,
-                "rationale": "too strong"
-            }
+    fn test_args_candidates_table_rejects_with_target_filter() {
+        let result = parse_args(&[
+            "--target-filter",
+            "c2.id IS NOT NULL",
+            "--candidates-table",
+            "t",
         ]);
-
-        let results = parse_validation_response(&json, 1);
-        assert!(results.is_empty(), "Strength > 1.0 should be rejected");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("mutually exclusive"));
     }
 
     #[test]
-    fn test_parse_response_pair_index_out_of_bounds() {
-        let json = serde_json::json!([
-            {
-                "pair_index": 5,
-                "valid": true,
-                "relationship": "supports",
-                "strength": 0.5,
-                "rationale": "reason"
-            }
-        ]);
-
-        let results = parse_validation_response(&json, 3);
-        assert!(
-            results.is_empty(),
-            "pair_index >= batch_size should be rejected"
-        );
-    }
-
-    #[test]
-    fn test_parse_response_not_array() {
-        let json = serde_json::json!({"error": "something"});
-        let results = parse_validation_response(&json, 1);
-        assert!(results.is_empty());
-    }
-
-    #[test]
-    fn test_parse_response_empty_array() {
-        let json = serde_json::json!([]);
-        let results = parse_validation_response(&json, 5);
-        assert!(results.is_empty());
-    }
-
-    // ── Edge properties ─────────────────────────────────────────────────
-
-    #[test]
-    fn test_edge_properties_schema() {
-        let pair = make_pair("source claim", "target claim", 0.48);
-        let result = ValidationResult {
-            pair_index: 0,
-            valid: true,
-            relationship: Some("supports".to_string()),
-            strength: Some(0.75),
-            rationale: "Genuine scientific connection".to_string(),
-        };
-
-        let properties = serde_json::json!({
-            "strength": result.strength.unwrap_or(0.5),
-            "cosine_similarity": pair.similarity,
-            "validation_method": "llm_rerank",
-            "validation_model": "claude-haiku-4-5-20251001",
-            "rationale": result.rationale,
-            "source_doi": pair.source_doi,
-            "target_doi": pair.target_doi,
-            "source": "rerank_bridges",
-        });
-
-        // All required fields present
-        assert!(properties["strength"].is_number());
-        assert!(properties["cosine_similarity"].is_number());
-        assert_eq!(properties["validation_method"], "llm_rerank");
-        assert!(properties["validation_model"].is_string());
-        assert!(properties["rationale"].is_string());
-        assert_eq!(properties["source"], "rerank_bridges");
-    }
-
-    #[test]
-    fn test_valid_relationships_matches_domain_model() {
-        // These must match the SemanticLinkType enum in epigraph-core
-        assert!(VALID_RELATIONSHIPS.contains(&"supports"));
-        assert!(VALID_RELATIONSHIPS.contains(&"contradicts"));
-        assert!(VALID_RELATIONSHIPS.contains(&"derives_from"));
-        assert!(VALID_RELATIONSHIPS.contains(&"refines"));
-        assert!(VALID_RELATIONSHIPS.contains(&"analogous"));
-        assert_eq!(VALID_RELATIONSHIPS.len(), 5);
-    }
-
-    // ── Truncation ──────────────────────────────────────────────────────
-
-    #[test]
-    fn test_truncate_short_string() {
-        assert_eq!(truncate("hello", 10), "hello");
-    }
-
-    #[test]
-    fn test_truncate_long_string() {
-        let long = "A".repeat(500);
-        let result = truncate(&long, 300);
-        assert!(result.ends_with("..."));
-        assert!(result.len() <= 304); // 300 + "..."
-    }
-
-    #[test]
-    fn test_truncate_exact_length() {
-        let exact = "A".repeat(300);
-        assert_eq!(truncate(&exact, 300), exact);
+    fn test_to_config_propagates_fields() {
+        let args = parse_args(&[
+            "--min-similarity",
+            "0.55",
+            "--batch-size",
+            "7",
+            "--limit",
+            "42",
+            "--provider",
+            "mock",
+            "--dry-run",
+        ])
+        .unwrap();
+        let config = args.to_config();
+        assert!((config.min_similarity - 0.55).abs() < f64::EPSILON);
+        assert_eq!(config.batch_size, 7);
+        assert_eq!(config.limit, Some(42));
+        assert_eq!(config.provider, "mock");
+        assert!(config.dry_run);
+        assert!(config.verbose);
     }
 }

--- a/crates/epigraph-cli/src/bin/rerank_bridges.rs
+++ b/crates/epigraph-cli/src/bin/rerank_bridges.rs
@@ -238,11 +238,8 @@ async fn main() {
         }
     };
 
-    // If --model was specified, set ENRICHMENT_MODEL for the LLM client factory.
-    // (The factory reads from env, not parameters — keep the indirection at the bin layer.)
-    if let Some(ref model) = args.model {
-        std::env::set_var("ENRICHMENT_MODEL", model);
-    }
+    // `--model` is propagated to the LLM client via `ENRICHMENT_MODEL` inside
+    // the library (see rerank::core::rerank_inner).
 
     let auth_label = match args.provider.as_str() {
         "anthropic" => {

--- a/crates/epigraph-cli/src/bridge/candidates.rs
+++ b/crates/epigraph-cli/src/bridge/candidates.rs
@@ -1,0 +1,94 @@
+//! Per-source-atom kNN candidate-pair table builder for bridge sweeps.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Validate that a string is safe to interpolate into SQL as an identifier.
+/// Restricts to `[a-zA-Z0-9_]+` to block injection. The bridge bins generate
+/// names from UUIDs so this is the realistic shape.
+pub(crate) fn is_safe_table_name(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Build a temporary candidate-pair table containing per-source-atom top-K
+/// matches in the target atom set, filtered by cosine similarity ≥ min_similarity.
+///
+/// The table has columns `(source_id uuid, target_id uuid, similarity float8)`
+/// and is created with `CREATE TABLE` (NOT temp — `rerank_candidates_table`
+/// reads it from a separate connection in the pool, and TEMP tables are
+/// session-local).
+///
+/// Returns the row count.
+///
+/// Caller is responsible for dropping the table when done (or pass --keep-tables).
+pub async fn build_candidate_table(
+    pool: &PgPool,
+    table_name: &str,
+    source_atom_ids: &[Uuid],
+    target_atom_ids: &[Uuid],
+    min_similarity: f64,
+    top_k: u32,
+) -> Result<usize, sqlx::Error> {
+    if !is_safe_table_name(table_name) {
+        return Err(sqlx::Error::Protocol(format!(
+            "candidate table name must be [a-zA-Z0-9_]+: {table_name}"
+        )));
+    }
+
+    // Build the table.
+    let drop_sql = format!("DROP TABLE IF EXISTS {table_name}");
+    sqlx::query(&drop_sql).execute(pool).await?;
+
+    let create_sql = format!(
+        "CREATE TABLE {table_name} (\
+            source_id uuid NOT NULL, \
+            target_id uuid NOT NULL, \
+            similarity double precision NOT NULL, \
+            PRIMARY KEY (source_id, target_id)\
+         )"
+    );
+    sqlx::query(&create_sql).execute(pool).await?;
+
+    // Per-source-atom top-K insert. The lateral join uses HNSW (migration 030)
+    // to bound cost. Cosine similarity = 1 - distance.
+    let insert_sql = format!(
+        r#"
+        INSERT INTO {table_name} (source_id, target_id, similarity)
+        SELECT s.id, k.target_id, k.similarity
+        FROM (SELECT id, embedding FROM claims WHERE id = ANY($1) AND embedding IS NOT NULL) s
+        CROSS JOIN LATERAL (
+            SELECT t.id AS target_id, 1 - (t.embedding <=> s.embedding) AS similarity
+            FROM claims t
+            WHERE t.id = ANY($2)
+              AND t.embedding IS NOT NULL
+              AND (1 - (t.embedding <=> s.embedding)) >= $3
+            ORDER BY t.embedding <=> s.embedding
+            LIMIT $4
+        ) k
+        ON CONFLICT (source_id, target_id) DO NOTHING
+        "#
+    );
+
+    let rows_inserted = sqlx::query(&insert_sql)
+        .bind(source_atom_ids)
+        .bind(target_atom_ids)
+        .bind(min_similarity)
+        .bind(top_k as i64)
+        .execute(pool)
+        .await?
+        .rows_affected();
+
+    Ok(rows_inserted as usize)
+}
+
+/// Drop the candidate table.
+pub async fn drop_candidate_table(pool: &PgPool, table_name: &str) -> Result<(), sqlx::Error> {
+    if !is_safe_table_name(table_name) {
+        return Err(sqlx::Error::Protocol(format!(
+            "candidate table name must be [a-zA-Z0-9_]+: {table_name}"
+        )));
+    }
+    let drop_sql = format!("DROP TABLE IF EXISTS {table_name}");
+    sqlx::query(&drop_sql).execute(pool).await?;
+    Ok(())
+}

--- a/crates/epigraph-cli/src/bridge/components.rs
+++ b/crates/epigraph-cli/src/bridge/components.rs
@@ -1,0 +1,135 @@
+//! Connected-component enumeration over the claim graph.
+
+use sqlx::PgPool;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Edge relationships that define structural connectivity for component
+/// detection. Order does not matter; the union-find is symmetric.
+pub const STRUCTURAL_RELATIONSHIPS: &[&str] = &[
+    "decomposes_to",
+    "CORROBORATES",
+    "same_as",
+    "same_source",
+    "continues_argument",
+];
+
+#[derive(Debug, Clone)]
+pub struct ComponentSummary {
+    /// Canonical ID for the component: the smallest claim UUID it contains.
+    /// Stable across runs (UUID ordering is total).
+    pub component_id: Uuid,
+    pub claim_ids: Vec<Uuid>,
+    pub size: usize,
+}
+
+/// Compute connected components over the claim graph using STRUCTURAL_RELATIONSHIPS.
+///
+/// Returns one `ComponentSummary` per component, sorted by `size` descending.
+/// Singleton components (claims with no structural edges) are still returned —
+/// callers can filter.
+pub async fn compute_components(pool: &PgPool) -> Result<Vec<ComponentSummary>, sqlx::Error> {
+    // 1. Pull all claim IDs (compact-index them).
+    let claim_rows: Vec<(Uuid,)> = sqlx::query_as("SELECT id FROM claims ORDER BY id")
+        .fetch_all(pool)
+        .await?;
+    let claim_ids: Vec<Uuid> = claim_rows.into_iter().map(|(id,)| id).collect();
+    let n = claim_ids.len();
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    let mut index: HashMap<Uuid, usize> = HashMap::with_capacity(n);
+    for (i, id) in claim_ids.iter().enumerate() {
+        index.insert(*id, i);
+    }
+
+    // 2. Pull all structural edges (claim-to-claim only).
+    let edge_rows: Vec<(Uuid, Uuid)> = sqlx::query_as(
+        r#"
+        SELECT source_id, target_id
+        FROM edges
+        WHERE source_type = 'claim'
+          AND target_type = 'claim'
+          AND relationship = ANY($1)
+        "#,
+    )
+    .bind(STRUCTURAL_RELATIONSHIPS)
+    .fetch_all(pool)
+    .await?;
+
+    // 3. Union endpoints.
+    let mut uf = UnionFind::new(n);
+    for (s, t) in edge_rows {
+        if let (Some(&si), Some(&ti)) = (index.get(&s), index.get(&t)) {
+            uf.union(si, ti);
+        }
+    }
+
+    // 4. Group by canonical root.
+    let mut buckets: HashMap<usize, Vec<Uuid>> = HashMap::new();
+    for (i, id) in claim_ids.iter().enumerate() {
+        let root = uf.find(i);
+        buckets.entry(root).or_default().push(*id);
+    }
+
+    // 5. Build summaries.
+    let mut summaries: Vec<ComponentSummary> = buckets
+        .into_values()
+        .map(|mut ids| {
+            ids.sort_unstable();
+            let component_id = ids[0];
+            let size = ids.len();
+            ComponentSummary {
+                component_id,
+                claim_ids: ids,
+                size,
+            }
+        })
+        .collect();
+    summaries.sort_by(|a, b| {
+        b.size
+            .cmp(&a.size)
+            .then_with(|| a.component_id.cmp(&b.component_id))
+    });
+    Ok(summaries)
+}
+
+// ── Path-halved union-by-rank union-find ──────────────────────────────────
+
+struct UnionFind {
+    parent: Vec<usize>,
+    rank: Vec<usize>,
+}
+
+impl UnionFind {
+    fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+            rank: vec![0; n],
+        }
+    }
+
+    fn find(&mut self, mut x: usize) -> usize {
+        while self.parent[x] != x {
+            self.parent[x] = self.parent[self.parent[x]];
+            x = self.parent[x];
+        }
+        x
+    }
+
+    fn union(&mut self, x: usize, y: usize) {
+        let rx = self.find(x);
+        let ry = self.find(y);
+        if rx == ry {
+            return;
+        }
+        match self.rank[rx].cmp(&self.rank[ry]) {
+            std::cmp::Ordering::Less => self.parent[rx] = ry,
+            std::cmp::Ordering::Greater => self.parent[ry] = rx,
+            std::cmp::Ordering::Equal => {
+                self.parent[ry] = rx;
+                self.rank[rx] += 1;
+            }
+        }
+    }
+}

--- a/crates/epigraph-cli/src/bridge/mod.rs
+++ b/crates/epigraph-cli/src/bridge/mod.rs
@@ -4,4 +4,5 @@
 //!
 //! See docs/superpowers/specs/2026-05-05-cross-component-bridge-sweep-design.md.
 
+pub mod candidates;
 pub mod components;

--- a/crates/epigraph-cli/src/bridge/mod.rs
+++ b/crates/epigraph-cli/src/bridge/mod.rs
@@ -6,3 +6,4 @@
 
 pub mod candidates;
 pub mod components;
+pub mod spine;

--- a/crates/epigraph-cli/src/bridge/mod.rs
+++ b/crates/epigraph-cli/src/bridge/mod.rs
@@ -1,0 +1,7 @@
+//! Cross-component bridge sweep: detect disconnected components in the claim
+//! graph, generate cross-component candidate pairs, run the LLM reranker,
+//! emit spine-destination report.
+//!
+//! See docs/superpowers/specs/2026-05-05-cross-component-bridge-sweep-design.md.
+
+pub mod components;

--- a/crates/epigraph-cli/src/bridge/spine.rs
+++ b/crates/epigraph-cli/src/bridge/spine.rs
@@ -1,0 +1,81 @@
+//! Spine-destination report: for a candidate-pair table, aggregate the
+//! target-side claim-theme labels weighted by candidate count, returning
+//! the top N umbrellas. Used as a graph-health diagnostic on dry-runs.
+//!
+//! Schema note: this codebase stores themes as `claim_themes(id, label, ...)`
+//! and references them via a single FK column `claims.theme_id`. There is no
+//! separate `themes` table and no claim↔theme join table. Targets with
+//! `theme_id IS NULL` are dropped from the aggregation (they don't contribute
+//! to spine-destination weight).
+
+use serde::Serialize;
+use sqlx::PgPool;
+
+use crate::bridge::candidates::is_safe_table_name;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SpineUmbrella {
+    /// `claim_themes.label` for the umbrella.
+    pub umbrella: String,
+    /// Candidate count for this label divided by total candidates whose
+    /// target has any theme assignment.
+    pub weight: f64,
+    /// Raw candidate count for this label.
+    pub count: i64,
+}
+
+/// Compute spine-destination per spec §3. For each candidate row in
+/// `<candidates_table>`, look up the target_id's theme via `claims.theme_id`,
+/// aggregate counts by `claim_themes.label`, divide by total to produce
+/// weights, return the top `top_n` by weight descending.
+///
+/// Targets without a theme assignment (`claims.theme_id IS NULL`) are dropped
+/// — they don't contribute to spine-destination weight. If no targets have
+/// themes, returns an empty Vec.
+pub async fn compute_spine_destination(
+    pool: &PgPool,
+    candidates_table: &str,
+    top_n: usize,
+) -> Result<Vec<SpineUmbrella>, sqlx::Error> {
+    if !is_safe_table_name(candidates_table) {
+        return Err(sqlx::Error::Protocol(format!(
+            "candidate table name must be [a-zA-Z0-9_]+: {candidates_table}"
+        )));
+    }
+
+    let total_sql = format!(
+        "SELECT COUNT(*) FROM {candidates_table} ct \
+         JOIN claims c ON c.id = ct.target_id \
+         JOIN claim_themes ct_th ON ct_th.id = c.theme_id"
+    );
+    let total: i64 = sqlx::query_scalar(&total_sql).fetch_one(pool).await?;
+    if total == 0 {
+        return Ok(Vec::new());
+    }
+
+    let agg_sql = format!(
+        r#"
+        SELECT ct_th.label AS umbrella, COUNT(*)::bigint AS cnt
+        FROM {candidates_table} ct
+        JOIN claims c ON c.id = ct.target_id
+        JOIN claim_themes ct_th ON ct_th.id = c.theme_id
+        GROUP BY ct_th.label
+        ORDER BY cnt DESC, ct_th.label ASC
+        LIMIT $1
+        "#
+    );
+    let rows: Vec<(String, i64)> = sqlx::query_as(&agg_sql)
+        .bind(top_n as i64)
+        .fetch_all(pool)
+        .await?;
+
+    let total_f = total as f64;
+    Ok(rows
+        .into_iter()
+        .map(|(label, count)| SpineUmbrella {
+            umbrella: label,
+            weight: count as f64 / total_f,
+            count,
+        })
+        .collect())
+}

--- a/crates/epigraph-cli/src/lib.rs
+++ b/crates/epigraph-cli/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "db")]
+pub mod bridge;
 pub mod enrichment;
 #[cfg(feature = "db")]
 pub mod reembed;

--- a/crates/epigraph-cli/src/lib.rs
+++ b/crates/epigraph-cli/src/lib.rs
@@ -3,6 +3,8 @@ pub mod bridge;
 pub mod enrichment;
 #[cfg(feature = "db")]
 pub mod reembed;
+#[cfg(feature = "genai")]
+pub mod rerank;
 
 #[cfg(feature = "db")]
 use sqlx::PgPool;

--- a/crates/epigraph-cli/src/rerank/candidates.rs
+++ b/crates/epigraph-cli/src/rerank/candidates.rs
@@ -1,0 +1,42 @@
+//! Candidate-pair types shared between the global-join and candidates-table paths.
+//!
+//! The shapes here are the historical types from `bin/rerank_bridges.rs` —
+//! deserialization of the LLM response depends on the exact field names
+//! (`pair_index`, `valid`), so any rename is a breaking JSON-schema change.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// One candidate claim pair under consideration by the LLM reranker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CandidatePair {
+    pub source_id: Uuid,
+    pub target_id: Uuid,
+    pub source_content: String,
+    pub target_content: String,
+    pub source_doi: Option<String>,
+    pub target_doi: Option<String>,
+    pub similarity: f64,
+}
+
+/// Per-pair LLM verdict, parsed from the model's JSON array response.
+///
+/// Field names are part of the LLM contract — `pair_index` and `valid`
+/// are required by the prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationResult {
+    pub pair_index: usize,
+    pub valid: bool,
+    pub relationship: Option<String>,
+    pub strength: Option<f64>,
+    pub rationale: String,
+}
+
+/// Relationship strings the LLM is allowed to emit.
+pub const VALID_RELATIONSHIPS: &[&str] = &[
+    "supports",
+    "contradicts",
+    "derives_from",
+    "refines",
+    "analogous",
+];

--- a/crates/epigraph-cli/src/rerank/core.rs
+++ b/crates/epigraph-cli/src/rerank/core.rs
@@ -1,0 +1,540 @@
+//! Library API for the LLM bridge reranker.
+//!
+//! Two entry points:
+//! - [`rerank_global_join`] — original behaviour: scan all pairs above similarity
+//!   threshold (drives the `rerank_bridges` CLI default mode).
+//! - [`rerank_candidates_table`] — read pairs from a caller-supplied temp table
+//!   (drives `bridge_component` / `bridge_sweep`, issue #53).
+//!
+//! Both share the same batch loop, prompt, and edge-creation helpers.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::enrichment::llm_client::{create_llm_client, LlmClient, LlmError};
+use crate::rerank::candidates::{CandidatePair, ValidationResult};
+use crate::rerank::errors::RerankError;
+use crate::rerank::prompt::{build_validation_prompt, parse_validation_response};
+
+// =============================================================================
+// CONFIG / SUMMARY
+// =============================================================================
+
+#[derive(Debug, Clone)]
+pub struct RerankConfig {
+    pub min_similarity: f64,
+    pub batch_size: usize,
+    pub provider: String,
+    pub model: Option<String>,
+    pub dry_run: bool,
+    pub limit: Option<i64>,
+    /// Print per-batch progress to stdout. Binary sets true; library callers
+    /// that just want a summary should leave false.
+    pub verbose: bool,
+}
+
+impl Default for RerankConfig {
+    fn default() -> Self {
+        Self {
+            min_similarity: 0.40,
+            batch_size: 10,
+            provider: "anthropic".to_string(),
+            model: None,
+            dry_run: false,
+            limit: None,
+            verbose: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RerankSummary {
+    /// Number of candidate pairs sent to the LLM (= input candidate count).
+    pub candidates_evaluated: usize,
+    /// Pairs the LLM marked `valid: true` (regardless of edge creation).
+    pub llm_accepted: usize,
+    /// Pairs the LLM marked `valid: false`.
+    pub llm_rejected: usize,
+    /// Edges actually inserted (zero if `dry_run` is set).
+    pub edges_created: usize,
+    /// Per-batch errors (LLM failures, edge insert failures, missing entries).
+    pub errors: usize,
+    /// Wall-clock duration of the rerank loop.
+    pub duration_ms: u128,
+    /// First accepted pair whose relationship is `contradicts`.
+    pub sample_contradiction: Option<CandidatePair>,
+    /// Counts per accepted relationship type.
+    pub relationship_counts: std::collections::HashMap<String, usize>,
+}
+
+// =============================================================================
+// PUBLIC ENTRY POINTS
+// =============================================================================
+
+/// Rerank the global candidate space — equivalent to the original
+/// `rerank_bridges` invocation pattern. `source_filter` and `target_filter`
+/// are optional WHERE fragments aliased as `c1` / `c2`.
+pub async fn rerank_global_join(
+    pool: &PgPool,
+    source_filter: Option<&str>,
+    target_filter: Option<&str>,
+    config: &RerankConfig,
+) -> Result<RerankSummary, RerankError> {
+    let candidates = find_candidates_global(pool, source_filter, target_filter, config).await?;
+    rerank_inner(pool, candidates, config).await
+}
+
+/// Rerank pairs from a caller-supplied temp table. The table must have
+/// `(source_id uuid, target_id uuid)` columns; any extra columns are ignored.
+/// Similarity is recomputed in SQL for consistency with the global path.
+///
+/// Introduced for issue #53 (cross-component bridge sweep). The caller —
+/// e.g. `bridge_component` — populates the table via a per-source kNN insert
+/// before calling this function.
+pub async fn rerank_candidates_table(
+    pool: &PgPool,
+    candidates_table: &str,
+    config: &RerankConfig,
+) -> Result<RerankSummary, RerankError> {
+    let candidates = find_candidates_from_table(pool, candidates_table, config).await?;
+    rerank_inner(pool, candidates, config).await
+}
+
+// =============================================================================
+// CANDIDATE DISCOVERY
+// =============================================================================
+
+async fn find_candidates_global(
+    pool: &PgPool,
+    source_filter: Option<&str>,
+    target_filter: Option<&str>,
+    config: &RerankConfig,
+) -> Result<Vec<CandidatePair>, RerankError> {
+    let source_clause = source_filter.map_or(String::new(), |f| format!("AND {f}"));
+    let target_clause = target_filter.map_or(String::new(), |f| format!("AND {f}"));
+    let limit_clause = config
+        .limit
+        .map_or("LIMIT 10000".to_string(), |n| format!("LIMIT {n}"));
+
+    let query = format!(
+        r#"
+        SELECT
+            c1.id AS source_id,
+            c1.content AS source_content,
+            c1.properties->>'paper_doi' AS source_doi,
+            c2.id AS target_id,
+            c2.content AS target_content,
+            c2.properties->>'paper_doi' AS target_doi,
+            (1 - (c1.embedding <=> c2.embedding))::float8 AS similarity
+        FROM claims c1
+        JOIN claims c2 ON c2.id > c1.id
+        WHERE c1.embedding IS NOT NULL
+          AND c2.embedding IS NOT NULL
+          AND (1 - (c1.embedding <=> c2.embedding)) >= $1
+          AND NOT EXISTS (
+              SELECT 1 FROM edges e
+              WHERE (e.source_id = c1.id AND e.target_id = c2.id)
+                 OR (e.source_id = c2.id AND e.target_id = c1.id)
+          )
+          {source_clause}
+          {target_clause}
+        ORDER BY similarity DESC
+        {limit_clause}
+        "#
+    );
+
+    let rows = sqlx::query_as::<
+        _,
+        (
+            Uuid,
+            String,
+            Option<String>,
+            Uuid,
+            String,
+            Option<String>,
+            f64,
+        ),
+    >(&query)
+    .bind(config.min_similarity)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(
+                source_id,
+                source_content,
+                source_doi,
+                target_id,
+                target_content,
+                target_doi,
+                similarity,
+            )| CandidatePair {
+                source_id,
+                target_id,
+                source_content,
+                target_content,
+                source_doi,
+                target_doi,
+                similarity,
+            },
+        )
+        .collect())
+}
+
+async fn find_candidates_from_table(
+    pool: &PgPool,
+    candidates_table: &str,
+    config: &RerankConfig,
+) -> Result<Vec<CandidatePair>, RerankError> {
+    // SECURITY: candidates_table is interpolated into SQL — restrict to a
+    // safe identifier shape to block injection. Caller is internal but the
+    // table name comes from CLI args.
+    if !is_safe_identifier(candidates_table) {
+        return Err(RerankError::Config(format!(
+            "candidates_table name must be [a-zA-Z0-9_]+: {candidates_table}"
+        )));
+    }
+
+    let limit_clause = config.limit.map_or(String::new(), |n| format!("LIMIT {n}"));
+
+    let query = format!(
+        r#"
+        SELECT
+            c1.id AS source_id,
+            c1.content AS source_content,
+            c1.properties->>'paper_doi' AS source_doi,
+            c2.id AS target_id,
+            c2.content AS target_content,
+            c2.properties->>'paper_doi' AS target_doi,
+            (1 - (c1.embedding <=> c2.embedding))::float8 AS similarity
+        FROM {candidates_table} ct
+        JOIN claims c1 ON c1.id = ct.source_id
+        JOIN claims c2 ON c2.id = ct.target_id
+        WHERE c1.embedding IS NOT NULL
+          AND c2.embedding IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM edges e
+              WHERE (e.source_id = c1.id AND e.target_id = c2.id)
+                 OR (e.source_id = c2.id AND e.target_id = c1.id)
+          )
+        ORDER BY similarity DESC
+        {limit_clause}
+        "#
+    );
+
+    let rows = sqlx::query_as::<
+        _,
+        (
+            Uuid,
+            String,
+            Option<String>,
+            Uuid,
+            String,
+            Option<String>,
+            f64,
+        ),
+    >(&query)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(
+                source_id,
+                source_content,
+                source_doi,
+                target_id,
+                target_content,
+                target_doi,
+                similarity,
+            )| CandidatePair {
+                source_id,
+                target_id,
+                source_content,
+                target_content,
+                source_doi,
+                target_doi,
+                similarity,
+            },
+        )
+        .collect())
+}
+
+fn is_safe_identifier(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+// =============================================================================
+// CORE BATCH LOOP
+// =============================================================================
+
+async fn rerank_inner(
+    pool: &PgPool,
+    candidates: Vec<CandidatePair>,
+    config: &RerankConfig,
+) -> Result<RerankSummary, RerankError> {
+    let started = std::time::Instant::now();
+    let mut summary = RerankSummary {
+        candidates_evaluated: candidates.len(),
+        ..Default::default()
+    };
+
+    if candidates.is_empty() {
+        summary.duration_ms = started.elapsed().as_millis();
+        return Ok(summary);
+    }
+
+    let llm = create_llm_client(&config.provider).map_err(|e| RerankError::Llm(e.to_string()))?;
+    let model_name = llm.model_name().to_string();
+
+    let num_batches = candidates.len().div_ceil(config.batch_size);
+
+    for (batch_idx, batch) in candidates.chunks(config.batch_size).enumerate() {
+        if config.verbose {
+            println!(
+                "\n--- Batch {}/{} ({} pairs) ---",
+                batch_idx + 1,
+                num_batches,
+                batch.len()
+            );
+        }
+
+        let prompt = build_validation_prompt(batch);
+
+        let json = match call_llm_with_retry(&*llm, &prompt).await {
+            Ok(j) => j,
+            Err(e) => {
+                eprintln!("  ERROR calling LLM: {e}");
+                summary.errors += batch.len();
+                continue;
+            }
+        };
+
+        let results = parse_validation_response(&json, batch.len());
+
+        for result in &results {
+            let pair = &batch[result.pair_index];
+
+            if result.valid {
+                summary.llm_accepted += 1;
+                let rel = result.relationship.as_deref().unwrap_or("analogous");
+                let str_val = result.strength.unwrap_or(0.5);
+
+                *summary
+                    .relationship_counts
+                    .entry(rel.to_string())
+                    .or_insert(0) += 1;
+
+                if rel == "contradicts" && summary.sample_contradiction.is_none() {
+                    summary.sample_contradiction = Some(pair.clone());
+                }
+
+                if config.verbose {
+                    let rationale_preview: String = result.rationale.chars().take(80).collect();
+                    println!(
+                        "  ACCEPT pair {} (sim={:.3}): {} --[{}({:.2})]--> {} | {}",
+                        result.pair_index,
+                        pair.similarity,
+                        &pair.source_id.to_string()[..8],
+                        rel,
+                        str_val,
+                        &pair.target_id.to_string()[..8],
+                        rationale_preview
+                    );
+                }
+
+                if !config.dry_run {
+                    match edge_exists(pool, pair.source_id, pair.target_id).await {
+                        Ok(true) => {
+                            if config.verbose {
+                                println!("    (edge already exists, skipping)");
+                            }
+                        }
+                        Ok(false) => match create_edge(pool, pair, result, &model_name).await {
+                            Ok(edge_id) => {
+                                summary.edges_created += 1;
+                                if config.verbose {
+                                    println!("    Created edge {edge_id}");
+                                }
+                            }
+                            Err(e) => {
+                                summary.errors += 1;
+                                eprintln!("    ERROR creating edge: {e}");
+                            }
+                        },
+                        Err(e) => {
+                            summary.errors += 1;
+                            eprintln!("    ERROR checking edge existence: {e}");
+                        }
+                    }
+                }
+            } else {
+                summary.llm_rejected += 1;
+                if config.verbose {
+                    let rationale_preview: String = result.rationale.chars().take(100).collect();
+                    println!(
+                        "  REJECT pair {} (sim={:.3}): {}",
+                        result.pair_index, pair.similarity, rationale_preview
+                    );
+                }
+            }
+        }
+
+        // Count pairs the LLM didn't return results for
+        let responded_indices: std::collections::HashSet<usize> =
+            results.iter().map(|r| r.pair_index).collect();
+        for i in 0..batch.len() {
+            if !responded_indices.contains(&i) {
+                eprintln!("  WARNING: LLM did not return a result for pair {i}");
+                summary.errors += 1;
+            }
+        }
+    }
+
+    summary.duration_ms = started.elapsed().as_millis();
+    Ok(summary)
+}
+
+// =============================================================================
+// EDGE HELPERS (private)
+// =============================================================================
+
+/// Check if an edge already exists between two claims (either direction).
+pub(crate) async fn edge_exists(pool: &PgPool, a: Uuid, b: Uuid) -> Result<bool, sqlx::Error> {
+    let row = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT COUNT(*) FROM edges
+        WHERE source_type = 'claim' AND target_type = 'claim'
+          AND ((source_id = $1 AND target_id = $2)
+            OR (source_id = $2 AND target_id = $1))
+        "#,
+    )
+    .bind(a)
+    .bind(b)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(row > 0)
+}
+
+/// Create a validated edge in the edges table.
+pub(crate) async fn create_edge(
+    pool: &PgPool,
+    pair: &CandidatePair,
+    result: &ValidationResult,
+    model_name: &str,
+) -> Result<Uuid, sqlx::Error> {
+    let properties = serde_json::json!({
+        "strength": result.strength.unwrap_or(0.5),
+        "cosine_similarity": pair.similarity,
+        "validation_method": "llm_rerank",
+        "validation_model": model_name,
+        "rationale": result.rationale,
+        "source_doi": pair.source_doi,
+        "target_doi": pair.target_doi,
+        "source": "rerank_bridges",
+    });
+
+    let relationship = result.relationship.as_deref().unwrap_or("analogous");
+
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO edges (source_id, source_type, target_id, target_type, relationship, properties)
+        VALUES ($1, 'claim', $2, 'claim', $3, $4)
+        RETURNING id
+        "#,
+    )
+    .bind(pair.source_id)
+    .bind(pair.target_id)
+    .bind(relationship)
+    .bind(properties)
+    .fetch_one(pool)
+    .await
+}
+
+/// Call the LLM with one retry on rate limit.
+async fn call_llm_with_retry(
+    llm: &dyn LlmClient,
+    prompt: &str,
+) -> Result<serde_json::Value, LlmError> {
+    match llm.complete_json(prompt).await {
+        Ok(v) => Ok(v),
+        Err(LlmError::RateLimited { retry_after_secs }) => {
+            eprintln!("  Rate limited, waiting {retry_after_secs}s before retry...");
+            tokio::time::sleep(std::time::Duration::from_secs(retry_after_secs)).await;
+            llm.complete_json(prompt).await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_safe_identifier_accepts_alphanumeric_underscore() {
+        assert!(is_safe_identifier("foo"));
+        assert!(is_safe_identifier("foo_bar"));
+        assert!(is_safe_identifier("Foo123"));
+        assert!(is_safe_identifier("_underscore"));
+        assert!(is_safe_identifier("bridge_test_candidates"));
+    }
+
+    #[test]
+    fn test_is_safe_identifier_rejects_injection() {
+        assert!(!is_safe_identifier(""));
+        assert!(!is_safe_identifier("foo; DROP TABLE"));
+        assert!(!is_safe_identifier("foo bar"));
+        assert!(!is_safe_identifier("foo-bar"));
+        assert!(!is_safe_identifier("foo.bar"));
+        assert!(!is_safe_identifier("foo'bar"));
+        assert!(!is_safe_identifier("\"foo\""));
+    }
+
+    #[test]
+    fn test_edge_properties_schema() {
+        let pair = CandidatePair {
+            source_id: Uuid::new_v4(),
+            target_id: Uuid::new_v4(),
+            source_content: "src".to_string(),
+            target_content: "tgt".to_string(),
+            source_doi: Some("paper/123".to_string()),
+            target_doi: Some("textbook/chem".to_string()),
+            similarity: 0.48,
+        };
+        let result = ValidationResult {
+            pair_index: 0,
+            valid: true,
+            relationship: Some("supports".to_string()),
+            strength: Some(0.75),
+            rationale: "Genuine scientific connection".to_string(),
+        };
+
+        // Mirror the JSON shape that create_edge() builds — keep this in sync.
+        let properties = serde_json::json!({
+            "strength": result.strength.unwrap_or(0.5),
+            "cosine_similarity": pair.similarity,
+            "validation_method": "llm_rerank",
+            "validation_model": "claude-haiku-4-5-20251001",
+            "rationale": result.rationale,
+            "source_doi": pair.source_doi,
+            "target_doi": pair.target_doi,
+            "source": "rerank_bridges",
+        });
+
+        assert!(properties["strength"].is_number());
+        assert!(properties["cosine_similarity"].is_number());
+        assert_eq!(properties["validation_method"], "llm_rerank");
+        assert!(properties["validation_model"].is_string());
+        assert!(properties["rationale"].is_string());
+        assert_eq!(properties["source"], "rerank_bridges");
+    }
+}

--- a/crates/epigraph-cli/src/rerank/core.rs
+++ b/crates/epigraph-cli/src/rerank/core.rs
@@ -91,6 +91,14 @@ pub async fn rerank_global_join(
 /// Introduced for issue #53 (cross-component bridge sweep). The caller —
 /// e.g. `bridge_component` — populates the table via a per-source kNN insert
 /// before calling this function.
+///
+/// Caveats for callers (Tasks 4/5):
+/// - `config.min_similarity` is **ignored** in this path — selection is the
+///   caller's responsibility.
+/// - The caller should deduplicate pairs ordered consistently (e.g. always
+///   `min(a,b), max(a,b)`); duplicate `(A,B)` and `(B,A)` rows would burn LLM
+///   tokens twice before the post-hoc `edge_exists` check skips the second
+///   insert.
 pub async fn rerank_candidates_table(
     pool: &PgPool,
     candidates_table: &str,
@@ -285,6 +293,14 @@ async fn rerank_inner(
     if candidates.is_empty() {
         summary.duration_ms = started.elapsed().as_millis();
         return Ok(summary);
+    }
+
+    // The LLM client factory reads `ENRICHMENT_MODEL` from env. If the caller
+    // supplied an override via `config.model`, propagate it before constructing
+    // the client. (Process-global mutation; library callers in async contexts
+    // should be aware, but the rerank loop is single-shot per process today.)
+    if let Some(ref model) = config.model {
+        std::env::set_var("ENRICHMENT_MODEL", model);
     }
 
     let llm = create_llm_client(&config.provider).map_err(|e| RerankError::Llm(e.to_string()))?;

--- a/crates/epigraph-cli/src/rerank/errors.rs
+++ b/crates/epigraph-cli/src/rerank/errors.rs
@@ -1,0 +1,15 @@
+//! Error type for the rerank library.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RerankError {
+    #[error("database: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("LLM client: {0}")]
+    Llm(String),
+    #[error("config: {0}")]
+    Config(String),
+    #[error("other: {0}")]
+    Other(String),
+}

--- a/crates/epigraph-cli/src/rerank/mod.rs
+++ b/crates/epigraph-cli/src/rerank/mod.rs
@@ -1,0 +1,16 @@
+//! Library API for the bridge-validation reranker.
+//!
+//! Two entry points:
+//! - [`rerank_global_join`] — original behavior: scan all pairs above similarity threshold.
+//! - [`rerank_candidates_table`] — new (issue #53): score pairs from a caller-supplied temp
+//!   table of `(source_id, target_id)` rows, bypassing the O(N²) global join.
+//!
+//! See docs/superpowers/specs/2026-05-05-cross-component-bridge-sweep-design.md §2.2.
+
+pub mod candidates;
+pub mod core;
+pub mod errors;
+mod prompt;
+
+pub use core::{rerank_candidates_table, rerank_global_join, RerankConfig, RerankSummary};
+pub use errors::RerankError;

--- a/crates/epigraph-cli/src/rerank/prompt.rs
+++ b/crates/epigraph-cli/src/rerank/prompt.rs
@@ -1,0 +1,402 @@
+//! LLM prompt construction and response parsing for the bridge reranker.
+//!
+//! Moved here from `bin/rerank_bridges.rs` so the same prompt logic is
+//! reused by both the original global-join CLI and the new candidates-table
+//! library entry point.
+
+use crate::rerank::candidates::{CandidatePair, ValidationResult, VALID_RELATIONSHIPS};
+
+/// Build the validation prompt for a batch of candidate pairs.
+pub(crate) fn build_validation_prompt(pairs: &[CandidatePair]) -> String {
+    let mut pairs_text = String::new();
+    for (i, pair) in pairs.iter().enumerate() {
+        let src_doi = pair.source_doi.as_deref().unwrap_or("unknown");
+        let tgt_doi = pair.target_doi.as_deref().unwrap_or("unknown");
+        // Truncate content to keep prompt manageable
+        let src = truncate(&pair.source_content, 300);
+        let tgt = truncate(&pair.target_content, 300);
+        pairs_text.push_str(&format!(
+            "Pair {i} (cosine similarity: {:.4}):\n  Source [{src_doi}]: \"{src}\"\n  Target [{tgt_doi}]: \"{tgt}\"\n\n",
+            pair.similarity
+        ));
+    }
+
+    format!(
+        r#"You are a scientific relationship validator for an epistemic knowledge graph.
+You evaluate whether pairs of scientific claims have a genuine scientific
+relationship, or if their high embedding similarity is merely vocabulary overlap.
+
+## CRITICAL DISTINCTION
+
+GENUINE relationship: Claim A's truth or methodology meaningfully bears on Claim B.
+One claim provides evidence, theoretical basis, or specific application of the other.
+
+FALSE POSITIVE (reject): Both claims use the same terms (e.g., "octahedral",
+"geometry", "lattice") but in unrelated scientific contexts. Example:
+Crystal Field Theory (d-orbital splitting in transition metal complexes) vs
+DNA origami (octahedral nanostructure shape) — shared word "octahedral", zero mechanistic link.
+
+## Candidate Pairs
+
+{pairs_text}
+## Relationship Types
+
+- supports: A provides evidence or theoretical basis for B
+- contradicts: A provides evidence undermining B
+- derives_from: A is a logical consequence or application of B
+- refines: A adds precision or qualifies B
+- analogous: genuinely parallel phenomena in related domains
+
+## Rules
+
+1. REJECT pairs where the ONLY connection is shared vocabulary in different contexts
+2. A relationship must be defensible in a peer-reviewed context
+3. If uncertain, REJECT — false negatives are preferable to false positives
+4. Strength range: 0.3 to 1.0 (for accepted pairs)
+5. Rationale must name the SPECIFIC scientific mechanism connecting the claims
+
+## Output
+
+Return a JSON array with one object per pair:
+- pair_index: integer (0-based)
+- valid: boolean
+- relationship: string or null (supports/contradicts/derives_from/refines/analogous)
+- strength: number or null (0.3 to 1.0)
+- rationale: string (explain the specific scientific connection or why it's a false positive)
+
+Return ONLY the JSON array. Include an entry for EVERY pair."#
+    )
+}
+
+/// Truncate a string to `max_len` characters, appending "..." if truncated.
+pub(crate) fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        let end = s
+            .char_indices()
+            .nth(max_len)
+            .map_or(s.len(), |(idx, _)| idx);
+        format!("{}...", &s[..end])
+    }
+}
+
+/// Parse and validate the LLM's JSON response into `ValidationResult`s.
+pub(crate) fn parse_validation_response(
+    json: &serde_json::Value,
+    batch_size: usize,
+) -> Vec<ValidationResult> {
+    let arr = match json.as_array() {
+        Some(a) => a,
+        None => {
+            eprintln!("  WARNING: LLM response is not a JSON array");
+            return Vec::new();
+        }
+    };
+
+    let mut results = Vec::new();
+    for item in arr {
+        let parsed: ValidationResult = match serde_json::from_value(item.clone()) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("  WARNING: Failed to parse validation item: {e}");
+                continue;
+            }
+        };
+
+        // Bounds check
+        if parsed.pair_index >= batch_size {
+            eprintln!(
+                "  WARNING: pair_index {} out of bounds (batch size {})",
+                parsed.pair_index, batch_size
+            );
+            continue;
+        }
+
+        // Validate accepted pairs
+        if parsed.valid {
+            if let Some(ref rel) = parsed.relationship {
+                if !VALID_RELATIONSHIPS.contains(&rel.as_str()) {
+                    eprintln!(
+                        "  WARNING: pair {}: invalid relationship '{}', skipping",
+                        parsed.pair_index, rel
+                    );
+                    continue;
+                }
+            }
+            if let Some(strength) = parsed.strength {
+                if !(0.3..=1.0).contains(&strength) {
+                    eprintln!(
+                        "  WARNING: pair {}: strength {:.2} out of [0.3, 1.0], skipping",
+                        parsed.pair_index, strength
+                    );
+                    continue;
+                }
+            }
+        }
+
+        results.push(parsed);
+    }
+
+    results
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn make_pair(src: &str, tgt: &str, sim: f64) -> CandidatePair {
+        CandidatePair {
+            source_id: Uuid::new_v4(),
+            target_id: Uuid::new_v4(),
+            source_content: src.to_string(),
+            target_content: tgt.to_string(),
+            source_doi: Some("paper/123".to_string()),
+            target_doi: Some("textbook/chem".to_string()),
+            similarity: sim,
+        }
+    }
+
+    #[test]
+    fn test_build_prompt_contains_pairs() {
+        let pairs = vec![
+            make_pair(
+                "DNA nanoengine driven by chemical energy",
+                "DNA is a polymer of four nucleotides",
+                0.51,
+            ),
+            make_pair(
+                "CO on Cu(111) occupies on-top sites",
+                "Crystal field theory explains d-orbital splitting",
+                0.49,
+            ),
+        ];
+
+        let prompt = build_validation_prompt(&pairs);
+
+        assert!(prompt.contains("Pair 0"));
+        assert!(prompt.contains("Pair 1"));
+        assert!(prompt.contains("DNA nanoengine"));
+        assert!(prompt.contains("CO on Cu(111)"));
+        assert!(prompt.contains("0.5100"));
+        assert!(prompt.contains("0.4900"));
+    }
+
+    #[test]
+    fn test_build_prompt_includes_rejection_criteria() {
+        let pairs = vec![make_pair("a", "b", 0.5)];
+        let prompt = build_validation_prompt(&pairs);
+
+        assert!(prompt.contains("FALSE POSITIVE"));
+        assert!(prompt.contains("Crystal Field"));
+        assert!(prompt.contains("vocabulary overlap"));
+        assert!(prompt.contains("REJECT"));
+        assert!(prompt.contains("peer-reviewed"));
+    }
+
+    #[test]
+    fn test_build_prompt_includes_all_relationship_types() {
+        let pairs = vec![make_pair("a", "b", 0.5)];
+        let prompt = build_validation_prompt(&pairs);
+
+        for rel in VALID_RELATIONSHIPS {
+            assert!(
+                prompt.contains(rel),
+                "Prompt missing relationship type: {rel}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_prompt_truncates_long_content() {
+        let long_content = "A".repeat(500);
+        let pairs = vec![make_pair(&long_content, "short", 0.5)];
+        let prompt = build_validation_prompt(&pairs);
+
+        // Should be truncated to 300 chars + "..."
+        assert!(!prompt.contains(&"A".repeat(400)));
+        assert!(prompt.contains("..."));
+    }
+
+    #[test]
+    fn test_parse_response_accepted() {
+        let json = serde_json::json!([
+            {
+                "pair_index": 0,
+                "valid": true,
+                "relationship": "supports",
+                "strength": 0.75,
+                "rationale": "DNA origami uses DNA polymer structure"
+            }
+        ]);
+
+        let results = parse_validation_response(&json, 1);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].valid);
+        assert_eq!(results[0].relationship.as_deref(), Some("supports"));
+        assert!((results[0].strength.unwrap() - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_response_rejected() {
+        let json = serde_json::json!([
+            {
+                "pair_index": 0,
+                "valid": false,
+                "relationship": null,
+                "strength": null,
+                "rationale": "Vocabulary overlap: both use 'octahedral' in different contexts"
+            }
+        ]);
+
+        let results = parse_validation_response(&json, 1);
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].valid);
+        assert!(results[0].relationship.is_none());
+        assert!(results[0].strength.is_none());
+    }
+
+    #[test]
+    fn test_parse_response_mixed() {
+        let json = serde_json::json!([
+            {
+                "pair_index": 0,
+                "valid": true,
+                "relationship": "derives_from",
+                "strength": 0.6,
+                "rationale": "EUV photon energy relates to photoelectric effect"
+            },
+            {
+                "pair_index": 1,
+                "valid": false,
+                "relationship": null,
+                "strength": null,
+                "rationale": "No genuine link between CFT and DNA lattice"
+            }
+        ]);
+
+        let results = parse_validation_response(&json, 2);
+        assert_eq!(results.len(), 2);
+        assert!(results[0].valid);
+        assert!(!results[1].valid);
+    }
+
+    #[test]
+    fn test_parse_response_invalid_relationship() {
+        let json = serde_json::json!([
+            {
+                "pair_index": 0,
+                "valid": true,
+                "relationship": "causes",
+                "strength": 0.7,
+                "rationale": "some reason"
+            }
+        ]);
+
+        let results = parse_validation_response(&json, 1);
+        assert!(
+            results.is_empty(),
+            "Invalid relationship type should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_parse_response_strength_too_low() {
+        let json = serde_json::json!([
+            {
+                "pair_index": 0,
+                "valid": true,
+                "relationship": "supports",
+                "strength": 0.1,
+                "rationale": "weak connection"
+            }
+        ]);
+
+        let results = parse_validation_response(&json, 1);
+        assert!(results.is_empty(), "Strength < 0.3 should be rejected");
+    }
+
+    #[test]
+    fn test_parse_response_strength_too_high() {
+        let json = serde_json::json!([
+            {
+                "pair_index": 0,
+                "valid": true,
+                "relationship": "supports",
+                "strength": 1.5,
+                "rationale": "too strong"
+            }
+        ]);
+
+        let results = parse_validation_response(&json, 1);
+        assert!(results.is_empty(), "Strength > 1.0 should be rejected");
+    }
+
+    #[test]
+    fn test_parse_response_pair_index_out_of_bounds() {
+        let json = serde_json::json!([
+            {
+                "pair_index": 5,
+                "valid": true,
+                "relationship": "supports",
+                "strength": 0.5,
+                "rationale": "reason"
+            }
+        ]);
+
+        let results = parse_validation_response(&json, 3);
+        assert!(
+            results.is_empty(),
+            "pair_index >= batch_size should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_parse_response_not_array() {
+        let json = serde_json::json!({"error": "something"});
+        let results = parse_validation_response(&json, 1);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_response_empty_array() {
+        let json = serde_json::json!([]);
+        let results = parse_validation_response(&json, 5);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_valid_relationships_matches_domain_model() {
+        // These must match the SemanticLinkType enum in epigraph-core
+        assert!(VALID_RELATIONSHIPS.contains(&"supports"));
+        assert!(VALID_RELATIONSHIPS.contains(&"contradicts"));
+        assert!(VALID_RELATIONSHIPS.contains(&"derives_from"));
+        assert!(VALID_RELATIONSHIPS.contains(&"refines"));
+        assert!(VALID_RELATIONSHIPS.contains(&"analogous"));
+        assert_eq!(VALID_RELATIONSHIPS.len(), 5);
+    }
+
+    #[test]
+    fn test_truncate_short_string() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_long_string() {
+        let long = "A".repeat(500);
+        let result = truncate(&long, 300);
+        assert!(result.ends_with("..."));
+        assert!(result.len() <= 304); // 300 + "..."
+    }
+
+    #[test]
+    fn test_truncate_exact_length() {
+        let exact = "A".repeat(300);
+        assert_eq!(truncate(&exact, 300), exact);
+    }
+}

--- a/crates/epigraph-cli/tests/bridge_candidates.rs
+++ b/crates/epigraph-cli/tests/bridge_candidates.rs
@@ -1,0 +1,116 @@
+use epigraph_cli::bridge::candidates::{build_candidate_table, drop_candidate_table};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+/// Seed a claim with a 1536-dim unit-ish embedding split across two axes.
+/// `axis0` is the magnitude on axis 0, `axis1` is the magnitude on axis 1.
+/// Because pgvector cosine distance ignores magnitude (direction only), tests
+/// that need varying *similarity* must vary the direction — e.g. axis0=1, axis1=0
+/// vs axis0=0, axis1=1 yields cosine similarity 0.
+async fn seed_atom_with_embedding(pool: &PgPool, agent_id: Uuid, axis0: f64, axis1: f64) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    let mut zeros = vec!["0.0".to_string(); 1536];
+    zeros[0] = axis0.to_string();
+    zeros[1] = axis1.to_string();
+    let pgvec = format!("[{}]", zeros.join(","));
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding) \
+         VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', 3), $5::vector)",
+    )
+    .bind(id)
+    .bind(format!("a-{id}"))
+    .bind(hash)
+    .bind(agent_id)
+    .bind(&pgvec)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn build_candidate_table_caps_at_top_k(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    // 1 source atom on axis 0; 5 target atoms with mixed axis0/axis1 components.
+    // Cosine similarity to [1, 0, ...] = axis0 / sqrt(axis0^2 + axis1^2), so
+    // varying these changes direction (and therefore similarity), unlike
+    // pure-magnitude scaling along a single axis.
+    let src = seed_atom_with_embedding(&pool, agent, 1.0, 0.0).await;
+    let mut targets = vec![];
+    for (a, b) in [(1.0, 0.0), (1.0, 0.1), (1.0, 0.5), (1.0, 1.0), (0.0, 1.0)] {
+        targets.push(seed_atom_with_embedding(&pool, agent, a, b).await);
+    }
+
+    let table = format!("test_cands_{}", Uuid::new_v4().simple());
+    let n = build_candidate_table(&pool, &table, &[src], &targets, 0.5, 3)
+        .await
+        .unwrap();
+    // Top-3 by similarity, all >= 0.5: should be 3 (mag 0.45 below threshold).
+    // Actually similarity = 1 - cosine_distance which depends on the vectors;
+    // the check below is the real assertion.
+    let rows: i64 = sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {table}"))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(rows <= 3, "top_k=3 should cap at 3, got {rows}");
+    assert_eq!(n as i64, rows);
+
+    drop_candidate_table(&pool, &table).await.unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn build_candidate_table_filters_by_min_similarity(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    // Source on axis 0; close target also on axis 0 (cosine sim ~1.0);
+    // far target on axis 1 (cosine sim 0).
+    let src = seed_atom_with_embedding(&pool, agent, 1.0, 0.0).await;
+    let close = seed_atom_with_embedding(&pool, agent, 1.0, 0.0).await;
+    let far = seed_atom_with_embedding(&pool, agent, 0.0, 1.0).await;
+
+    let table = format!("test_cands_{}", Uuid::new_v4().simple());
+    build_candidate_table(&pool, &table, &[src], &[close, far], 0.95, 10)
+        .await
+        .unwrap();
+    let row_ids: Vec<Uuid> = sqlx::query_scalar(&format!("SELECT target_id FROM {table}"))
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert!(row_ids.contains(&close), "near match must appear");
+    assert!(
+        !row_ids.contains(&far),
+        "far match must be filtered by min_similarity"
+    );
+
+    drop_candidate_table(&pool, &table).await.unwrap();
+}
+
+#[tokio::test]
+async fn rejects_unsafe_table_name() {
+    // We can call build_candidate_table without a real pool by using a dummy
+    // pool; instead just probe `is_safe_table_name` indirectly through the
+    // public surface by using a name with semicolons and verifying the
+    // returned error.
+
+    // Use a quick lazy connection that won't actually be used.
+    let pool = sqlx::PgPool::connect_lazy("postgres://_/_").expect("connect_lazy never errors");
+    let result = build_candidate_table(&pool, "t; DROP TABLE x", &[], &[], 0.5, 10).await;
+    assert!(result.is_err(), "unsafe table name must error");
+}

--- a/crates/epigraph-cli/tests/bridge_component_pipeline.rs
+++ b/crates/epigraph-cli/tests/bridge_component_pipeline.rs
@@ -1,0 +1,88 @@
+//! End-to-end test of the bridge_component pipeline through `run_pipeline`-equivalent
+//! library code. Uses --provider mock so no real LLM call.
+
+#![cfg(feature = "genai")]
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// Imitate what bridge_component does: detect components, build candidate
+// table, call rerank_candidates_table — all in-process.
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn pipeline_dry_run_with_isolated_components(pool: PgPool) {
+    use epigraph_cli::bridge::candidates::{build_candidate_table, drop_candidate_table};
+    use epigraph_cli::bridge::components::compute_components;
+    use epigraph_cli::rerank::{rerank_candidates_table, RerankConfig};
+
+    // Seed: agent + 2 disconnected components, each with one level=3 atom
+    // that has a 1536d embedding.
+    let agent = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(agent)
+        .bind("aa".repeat(32))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    async fn seed_atom(pool: &PgPool, agent: Uuid, mag: f64) -> Uuid {
+        let id = Uuid::new_v4();
+        let hash: Vec<u8> = id
+            .as_bytes()
+            .iter()
+            .copied()
+            .chain(std::iter::repeat_n(0, 16))
+            .take(32)
+            .collect();
+        let mut zeros = vec!["0.0".to_string(); 1536];
+        zeros[0] = mag.to_string();
+        let pgvec = format!("[{}]", zeros.join(","));
+        sqlx::query(
+            "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding) \
+             VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', 3), $5::vector)",
+        )
+        .bind(id)
+        .bind(format!("a-{id}"))
+        .bind(hash)
+        .bind(agent)
+        .bind(&pgvec)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    let small_atom = seed_atom(&pool, agent, 0.99).await;
+    let target_atom = seed_atom(&pool, agent, 0.95).await;
+
+    // No structural edges — they are isolated components.
+    let components = compute_components(&pool).await.unwrap();
+    assert_eq!(
+        components.len(),
+        2,
+        "expected 2 isolated singleton components"
+    );
+
+    let table = format!("test_pipeline_{}", Uuid::new_v4().simple());
+    let count = build_candidate_table(&pool, &table, &[small_atom], &[target_atom], 0.5, 10)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "expected 1 candidate pair");
+
+    let config = RerankConfig {
+        min_similarity: 0.5,
+        batch_size: 10,
+        provider: "mock".to_string(),
+        model: None,
+        dry_run: true, // dry-run: no edge creation
+        limit: None,
+        verbose: false,
+    };
+    let summary = rerank_candidates_table(&pool, &table, &config)
+        .await
+        .unwrap();
+    assert_eq!(summary.candidates_evaluated, 1);
+    assert_eq!(summary.edges_created, 0, "dry-run must not create edges");
+
+    drop_candidate_table(&pool, &table).await.unwrap();
+}

--- a/crates/epigraph-cli/tests/bridge_components.rs
+++ b/crates/epigraph-cli/tests/bridge_components.rs
@@ -1,0 +1,137 @@
+use epigraph_cli::bridge::components::{
+    compute_components, ComponentSummary, STRUCTURAL_RELATIONSHIPS,
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn seed_claim(pool: &PgPool, agent_id: Uuid, level: i32) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash_bytes: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat(0).take(16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties) \
+         VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', $5::int))",
+    )
+    .bind(id)
+    .bind(format!("c-{id}"))
+    .bind(hash_bytes)
+    .bind(agent_id)
+    .bind(level)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn seed_edge(
+    pool: &PgPool,
+    source_id: Uuid,
+    source_type: &str,
+    target_id: Uuid,
+    target_type: &str,
+    relationship: &str,
+) {
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)",
+    )
+    .bind(source_id)
+    .bind(source_type)
+    .bind(target_id)
+    .bind(target_type)
+    .bind(relationship)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn two_isolated_components(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    // Section A with paragraphs A1, A2 linked by continues_argument.
+    let s_a = seed_claim(&pool, agent, 1).await;
+    let p_a1 = seed_claim(&pool, agent, 2).await;
+    let p_a2 = seed_claim(&pool, agent, 2).await;
+    seed_edge(&pool, s_a, "claim", p_a1, "claim", "decomposes_to").await;
+    seed_edge(&pool, s_a, "claim", p_a2, "claim", "decomposes_to").await;
+    seed_edge(&pool, p_a1, "claim", p_a2, "claim", "continues_argument").await;
+
+    // Section B with paragraphs B1, B2 — no edge between A and B.
+    let s_b = seed_claim(&pool, agent, 1).await;
+    let p_b1 = seed_claim(&pool, agent, 2).await;
+    let p_b2 = seed_claim(&pool, agent, 2).await;
+    seed_edge(&pool, s_b, "claim", p_b1, "claim", "decomposes_to").await;
+    seed_edge(&pool, s_b, "claim", p_b2, "claim", "decomposes_to").await;
+    seed_edge(&pool, p_b1, "claim", p_b2, "claim", "continues_argument").await;
+
+    let components = compute_components(&pool).await.unwrap();
+    let sizes: Vec<usize> = components.iter().map(|c| c.size).collect();
+    assert!(
+        sizes.contains(&3),
+        "section A's 3-claim component must appear; got sizes={sizes:?}"
+    );
+    assert_eq!(
+        sizes.iter().filter(|&&s| s == 3).count(),
+        2,
+        "exactly two 3-claim components expected (A and B); got sizes={sizes:?}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn shared_atom_unifies_components(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    // Two paragraphs in different sections, each decomposes_to a distinct atom.
+    // Then a CORROBORATES between the two atoms unifies the whole structure.
+    let p1 = seed_claim(&pool, agent, 2).await;
+    let a1 = seed_claim(&pool, agent, 3).await;
+    seed_edge(&pool, p1, "claim", a1, "claim", "decomposes_to").await;
+
+    let p2 = seed_claim(&pool, agent, 2).await;
+    let a2 = seed_claim(&pool, agent, 3).await;
+    seed_edge(&pool, p2, "claim", a2, "claim", "decomposes_to").await;
+
+    seed_edge(&pool, a1, "claim", a2, "claim", "CORROBORATES").await;
+
+    let components = compute_components(&pool).await.unwrap();
+    let large = components
+        .iter()
+        .find(|c| c.size == 4)
+        .expect("expected 1 component of size 4 (p1, a1, p2, a2)");
+    assert!(large.claim_ids.contains(&p1));
+    assert!(large.claim_ids.contains(&p2));
+    assert!(large.claim_ids.contains(&a1));
+    assert!(large.claim_ids.contains(&a2));
+}
+
+#[test]
+fn structural_relationships_includes_all_five() {
+    let names: Vec<&str> = STRUCTURAL_RELATIONSHIPS.to_vec();
+    for r in [
+        "decomposes_to",
+        "CORROBORATES",
+        "same_as",
+        "same_source",
+        "continues_argument",
+    ] {
+        assert!(names.contains(&r), "missing {r}");
+    }
+}
+
+#[allow(dead_code)]
+fn _types_exist(_s: ComponentSummary) {}

--- a/crates/epigraph-cli/tests/bridge_spine.rs
+++ b/crates/epigraph-cli/tests/bridge_spine.rs
@@ -1,0 +1,209 @@
+//! Integration tests for `compute_spine_destination`.
+//!
+//! Schema reminder: themes are stored in `claim_themes(id, label, ...)` and
+//! referenced via the `claims.theme_id` FK. A claim with `theme_id IS NULL`
+//! has no umbrella and is excluded from the aggregation.
+
+use epigraph_cli::bridge::spine::compute_spine_destination;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn seed_atom(pool: &PgPool, agent: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties) \
+         VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', 3))",
+    )
+    .bind(id)
+    .bind(format!("a-{id}"))
+    .bind(hash)
+    .bind(agent)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn seed_theme(pool: &PgPool, label: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO claim_themes (id, label) VALUES ($1, $2)")
+        .bind(id)
+        .bind(label)
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn assign_theme(pool: &PgPool, claim_id: Uuid, theme_id: Uuid) {
+    sqlx::query("UPDATE claims SET theme_id = $1 WHERE id = $2")
+        .bind(theme_id)
+        .bind(claim_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn spine_aggregates_top_themes(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let s = seed_atom(&pool, agent).await;
+
+    let t_a = seed_atom(&pool, agent).await; // theme A
+    let t_b = seed_atom(&pool, agent).await; // theme A
+    let t_c = seed_atom(&pool, agent).await; // theme B
+    let t_d = seed_atom(&pool, agent).await; // no theme
+
+    let theme_a = seed_theme(&pool, "A").await;
+    let theme_b = seed_theme(&pool, "B").await;
+    assign_theme(&pool, t_a, theme_a).await;
+    assign_theme(&pool, t_b, theme_a).await;
+    assign_theme(&pool, t_c, theme_b).await;
+    // t_d intentionally left untouched.
+
+    // Build candidate table.
+    let table = format!("test_spine_{}", Uuid::new_v4().simple());
+    sqlx::query(&format!(
+        "CREATE TABLE {table} (source_id uuid, target_id uuid, similarity float8)"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    for tgt in [t_a, t_b, t_c, t_d] {
+        sqlx::query(&format!(
+            "INSERT INTO {table} (source_id, target_id, similarity) VALUES ($1, $2, 0.8)"
+        ))
+        .bind(s)
+        .bind(tgt)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    let umbrellas = compute_spine_destination(&pool, &table, 3).await.unwrap();
+
+    // 3 of 4 candidates have themes (t_d is dropped).
+    // Total = 3. A weight = 2/3, B weight = 1/3.
+    let a = umbrellas
+        .iter()
+        .find(|u| u.umbrella == "A")
+        .expect("missing A");
+    let b = umbrellas
+        .iter()
+        .find(|u| u.umbrella == "B")
+        .expect("missing B");
+    assert_eq!(a.count, 2);
+    assert_eq!(b.count, 1);
+    assert!((a.weight - 2.0 / 3.0).abs() < 1e-9);
+    assert!((b.weight - 1.0 / 3.0).abs() < 1e-9);
+    assert_eq!(umbrellas.len(), 2, "only A and B should appear");
+
+    sqlx::query(&format!("DROP TABLE {table}"))
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn spine_returns_empty_when_no_targets_have_themes(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let s = seed_atom(&pool, agent).await;
+    let t = seed_atom(&pool, agent).await;
+
+    let table = format!("test_spine_{}", Uuid::new_v4().simple());
+    sqlx::query(&format!(
+        "CREATE TABLE {table} (source_id uuid, target_id uuid, similarity float8)"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO {table} (source_id, target_id, similarity) VALUES ($1, $2, 0.8)"
+    ))
+    .bind(s)
+    .bind(t)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let umbrellas = compute_spine_destination(&pool, &table, 3).await.unwrap();
+    assert!(umbrellas.is_empty());
+
+    sqlx::query(&format!("DROP TABLE {table}"))
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn spine_top_n_truncates_lowest_weight_umbrellas(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let s = seed_atom(&pool, agent).await;
+
+    let t_a1 = seed_atom(&pool, agent).await;
+    let t_a2 = seed_atom(&pool, agent).await;
+    let t_a3 = seed_atom(&pool, agent).await;
+    let t_b1 = seed_atom(&pool, agent).await;
+    let t_b2 = seed_atom(&pool, agent).await;
+    let t_c1 = seed_atom(&pool, agent).await;
+
+    let theme_a = seed_theme(&pool, "A").await;
+    let theme_b = seed_theme(&pool, "B").await;
+    let theme_c = seed_theme(&pool, "C").await;
+    for tgt in [t_a1, t_a2, t_a3] {
+        assign_theme(&pool, tgt, theme_a).await;
+    }
+    for tgt in [t_b1, t_b2] {
+        assign_theme(&pool, tgt, theme_b).await;
+    }
+    assign_theme(&pool, t_c1, theme_c).await;
+
+    let table = format!("test_spine_{}", Uuid::new_v4().simple());
+    sqlx::query(&format!(
+        "CREATE TABLE {table} (source_id uuid, target_id uuid, similarity float8)"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    for tgt in [t_a1, t_a2, t_a3, t_b1, t_b2, t_c1] {
+        sqlx::query(&format!(
+            "INSERT INTO {table} (source_id, target_id, similarity) VALUES ($1, $2, 0.8)"
+        ))
+        .bind(s)
+        .bind(tgt)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    // top_n = 2 → C is dropped, A and B remain ordered by count desc.
+    let umbrellas = compute_spine_destination(&pool, &table, 2).await.unwrap();
+    assert_eq!(umbrellas.len(), 2);
+    assert_eq!(umbrellas[0].umbrella, "A");
+    assert_eq!(umbrellas[0].count, 3);
+    assert_eq!(umbrellas[1].umbrella, "B");
+    assert_eq!(umbrellas[1].count, 2);
+
+    sqlx::query(&format!("DROP TABLE {table}"))
+        .execute(&pool)
+        .await
+        .unwrap();
+}

--- a/crates/epigraph-cli/tests/bridge_sweep_pipeline.rs
+++ b/crates/epigraph-cli/tests/bridge_sweep_pipeline.rs
@@ -1,0 +1,190 @@
+//! End-to-end test of the bridge_sweep pipeline through library code.
+//! Two small components + a giant; assert each small produces a candidate
+//! and the spine populates only when themes exist.
+
+#![cfg(feature = "genai")]
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use epigraph_cli::bridge::candidates::{build_candidate_table, drop_candidate_table};
+use epigraph_cli::bridge::components::{compute_components, ComponentSummary};
+use epigraph_cli::bridge::spine::compute_spine_destination;
+use epigraph_cli::rerank::{rerank_candidates_table, RerankConfig};
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn seed_atom(pool: &PgPool, agent: Uuid, mag: f64) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    let mut zeros = vec!["0.0".to_string(); 1536];
+    zeros[0] = mag.to_string();
+    let pgvec = format!("[{}]", zeros.join(","));
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding) \
+         VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', 3), $5::vector)",
+    )
+    .bind(id)
+    .bind(format!("a-{id}"))
+    .bind(hash)
+    .bind(agent)
+    .bind(&pgvec)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn seed_corroborates(pool: &PgPool, source: Uuid, target: Uuid) {
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, 'claim', $2, 'claim', 'CORROBORATES')",
+    )
+    .bind(source)
+    .bind(target)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn seed_theme(pool: &PgPool, label: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO claim_themes (id, label) VALUES ($1, $2)")
+        .bind(id)
+        .bind(label)
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn assign_theme(pool: &PgPool, claim_id: Uuid, theme_id: Uuid) {
+    sqlx::query("UPDATE claims SET theme_id = $1 WHERE id = $2")
+        .bind(theme_id)
+        .bind(claim_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+/// Locate the component containing `claim`.
+fn find_component_by_member<'a>(
+    components: &'a [ComponentSummary],
+    claim: &Uuid,
+) -> &'a ComponentSummary {
+    components
+        .iter()
+        .find(|c| c.claim_ids.contains(claim))
+        .expect("component for claim")
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn sweep_dry_run_with_two_small_components(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+
+    // Giant: 5 atoms unified by CORROBORATES (chain).
+    let g0 = seed_atom(&pool, agent, 0.99).await;
+    let g1 = seed_atom(&pool, agent, 0.98).await;
+    let g2 = seed_atom(&pool, agent, 0.97).await;
+    let g3 = seed_atom(&pool, agent, 0.96).await;
+    let g4 = seed_atom(&pool, agent, 0.95).await;
+    seed_corroborates(&pool, g0, g1).await;
+    seed_corroborates(&pool, g1, g2).await;
+    seed_corroborates(&pool, g2, g3).await;
+    seed_corroborates(&pool, g3, g4).await;
+
+    // Small A: 2 atoms unified by CORROBORATES.
+    let a0 = seed_atom(&pool, agent, 0.94).await;
+    let a1 = seed_atom(&pool, agent, 0.93).await;
+    seed_corroborates(&pool, a0, a1).await;
+
+    // Small B: 2 atoms unified by CORROBORATES.
+    let b0 = seed_atom(&pool, agent, 0.92).await;
+    let b1 = seed_atom(&pool, agent, 0.91).await;
+    seed_corroborates(&pool, b0, b1).await;
+
+    // Theme assignment so spine has something to aggregate (only on the
+    // giant — small_b will have an unthemed-target spine result, which is
+    // fine for the spine assertion).
+    let theme_x = seed_theme(&pool, "X").await;
+    for tgt in [g0, g1, g2, g3, g4] {
+        assign_theme(&pool, tgt, theme_x).await;
+    }
+
+    // Compute components — expect 3.
+    let components = compute_components(&pool).await.unwrap();
+    assert_eq!(components.len(), 3, "expected 3 components total");
+
+    // Largest is the giant.
+    let target = &components[0];
+    assert_eq!(target.size, 5, "giant should have 5 claims");
+
+    let small_a = find_component_by_member(&components, &a0);
+    let small_b = find_component_by_member(&components, &b0);
+    assert_eq!(small_a.size, 2);
+    assert_eq!(small_b.size, 2);
+    assert_ne!(small_a.component_id, target.component_id);
+    assert_ne!(small_b.component_id, target.component_id);
+
+    // Drive the sweep manually for both small components.
+    // (Mirrors what bridge_sweep::run_sweep does when --components is given.)
+    let target_atoms = vec![g0, g1, g2, g3, g4];
+
+    let mut total_processed = 0;
+    let mut total_edges_created = 0;
+    let mut spine_seen = false;
+
+    for (small, source_atoms) in [(small_a, vec![a0, a1]), (small_b, vec![b0, b1])] {
+        assert_ne!(small.component_id, target.component_id, "must skip target");
+
+        let table = format!("test_sweep_{}", Uuid::new_v4().simple());
+        let count = build_candidate_table(&pool, &table, &source_atoms, &target_atoms, 0.5, 10)
+            .await
+            .unwrap();
+        assert!(count > 0, "expected at least one candidate pair");
+
+        let spine = compute_spine_destination(&pool, &table, 5).await.unwrap();
+        if !spine.is_empty() {
+            spine_seen = true;
+            // Targets are all under theme "X".
+            assert_eq!(spine[0].umbrella, "X");
+        }
+
+        let config = RerankConfig {
+            min_similarity: 0.5,
+            batch_size: 10,
+            provider: "mock".to_string(),
+            model: None,
+            dry_run: true, // dry-run
+            limit: None,
+            verbose: false,
+        };
+        let summary = rerank_candidates_table(&pool, &table, &config)
+            .await
+            .unwrap();
+        assert_eq!(summary.edges_created, 0, "dry-run must not create edges");
+        total_edges_created += summary.edges_created;
+        total_processed += 1;
+
+        drop_candidate_table(&pool, &table).await.unwrap();
+    }
+
+    assert_eq!(total_processed, 2, "expected 2 small components processed");
+    assert_eq!(total_edges_created, 0, "dry-run must create no edges");
+    assert!(spine_seen, "spine should populate when target themes exist");
+}

--- a/crates/epigraph-cli/tests/rerank_candidates_table.rs
+++ b/crates/epigraph-cli/tests/rerank_candidates_table.rs
@@ -1,0 +1,120 @@
+//! Verify the candidates-table mode finds the right pairs.
+//!
+//! Wires the new `rerank_candidates_table` library entry point against a
+//! seeded temp table and confirms summary accounting works under `--provider mock`
+//! (which returns an empty JSON array, so accept counts are zero by design).
+
+#![cfg(feature = "genai")]
+
+use epigraph_cli::rerank::{rerank_candidates_table, RerankConfig};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn candidates_table_with_mock_provider_returns_summary(pool: PgPool) {
+    // Seed agent
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(agent_id)
+        .bind("aa".repeat(32))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Build a 1536-dim pgvector literal with one nonzero component so the
+    // embedding column is non-null and similarity is defined.
+    let mut zeros = vec!["0.0"; 1536];
+    zeros[0] = "0.99";
+    let pgvec = format!("[{}]", zeros.join(","));
+
+    let mut ids = Vec::new();
+    for i in 0..2 {
+        let id = Uuid::new_v4();
+        let hash: Vec<u8> = id
+            .as_bytes()
+            .iter()
+            .copied()
+            .chain(std::iter::repeat_n(0, 16))
+            .take(32)
+            .collect();
+        sqlx::query(
+            "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding) \
+             VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', 3), $5::vector)",
+        )
+        .bind(id)
+        .bind(format!("c{i}"))
+        .bind(hash)
+        .bind(agent_id)
+        .bind(&pgvec)
+        .execute(&pool)
+        .await
+        .unwrap();
+        ids.push(id);
+    }
+
+    // Populate the candidate table with the single (s, t) pair.
+    // NOTE: regular table, not TEMP — sqlx pool may check out a different
+    // connection for the rerank query and would lose session-local TEMPs.
+    // sqlx::test gives each test its own database so cleanup isn't needed.
+    sqlx::query("CREATE TABLE bridge_test_candidates (source_id uuid, target_id uuid)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO bridge_test_candidates VALUES ($1, $2)")
+        .bind(ids[0])
+        .bind(ids[1])
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let config = RerankConfig {
+        min_similarity: 0.0,
+        batch_size: 10,
+        provider: "mock".to_string(),
+        model: None,
+        dry_run: true,
+        limit: None,
+        verbose: false,
+    };
+
+    let summary = rerank_candidates_table(&pool, "bridge_test_candidates", &config)
+        .await
+        .expect("rerank_candidates_table failed");
+
+    assert_eq!(
+        summary.candidates_evaluated, 1,
+        "should evaluate the one pair we seeded"
+    );
+    // Mock provider returns empty `[]` → no accepts → no edges, dry_run reinforces it.
+    assert_eq!(
+        summary.edges_created, 0,
+        "dry_run + mock empty response must not create edges"
+    );
+    assert_eq!(summary.llm_accepted, 0);
+    // duration_ms is `u128`; just make sure the field is populated as expected (>= 0 always true).
+    let _ = summary.duration_ms;
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn candidates_table_rejects_unsafe_identifier(pool: PgPool) {
+    let config = RerankConfig {
+        min_similarity: 0.0,
+        batch_size: 10,
+        provider: "mock".to_string(),
+        model: None,
+        dry_run: true,
+        limit: None,
+        verbose: false,
+    };
+
+    let result = rerank_candidates_table(&pool, "foo; DROP TABLE claims", &config).await;
+    assert!(
+        result.is_err(),
+        "SQL-injection-shaped table name must be rejected"
+    );
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("[a-zA-Z0-9_]+"),
+        "error should explain identifier shape, got: {msg}"
+    );
+}

--- a/crates/epigraph-cli/tests/rerank_candidates_table.rs
+++ b/crates/epigraph-cli/tests/rerank_candidates_table.rs
@@ -91,6 +91,16 @@ async fn candidates_table_with_mock_provider_returns_summary(pool: PgPool) {
         "dry_run + mock empty response must not create edges"
     );
     assert_eq!(summary.llm_accepted, 0);
+    assert_eq!(summary.llm_rejected, 0);
+    // The mock LLM returns `[]` for every call. The batch loop counts each
+    // missing per-pair entry as an error — so for 1 pair we expect errors=1.
+    // This is the "missing pair" warning branch in `rerank_inner`, not an
+    // actual failure mode; documenting it here so future refactors don't
+    // silently change the meaning of `errors`.
+    assert_eq!(
+        summary.errors, 1,
+        "mock LLM returns [] → missing-pair branch increments errors once"
+    );
     // duration_ms is `u128`; just make sure the field is populated as expected (>= 0 always true).
     let _ = summary.duration_ms;
 }

--- a/migrations/030_atom_embedding_partial_index.sql
+++ b/migrations/030_atom_embedding_partial_index.sql
@@ -1,0 +1,16 @@
+-- Partial HNSW index on level=3 (atom) claims for cross-component bridge
+-- sweep (issue #53). Bridge candidates are atom-to-atom; paragraph-level
+-- partial index from migration 029 is non-overlapping. 3072d path stays
+-- seq-scan (atom counts ≤ ~150k; HNSW build cost not justified for the
+-- second column).
+--
+-- Expected sequential build duration: 5-15 minutes on a 150k-atom corpus
+-- with m=16, ef_construction=64. Holds ACCESS EXCLUSIVE on `claims` for
+-- the duration. Operators who can't tolerate the lock should skip this
+-- migration in `sqlx migrate run`, then apply manually with:
+--   psql -c "CREATE INDEX CONCURRENTLY idx_claims_atom_embedding ..."
+-- and stamp `_sqlx_migrations` after.
+CREATE INDEX IF NOT EXISTS idx_claims_atom_embedding
+    ON claims USING hnsw (embedding vector_cosine_ops)
+    WITH (m=16, ef_construction=64)
+    WHERE (properties->>'level')::int = 3 AND embedding IS NOT NULL;


### PR DESCRIPTION
Closes #53.

## Summary
- Migration 030: partial HNSW index on level=3 atoms (bridge substrate).
- New library: `epigraph_cli::bridge::{components, candidates, spine}` — connected-component enumeration via union-find over `decomposes_to`/`CORROBORATES`/`same_as`/`same_source`/`continues_argument`; per-source-atom kNN candidate-table builder; spine-destination aggregation over `claim_themes`.
- `rerank_bridges` refactored into a library API (`epigraph_cli::rerank::{rerank_global_join, rerank_candidates_table, RerankConfig, RerankSummary}`); existing CLI behavior preserved. New `--candidates-table <NAME>` flag mutually exclusive with `--source-filter`/`--target-filter`.
- New `epigraph-cli bridge_component <UUID>` for one-shot component bridging.
- New `epigraph-cli bridge_sweep [--components <UUID,...> | --all]` with per-component spine-destination report.
- `--dry-run` is the default; `--apply` to commit edges.
- Edge metadata under `properties.{strength, cosine_similarity, validation_method, rationale, ...}` (already from the legacy `rerank_bridges`; unchanged).

Internal-repo `rerank_bridges` sync (`--candidates-table` flag + provider parity) tracked separately.

## Test plan
- [x] `compute_components` returns 2 CCs for two isolated sections; 1 CC when bridged by CORROBORATES.
- [x] `build_candidate_table` per-source-atom top-K with HNSW; rejects unsafe table names.
- [x] `rerank_candidates_table` evaluates the table-supplied pairs; `--provider mock --dry-run` keeps `edges_created = 0`.
- [x] `compute_spine_destination` aggregates by `claim_themes.label`, weights to fractions, drops unthemed targets, returns empty when no themes.
- [x] `bridge_sweep` `--all --provider mock --dry-run` iterates non-target components and produces per-component reports including spine.
- [x] `bridge_component` and `bridge_sweep` both print USAGE on `--help` (exit 0) and reject mutex violations (exit 1).
- [x] cargo fmt --check, cargo clippy -p epigraph-cli --features genai -- -D warnings, full per-package test suite all green.

## Out of scope (follow-up issues)
- HNSW build via `CREATE INDEX CONCURRENTLY` automation (operator runbook step today; spec §2.1).
- Job-runner / cron integration — deferred until production sweep yields cadence data.
- Internal-repo `rerank_bridges` sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)