### PR TITLE
fix: PR #100 follow-ups Bundle A — security & correctness

### DIFF
--- a/crates/epigraph-api/src/openapi.rs
+++ b/crates/epigraph-api/src/openapi.rs
@@ -305,6 +305,7 @@ async fn supersede_claim_doc() {}
         (status = 200, body = DedupResponse),
         (status = 400),
         (status = 401),
+        (status = 403),
         (status = 404),
         (status = 409),
     ),

--- a/crates/epigraph-api/src/openapi.rs
+++ b/crates/epigraph-api/src/openapi.rs
@@ -286,6 +286,8 @@ async fn list_challenges() {}
     responses(
         (status = 201, body = SupersessionResponse),
         (status = 400),
+        (status = 401),
+        (status = 403),
         (status = 404),
     ),
     security(("ed25519_signature" = []))

--- a/crates/epigraph-api/src/routes/versioning.rs
+++ b/crates/epigraph-api/src/routes/versioning.rs
@@ -150,6 +150,8 @@ pub struct VersionHistoryResponse {
     responses(
         (status = 201, body = SupersessionResponse),
         (status = 400),
+        (status = 401),
+        (status = 403),
         (status = 404),
     ),
     security(("ed25519_signature" = [])),
@@ -157,9 +159,17 @@ pub struct VersionHistoryResponse {
 )]
 pub async fn supersede_claim(
     State(state): State<AppState>,
+    auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>,
     Path(claim_id): Path<Uuid>,
     Json(request): Json<SupersedeRequest>,
 ) -> Result<(StatusCode, Json<SupersessionResponse>), ApiError> {
+    let auth = auth_ctx
+        .ok_or(ApiError::Unauthorized {
+            reason: "supersede requires authentication".into(),
+        })?
+        .0;
+    crate::middleware::scopes::check_scopes(&auth, &["claims:write"])?;
+
     // 1. Validate content is not empty
     if request.content.trim().is_empty() {
         return Err(ApiError::ValidationError {

--- a/crates/epigraph-api/src/routes/versioning.rs
+++ b/crates/epigraph-api/src/routes/versioning.rs
@@ -382,6 +382,7 @@ pub async fn supersede_claim(
         (status = 200, body = DedupResponse),
         (status = 400),
         (status = 401),
+        (status = 403),
         (status = 404),
         (status = 409),
     ),
@@ -399,7 +400,16 @@ pub async fn mark_duplicate(
             reason: "dedup requires authentication".into(),
         })?
         .0;
-    crate::middleware::scopes::check_scopes(&auth, &["claims:write"])?;
+    crate::middleware::scopes::check_scopes(&auth, &["claims:admin"])?;
+
+    let principal = auth.owner_id.unwrap_or(auth.client_id);
+    tracing::info!(
+        principal = %principal,
+        dup_id = %dup_id,
+        canonical_id = %req.canonical_id,
+        reason = req.reason.as_deref().unwrap_or(""),
+        "mark_duplicate"
+    );
 
     if dup_id == req.canonical_id {
         return Err(ApiError::BadRequest {
@@ -427,7 +437,6 @@ pub async fn mark_duplicate(
     })?;
 
     // Provenance: best-effort (.ok() swallow). content_hash is zero-bytes for mark_duplicate.
-    let principal = auth.owner_id.unwrap_or(auth.client_id);
     if let Ok(mut tx) = state.db_pool.begin().await {
         let _ = epigraph_db::ProvenanceRepository::append_conn(
             &mut tx,

--- a/crates/epigraph-api/tests/dedup_admin_scope_test.rs
+++ b/crates/epigraph-api/tests/dedup_admin_scope_test.rs
@@ -1,0 +1,54 @@
+#![cfg(feature = "db")]
+mod common;
+
+/// claims:write-only token must NOT pass the claims:admin gate on dedup.
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_with_claims_write_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:write"]);
+    let dup = uuid::Uuid::new_v4();
+    let canonical = uuid::Uuid::new_v4();
+    let body = serde_json::json!({ "canonical_id": canonical, "reason": "test" });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{dup}/dedup"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 (claims:write should not satisfy claims:admin); got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// No token at all must return 401.
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_without_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let dup = uuid::Uuid::new_v4();
+    let canonical = uuid::Uuid::new_v4();
+    let body = serde_json::json!({ "canonical_id": canonical, "reason": "test" });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{dup}/dedup"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401 Unauthorized; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}

--- a/crates/epigraph-api/tests/dedup_endpoint_test.rs
+++ b/crates/epigraph-api/tests/dedup_endpoint_test.rs
@@ -17,7 +17,7 @@ async fn dedup_marks_duplicate_without_creating_new_claim() {
 
     let (addr, _shutdown) = common::spawn_app(&url).await;
     let (token, _client_id) =
-        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:admin"]).await;
     let body = serde_json::json!({
         "canonical_id": canonical,
         "reason": "auto-detected duplicate by content_hash",

--- a/crates/epigraph-api/tests/supersede_scope_check_test.rs
+++ b/crates/epigraph-api/tests/supersede_scope_check_test.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "db")]
+mod common;
+
+/// POST /api/v1/claims/:id/supersede with no Authorization header must return 401.
+/// Auth check fires before any DB lookup, so a non-existent UUID is sufficient.
+#[tokio::test(flavor = "multi_thread")]
+async fn supersede_without_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let body = serde_json::json!({
+        "content": "new content",
+        "truth_value": 0.8,
+        "reason": "test reason",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{fake_id}/supersede"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401 Unauthorized, got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// POST /api/v1/claims/:id/supersede with a claims:read-only token must return 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn supersede_with_read_only_token_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:read"]);
+    let fake_id = uuid::Uuid::new_v4();
+    let body = serde_json::json!({
+        "content": "new content",
+        "truth_value": 0.8,
+        "reason": "test reason",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{fake_id}/supersede"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 Forbidden, got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -1847,15 +1847,22 @@ impl ClaimRepository {
         let parent_uuid: Uuid = parent.into();
         let mut tx = pool.begin().await?;
 
-        let row: Option<(Option<Uuid>,)> =
-            sqlx::query_as("SELECT step_lineage_id FROM claims WHERE id = $1 FOR UPDATE")
+        let row: Option<(Option<Uuid>, bool)> =
+            sqlx::query_as("SELECT step_lineage_id, COALESCE(is_current, true) FROM claims WHERE id = $1 FOR UPDATE")
                 .bind(parent_uuid)
                 .fetch_optional(&mut *tx)
                 .await?;
-        let (existing_lineage,) = row.ok_or(DbError::NotFound {
+        let (existing_lineage, parent_current) = row.ok_or(DbError::NotFound {
             entity: "Claim".into(),
             id: parent_uuid,
         })?;
+        if edge_type == "supersedes" && !parent_current {
+            return Err(DbError::QueryFailed {
+                source: sqlx::Error::Protocol(format!(
+                    "evolve_step: cannot supersede a non-current step {parent_uuid}"
+                )),
+            });
+        }
         let lineage_id = match existing_lineage {
             Some(l) => l,
             None => {

--- a/crates/epigraph-db/tests/evolve_step_repo.rs
+++ b/crates/epigraph-db/tests/evolve_step_repo.rs
@@ -107,3 +107,44 @@ async fn evolve_step_rejects_bad_edge_type(pool: PgPool) {
     .unwrap();
     assert!(format!("{err:?}").contains("supersedes"), "{err:?}");
 }
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn evolve_step_supersedes_rejects_non_current_parent(pool: PgPool) {
+    // Build agent + v1 step using existing seed helpers.
+    let agent_id = seed_agent(&pool).await;
+    let v1 = seed_claim(&pool, agent_id, "v1 content", 0.7).await;
+
+    // First supersedes succeeds, flips v1.is_current = false.
+    ClaimRepository::evolve_step(
+        &pool,
+        ClaimId::from_uuid(v1),
+        "v2 content",
+        "supersedes",
+        Some("first"),
+        2,
+        agent_id,
+    )
+    .await
+    .expect("first supersedes");
+
+    // Second supersedes against the same now-non-current v1 must error.
+    // Note: 'revises' against a non-current parent is allowed by design — only
+    // 'supersedes' is forbidden to prevent forking the lineage chain.
+    let err = ClaimRepository::evolve_step(
+        &pool,
+        ClaimId::from_uuid(v1),
+        "v2 fork",
+        "supersedes",
+        Some("attempted fork"),
+        2,
+        agent_id,
+    )
+    .await
+    .expect_err("second supersedes against non-current parent must error");
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("non-current step") || msg.contains("cannot supersede"),
+        "expected non-current-step error message, got: {msg}"
+    );
+}

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -626,13 +626,23 @@ pub async fn improve_workflow(
         .map_err(internal_error)?;
 
         // Tag the variant as a workflow so cascade walkers can find it.
-        let _ = epigraph_db::ClaimRepository::update_labels(
+        match epigraph_db::ClaimRepository::update_labels(
             &server.pool,
             claim_uuid,
             &["workflow".to_string()],
             &[],
         )
-        .await;
+        .await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    variant_id = %claim_uuid,
+                    error = %e,
+                    "failed to apply 'workflow' label to improve_workflow variant; cascade may miss this variant"
+                );
+            }
+        }
 
         let embed_text = workflow_embed_text(&goal, &steps, &prereqs);
         server
@@ -681,6 +691,8 @@ pub async fn deprecate_workflow(
         // claim-version supersedes chains.
         const DESCENDANT_REL: &[&str] = &["variant_of", "supersedes"];
 
+        let mut visited: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
+        visited.insert(workflow_id);
         let mut queue = vec![workflow_id];
         while let Some(current) = queue.pop() {
             let edges = EdgeRepository::get_by_target(&server.pool, current, "claim")
@@ -701,6 +713,10 @@ pub async fn deprecate_workflow(
                         .map_err(internal_error)?
                         .unwrap_or(false);
                 if !is_workflow {
+                    continue;
+                }
+
+                if !visited.insert(child_id) {
                     continue;
                 }
 

--- a/crates/epigraph-mcp/tests/deprecate_cascade_visited_test.rs
+++ b/crates/epigraph-mcp/tests/deprecate_cascade_visited_test.rs
@@ -1,0 +1,83 @@
+use sqlx::PgPool;
+mod common;
+use common::*;
+
+/// Verify that the BFS cascade in `deprecate_workflow` handles a diamond DAG
+/// correctly: no node is processed twice and all 4 claims are deprecated.
+///
+/// Diamond shape:
+///   A → root (variant_of)
+///   B → root (variant_of)
+///   C → A    (variant_of)
+///   C → B    (variant_of)
+///
+/// Without a visited-set, C would be enqueued twice (once from A, once from B)
+/// and appear twice in `deprecated_ids`.
+#[sqlx::test(migrations = "../../migrations")]
+async fn deprecate_workflow_diamond_dag_no_duplicates(pool: PgPool) {
+    let root = seed_workflow_claim(&pool, "root workflow", &["step1"]).await;
+    let a = seed_workflow_claim(&pool, "variant A", &["step1"]).await;
+    let b = seed_workflow_claim(&pool, "variant B", &["step1"]).await;
+    let c = seed_workflow_claim(&pool, "variant C", &["step1"]).await;
+
+    // Diamond edges: source → target (variant_of means source is a variant of target)
+    insert_claim_edge(&pool, a, root, "variant_of").await;
+    insert_claim_edge(&pool, b, root, "variant_of").await;
+    insert_claim_edge(&pool, c, a, "variant_of").await;
+    insert_claim_edge(&pool, c, b, "variant_of").await;
+
+    let server = build_test_server(pool.clone());
+    let result = epigraph_mcp::tools::workflows::deprecate_workflow(
+        &server,
+        epigraph_mcp::types::DeprecateWorkflowParams {
+            workflow_id: root.to_string(),
+            reason: "diamond test".into(),
+            cascade: Some(true),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Parse the response JSON
+    let body = first_text(&result);
+    let deprecated_raw: Vec<String> = body["deprecated_ids"]
+        .as_array()
+        .expect("deprecated_ids must be an array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+
+    // All 4 IDs must appear exactly once — use a HashSet to check for uniqueness
+    let deprecated_set: std::collections::HashSet<String> =
+        deprecated_raw.iter().cloned().collect();
+
+    assert_eq!(
+        deprecated_raw.len(),
+        deprecated_set.len(),
+        "deprecated_ids contains duplicates: {:?}",
+        deprecated_raw
+    );
+
+    let expected_ids: std::collections::HashSet<String> =
+        [root, a, b, c].iter().map(|id| id.to_string()).collect();
+
+    assert_eq!(
+        deprecated_set, expected_ids,
+        "deprecated_ids does not match expected set"
+    );
+
+    // Verify DB state: all 4 claims have is_current=false and truth_value≈0.05
+    for id in [root, a, b, c] {
+        let (truth, is_current): (f64, bool) =
+            sqlx::query_as("SELECT truth_value, is_current FROM claims WHERE id = $1")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            (truth - 0.05).abs() < 1e-9,
+            "claim {id} truth_value should be 0.05, got {truth}"
+        );
+        assert!(!is_current, "claim {id} is_current should be false");
+    }
+}

--- a/docs/superpowers/plans/2026-05-08-pr100-followups.md
+++ b/docs/superpowers/plans/2026-05-08-pr100-followups.md
@@ -1,0 +1,146 @@
+# PR #100 Follow-ups: Issue Triage & Bundle Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve the 9 GitHub issues filed against the now-merged PR #100 (workflow/claim MCP↔API parity), in coherent bundles ordered by severity.
+
+**Architecture alignment:** Findings are consistent with `docs/architecture/noun-claims-and-verb-edges.md`:
+- `mark_duplicate` is a verb-event mutating a noun-claim; the doc explicitly warns that "mutating an existing canonical noun-claim from a different caller's request is surprising; it bypasses ownership/authorisation checks." → admin-scope gate is the right architectural move (#104).
+- Cascade walker traverses edges (verbs); BFS over a DAG must dedup (#102).
+- `evolve_step` correctness invariants live alongside `supersede` in `ClaimRepository` and should match (#103).
+
+**Design decision (2026-05-08):** Dedup is an **admin-only** operation. Introduce a `claims:admin` scope and an `epigraph-admin` OAuth client provisioned with it. Admin-scope is the right axis (not ownership-by-authorship): dedup decisions are operator-driven judgments about graph integrity, not author-driven edits to one's own claims. Many duplicate pairs span agents anyway, which would defeat ownership checks.
+
+**Tech stack:** Rust workspace (sqlx + Postgres, axum, rmcp). Tests: `#[sqlx::test(migrations = "../../migrations")]` against `epigraph_db_repo_test`.
+
+---
+
+## Triage table
+
+| # | Title | Class | Severity | Effort | Bundle |
+|---|---|---|---|---|---|
+| 101 | supersede_claim has no scope check | Security | **CRITICAL** | XS | A |
+| 104 | mark_duplicate lets any claims:write hide any claim | Security | **HIGH** | S | A |
+| 103 | evolve_step doesn't guard non-current parent | Correctness | HIGH | XS | A |
+| 102 | MCP cascade walker has no visited-set | Correctness | MEDIUM | XS | A |
+| 105 | improve_workflow label apply silently fails | Operational | MEDIUM | XS | A |
+| 107 | missing 401/403/404/409 negative tests | Tests | HIGH | M | B |
+| 108 | openapi_paths_test only checks path keys | Tests | LOW | S | B |
+| 106 | OpenAPI uses serde_json::Value for 4 endpoints | API/UX | MEDIUM | M | C |
+| 109 | find_workflow_hierarchical resolve_to_latest is N+1 | Performance | LOW | M-L | D |
+
+XS = ≤30 min, S = ≤2 hr, M = ≤1 day, L = multi-day.
+
+---
+
+## Bundle A — Security & Correctness (urgent, single PR)
+
+Fix the 5 small high-severity issues together. They're independent edits in 4 files, total under 200 LoC + tests. One PR is the right granularity — splitting them adds review overhead with no isolation benefit.
+
+**Order within the PR:**
+1. **#101** — `crates/epigraph-api/src/routes/versioning.rs::supersede_claim` — add `auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>` parameter; mirror the exact pattern from `mark_duplicate` (see lines 381–392 of same file). Add scope-check `claims:write`. Update three router registrations (lines 618, 1266, 1318).
+2. **#104** — `crates/epigraph-api/src/routes/versioning.rs::mark_duplicate` — change scope check from `["claims:write"]` to `["claims:admin"]`. Tighten the OpenAPI doc-stub similarly (no functional effect, just spec accuracy). Add structured INFO log on every dedup with `principal`, `dup_id`, `canonical_id`, `reason` — admin operations should always be observable. Tests must be updated: the existing `dedup_endpoint_test.rs` mints a `claims:write` token; switch it to `claims:admin` (use `test_bearer_token_with_scopes` from `crates/epigraph-api/tests/common/mod.rs`).
+3. **#103** — `crates/epigraph-db/src/repos/claim.rs::evolve_step` (lines 1850–1858) — change `SELECT step_lineage_id` to `SELECT step_lineage_id, COALESCE(is_current, true) FROM claims WHERE id = $1 FOR UPDATE`. After the row.ok_or check, if `edge_type == "supersedes" && !parent_current`, return `DbError::QueryFailed` with the message from issue #103.
+4. **#102** — `crates/epigraph-mcp/src/tools/workflows.rs::deprecate_workflow` (lines 678–717) — add `let mut visited: HashSet<Uuid> = HashSet::new(); visited.insert(workflow_id);` before the loop; replace `queue.push(child_id)` with `if visited.insert(child_id) { queue.push(child_id); }`.
+5. **#105** — `crates/epigraph-mcp/src/tools/workflows.rs` (lines 629–635) — replace `let _ = ...` with `match` block emitting `tracing::warn!(variant_id, error, "...")` on Err. Per the issue, do **not** make this fatal — the warning is the right balance for v1 (failing the whole `improve_workflow` over a label apply is a worse UX). File a follow-up if observed warnings become an operational pain point.
+
+**Tests added** (alongside fixes, TDD-style):
+- `supersede_scope_check_test.rs` — minted `claims:read`-only token gets 403 against `/api/v1/claims/{id}/supersede`.
+- `dedup_admin_scope_test.rs` — `claims:write`-only token gets 403; `claims:admin` token succeeds; unauthenticated gets 401. Update existing `dedup_endpoint_test.rs` to mint a `claims:admin` token (or merge into the new file).
+- `evolve_step_repo.rs` — extend with a test that calls `evolve_step` twice with `"supersedes"` and asserts the second call errors.
+- `mcp_cascade_visited_test.rs` (in `crates/epigraph-mcp/tests/`) — diamond DAG (root → A, root → B, A → C, B → C); `deprecate_workflow(root, cascade=true)` deprecates each node exactly once and terminates.
+- `improve_workflow_label_failure_log_test.rs` — observable behavior is hard to test; settle for a comment explaining why and skip. (Don't fight tooling for a 5-line fix.)
+
+**Estimated effort:** half a day with subagent-driven dev.
+
+**Risk:** Low. Each change is local, well-bounded, and mirrors an existing pattern.
+
+**Out of scope (filed as follow-ups, not blockers):**
+- **Provisioning the `epigraph-admin` OAuth client.** This bundle introduces the `claims:admin` scope and the handler-side gate; minting the actual admin client is an operational task. Add a runbook entry and a `scripts/provision_admin_client.sh` (or document the `agents.rs::register_oauth_client` payload to use). Track as a separate ops issue if not done in parallel.
+- **Auditing other write endpoints for admin-only candidates.** `supersede_claim`, `patch_claim`, label edits, and workflow `deprecate` all rewrite/hide content. Worth a sweep — but it's a scope-policy review, not part of this fix bundle. File as follow-up.
+- Migrating to a single transaction in `deprecate_workflow` cascade (current code does N UPDATEs, no atomicity guarantee). File as separate issue if observed.
+
+---
+
+## Bundle B — Test Hardening (one PR, after A)
+
+#107 and #108 both extend test coverage on the surface PR #100 introduced. Bundle them.
+
+**#107 — Negative tests for HTTP endpoints:**
+- `evolve_step`: 401 (no token), 403 (`graph:read` token), 400 (path/body parent_id mismatch is already tested; verify), 404 (parent doesn't exist).
+- `mark_duplicate`: 401, 400 (self-dedup is already tested in `dedup_endpoint_test.rs`; verify), 404 (dup or canonical not found), 409 (target already superseded).
+- `patch_claim`: full HTTP integration test missing post-PR-#100 refactor. Add 200 (happy), 401, 403 (`graph:read` only), 404, 400 (validation).
+- `supersede_claim`: post-#101 fix, add 403 test for `graph:read`-only token.
+
+Use existing `test_bearer_token_with_scopes` helper to mint scope-restricted tokens.
+
+**#108 — Strengthen `openapi_paths_test.rs`:**
+- For each write endpoint, assert `paths[<path>][<method>]` is a JSON object (proves method registration).
+- Assert `security` array contains `ed25519_signature`.
+- Assert request body schema `$ref` resolves to the typed schema name (e.g., `EvolveStepRequest`), not `serde_json::Value`. (After Bundle C lands, this assertion gets stronger automatically.)
+
+**Estimated effort:** 1 day. Bulk of work is mechanical test scaffolding.
+
+---
+
+## Bundle C — OpenAPI Typed Schemas (one PR)
+
+**#106** — promote untyped bodies to typed schemas:
+
+1. Add `#[derive(serde::Serialize, utoipa::ToSchema)]` (and `Deserialize` if missing) to:
+   - `routes::workflows::ImproveWorkflowRequest` (line 81)
+   - `routes::workflows::ReportOutcomeRequest` (line 61)
+   - `routes::workflows::StepExecution` (line 71) — referenced by `ReportOutcomeRequest`
+   - `epigraph_ingest::workflow::WorkflowExtraction` — needs cross-crate annotation; verify `epigraph-ingest`'s `Cargo.toml` exposes utoipa as optional or unconditional.
+2. Introduce `routes::workflows::HierarchicalSearchResponse` struct mirroring the JSON the handler currently builds. Refactor `find_workflow_hierarchical` to return `Json<HierarchicalSearchResponse>`. Don't break wire format; this is a pure type-tightening exercise.
+3. Update `crates/epigraph-api/src/openapi.rs`:
+   - Replace `serde_json::Value` references in 4 doc-stubs (lines 374, 387, 403, 437) with the real types.
+   - Register the new schemas in `components(schemas(...))`.
+
+**Risk:** Cross-crate `ToSchema` derive on `WorkflowExtraction` is the only sharp edge. If `epigraph-ingest` doesn't already depend on `utoipa`, add it under an `openapi` feature flag rather than unconditionally. Build with `cargo build --workspace` to verify.
+
+**Test:** the strengthened `openapi_paths_test` from Bundle B will detect any unregistered schemas after this lands.
+
+**Estimated effort:** half-to-full day depending on `WorkflowExtraction`'s shape.
+
+---
+
+## Bundle D — Performance: N+1 in `find_workflow_hierarchical` (one PR)
+
+**#109** — fix the resolve-to-latest fan-out.
+
+**Recommendation:** ship the cheap fix first, file a follow-up for the proper fix.
+
+**Cheap fix (option 3 in the issue):** wrap the per-workflow resolution in `futures::future::try_join_all`. Round-trip count unchanged (still N×M), but wall-clock cuts by parallelism. With `limit=50` clamp + `db_pool.max_connections` tuning, this clears p99 spikes for now.
+
+```rust
+// In find_workflow_hierarchical, after computing `workflows` Vec:
+let resolution_futures = workflows.iter().map(|w| {
+    let id = w["workflow_id"].as_str().unwrap().parse::<Uuid>().unwrap();
+    epigraph_db::WorkflowRepository::resolve_steps_to_heads(&state.db_pool, id)
+});
+let results = futures::future::try_join_all(resolution_futures).await?;
+```
+
+Plus a similar `try_join_all` inside `resolve_steps_to_heads` for the per-step `latest_in_lineage` calls.
+
+**Proper fix (option 1, defer to follow-up):** single batched CTE that takes all workflow IDs + walks lineages in one round-trip. Big diff, real win, but the cheap fix buys time.
+
+**Test:** `find_workflow_hierarchical_resolve_test.rs` already exists; extend it to assert ≤ 1.5x latency over `resolve_to_latest=false` for a 5-workflow corpus. (Wall-clock assertion is fragile in CI; instead count round-trips via a query-counter sqlx logging hook if available, otherwise skip the perf assertion and rely on the prior correctness coverage.)
+
+**Estimated effort:** half-day for the cheap fix. The proper batched-CTE fix is a 2-3 day project on its own.
+
+---
+
+## Recommended sequence
+
+1. **Bundle A — this week.** Security + correctness, blocks any clean upgrade story for callers depending on auth gates.
+2. **Bundle B — next.** Lock in the fixes from A with negative tests.
+3. **Bundle C — opportunistic.** Improves SDK ergonomics; do when API consumers ask or someone has a slow afternoon.
+4. **Bundle D — when latency profile shows it.** Unblocked by A/B/C; can land any time.
+
+## Cross-cutting observations
+
+- **None of these issues invalidates the PR #100 architectural design.** They're follow-ups against an intentionally-shipped surface — the council was fed PR #100 with full knowledge that follow-ups would be filed.
+- **`claims:admin` scope** is introduced by this bundle. It's a new privilege tier; once shipped, the team should sweep other write endpoints for admin-only candidates (see Out of scope above).
+- **Memory update warranted:** save a feedback memory recording "dedup is admin-only, gated on `claims:admin` scope; provision an `epigraph-admin` OAuth client to call it" — this decision will recur (e.g., when future cleanup tools are designed).


### PR DESCRIPTION
## Summary

Closes 5 GitHub issues filed against the now-merged PR #100. Bundle A is the security + correctness wave.

| Issue | Class | Fix |
|---|---|---|
| #101 | Security | `supersede_claim` now requires Bearer auth + `claims:write` scope (mirrors `mark_duplicate` pattern) |
| #104 | Security | `mark_duplicate` escalated from `claims:write` to **new scope `claims:admin`** + structured INFO log |
| #103 | Correctness | `ClaimRepository::evolve_step` rejects `supersedes` against a non-current parent (mirrors `supersede`'s guard) |
| #102 | Correctness | `deprecate_workflow` BFS cascade adds `HashSet<Uuid>` visited-set; diamond DAGs no longer double-process; cycles can't infinite-loop |
| #105 | Operational | `improve_workflow`'s post-create `'workflow'` label apply now emits `tracing::warn!` on Err (was fire-and-forget) |

## Design decision

#104's mitigation introduces a new `claims:admin` scope. Rationale: dedup is an operator-driven graph-integrity decision, not an author-driven edit (most duplicate pairs span agents anyway, defeating ownership-by-authorship).

The intended caller is a separately-provisioned `epigraph-admin` OAuth client. **Provisioning that client is operational work tracked separately** — this PR introduces only the scope and the handler-side gate.

Plan + rationale: `docs/superpowers/plans/2026-05-08-pr100-followups.md`.

## Test plan

- [x] `crates/epigraph-api/tests/supersede_scope_check_test.rs` — 401 (no token), 403 (`claims:read`-only)
- [x] `crates/epigraph-api/tests/dedup_admin_scope_test.rs` — 401 (no token), 403 (`claims:write`-only fails admin gate)
- [x] `crates/epigraph-api/tests/dedup_endpoint_test.rs` — happy path retargeted to `claims:admin` token
- [x] `crates/epigraph-db/tests/evolve_step_repo.rs` — second `evolve_step(parent, "supersedes")` on now-non-current parent errors
- [x] `crates/epigraph-mcp/tests/deprecate_cascade_visited_test.rs` — diamond DAG (root←A, root←B, A←C, B←C); each node deprecated exactly once
- [x] `cargo build --workspace` clean
- [x] `cargo fmt --check` clean
- [ ] Local test execution blocked by VM env (`epigraph_admin` Postgres role lacks CREATEDB for sqlx-test snapshots) — CI is authoritative

## Out of scope (tracked as separate follow-up bundles)

- #106 OpenAPI typed schemas — Bundle C
- #107 negative-test sweep across all PR #100 endpoints — Bundle B
- #108 strengthen `openapi_paths_test` — Bundle B
- #109 N+1 in `find_workflow_hierarchical` — Bundle D
- Sweeping other write endpoints for admin-only candidates (separate scope-policy review)
- Provisioning the `epigraph-admin` OAuth client (operational task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)