### PR TITLE
improve_workflow emits 'supersedes' (was 'variant_of')

### DIFF
--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -909,10 +909,13 @@ pub async fn improve_workflow(
         message: format!("Failed to create variant: {e}"),
     })?;
 
-    // Create variant_of edge
+    // Create supersedes edge: the new improved variant supersedes the parent.
+    // (Was 'variant_of' historically; switched to 'supersedes' so the relationship
+    // is in the edges API allowlist and matches the flat-to-hierarchical
+    // migration's back-edge convention.)
     let _ = sqlx::query(
         "INSERT INTO edges (source_id, target_id, source_type, target_type, relationship, properties) \
-         VALUES ($1, $2, 'claim', 'claim', 'variant_of', $3)",
+         VALUES ($1, $2, 'claim', 'claim', 'supersedes', $3)",
     )
     .bind(variant_id)
     .bind(parent_id)


### PR DESCRIPTION
## Summary

- The `improve_workflow` handler at `crates/epigraph-api/src/routes/workflows.rs:912` previously emitted edges with `relationship='variant_of'` via direct SQL because `variant_of` is not in the edges API allowlist (`routes/edges.rs:47-115`).
- The 20 production claim/claim `variant_of` edges have already been data-migrated to `supersedes` with a `migrated_from='variant_of'` marker on properties.
- This PR updates the handler to emit `supersedes` going forward, matching the convention used by the flat-to-hierarchical migration script (PRs #96, #98).

## Out of scope

- The hierarchical `workflow→workflow` `variant_of` edges emitted by `epigraph-ingest-executor` (PR #85, closes #51) are NOT changed. Different entity types, different semantics (hierarchical lineage), and they go through `EdgeRepository` rather than direct SQL.

## Test plan

- [x] `cargo build -p epigraph-api --features db` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI green.

Refs #36.