### PR TITLE
Step-level versioning: lineage UUID, supersedes/revises, evolve_step (#91)

### DIFF
--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -94,6 +94,7 @@ const VALID_RELATIONSHIPS: &[&str] = &[
     "EQUIVALENT_TO",         // claim → claim (semantic equivalence)
     "CONTRADICTS",           // claim → claim (contradiction)
     "supersedes",            // claim → claim (version chain)
+    "revises",               // claim → claim (concurrent branch from common ancestor)
     "enables",               // claim → claim (enablement)
     "has_method_capability", // method → capability (method graph)
     "interpreted_by",        // claim → agent (interpretation provenance)

--- a/crates/epigraph-db/src/lib.rs
+++ b/crates/epigraph-db/src/lib.rs
@@ -70,7 +70,7 @@ pub use repos::{
     ExperimentRepository, ExperimentResultRepository, ExperimentResultRow, ExperimentRow,
     FactorRepository, FrameRepository, GapAnalysisResult, GapChallengeRow, GapRecord,
     GapRepository, GroupKeyEpochRepository, GroupMembershipRepository, GroupRepository, GroupRow,
-    HierarchicalWorkflowRow, KeyEpochRow, LearningEventRepository, LearningEventRow,
+    HierarchicalWorkflowRow, KeyEpochRow, LearningEventRepository, LearningEventRow, LineageHead,
     LineageRepository, MassFunctionRepository, MembershipRow, MentionRow, MethodCapability,
     MethodEvidenceStrength, MethodFailureModes, MethodForCapability, MethodRecord,
     MethodRepository, MethodSearchResult, MethodSourcePaper, MethodUsageExample,

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -20,6 +20,19 @@ pub struct ClaimEmbeddingHit {
     pub similarity: f64,
 }
 
+/// Result row for [`ClaimRepository::latest_in_lineage`].
+///
+/// Represents a head of a step lineage: a claim with `step_lineage_id = $1`
+/// and no incoming `supersedes` edge. See spec §3.1 in
+/// `docs/superpowers/specs/2026-05-05-step-level-versioning-design.md`.
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct LineageHead {
+    pub id: Uuid,
+    pub content: String,
+    pub truth_value: f64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// Build a Claim from database row data.
 ///
 /// This helper function handles the crypto fields that may not exist in
@@ -1495,6 +1508,40 @@ impl ClaimRepository {
         }
 
         Ok(was_inserted)
+    }
+
+    /// Walks `supersedes` edges on a step lineage. Returns one row per head:
+    /// claims with `step_lineage_id = $1` and NO incoming `supersedes` edge.
+    /// Multiple heads = unmerged concurrent branches (created via `revises`).
+    /// Empty = no claims have this `step_lineage_id`.
+    ///
+    /// `revises` does NOT remove head status — only `supersedes` does. See
+    /// `docs/superpowers/specs/2026-05-05-step-level-versioning-design.md` §3.1.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn latest_in_lineage(
+        pool: &PgPool,
+        lineage_id: Uuid,
+    ) -> Result<Vec<LineageHead>, DbError> {
+        let rows = sqlx::query_as::<_, LineageHead>(
+            r#"
+            SELECT c.id, c.content, c.truth_value, c.created_at
+            FROM claims c
+            WHERE c.step_lineage_id = $1
+              AND NOT EXISTS (
+                  SELECT 1 FROM edges e
+                  WHERE e.target_id = c.id
+                    AND e.relationship = 'supersedes'
+              )
+            ORDER BY c.created_at DESC
+            "#,
+        )
+        .bind(lineage_id)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows)
     }
 }
 

--- a/crates/epigraph-db/src/repos/mod.rs
+++ b/crates/epigraph-db/src/repos/mod.rs
@@ -61,7 +61,7 @@ pub use agent::{AgentCapabilitiesRow, AgentIdentityRow, AgentRepository, Capabil
 pub use agent_key::{AgentKeyRepository, AgentKeyRow};
 pub use analysis::{AnalysisRecord, AnalysisRepository, ClaimSummary};
 pub use challenge::{ChallengeRepository, ChallengeRow, GapChallengeRow};
-pub use claim::{ClaimEmbeddingHit, ClaimPairDistance, ClaimRepository};
+pub use claim::{ClaimEmbeddingHit, ClaimPairDistance, ClaimRepository, LineageHead};
 pub use claim_theme::{
     BoundaryClaimRow, ClaimThemeRepository, ClaimThemeRow, DistantClaimsRow, RecomputedThemeRow,
     SplitCandidateRow,

--- a/crates/epigraph-db/tests/lineage_heads.rs
+++ b/crates/epigraph-db/tests/lineage_heads.rs
@@ -1,0 +1,121 @@
+//! Integration tests for `ClaimRepository::latest_in_lineage`.
+//!
+//! Verifies the head-walking semantics defined in spec §3.1
+//! (`docs/superpowers/specs/2026-05-05-step-level-versioning-design.md`):
+//! a claim is a head of its `step_lineage_id` if and only if no other
+//! claim has a `supersedes` edge pointing AT it. `revises` edges do
+//! not remove head status — they mark concurrent branches.
+
+use epigraph_db::ClaimRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn seed_versioned_claim(pool: &PgPool, agent: Uuid, lineage: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, step_lineage_id) \
+         VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', 2, 'step_lineage_id', $5::text), $5)",
+    )
+    .bind(id)
+    .bind(format!("c-{id}"))
+    .bind(hash)
+    .bind(agent)
+    .bind(lineage)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn seed_edge(pool: &PgPool, src: Uuid, tgt: Uuid, rel: &str) {
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES (gen_random_uuid(), $1, 'claim', $2, 'claim', $3)",
+    )
+    .bind(src)
+    .bind(tgt)
+    .bind(rel)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn linear_supersedes_chain_has_one_head(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let lineage = Uuid::new_v4();
+
+    // v1 -> v2 -> v3 (each supersedes the previous)
+    let v1 = seed_versioned_claim(&pool, agent, lineage).await;
+    let v2 = seed_versioned_claim(&pool, agent, lineage).await;
+    let v3 = seed_versioned_claim(&pool, agent, lineage).await;
+    seed_edge(&pool, v2, v1, "supersedes").await;
+    seed_edge(&pool, v3, v2, "supersedes").await;
+
+    let heads = ClaimRepository::latest_in_lineage(&pool, lineage)
+        .await
+        .unwrap();
+    let head_ids: Vec<Uuid> = heads.iter().map(|h| h.id).collect();
+    assert_eq!(heads.len(), 1, "single head expected; got {head_ids:?}");
+    assert_eq!(
+        head_ids[0], v3,
+        "v3 must be the head (v2 superseded v1, v3 superseded v2)"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn revises_branches_produce_multiple_heads(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let lineage = Uuid::new_v4();
+
+    // v1 revised by both A_v2 and B_v2 (no supersedes edges)
+    let v1 = seed_versioned_claim(&pool, agent, lineage).await;
+    let a_v2 = seed_versioned_claim(&pool, agent, lineage).await;
+    let b_v2 = seed_versioned_claim(&pool, agent, lineage).await;
+    seed_edge(&pool, a_v2, v1, "revises").await;
+    seed_edge(&pool, b_v2, v1, "revises").await;
+
+    let heads = ClaimRepository::latest_in_lineage(&pool, lineage)
+        .await
+        .unwrap();
+    let head_ids: std::collections::HashSet<Uuid> = heads.iter().map(|h| h.id).collect();
+
+    // Per spec §3.1, head = not pointed-at by any supersedes edge.
+    // v1 has incoming `revises` edges (from a_v2 and b_v2) but NO incoming `supersedes`.
+    // a_v2 and b_v2 have no incoming edges of either kind.
+    // So all three are heads.
+    assert_eq!(
+        heads.len(),
+        3,
+        "v1, a_v2, b_v2 must all be heads (revises does not remove head status); got {head_ids:?}"
+    );
+    assert!(head_ids.contains(&v1));
+    assert!(head_ids.contains(&a_v2));
+    assert!(head_ids.contains(&b_v2));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn empty_when_lineage_has_no_claims(pool: PgPool) {
+    let heads = ClaimRepository::latest_in_lineage(&pool, Uuid::new_v4())
+        .await
+        .unwrap();
+    assert!(heads.is_empty());
+}

--- a/crates/epigraph-ingest-executor/src/workflow.rs
+++ b/crates/epigraph-ingest-executor/src/workflow.rs
@@ -183,9 +183,36 @@ pub async fn execute_workflow_ingest_plan(
         .await?;
 
         if was_new {
-            // Set properties via raw SQL (no set_properties method on ClaimRepository).
-            sqlx::query("UPDATE claims SET properties = $1 WHERE id = $2")
-                .bind(&planned.properties)
+            // For level=2 (steps) and level=3 (operations), assign a
+            // `step_lineage_id` UUID — see spec
+            // `2026-05-05-step-level-versioning-design.md` §6.1, §6.2, §9.6, §9.7.
+            // If the caller supplied one in `properties.step_lineage_id`, preserve it;
+            // otherwise generate `Uuid::new_v4()`. Level=0/1 (thesis/phase) leave the
+            // column NULL — workflow-level `variant_of` covers their evolution (§9.8).
+            let mut properties = planned.properties.clone();
+            let lineage_uuid: Option<Uuid> = if planned.level == 2 || planned.level == 3 {
+                let existing = properties
+                    .get("step_lineage_id")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| Uuid::parse_str(s).ok());
+                let chosen = existing.unwrap_or_else(Uuid::new_v4);
+                properties
+                    .as_object_mut()
+                    .expect("PlannedClaim.properties must be a JSON object")
+                    .insert(
+                        "step_lineage_id".to_string(),
+                        serde_json::Value::String(chosen.to_string()),
+                    );
+                Some(chosen)
+            } else {
+                None
+            };
+
+            // Set properties + step_lineage_id via raw SQL (no set_properties
+            // method on ClaimRepository).
+            sqlx::query("UPDATE claims SET properties = $1, step_lineage_id = $2 WHERE id = $3")
+                .bind(&properties)
+                .bind(lineage_uuid)
                 .bind(planned.id)
                 .execute(pool)
                 .await?;

--- a/crates/epigraph-ingest-executor/tests/lineage_assignment.rs
+++ b/crates/epigraph-ingest-executor/tests/lineage_assignment.rs
@@ -1,0 +1,213 @@
+//! Verify the executor injects `step_lineage_id` for level=2/3 claims at ingest
+//! and leaves level=0/1 (thesis/phase) NULL — see spec
+//! `docs/superpowers/specs/2026-05-05-step-level-versioning-design.md` §6.1,
+//! §6.2, §9.6, §9.7, §9.8.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use epigraph_ingest::common::schema::ThesisDerivation;
+use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowSource};
+use epigraph_ingest::workflow::WorkflowExtraction;
+
+/// One thesis (L0), one phase (L1), one step (L2), one operation (L3).
+/// `op_text` is parameterized so callers can keep operation `claim_id`s unique
+/// across tests sharing a DB pool (atom-namespace ID is content-hash derived).
+fn build_one_of_each_extraction(canonical_name: &str, op_text: &str) -> WorkflowExtraction {
+    WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: canonical_name.to_string(),
+            goal: "Validate step_lineage_id injection for level=2/3 claims".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: Some(format!("thesis content for {canonical_name}")),
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "Phase A".to_string(),
+            summary: format!("phase summary for {canonical_name}"),
+            steps: vec![Step {
+                compound: format!("step compound for {canonical_name}"),
+                rationale: "step rationale".to_string(),
+                operations: vec![op_text.to_string()],
+                generality: vec![1],
+                confidence: 0.9,
+            }],
+        }],
+        relationships: vec![],
+    }
+}
+
+/// Resolve the `claim_id` at a given path index (`thesis`, `phases[0]`,
+/// `phases[0].steps[0]`, `phases[0].steps[0].operations[0]`).
+fn id_at(plan: &epigraph_ingest::common::plan::IngestPlan, path: &str) -> Uuid {
+    *plan
+        .path_index
+        .get(path)
+        .unwrap_or_else(|| panic!("path_index missing key {path}"))
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn lineage_assigned_to_level_2_and_3_only(pool: PgPool) {
+    let extraction = build_one_of_each_extraction(
+        "lineage-l23-only-test",
+        "operation text for lineage-l23-only-test",
+    );
+    let plan = epigraph_ingest::workflow::builder::build_ingest_plan(&extraction);
+
+    let thesis_id = id_at(&plan, "thesis");
+    let phase_id = id_at(&plan, "phases[0]");
+    let step_id = id_at(&plan, "phases[0].steps[0]");
+    let op_id = id_at(&plan, "phases[0].steps[0].operations[0]");
+
+    let result = epigraph_ingest_executor::execute_workflow_ingest_plan(&pool, &plan, &extraction)
+        .await
+        .expect("ingest plan");
+    assert!(!result.already_ingested);
+    assert!(
+        result.claims_ingested >= 4,
+        "expected at least 4 claims (thesis/phase/step/op), got {}",
+        result.claims_ingested
+    );
+
+    // Level=0 (thesis) — column is NULL.
+    let row: (Option<Uuid>,) = sqlx::query_as("SELECT step_lineage_id FROM claims WHERE id = $1")
+        .bind(thesis_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        row.0.is_none(),
+        "thesis (level=0) must have NULL step_lineage_id, got {:?}",
+        row.0
+    );
+
+    // Level=1 (phase) — column is NULL.
+    let row: (Option<Uuid>,) = sqlx::query_as("SELECT step_lineage_id FROM claims WHERE id = $1")
+        .bind(phase_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        row.0.is_none(),
+        "phase (level=1) must have NULL step_lineage_id, got {:?}",
+        row.0
+    );
+
+    // Level=2 (step) — column populated.
+    let row: (Option<Uuid>,) = sqlx::query_as("SELECT step_lineage_id FROM claims WHERE id = $1")
+        .bind(step_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let step_lineage = row.0.expect("step (level=2) must have step_lineage_id");
+
+    // Level=3 (operation) — column populated.
+    let row: (Option<Uuid>,) = sqlx::query_as("SELECT step_lineage_id FROM claims WHERE id = $1")
+        .bind(op_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let op_lineage = row
+        .0
+        .expect("operation (level=3) must have step_lineage_id");
+
+    // Properties JSONB must mirror the column for level=2/3.
+    let row: (serde_json::Value, Option<Uuid>) =
+        sqlx::query_as("SELECT properties, step_lineage_id FROM claims WHERE id = $1")
+            .bind(step_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let prop_lineage = row
+        .0
+        .get("step_lineage_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok());
+    assert_eq!(
+        prop_lineage,
+        Some(step_lineage),
+        "step properties.step_lineage_id must mirror the column"
+    );
+    assert_eq!(row.1, Some(step_lineage));
+
+    let row: (serde_json::Value, Option<Uuid>) =
+        sqlx::query_as("SELECT properties, step_lineage_id FROM claims WHERE id = $1")
+            .bind(op_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let prop_lineage = row
+        .0
+        .get("step_lineage_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok());
+    assert_eq!(
+        prop_lineage,
+        Some(op_lineage),
+        "operation properties.step_lineage_id must mirror the column"
+    );
+    assert_eq!(row.1, Some(op_lineage));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn caller_supplied_lineage_uuid_preserved(pool: PgPool) {
+    let preset = Uuid::new_v4();
+
+    let extraction = build_one_of_each_extraction(
+        "lineage-caller-supplied-test",
+        "operation text for lineage-caller-supplied-test",
+    );
+    let mut plan = epigraph_ingest::workflow::builder::build_ingest_plan(&extraction);
+
+    // Inject the caller-supplied lineage UUID into the level=2 step's
+    // properties. The executor reads `planned.properties.get("step_lineage_id")`
+    // and preserves valid values rather than minting a fresh one.
+    let step_id = id_at(&plan, "phases[0].steps[0]");
+    let step_planned = plan
+        .claims
+        .iter_mut()
+        .find(|c| c.id == step_id)
+        .expect("plan must contain the step claim");
+    assert_eq!(step_planned.level, 2);
+    step_planned
+        .properties
+        .as_object_mut()
+        .expect("PlannedClaim.properties is a JSON object")
+        .insert(
+            "step_lineage_id".to_string(),
+            serde_json::Value::String(preset.to_string()),
+        );
+
+    let _result = epigraph_ingest_executor::execute_workflow_ingest_plan(&pool, &plan, &extraction)
+        .await
+        .expect("ingest plan");
+
+    let row: (Option<Uuid>,) = sqlx::query_as("SELECT step_lineage_id FROM claims WHERE id = $1")
+        .bind(step_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.0,
+        Some(preset),
+        "caller-supplied step_lineage_id must be preserved"
+    );
+
+    // Properties JSONB must also reflect the preset.
+    let props: (serde_json::Value,) = sqlx::query_as("SELECT properties FROM claims WHERE id = $1")
+        .bind(step_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let prop_lineage = props
+        .0
+        .get("step_lineage_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok());
+    assert_eq!(prop_lineage, Some(preset));
+}

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -232,6 +232,17 @@ impl EpiGraphMcpFull {
         crate::tools::recall::recall_with_context(self, params).await
     }
 
+    #[tool(
+        description = "Evolve a versioned step or operation by atomically creating a new claim that supersedes or revises an existing one. Use 'supersedes' for linear refinement; 'revises' for a concurrent branch from a common ancestor. The new claim shares the same step_lineage_id as the parent."
+    )]
+    async fn evolve_step(
+        &self,
+        Parameters(params): Parameters<crate::tools::evolve_step::EvolveStepParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        crate::tools::evolve_step::evolve_step(self, params).await
+    }
+
     // ── Ingestion ──
 
     #[tool(

--- a/crates/epigraph-mcp/src/tools/evolve_step.rs
+++ b/crates/epigraph-mcp/src/tools/evolve_step.rs
@@ -1,0 +1,127 @@
+//! `evolve_step` — atomic creation of a versioned claim + supersedes/revises edge.
+//!
+//! See docs/superpowers/specs/2026-05-05-step-level-versioning-design.md §5, §9.9.
+//!
+//! Use `supersedes` for linear refinement (new claim takes over from parent);
+//! use `revises` for a concurrent branch sharing a common ancestor. The new
+//! claim shares the same `step_lineage_id` as the parent.
+
+use epigraph_crypto::ContentHasher;
+use rmcp::model::{CallToolResult, Content};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::{internal_error, invalid_params, parse_uuid, McpError};
+use crate::server::EpiGraphMcpFull;
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct EvolveStepParams {
+    /// Existing lineage UUID. Required.
+    pub step_lineage_id: String,
+    /// Claim being superseded or branched from. Required.
+    pub parent_id: String,
+    /// New step content.
+    pub content: String,
+    /// "supersedes" (linear refinement) or "revises" (concurrent branch).
+    pub edge_type: String,
+    /// Optional human-readable rationale.
+    pub rationale: Option<String>,
+    /// 2 (step) or 3 (operation). Default 2.
+    pub level: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EvolveStepResponse {
+    pub claim_id: Uuid,
+    pub step_lineage_id: Uuid,
+    pub edge_id: Uuid,
+}
+
+pub async fn evolve_step(
+    server: &EpiGraphMcpFull,
+    params: EvolveStepParams,
+) -> Result<CallToolResult, McpError> {
+    if params.edge_type != "supersedes" && params.edge_type != "revises" {
+        return Err(invalid_params(format!(
+            "edge_type must be \"supersedes\" or \"revises\", got: {}",
+            params.edge_type
+        )));
+    }
+    let level = params.level.unwrap_or(2);
+    if level != 2 && level != 3 {
+        return Err(invalid_params(format!(
+            "level must be 2 or 3 (got {level})"
+        )));
+    }
+    if params.content.trim().is_empty() {
+        return Err(invalid_params("content must not be empty".to_string()));
+    }
+
+    let step_lineage_id = parse_uuid(&params.step_lineage_id)?;
+    let parent_id = parse_uuid(&params.parent_id)?;
+
+    let agent_id = server.agent_id().await?;
+
+    let mut tx = server
+        .pool
+        .begin()
+        .await
+        .map_err(|e| internal_error(format!("begin tx: {e}")))?;
+
+    let claim_id = Uuid::new_v4();
+    let content_hash = ContentHasher::hash(params.content.as_bytes());
+    let properties = serde_json::json!({
+        "level": level,
+        "step_lineage_id": step_lineage_id.to_string(),
+    });
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, step_lineage_id) \
+         VALUES ($1, $2, $3, $4, 0.5, $5, $6)",
+    )
+    .bind(claim_id)
+    .bind(&params.content)
+    .bind(content_hash.as_slice())
+    .bind(agent_id)
+    .bind(&properties)
+    .bind(step_lineage_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| internal_error(format!("insert claim: {e}")))?;
+
+    let edge_id = Uuid::new_v4();
+    // `evolved_at` covers both supersedes (linear) and revises (branch)
+    // semantically; the spec (§5, §9.9) does not pin the field name.
+    let edge_props = serde_json::json!({
+        "rationale": params.rationale,
+        "evolved_at": chrono::Utc::now().to_rfc3339(),
+    });
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship, properties) \
+         VALUES ($1, $2, 'claim', $3, 'claim', $4, $5)",
+    )
+    .bind(edge_id)
+    .bind(claim_id)
+    .bind(parent_id)
+    .bind(&params.edge_type)
+    .bind(&edge_props)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| internal_error(format!("insert edge: {e}")))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| internal_error(format!("commit: {e}")))?;
+
+    success_json(&EvolveStepResponse {
+        claim_id,
+        step_lineage_id,
+        edge_id,
+    })
+}
+
+fn success_json<T: Serialize>(value: &T) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(value).map_err(internal_error)?,
+    )]))
+}

--- a/crates/epigraph-mcp/src/tools/mod.rs
+++ b/crates/epigraph-mcp/src/tools/mod.rs
@@ -4,6 +4,7 @@ pub mod claims;
 pub mod ds;
 pub mod ds_auto;
 pub mod events;
+pub mod evolve_step;
 pub mod graph;
 pub mod ingestion;
 pub mod memory;

--- a/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
@@ -13,6 +13,7 @@
 //! `GET /api/v1/workflows/hierarchical/search` and
 //! `POST /api/v1/workflows/hierarchical/:id/outcome`.
 
+use epigraph_db::{ClaimRepository, LineageHead};
 use rmcp::model::*;
 use uuid::Uuid;
 
@@ -53,6 +54,8 @@ pub async fn find_workflow_hierarchical(
     params: FindWorkflowHierarchicalParams,
 ) -> Result<CallToolResult, McpError> {
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
+    let resolve_to_latest = params.resolve_to_latest.unwrap_or(false);
+
     let rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
         &server.pool,
         &params.query,
@@ -61,25 +64,88 @@ pub async fn find_workflow_hierarchical(
     .await
     .map_err(internal_error)?;
 
-    let workflows: Vec<serde_json::Value> = rows
-        .into_iter()
-        .map(|r| {
-            serde_json::json!({
-                "workflow_id": r.id,
-                "canonical_name": r.canonical_name,
-                "generation": r.generation,
-                "goal": r.goal,
-                "parent_id": r.parent_id,
-                "metadata": r.metadata,
-                "created_at": r.created_at,
-            })
-        })
-        .collect();
+    let mut workflows: Vec<serde_json::Value> = Vec::with_capacity(rows.len());
+    for r in rows {
+        let mut entry = serde_json::json!({
+            "workflow_id": r.id,
+            "canonical_name": r.canonical_name,
+            "generation": r.generation,
+            "goal": r.goal,
+            "parent_id": r.parent_id,
+            "metadata": r.metadata,
+            "created_at": r.created_at,
+        });
+
+        if resolve_to_latest {
+            let resolved = build_resolved_steps(&server.pool, r.id).await?;
+            entry["resolved_steps"] = serde_json::to_value(resolved).map_err(internal_error)?;
+        }
+
+        workflows.push(entry);
+    }
 
     success_json(&serde_json::json!({
         "workflows": workflows,
         "total": workflows.len(),
+        "resolve_to_latest": resolve_to_latest,
     }))
+}
+
+/// Per-step resolution result for `find_workflow_hierarchical(resolve_to_latest=true)`.
+///
+/// `frozen_claim_id` is the original step claim attached to the workflow via
+/// the `executes` edge. `heads` lists the current head(s) of the step's
+/// lineage (claims with `step_lineage_id = $lineage` and no incoming
+/// `supersedes` edge); empty when the step has no `step_lineage_id` (legacy)
+/// or when the lineage has been pruned. `pending_resolution` is true when
+/// the lineage has more than one head — caller must reconcile before reuse.
+#[derive(serde::Serialize)]
+struct ResolvedStep {
+    step_index: usize,
+    frozen_claim_id: Uuid,
+    step_lineage_id: Option<Uuid>,
+    heads: Vec<LineageHead>,
+    pending_resolution: bool,
+}
+
+async fn build_resolved_steps(
+    pool: &sqlx::PgPool,
+    workflow_id: Uuid,
+) -> Result<Vec<ResolvedStep>, McpError> {
+    // Pull all level=2 step claims under this workflow with their
+    // step_lineage_id, ordered by edge created_at + claim id (matches
+    // do_report_hierarchical_outcome_via_pool).
+    let step_rows: Vec<(Uuid, Option<Uuid>)> = sqlx::query_as(
+        "SELECT c.id, c.step_lineage_id \
+         FROM edges e \
+         JOIN claims c ON c.id = e.target_id \
+         WHERE e.source_id = $1 AND e.relationship = 'executes' AND (c.properties->>'level')::int = 2 \
+         ORDER BY e.created_at ASC, c.id ASC",
+    )
+    .bind(workflow_id)
+    .fetch_all(pool)
+    .await
+    .map_err(internal_error)?;
+
+    let mut resolved = Vec::with_capacity(step_rows.len());
+    for (step_index, (frozen_claim_id, step_lineage_id)) in step_rows.into_iter().enumerate() {
+        let heads = if let Some(lineage_id) = step_lineage_id {
+            ClaimRepository::latest_in_lineage(pool, lineage_id)
+                .await
+                .map_err(internal_error)?
+        } else {
+            Vec::new()
+        };
+        let pending_resolution = heads.len() > 1;
+        resolved.push(ResolvedStep {
+            step_index,
+            frozen_claim_id,
+            step_lineage_id,
+            heads,
+            pending_resolution,
+        });
+    }
+    Ok(resolved)
 }
 
 // ── report_hierarchical_outcome ────────────────────────────────────────────

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -370,6 +370,11 @@ pub struct FindWorkflowHierarchicalParams {
 
     #[schemars(description = "Maximum number of workflows to return (default 10, max 50).")]
     pub limit: Option<i64>,
+
+    #[schemars(
+        description = "When true, walk each step's step_lineage_id to the head version(s) and surface them as `resolved_steps`. Defaults to false (frozen step references)."
+    )]
+    pub resolve_to_latest: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/epigraph-mcp/tests/step_versioning.rs
+++ b/crates/epigraph-mcp/tests/step_versioning.rs
@@ -1,0 +1,385 @@
+//! Integration tests for step-level versioning end-to-end.
+//!
+//! Covers:
+//! - evolve_step with supersedes (linear chain): old → new flips head ownership
+//! - evolve_step with revises (concurrent branch): produces parallel heads
+//! - find_workflow_hierarchical resolve_to_latest=false: behavior unchanged
+//! - find_workflow_hierarchical resolve_to_latest=true: surfaces heads + pending_resolution
+//! - evolve_step rejects bad edge_type
+//! - evolve_step rejects level=0/1
+
+use epigraph_crypto::AgentSigner;
+use epigraph_db::ClaimRepository;
+use epigraph_mcp::embed::McpEmbedder;
+use epigraph_mcp::tools::evolve_step::{evolve_step, EvolveStepParams};
+use epigraph_mcp::tools::workflow_hierarchical::find_workflow_hierarchical;
+use epigraph_mcp::types::FindWorkflowHierarchicalParams;
+use epigraph_mcp::EpiGraphMcpFull;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Build a minimal MCP server for tests. Mirrors the pattern in
+/// `tool_resubmit_tests.rs` (signer from a fixed seed, mock embedder).
+fn build_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0xA7u8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None); // mock — no API key
+    EpiGraphMcpFull::new(pool, signer, embedder, /* read_only */ false)
+}
+
+/// Insert a freestanding agent for seeded parent claims. The server will
+/// lazily create its OWN agent (keyed off the signer's public key) the
+/// first time `evolve_step` is invoked — this seeded agent is just a
+/// foreign-key target for the bootstrap parent claim.
+async fn insert_seed_agent(pool: &PgPool) -> Uuid {
+    let agent_id = Uuid::new_v4();
+    sqlx::query(
+        r#"INSERT INTO agents (id, public_key, created_at, updated_at)
+           VALUES ($1, sha256($1::text::bytea), NOW(), NOW())
+           ON CONFLICT (id) DO NOTHING"#,
+    )
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("upsert agent");
+    agent_id
+}
+
+/// Seed a level=2 step claim with `step_lineage_id` set. Used as the
+/// `parent_id` argument to `evolve_step`.
+async fn seed_versioned_step(pool: &PgPool, agent: Uuid, lineage: Uuid, content: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0u8, 16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, step_lineage_id) \
+         VALUES ($1, $2, $3, $4, 0.5, jsonb_build_object('level', 2, 'step_lineage_id', $5::text), $5)",
+    )
+    .bind(id)
+    .bind(content)
+    .bind(hash)
+    .bind(agent)
+    .bind(lineage)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+/// Pull the JSON body out of a `CallToolResult` (text content envelope).
+fn parse_body(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("result has at least one text content block");
+    serde_json::from_str(&text).expect("payload is valid JSON")
+}
+
+// ── evolve_step happy paths ──────────────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn evolve_step_supersedes_flips_head(pool: PgPool) {
+    let server = build_server(pool.clone());
+    let agent = insert_seed_agent(&pool).await;
+    let lineage = Uuid::new_v4();
+
+    let v1 = seed_versioned_step(&pool, agent, lineage, "step v1 content").await;
+
+    let params = EvolveStepParams {
+        step_lineage_id: lineage.to_string(),
+        parent_id: v1.to_string(),
+        content: "step v2 content".to_string(),
+        edge_type: "supersedes".to_string(),
+        rationale: Some("clarified wording".to_string()),
+        level: Some(2),
+    };
+    let _result = evolve_step(&server, params).await.expect("evolve_step");
+
+    let heads = ClaimRepository::latest_in_lineage(&pool, lineage)
+        .await
+        .unwrap();
+    assert_eq!(heads.len(), 1, "supersession produces one head");
+    let head_content: Vec<&str> = heads.iter().map(|h| h.content.as_str()).collect();
+    assert!(head_content.contains(&"step v2 content"));
+    assert!(!head_content.contains(&"step v1 content"));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn evolve_step_revises_produces_parallel_heads(pool: PgPool) {
+    let server = build_server(pool.clone());
+    let agent = insert_seed_agent(&pool).await;
+    let lineage = Uuid::new_v4();
+
+    let v1 = seed_versioned_step(&pool, agent, lineage, "v1").await;
+
+    // Agent A revises v1.
+    evolve_step(
+        &server,
+        EvolveStepParams {
+            step_lineage_id: lineage.to_string(),
+            parent_id: v1.to_string(),
+            content: "v1 + agent A refinement".to_string(),
+            edge_type: "revises".to_string(),
+            rationale: None,
+            level: Some(2),
+        },
+    )
+    .await
+    .expect("revises A");
+
+    // Agent B revises v1 too.
+    evolve_step(
+        &server,
+        EvolveStepParams {
+            step_lineage_id: lineage.to_string(),
+            parent_id: v1.to_string(),
+            content: "v1 + agent B refinement".to_string(),
+            edge_type: "revises".to_string(),
+            rationale: None,
+            level: Some(2),
+        },
+    )
+    .await
+    .expect("revises B");
+
+    let heads = ClaimRepository::latest_in_lineage(&pool, lineage)
+        .await
+        .unwrap();
+    // v1 (no incoming supersedes) + A's revision + B's revision = 3 heads.
+    // `revises` does NOT remove head status per spec §3.1.
+    assert_eq!(heads.len(), 3, "v1 + A + B all heads");
+}
+
+// ── evolve_step validation ───────────────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn evolve_step_rejects_bad_edge_type(pool: PgPool) {
+    let server = build_server(pool.clone());
+    let agent = insert_seed_agent(&pool).await;
+    let lineage = Uuid::new_v4();
+    let v1 = seed_versioned_step(&pool, agent, lineage, "v1").await;
+
+    let result = evolve_step(
+        &server,
+        EvolveStepParams {
+            step_lineage_id: lineage.to_string(),
+            parent_id: v1.to_string(),
+            content: "v2".to_string(),
+            edge_type: "BOGUS".to_string(),
+            rationale: None,
+            level: Some(2),
+        },
+    )
+    .await;
+    assert!(result.is_err(), "BOGUS edge_type must error");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn evolve_step_rejects_level_0_or_1(pool: PgPool) {
+    let server = build_server(pool.clone());
+    let agent = insert_seed_agent(&pool).await;
+    let lineage = Uuid::new_v4();
+    let v1 = seed_versioned_step(&pool, agent, lineage, "v1").await;
+
+    for bad_level in [0u32, 1, 4] {
+        let result = evolve_step(
+            &server,
+            EvolveStepParams {
+                step_lineage_id: lineage.to_string(),
+                parent_id: v1.to_string(),
+                content: "v2".to_string(),
+                edge_type: "supersedes".to_string(),
+                rationale: None,
+                level: Some(bad_level),
+            },
+        )
+        .await;
+        assert!(result.is_err(), "level={bad_level} must error");
+    }
+}
+
+// ── find_workflow_hierarchical with resolve_to_latest ────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn find_workflow_hierarchical_frozen_by_default(pool: PgPool) {
+    let server = build_server(pool.clone());
+
+    let workflow_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO workflows (id, canonical_name, generation, goal, parent_id, metadata, created_at) \
+         VALUES ($1, $2, 0, $3, NULL, '{}', NOW())",
+    )
+    .bind(workflow_id)
+    .bind("test_wf")
+    .bind("test goal — versioning probe")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let result = find_workflow_hierarchical(
+        &server,
+        FindWorkflowHierarchicalParams {
+            query: "versioning probe".to_string(),
+            limit: Some(5),
+            resolve_to_latest: None,
+        },
+    )
+    .await
+    .expect("find_workflow_hierarchical");
+
+    let body = parse_body(&result);
+    let workflows = body["workflows"].as_array().expect("workflows array");
+    assert!(!workflows.is_empty(), "should find the seeded workflow");
+    for w in workflows {
+        assert!(
+            w.get("resolved_steps").is_none(),
+            "frozen mode must not include resolved_steps"
+        );
+    }
+    assert_eq!(body["resolve_to_latest"], serde_json::json!(false));
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn find_workflow_hierarchical_resolve_walks_lineage(pool: PgPool) {
+    let server = build_server(pool.clone());
+    let agent = insert_seed_agent(&pool).await;
+
+    let workflow_id = Uuid::new_v4();
+    let lineage_a = Uuid::new_v4();
+    let lineage_b = Uuid::new_v4();
+
+    // Insert workflow row.
+    sqlx::query(
+        "INSERT INTO workflows (id, canonical_name, generation, goal, parent_id, metadata, created_at) \
+         VALUES ($1, $2, 0, $3, NULL, '{}', NOW())",
+    )
+    .bind(workflow_id)
+    .bind("resolve_test")
+    .bind("resolve_to_latest target")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Step 0: lineage_a, evolved via supersedes (single head).
+    let s0_v1 = seed_versioned_step(&pool, agent, lineage_a, "step 0 v1").await;
+    evolve_step(
+        &server,
+        EvolveStepParams {
+            step_lineage_id: lineage_a.to_string(),
+            parent_id: s0_v1.to_string(),
+            content: "step 0 v2 (refined)".to_string(),
+            edge_type: "supersedes".to_string(),
+            rationale: None,
+            level: Some(2),
+        },
+    )
+    .await
+    .expect("evolve s0");
+    let (s0_v2_id,): (Uuid,) =
+        sqlx::query_as("SELECT id FROM claims WHERE step_lineage_id = $1 AND content = $2")
+            .bind(lineage_a)
+            .bind("step 0 v2 (refined)")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    // Step 1: lineage_b, two concurrent revises (multi-head).
+    let s1_v1 = seed_versioned_step(&pool, agent, lineage_b, "step 1 v1").await;
+    evolve_step(
+        &server,
+        EvolveStepParams {
+            step_lineage_id: lineage_b.to_string(),
+            parent_id: s1_v1.to_string(),
+            content: "step 1 v2 — agent A".to_string(),
+            edge_type: "revises".to_string(),
+            rationale: None,
+            level: Some(2),
+        },
+    )
+    .await
+    .expect("revises s1 A");
+    evolve_step(
+        &server,
+        EvolveStepParams {
+            step_lineage_id: lineage_b.to_string(),
+            parent_id: s1_v1.to_string(),
+            content: "step 1 v2 — agent B".to_string(),
+            edge_type: "revises".to_string(),
+            rationale: None,
+            level: Some(2),
+        },
+    )
+    .await
+    .expect("revises s1 B");
+
+    // Wire executes edges: workflow → s0_v1, workflow → s1_v1
+    // (frozen references at ingest time). Order-by uses (created_at, id),
+    // so we offset created_at to enforce s0 before s1.
+    for (step_claim, ts_offset) in [(s0_v1, 0i32), (s1_v1, 1)] {
+        sqlx::query(
+            "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship, created_at) \
+             VALUES (gen_random_uuid(), $1, 'workflow', $2, 'claim', 'executes', NOW() + ($3 * INTERVAL '1 millisecond'))",
+        )
+        .bind(workflow_id)
+        .bind(step_claim)
+        .bind(ts_offset)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    let result = find_workflow_hierarchical(
+        &server,
+        FindWorkflowHierarchicalParams {
+            query: "resolve_to_latest target".to_string(),
+            limit: Some(5),
+            resolve_to_latest: Some(true),
+        },
+    )
+    .await
+    .expect("find_workflow_hierarchical");
+
+    let body = parse_body(&result);
+    let workflows = body["workflows"].as_array().expect("workflows array");
+    let wf = workflows
+        .iter()
+        .find(|w| w["workflow_id"].as_str() == Some(&workflow_id.to_string()))
+        .expect("seeded workflow not in results");
+
+    let resolved = wf["resolved_steps"]
+        .as_array()
+        .expect("resolved_steps array");
+    assert_eq!(resolved.len(), 2, "two steps under workflow");
+
+    // Step 0: single head (supersedes chain ended at v2).
+    let s0 = &resolved[0];
+    assert_eq!(
+        s0["frozen_claim_id"].as_str(),
+        Some(s0_v1.to_string().as_str())
+    );
+    assert_eq!(s0["pending_resolution"], serde_json::json!(false));
+    let s0_heads = s0["heads"].as_array().unwrap();
+    assert_eq!(s0_heads.len(), 1, "single supersedes head");
+    assert_eq!(
+        s0_heads[0]["id"].as_str(),
+        Some(s0_v2_id.to_string().as_str())
+    );
+
+    // Step 1: three heads (v1 + revises A + revises B). pending_resolution = true.
+    let s1 = &resolved[1];
+    assert_eq!(s1["pending_resolution"], serde_json::json!(true));
+    let s1_heads = s1["heads"].as_array().unwrap();
+    assert_eq!(
+        s1_heads.len(),
+        3,
+        "v1 + A's revision + B's revision = 3 heads"
+    );
+
+    assert_eq!(body["resolve_to_latest"], serde_json::json!(true));
+}

--- a/migrations/031_step_lineage_id.sql
+++ b/migrations/031_step_lineage_id.sql
@@ -1,0 +1,11 @@
+-- Step-level versioning (spec 2026-05-05-step-level-versioning-design.md).
+-- Adds stable lineage identity to level=2 (steps) and level=3 (operations) claims.
+-- NULL means "not in a versioned lineage" (legacy claims; all level=0/1 claims).
+-- Edge types `supersedes` and `revises` capture chain + branch semantics —
+-- `supersedes` is already in routes/edges.rs::VALID_RELATIONSHIPS;
+-- `revises` is added in this same PR.
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS step_lineage_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_claims_step_lineage_id
+    ON claims(step_lineage_id)
+    WHERE step_lineage_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds `claims.step_lineage_id UUID` + partial index, enabling stable identity across step rewrites (migration 031).
- New edge relationship `revises` for concurrent branches; `supersedes` already valid.
- Executor injects lineage UUIDs for level=2/3 claims at ingest; preserves caller-supplied values.
- `ClaimRepository::latest_in_lineage` walks supersedes heads (any `revises`-only branches stay alive as parallel heads).
- New MCP tool `evolve_step` — atomic claim + supersedes/revises edge in one transaction.
- `find_workflow_hierarchical?resolve_to_latest=true` walks each step's lineage; multi-head returns `pending_resolution: true`. Frozen by default per audit semantics.

Implements ratified spec `docs/superpowers/specs/2026-05-05-step-level-versioning-design.md`. Closes #91.

## Test plan
- [ ] CI green (`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, full `cargo test`).
- [ ] `crates/epigraph-db/tests/lineage_heads.rs` — 3 tests (linear chain → 1 head, revises branches → multiple heads, empty lineage).
- [ ] `crates/epigraph-ingest-executor/tests/lineage_assignment.rs` — 2 tests (lineage assigned to L2/L3 only, caller-supplied UUID preserved).
- [ ] `crates/epigraph-mcp/tests/step_versioning.rs` — 6 tests (evolve_step supersedes/revises happy paths, edge_type/level rejection, find_workflow_hierarchical frozen vs resolve walks).