### PR TITLE
Pluggable LlmProvider registry + 'epigraph' default selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,7 @@ dependencies = [
  "epigraph-db",
  "epigraph-embeddings",
  "epigraph-engine",
+ "epigraph-interfaces",
  "futures",
  "hex",
  "linfa",

--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -80,6 +80,7 @@ epigraph-core = { workspace = true }
 epigraph-engine = { workspace = true }
 epigraph-crypto = { workspace = true }
 epigraph-embeddings = { workspace = true }
+epigraph-interfaces = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 epigraph-db = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/epigraph-cli/src/bin/bridge_component.rs
+++ b/crates/epigraph-cli/src/bin/bridge_component.rs
@@ -21,7 +21,7 @@ OPTIONS:
   --min-similarity <FLOAT>   Cosine threshold [default: 0.50]
   --top-k <N>                Per-source-atom [default: 50]
   --batch-size <N>           Pairs per LLM call [default: 10]
-  --provider <NAME>          LLM provider [default: claude-cli]
+  --provider <NAME>          LLM provider [default: epigraph (auto-detect)]
   --model <NAME>             Model override
   --dry-run                  Default. Reports candidates + LLM eval; creates no edges.
   --apply                    Commit edges (overrides --dry-run).
@@ -54,7 +54,7 @@ impl Args {
         let mut min_similarity = 0.50;
         let mut top_k = 50_u32;
         let mut batch_size = 10_usize;
-        let mut provider = "claude-cli".to_string();
+        let mut provider = "epigraph".to_string();
         let mut model = None;
         let mut apply = false;
         let mut keep_tables = false;

--- a/crates/epigraph-cli/src/bin/bridge_sweep.rs
+++ b/crates/epigraph-cli/src/bin/bridge_sweep.rs
@@ -29,7 +29,7 @@ OPTIONS:
   --min-similarity <FLOAT>   [default: 0.50]
   --top-k <N>                Per-source-atom [default: 50]
   --batch-size <N>           [default: 10]
-  --provider <NAME>          [default: claude-cli]
+  --provider <NAME>          [default: epigraph (auto-detect)]
   --model <NAME>             Model override
   --dry-run                  Default.
   --apply                    Commit edges (overrides --dry-run).
@@ -69,7 +69,7 @@ impl Args {
         let mut min_similarity = 0.50_f64;
         let mut top_k = 50_u32;
         let mut batch_size = 10_usize;
-        let mut provider = "claude-cli".to_string();
+        let mut provider = "epigraph".to_string();
         let mut model: Option<String> = None;
         let mut apply = false;
         let mut keep_tables = false;

--- a/crates/epigraph-cli/src/bin/embed_bridge.rs
+++ b/crates/epigraph-cli/src/bin/embed_bridge.rs
@@ -10,7 +10,7 @@
 //! - `anthropic` (default) — direct API, requires `ANTHROPIC_API_KEY` or OAuth token
 //! - `mock` — returns empty results (for testing)
 
-use epigraph_cli::enrichment::llm_client::{create_llm_client, LlmClient};
+use epigraph_cli::enrichment::llm_client::{create_llm_client, LlmProvider};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -269,7 +269,7 @@ Return ONLY the JSON array. If no genuine relationships exist, return []."#
 
 /// Call the LLM to classify relationships, using the shared `LlmClient` trait.
 async fn call_llm(
-    client: &dyn LlmClient,
+    client: &dyn LlmProvider,
     prompt: &str,
 ) -> Result<Vec<LlmRelationship>, Box<dyn std::error::Error>> {
     let json_value = client
@@ -339,19 +339,21 @@ async fn main() {
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let dry_run = std::env::args().any(|a| a == "--dry-run");
 
-    // Parse --provider (default: anthropic)
+    // Parse --provider (default: epigraph auto-detect)
     let args: Vec<String> = std::env::args().collect();
     let provider = args
         .windows(2)
         .find(|w| w[0] == "--provider")
         .map(|w| w[1].as_str())
-        .unwrap_or("anthropic");
+        .unwrap_or("epigraph");
 
-    // Create LLM client via shared factory
-    let llm: Box<dyn LlmClient> = match create_llm_client(provider) {
+    // Resolve LLM provider via the kernel registry (interfaces). Built-ins
+    // are installed once from `register_builtin_llm_providers`; private
+    // extensions register themselves earlier in `main`.
+    let llm: std::sync::Arc<dyn LlmProvider> = match create_llm_client(provider) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("ERROR: Failed to create LLM client: {e}");
+            eprintln!("ERROR: Failed to resolve LLM provider: {e}");
             std::process::exit(1);
         }
     };

--- a/crates/epigraph-cli/src/bin/ingest_git.rs
+++ b/crates/epigraph-cli/src/bin/ingest_git.rs
@@ -380,13 +380,13 @@ impl CommitEnricher for NoopEnricher {
 /// between consecutive windows, so that relationships spanning window boundaries
 /// are still detected.
 struct LlmEnricher {
-    client: Box<dyn epigraph_cli::enrichment::llm_client::LlmClient>,
+    client: std::sync::Arc<dyn epigraph_cli::enrichment::llm_client::LlmProvider>,
     window_size: usize,
     overlap: usize,
 }
 
 impl LlmEnricher {
-    fn new(client: Box<dyn epigraph_cli::enrichment::llm_client::LlmClient>) -> Self {
+    fn new(client: std::sync::Arc<dyn epigraph_cli::enrichment::llm_client::LlmProvider>) -> Self {
         let window_size = std::env::var("ENRICHMENT_WINDOW_SIZE")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -405,7 +405,7 @@ impl LlmEnricher {
 
     #[cfg(test)]
     fn with_config(
-        client: Box<dyn epigraph_cli::enrichment::llm_client::LlmClient>,
+        client: std::sync::Arc<dyn epigraph_cli::enrichment::llm_client::LlmProvider>,
         window_size: usize,
         overlap: usize,
     ) -> Self {
@@ -1553,7 +1553,7 @@ async fn main() {
         EnricherMode::Noop => Box::new(NoopEnricher),
         EnricherMode::Llm => {
             let client = epigraph_cli::enrichment::llm_client::create_llm_client(
-                &std::env::var("ENRICHMENT_LLM_PROVIDER").unwrap_or_else(|_| "anthropic".into()),
+                &std::env::var("ENRICHMENT_LLM_PROVIDER").unwrap_or_else(|_| "epigraph".into()),
             )
             .unwrap_or_else(|e| {
                 eprintln!("Failed to create LLM client: {e}");
@@ -3709,7 +3709,7 @@ crates/epigraph-core/src/domain/mod.rs",
         ]);
 
         let client = MockLlmClient::with_responses(vec![mock_response]);
-        let enricher = LlmEnricher::with_config(Box::new(client), 20, 5);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 20, 5);
 
         let commits = vec![
             make_commit("aaa", CommitType::Feat, "core", vec![]),
@@ -3752,7 +3752,7 @@ crates/epigraph-core/src/domain/mod.rs",
         ]);
 
         let client = MockLlmClient::with_responses(vec![window1_response, window2_response]);
-        let enricher = LlmEnricher::with_config(Box::new(client), 3, 1);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 3, 1);
 
         let commits = vec![
             make_commit("a", CommitType::Feat, "core", vec![]),
@@ -3779,7 +3779,7 @@ crates/epigraph-core/src/domain/mod.rs",
         use epigraph_cli::enrichment::llm_client::MockLlmClient;
 
         let client = MockLlmClient::new();
-        let enricher = LlmEnricher::with_config(Box::new(client), 20, 5);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 20, 5);
 
         let result = enricher.enrich(&[]).await.unwrap();
         assert!(result.is_empty());
@@ -3792,7 +3792,7 @@ crates/epigraph-core/src/domain/mod.rs",
         // Simulate malformed response — enricher should not fail, just skip that window
         let client = MockLlmClient::new();
         client.set_malformed(true);
-        let enricher = LlmEnricher::with_config(Box::new(client), 20, 5);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 20, 5);
 
         let commits = vec![
             make_commit("aaa", CommitType::Feat, "core", vec![]),
@@ -3837,7 +3837,7 @@ crates/epigraph-core/src/domain/mod.rs",
         ]);
 
         let client = MockLlmClient::with_responses(vec![mock_response]);
-        let enricher = LlmEnricher::with_config(Box::new(client), 20, 5);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 20, 5);
 
         let commits = vec![
             make_commit("aaa", CommitType::Feat, "core", vec![]),
@@ -3855,7 +3855,7 @@ crates/epigraph-core/src/domain/mod.rs",
         use epigraph_cli::enrichment::llm_client::MockLlmClient;
 
         let client = MockLlmClient::new();
-        let enricher = LlmEnricher::new(Box::new(client));
+        let enricher = LlmEnricher::new(std::sync::Arc::new(client));
         assert_eq!(enricher.name(), "mock");
     }
 
@@ -4261,7 +4261,7 @@ crates/epigraph-core/src/domain/mod.rs",
         ])];
 
         let client = MockLlmClient::with_responses(mock_responses);
-        let enricher = LlmEnricher::with_config(Box::new(client), 20, 5);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 20, 5);
         let enrichments = enricher.enrich(&commits).await.unwrap();
         assert_eq!(enrichments.len(), 10);
 
@@ -4374,7 +4374,7 @@ crates/epigraph-core/src/domain/mod.rs",
         ])];
 
         let client = MockLlmClient::with_responses(mock_responses);
-        let enricher = LlmEnricher::with_config(Box::new(client), 20, 5);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 20, 5);
         let enrichments = enricher.enrich(&commits).await.unwrap();
 
         // Also count deterministic edges from parser (parent chains + fix-challenges-feat)
@@ -4464,7 +4464,7 @@ crates/epigraph-core/src/domain/mod.rs",
             { "source_index": 2, "target_index": 0, "relationship": "challenges", "strength": 0.8, "rationale": "r" },
         ])];
         let client = MockLlmClient::with_responses(mock_responses);
-        let enricher = LlmEnricher::with_config(Box::new(client), 20, 5);
+        let enricher = LlmEnricher::with_config(std::sync::Arc::new(client), 20, 5);
         let llm_enrichments = enricher.enrich(&commits).await.unwrap();
         let llm_edges: usize = llm_enrichments.iter().map(|e| e.semantic_edges.len()).sum();
 

--- a/crates/epigraph-cli/src/bin/method_search.rs
+++ b/crates/epigraph-cli/src/bin/method_search.rs
@@ -99,7 +99,7 @@ async fn run(args: Args) -> Result<bool, Box<dyn std::error::Error>> {
     // 3. Search for each gap
     use epigraph_cli::enrichment::llm_client::create_llm_client;
 
-    let client = create_llm_client("anthropic").map_err(|e| e.to_string())?;
+    let client = create_llm_client("epigraph").map_err(|e| e.to_string())?;
 
     let mut all_filled = true;
 

--- a/crates/epigraph-cli/src/bin/protocol_gen.rs
+++ b/crates/epigraph-cli/src/bin/protocol_gen.rs
@@ -162,11 +162,14 @@ IMPORTANT: Return ONLY the JSON object. No markdown wrapping, no explanation."##
         )?,
     );
 
-    // 5. Call Claude via Anthropic API
+    // 5. Call the LLM via the shared `epigraph` provider auto-detect.
     use epigraph_cli::enrichment::llm_client::create_llm_client;
 
-    let client = create_llm_client("anthropic").map_err(|e| e.to_string())?;
-    tracing::info!("Calling Anthropic API for protocol generation...");
+    let client = create_llm_client("epigraph").map_err(|e| e.to_string())?;
+    tracing::info!(
+        "Calling LLM ({}) for protocol generation...",
+        client.model_name()
+    );
 
     let response = client
         .complete_json(&prompt)

--- a/crates/epigraph-cli/src/bin/rerank_bridges.rs
+++ b/crates/epigraph-cli/src/bin/rerank_bridges.rs
@@ -50,7 +50,7 @@ OPTIONS:
   --candidates-table <NAME>  Read pairs from a caller-supplied table with
                              (source_id, target_id) columns. Mutually exclusive
                              with --source-filter / --target-filter.
-  --provider <NAME>          LLM provider: anthropic or mock [default: anthropic]
+  --provider <NAME>          LLM provider [default: epigraph (auto-detect)]
   --model <NAME>             Model override [default: ENRICHMENT_MODEL or claude-haiku-4-5-20251001]
   -n, --dry-run              Evaluate and report, don't create edges
   -h, --help                 Show this message
@@ -104,7 +104,7 @@ impl Args {
         let mut source_filter = None;
         let mut target_filter = None;
         let mut candidates_table = None;
-        let mut provider = "anthropic".to_string();
+        let mut provider = "epigraph".to_string();
         let mut model = None;
         let mut dry_run = false;
 
@@ -169,7 +169,7 @@ impl Args {
                     i += 1;
                     provider = args
                         .get(i)
-                        .ok_or("--provider requires a name (anthropic or mock)")?
+                        .ok_or("--provider requires a name (epigraph, anthropic, mock, or any registered extension)")?
                         .clone();
                 }
                 "--model" => {
@@ -242,6 +242,7 @@ async fn main() {
     // the library (see rerank::core::rerank_inner).
 
     let auth_label = match args.provider.as_str() {
+        "epigraph" => "auto-detect",
         "anthropic" => {
             if std::env::var("CLAUDE_CODE_OAUTH_TOKEN").is_ok_and(|t| !t.is_empty()) {
                 "OAuth token (Max plan)"
@@ -375,7 +376,7 @@ mod tests {
         let args = parse_args(&[]).unwrap();
         assert!((args.min_similarity - 0.40).abs() < f64::EPSILON);
         assert_eq!(args.batch_size, 10);
-        assert_eq!(args.provider, "anthropic");
+        assert_eq!(args.provider, "epigraph");
         assert!(!args.dry_run);
         assert!(args.limit.is_none());
         assert!(args.source_filter.is_none());

--- a/crates/epigraph-cli/src/enrichment/confidence.rs
+++ b/crates/epigraph-cli/src/enrichment/confidence.rs
@@ -7,7 +7,7 @@
 //!
 //! The final confidence is always ≤ the parser's value — LLM can only lower, never raise.
 
-use super::llm_client::LlmClient;
+use super::llm_client::LlmProvider;
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -97,7 +97,7 @@ Example: {{"rating": "STRONG_SUPPORT"}}"#
 
 /// Run the skeptic probe to assess evidence quality
 pub async fn skeptic_probe(
-    client: &dyn LlmClient,
+    client: &dyn LlmProvider,
     claim: &str,
     evidence: &[String],
 ) -> EvidenceSupport {
@@ -167,7 +167,7 @@ Example: {{"rating": "CONSISTENT"}}"#
 
 /// Run the coherence probe to check cross-claim consistency
 pub async fn coherence_probe(
-    client: &dyn LlmClient,
+    client: &dyn LlmProvider,
     claim: &str,
     scope: &str,
     prior_claims: &[(String, f64)],

--- a/crates/epigraph-cli/src/enrichment/llm_client.rs
+++ b/crates/epigraph-cli/src/enrichment/llm_client.rs
@@ -1,44 +1,31 @@
-//! LLM client abstraction for enrichment
+//! Built-in LLM provider impls (Anthropic + Mock) and registration helper.
 //!
-//! Provides a trait-based abstraction over LLM APIs so the enrichment
-//! pipeline can swap between mock, Anthropic, and other providers.
+//! The canonical [`LlmProvider`] trait, registry, and `default_llm_provider`
+//! helper live in [`epigraph_interfaces::llm`] — see the table at the top of
+//! `epigraph-interfaces`'s `lib.rs` for the kernel/enterprise extension-point
+//! contract this slots into.
+//!
+//! This module supplies the open-kernel built-ins:
+//!
+//! - [`AnthropicClient`] — direct HTTPS to `api.anthropic.com`, prefers
+//!   `CLAUDE_CODE_OAUTH_TOKEN` (Max plan, `Authorization: Bearer`) and falls
+//!   back to `ANTHROPIC_API_KEY` (`x-api-key`).
+//! - [`MockLlmClient`] — pre-configured or empty responses, used by tests.
+//!
+//! Both impl `epigraph_interfaces::LlmProvider`. Call
+//! [`register_builtin_llm_providers`] from each binary's `main` to install
+//! them into the kernel's process-wide registry. Private / enterprise
+//! extensions register themselves the same way and outrank built-ins in
+//! `default_llm_provider`'s walk.
+//!
+//! [`LlmProvider`]: epigraph_interfaces::LlmProvider
 
 use async_trait::async_trait;
-use std::fmt;
-use thiserror::Error;
+use std::sync::Arc;
 
-// =============================================================================
-// ERROR TYPES
-// =============================================================================
-
-#[derive(Error, Debug)]
-pub enum LlmError {
-    #[error("LLM API request failed: {message}")]
-    RequestFailed { message: String },
-
-    #[error("LLM returned malformed JSON: {message}")]
-    MalformedResponse { message: String },
-
-    #[error("LLM rate limited, retry after {retry_after_secs}s")]
-    RateLimited { retry_after_secs: u64 },
-
-    #[error("LLM API key not configured for provider: {provider}")]
-    MissingApiKey { provider: String },
-}
-
-// =============================================================================
-// LLM CLIENT TRAIT
-// =============================================================================
-
-/// Abstraction over LLM providers for structured JSON completion
-#[async_trait]
-pub trait LlmClient: Send + Sync + fmt::Debug {
-    /// Send a prompt and get back a parsed JSON value
-    async fn complete_json(&self, prompt: &str) -> Result<serde_json::Value, LlmError>;
-
-    /// Name of the model being used
-    fn model_name(&self) -> &str;
-}
+// Re-exports so existing call sites keep compiling without an import-path
+// churn pass: the canonical home is `epigraph_interfaces::llm`.
+pub use epigraph_interfaces::{LlmError, LlmProvider};
 
 // =============================================================================
 // MOCK CLIENT (for tests)
@@ -94,7 +81,21 @@ impl MockLlmClient {
 }
 
 #[async_trait]
-impl LlmClient for MockLlmClient {
+impl LlmProvider for MockLlmClient {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn model_name(&self) -> &str {
+        "mock"
+    }
+
+    fn is_active(&self) -> bool {
+        // Mock is always available, but `default_llm_provider` skips `mock`
+        // by name so it never wins auto-detect.
+        true
+    }
+
     async fn complete_json(&self, _prompt: &str) -> Result<serde_json::Value, LlmError> {
         // Check for simulated errors
         if self
@@ -126,10 +127,6 @@ impl LlmClient for MockLlmClient {
         };
 
         Ok(value)
-    }
-
-    fn model_name(&self) -> &str {
-        "mock"
     }
 }
 
@@ -218,7 +215,21 @@ impl AnthropicClient {
 }
 
 #[async_trait]
-impl LlmClient for AnthropicClient {
+impl LlmProvider for AnthropicClient {
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
+    fn is_active(&self) -> bool {
+        // If the client was constructed, credentials passed validation —
+        // it can serve requests (subject to network availability).
+        true
+    }
+
     async fn complete_json(&self, prompt: &str) -> Result<serde_json::Value, LlmError> {
         let body = self.build_request_body(prompt);
 
@@ -283,10 +294,6 @@ impl LlmClient for AnthropicClient {
             message: format!("Failed to parse JSON from LLM response: {e}. Raw text: {json_str}"),
         })
     }
-
-    fn model_name(&self) -> &str {
-        &self.model
-    }
 }
 
 // =============================================================================
@@ -322,34 +329,88 @@ fn extract_json_from_text(text: &str) -> String {
 }
 
 // =============================================================================
-// FACTORY
+// REGISTRATION + FACTORY (thin shims over `epigraph_interfaces::llm`)
 // =============================================================================
 
-/// Create an LLM client based on the provider configuration.
-///
-/// Providers:
-/// - `"anthropic"` — direct HTTP to `api.anthropic.com`. Prefers `CLAUDE_CODE_OAUTH_TOKEN`
-///   (Max plan, `Authorization: Bearer`) and falls back to `ANTHROPIC_API_KEY` (`x-api-key`).
-/// - `"mock"` — returns pre-configured or empty responses (for tests).
-pub fn create_llm_client(provider: &str) -> Result<Box<dyn LlmClient>, LlmError> {
-    match provider {
-        "mock" => Ok(Box::new(MockLlmClient::new())),
-        "anthropic" => {
-            let model = std::env::var("ENRICHMENT_MODEL").ok();
-            // Prefer OAuth token (Max plan — uses subscription, not pay-per-token)
-            if let Ok(oauth_token) = std::env::var("CLAUDE_CODE_OAUTH_TOKEN") {
-                if !oauth_token.is_empty() {
-                    return Ok(Box::new(AnthropicClient::with_oauth(oauth_token, model)?));
-                }
-            }
-            // Fall back to API key
-            let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
-            Ok(Box::new(AnthropicClient::new(api_key, model)?))
+/// Construct an [`AnthropicClient`] from the process environment, returning:
+/// - `None` if neither `CLAUDE_CODE_OAUTH_TOKEN` nor `ANTHROPIC_API_KEY` is
+///   set (call site can decide whether absent credentials are an error);
+/// - `Some(Err(_))` if a credential is set but client construction failed;
+/// - `Some(Ok(client))` with OAuth-preferred-over-API-key on success.
+pub fn build_anthropic_from_env() -> Option<Result<AnthropicClient, LlmError>> {
+    let model = std::env::var("ENRICHMENT_MODEL").ok();
+    if let Ok(oauth) = std::env::var("CLAUDE_CODE_OAUTH_TOKEN") {
+        if !oauth.is_empty() {
+            return Some(AnthropicClient::with_oauth(oauth, model));
         }
-        other => Err(LlmError::RequestFailed {
-            message: format!("Unknown LLM provider: {other}. Use 'anthropic' or 'mock'."),
-        }),
     }
+    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+        if !key.is_empty() {
+            return Some(AnthropicClient::new(key, model));
+        }
+    }
+    None
+}
+
+/// Install the open-kernel built-ins (Anthropic from env when credentials are
+/// present + Mock) into [`epigraph_interfaces::register_llm_provider`].
+/// Idempotent — internal `Once` guard means repeat calls are a no-op.
+///
+/// Each binary that wants the built-ins available calls this from `main`
+/// before invoking `default_llm_provider` or `create_llm_client`. Private
+/// extensions register themselves the same way and outrank the built-ins.
+pub fn register_builtin_llm_providers() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // Mock first so it sits behind Anthropic (which is registered next
+        // and thus prepended to the front). Both are below any private
+        // extension that registers later.
+        epigraph_interfaces::register_llm_provider(Arc::new(MockLlmClient::new()));
+        if let Some(Ok(c)) = build_anthropic_from_env() {
+            epigraph_interfaces::register_llm_provider(Arc::new(c));
+        }
+    });
+}
+
+/// Convenience selector over [`epigraph_interfaces::default_llm_provider`]
+/// and [`epigraph_interfaces::llm_provider_by_name`].
+///
+/// Selectors:
+/// - `"epigraph"` — kernel auto-detect. Returns the first registered
+///   active provider, skipping `mock`. Calls
+///   [`register_builtin_llm_providers`] first so the built-ins are present.
+/// - `"anthropic"` — built-in direct selector.
+/// - `"mock"` — built-in test selector (skipped by auto-detect).
+/// - any registered extension name — selects that provider directly.
+pub fn create_llm_client(provider: &str) -> Result<Arc<dyn LlmProvider>, LlmError> {
+    register_builtin_llm_providers();
+
+    if provider == "epigraph" {
+        let p = epigraph_interfaces::default_llm_provider();
+        if !p.is_active() {
+            let known = epigraph_interfaces::registered_llm_providers();
+            return Err(LlmError::NotAvailable(format!(
+                "No active LLM provider for `epigraph` auto-detect. \
+                 Registered: [{}]. Set CLAUDE_CODE_OAUTH_TOKEN or \
+                 ANTHROPIC_API_KEY, register a private provider via \
+                 `epigraph_interfaces::register_llm_provider`, or pass \
+                 `--provider mock`.",
+                known.join(", ")
+            )));
+        }
+        return Ok(p);
+    }
+
+    epigraph_interfaces::llm_provider_by_name(provider).ok_or_else(|| {
+        let known = epigraph_interfaces::registered_llm_providers();
+        LlmError::RequestFailed {
+            message: format!(
+                "Unknown LLM provider: {provider}. Use 'epigraph' (auto), \
+                 or one of: {}.",
+                known.join(", ")
+            ),
+        }
+    })
 }
 
 // =============================================================================
@@ -543,7 +604,39 @@ mod tests {
 
     #[test]
     fn test_create_llm_client_unknown_provider() {
-        let result = create_llm_client("invalid_provider");
-        assert!(result.is_err());
+        // `Arc<dyn LlmProvider>` doesn't impl `Debug`, so we can't use
+        // `unwrap_err()` (which requires `T: Debug`). Match instead.
+        let err = match create_llm_client("invalid_provider") {
+            Ok(_) => panic!("create_llm_client must reject unknown providers"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("epigraph"),
+            "error must mention 'epigraph': {msg}"
+        );
+    }
+
+    // The trait + registry semantics live in `epigraph_interfaces::llm`
+    // and are tested there. These cli-side tests cover only the
+    // `register_builtin_llm_providers` + `create_llm_client` thin shims.
+
+    #[test]
+    fn test_register_builtin_llm_providers_installs_mock() {
+        // Built-in mock is registered regardless of env credentials so the
+        // `--provider mock` selector always works in tests.
+        register_builtin_llm_providers();
+        let names = epigraph_interfaces::registered_llm_providers();
+        assert!(
+            names.iter().any(|n| n == "mock"),
+            "mock must be registered; full list: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_llm_client_mock_via_shim() {
+        let client = create_llm_client("mock").unwrap();
+        assert_eq!(client.model_name(), "mock");
+        assert_eq!(client.name(), "mock");
     }
 }

--- a/crates/epigraph-cli/src/rerank/core.rs
+++ b/crates/epigraph-cli/src/rerank/core.rs
@@ -11,7 +11,7 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::enrichment::llm_client::{create_llm_client, LlmClient, LlmError};
+use crate::enrichment::llm_client::{create_llm_client, LlmError, LlmProvider};
 use crate::rerank::candidates::{CandidatePair, ValidationResult};
 use crate::rerank::errors::RerankError;
 use crate::rerank::prompt::{build_validation_prompt, parse_validation_response};
@@ -38,7 +38,7 @@ impl Default for RerankConfig {
         Self {
             min_similarity: 0.40,
             batch_size: 10,
-            provider: "anthropic".to_string(),
+            provider: "epigraph".to_string(),
             model: None,
             dry_run: false,
             limit: None,
@@ -473,7 +473,7 @@ pub(crate) async fn create_edge(
 
 /// Call the LLM with one retry on rate limit.
 async fn call_llm_with_retry(
-    llm: &dyn LlmClient,
+    llm: &dyn LlmProvider,
     prompt: &str,
 ) -> Result<serde_json::Value, LlmError> {
     match llm.complete_json(prompt).await {

--- a/crates/epigraph-interfaces/src/lib.rs
+++ b/crates/epigraph-interfaces/src/lib.rs
@@ -1,17 +1,25 @@
 //! Extension point traits for the `EpiGraph` kernel.
 //!
-//! This crate defines the three interface boundaries that separate the open
-//! kernel from enterprise features:
+//! This crate defines the four interface boundaries that separate the open
+//! kernel from enterprise / private features:
 //!
-//! | Trait | Kernel default | Enterprise implementation |
+//! | Trait | Kernel default | Enterprise / private implementation |
 //! |---|---|---|
 //! | [`EncryptionProvider`] | [`NoOpEncryptionProvider`] — pass-through | AES-256-GCM group-keyed subgraphs |
 //! | [`PolicyGate`] | [`NoOpPolicyGate`] — allow all | RBAC/ABAC enforcement |
 //! | [`OrchestrationBackend`] | [`NoOpOrchestrationBackend`] — silent drop | Durable task queue |
+//! | [`LlmProvider`] | [`NoOpLlmProvider`] — error on use | Anthropic API, OpenAI, vLLM, private extensions, … |
 //!
-//! The kernel holds each as `Arc<dyn Trait>` in `AppState`, initialised to
-//! the no-op at startup. Enterprise deployments replace them at startup with
-//! their own implementations before calling `create_router`.
+//! The kernel holds each as `Arc<dyn Trait>`, initialised to the no-op at
+//! startup. Enterprise / private deployments replace them at startup with
+//! their own implementations.
+//!
+//! For [`LlmProvider`] specifically, multiple concrete impls can be
+//! registered simultaneously via [`register_llm_provider`]; the kernel-side
+//! [`default_llm_provider`] helper walks the registry and returns the first
+//! provider whose `is_active()` is `true`. Newer registrations outrank
+//! built-ins, so a private/enterprise extension always wins auto-detect
+//! when present.
 //!
 //! # Design principles
 //!
@@ -24,10 +32,15 @@
 //!   backend.
 
 pub mod encryption;
+pub mod llm;
 pub mod orchestration;
 pub mod policy;
 
 pub use encryption::{EncryptionError, EncryptionProvider, NoOpEncryptionProvider};
+pub use llm::{
+    default_llm_provider, llm_provider_by_name, register_llm_provider, registered_llm_providers,
+    LlmError, LlmProvider, NoOpLlmProvider,
+};
 pub use orchestration::{
     NoOpOrchestrationBackend, OrchestrationBackend, OrchestrationError, TaskStatus,
 };

--- a/crates/epigraph-interfaces/src/llm.rs
+++ b/crates/epigraph-interfaces/src/llm.rs
@@ -1,0 +1,332 @@
+//! `LlmProvider` — pluggable language-model backend for the `EpiGraph` kernel.
+//!
+//! The kernel ships with [`NoOpLlmProvider`], which fails every request with
+//! [`LlmError::NotAvailable`]. Concrete built-ins (Anthropic API, mock) plus
+//! any private/enterprise extensions register themselves at process startup
+//! via [`register_llm_provider`]; the [`default_llm_provider`] helper walks
+//! the registry and returns the first provider whose
+//! [`LlmProvider::is_active`] returns `true`.
+//!
+//! # Extension point contract
+//!
+//! - [`LlmProvider::is_active`] must be cheap (env-var check, file existence,
+//!   etc.) and may return different answers across calls if the environment
+//!   changes. The `default_llm_provider` walk skips inactive providers but
+//!   does not unregister them.
+//! - [`LlmProvider::complete_json`] is the canonical inference call. Errors
+//!   are wrapped in [`LlmError`]; HTTP-like rate limits get
+//!   [`LlmError::RateLimited`] so callers can implement backoff.
+//! - Names are unique. Registering a second provider with the same `name()`
+//!   replaces the existing entry (last write wins).
+//! - Insertion order matters: the most-recently-registered provider is
+//!   preferred by [`default_llm_provider`], so private/enterprise extensions
+//!   always outrank built-ins.
+
+use async_trait::async_trait;
+use std::sync::{Arc, OnceLock, RwLock};
+use thiserror::Error;
+
+/// Errors returned by [`LlmProvider`] implementations.
+#[derive(Error, Debug)]
+pub enum LlmError {
+    /// No active provider is registered (typical when callers forgot to
+    /// install built-ins or extensions, or when env credentials are absent).
+    #[error("no active LLM provider: {0}")]
+    NotAvailable(String),
+
+    /// The provider was reachable but the request failed.
+    #[error("LLM API request failed: {message}")]
+    RequestFailed { message: String },
+
+    /// The provider returned a response that did not parse as expected JSON.
+    #[error("LLM returned malformed JSON: {message}")]
+    MalformedResponse { message: String },
+
+    /// The provider rate-limited the request.
+    #[error("LLM rate limited, retry after {retry_after_secs}s")]
+    RateLimited { retry_after_secs: u64 },
+
+    /// The provider was selected but its credentials are missing.
+    #[error("LLM API key not configured for provider: {provider}")]
+    MissingApiKey { provider: String },
+}
+
+/// Pluggable language-model backend.
+///
+/// Implementors live in built-in crates (Anthropic, Mock) or in private /
+/// enterprise extension crates. Each kernel-side caller resolves an
+/// [`Arc<dyn LlmProvider>`] via [`default_llm_provider`] or
+/// [`llm_provider_by_name`] and uses the same async API regardless of
+/// backend.
+#[async_trait]
+pub trait LlmProvider: Send + Sync + 'static {
+    /// Stable selector name. Must be unique within the registry. The
+    /// `--provider <NAME>` CLI flag matches against this.
+    fn name(&self) -> &str;
+
+    /// Human-readable model identifier (e.g. `"claude-sonnet-4-5-20250929"`).
+    /// Surfaced in logs / status output. May be `"<provider>-not-configured"`
+    /// when [`is_active`](Self::is_active) is `false`.
+    fn model_name(&self) -> &str;
+
+    /// Returns `true` if this provider can serve a request right now.
+    ///
+    /// Implementations check for credentials, external binaries, network
+    /// reachability, etc. The result may change across calls (e.g. an env
+    /// var becomes set), so callers should not cache it.
+    ///
+    /// `default_llm_provider` skips providers whose `is_active` is `false`.
+    fn is_active(&self) -> bool;
+
+    /// Send a prompt; receive a parsed JSON value.
+    ///
+    /// The JSON shape is caller-defined; providers extract it from the
+    /// model's text output (typically by stripping markdown code fences and
+    /// running `serde_json::from_str`).
+    async fn complete_json(&self, prompt: &str) -> Result<serde_json::Value, LlmError>;
+}
+
+// =============================================================================
+// KERNEL-DEFAULT NO-OP PROVIDER
+// =============================================================================
+
+/// Kernel-default no-op LLM provider.
+///
+/// Every call returns [`LlmError::NotAvailable`]. Use it when a caller wants
+/// a non-`Option<Arc<dyn LlmProvider>>` API but no real backend has been
+/// configured — the resulting error message tells the operator what to fix.
+#[derive(Debug, Default, Clone)]
+pub struct NoOpLlmProvider;
+
+impl NoOpLlmProvider {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl LlmProvider for NoOpLlmProvider {
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    fn model_name(&self) -> &str {
+        "noop"
+    }
+
+    fn is_active(&self) -> bool {
+        false
+    }
+
+    async fn complete_json(&self, _prompt: &str) -> Result<serde_json::Value, LlmError> {
+        Err(LlmError::NotAvailable(
+            "no LLM provider registered. Call \
+             `epigraph_cli::enrichment::register_builtin_llm_providers()` \
+             from `main`, or register a private provider via \
+             `epigraph_interfaces::register_llm_provider`."
+                .into(),
+        ))
+    }
+}
+
+// =============================================================================
+// PROCESS-WIDE REGISTRY
+// =============================================================================
+
+type ProviderList = RwLock<Vec<Arc<dyn LlmProvider>>>;
+static REGISTRY: OnceLock<ProviderList> = OnceLock::new();
+
+fn registry() -> &'static ProviderList {
+    REGISTRY.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+/// Register a provider. New registrations are tried FIRST by
+/// [`default_llm_provider`], so private extensions outrank built-ins.
+/// Re-registering a provider with the same `name()` replaces the existing
+/// entry (last write wins).
+pub fn register_llm_provider(provider: Arc<dyn LlmProvider>) {
+    let r = registry();
+    let mut w = r.write().expect("LLM provider registry poisoned");
+    let name = provider.name().to_string();
+    w.retain(|p| p.name() != name);
+    w.insert(0, provider);
+}
+
+/// Names of currently registered providers, in priority (newest-first) order.
+pub fn registered_llm_providers() -> Vec<String> {
+    let r = registry();
+    let g = r.read().expect("LLM provider registry poisoned");
+    g.iter().map(|p| p.name().to_string()).collect()
+}
+
+/// Look up a registered provider by exact name.
+pub fn llm_provider_by_name(name: &str) -> Option<Arc<dyn LlmProvider>> {
+    let r = registry();
+    let g = r.read().expect("LLM provider registry poisoned");
+    g.iter().find(|p| p.name() == name).map(Arc::clone)
+}
+
+/// Return the first registered provider whose [`LlmProvider::is_active`] is
+/// `true`. Falls back to a fresh [`NoOpLlmProvider`] when no provider is
+/// active — call sites using the returned `Arc` will surface a clear
+/// `NotAvailable` error on first request, rather than panicking at lookup.
+///
+/// The `mock` built-in (registered by callers that opt into testing) is
+/// intentionally skipped by auto-detect; use [`llm_provider_by_name`] for
+/// explicit selection of `mock`.
+pub fn default_llm_provider() -> Arc<dyn LlmProvider> {
+    let r = registry();
+    let g = r.read().expect("LLM provider registry poisoned");
+    for p in g.iter() {
+        if p.name() == "mock" {
+            continue;
+        }
+        if p.is_active() {
+            return Arc::clone(p);
+        }
+    }
+    Arc::new(NoOpLlmProvider::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test provider that reports a configurable `is_active` and returns a
+    /// fixed JSON value from `complete_json`. Used to exercise registry
+    /// semantics without env-var coupling.
+    #[derive(Debug)]
+    struct TestProvider {
+        name: &'static str,
+        active: bool,
+    }
+
+    #[async_trait]
+    impl LlmProvider for TestProvider {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn model_name(&self) -> &str {
+            "test"
+        }
+        fn is_active(&self) -> bool {
+            self.active
+        }
+        async fn complete_json(&self, _prompt: &str) -> Result<serde_json::Value, LlmError> {
+            Ok(serde_json::json!({ "from": self.name }))
+        }
+    }
+
+    #[test]
+    fn noop_provider_is_inactive_and_errors_clearly() {
+        let p = NoOpLlmProvider::new();
+        assert_eq!(p.name(), "noop");
+        assert!(!p.is_active());
+    }
+
+    #[tokio::test]
+    async fn noop_complete_json_errors_with_not_available() {
+        let p = NoOpLlmProvider::new();
+        let err = p.complete_json("prompt").await.unwrap_err();
+        assert!(matches!(err, LlmError::NotAvailable(_)));
+    }
+
+    #[test]
+    fn register_provider_appears_in_registry() {
+        register_llm_provider(Arc::new(TestProvider {
+            name: "iface_test_appears",
+            active: true,
+        }));
+        assert!(registered_llm_providers()
+            .iter()
+            .any(|n| n == "iface_test_appears"));
+    }
+
+    #[test]
+    fn register_provider_dedups_by_name() {
+        register_llm_provider(Arc::new(TestProvider {
+            name: "iface_test_dedup",
+            active: false,
+        }));
+        register_llm_provider(Arc::new(TestProvider {
+            name: "iface_test_dedup",
+            active: false,
+        }));
+        let count = registered_llm_providers()
+            .into_iter()
+            .filter(|n| n == "iface_test_dedup")
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn register_provider_outranks_earlier_registrations() {
+        register_llm_provider(Arc::new(TestProvider {
+            name: "iface_test_first",
+            active: false,
+        }));
+        register_llm_provider(Arc::new(TestProvider {
+            name: "iface_test_second",
+            active: false,
+        }));
+        let names = registered_llm_providers();
+        let first = names.iter().position(|n| n == "iface_test_first");
+        let second = names.iter().position(|n| n == "iface_test_second");
+        if let (Some(f), Some(s)) = (first, second) {
+            assert!(
+                s < f,
+                "later registration must come first; full list: {names:?}"
+            );
+        } else {
+            panic!("both names must be present; full list: {names:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn default_llm_provider_returns_first_active() {
+        register_llm_provider(Arc::new(TestProvider {
+            name: "iface_test_default_active",
+            active: true,
+        }));
+        let p = default_llm_provider();
+        // We can't assert `p.name() == "iface_test_default_active"` because
+        // other tests register their own active providers in parallel. Verify
+        // the contract behaviorally instead: the returned provider must be
+        // active.
+        assert!(
+            p.is_active(),
+            "default_llm_provider must return an active provider when one is registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_llm_provider_skips_mock() {
+        // mock should NEVER be auto-selected (it's opt-in via name lookup).
+        register_llm_provider(Arc::new(TestProvider {
+            name: "mock",
+            active: true,
+        }));
+        let p = default_llm_provider();
+        assert_ne!(
+            p.name(),
+            "mock",
+            "default_llm_provider must skip the `mock` provider"
+        );
+    }
+
+    #[test]
+    fn llm_provider_by_name_finds_registered() {
+        register_llm_provider(Arc::new(TestProvider {
+            name: "iface_test_by_name",
+            active: true,
+        }));
+        let p = llm_provider_by_name("iface_test_by_name").expect("present");
+        assert_eq!(p.name(), "iface_test_by_name");
+    }
+
+    #[test]
+    fn llm_provider_by_name_misses_return_none() {
+        assert!(llm_provider_by_name("iface_test_nonexistent_provider").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

`LlmProvider` is the **fourth** kernel extension point, alongside `EncryptionProvider` / `PolicyGate` / `OrchestrationBackend`. The trait, registry, NoOp default, and `default_llm_provider` walker live in `epigraph-interfaces` (per the existing kernel/enterprise convention). `epigraph-cli` is a consumer: it provides built-in concrete impls (`AnthropicClient`, `MockLlmClient`) plus a `register_builtin_llm_providers()` startup helper. Private/enterprise deployments register their own backend at startup and outrank the built-ins in auto-detect.

Every public caller now defaults to the `"epigraph"` selector — kernel auto-detect — which fixes a regression in PR #90 where `bridge_component` and `bridge_sweep` defaulted to a provider name the public factory did not accept and errored on every default-config run.

## Architecture

`epigraph-interfaces/src/llm.rs`:

```rust
#[async_trait]
pub trait LlmProvider: Send + Sync + 'static {
    fn name(&self) -> &str;
    fn model_name(&self) -> &str;
    fn is_active(&self) -> bool;
    async fn complete_json(&self, prompt: &str) -> Result<serde_json::Value, LlmError>;
}

pub struct NoOpLlmProvider;  // kernel default; errors with NotAvailable

pub fn register_llm_provider(provider: Arc<dyn LlmProvider>);
pub fn registered_llm_providers() -> Vec<String>;
pub fn llm_provider_by_name(name: &str) -> Option<Arc<dyn LlmProvider>>;
pub fn default_llm_provider() -> Arc<dyn LlmProvider>;  // walks registry, skips mock
```

`epigraph-cli/src/enrichment/llm_client.rs`:

```rust
pub use epigraph_interfaces::{LlmError, LlmProvider};
pub fn build_anthropic_from_env() -> Option<Result<AnthropicClient, LlmError>>;
pub fn register_builtin_llm_providers();  // installs Mock + (env-aware) Anthropic
pub fn create_llm_client(name: &str) -> Result<Arc<dyn LlmProvider>, LlmError>;
```

Private/enterprise extensions plug in by depending on `epigraph-interfaces` and calling `register_llm_provider` from `main`. Newer registrations outrank built-ins, so the extension wins auto-detect.

The four interfaces in `epigraph-interfaces/src/lib.rs`:

| Trait | Kernel default | Enterprise / private |
|---|---|---|
| `EncryptionProvider` | `NoOpEncryptionProvider` | AES-256-GCM |
| `PolicyGate` | `NoOpPolicyGate` | RBAC/ABAC |
| `OrchestrationBackend` | `NoOpOrchestrationBackend` | Durable task queue |
| **`LlmProvider`** | **`NoOpLlmProvider`** | **Anthropic / OpenAI / vLLM / private extensions** |

## Caller defaults

Every public caller now defaults to `"epigraph"`:

- `rerank::core::RerankConfig::Default`
- `bin/rerank_bridges.rs` (CLI default + help text + tests + auth-label match)
- `bin/bridge_component.rs` (was the broken default that errored at startup)
- `bin/bridge_sweep.rs` (same fix)
- `bin/embed_bridge.rs` (`unwrap_or("anthropic")` → `"epigraph"`)
- `bin/protocol_gen.rs` (hardcoded `"anthropic"` → `"epigraph"`)
- `bin/method_search.rs` (hardcoded `"anthropic"` → `"epigraph"`)
- `bin/ingest_git.rs` (`ENRICHMENT_LLM_PROVIDER` fallback → `"epigraph"`)

## Test plan

- [x] `cargo fmt --check`: clean.
- [x] `cargo clippy --workspace -- -D warnings`: clean.
- [x] `cargo test -p epigraph-interfaces`: 18 pass (9 new llm tests + 9 pre-existing for the other 3 interfaces).
- [x] `cargo test -p epigraph-cli --features genai --lib`: 63 pass.
- [x] `cargo test -p epigraph-cli --features genai --bins`: 10 pass.
- [x] CI green on the full suite.