### PR TITLE
test: PR #100 follow-ups Bundle B — negative + OpenAPI coverage

### DIFF
--- a/crates/epigraph-api/tests/dedup_negative_test.rs
+++ b/crates/epigraph-api/tests/dedup_negative_test.rs
@@ -1,0 +1,130 @@
+#![cfg(feature = "db")]
+use sqlx::postgres::PgPoolOptions;
+mod common;
+
+/// Calling dedup where the dup_id UUID does not exist → 404.
+/// The handler checks dup_id == canonical_id first (400), then calls
+/// ClaimRepository::mark_duplicate which returns DbError::NotFound when
+/// the dup row is absent → handler maps that to ApiError::NotFound → 404.
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_nonexistent_dup_returns_404() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    // We need a real canonical claim so the DB doesn't 404 on the canonical check first.
+    let canonical = common::seed_claim(&pool, "canonical for 404 test").await;
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:admin"]).await;
+
+    let nonexistent_dup = uuid::Uuid::new_v4();
+    let body = serde_json::json!({
+        "canonical_id": canonical,
+        "reason": "test 404",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/claims/{nonexistent_dup}/dedup"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        404,
+        "expected 404 for non-existent dup_id; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// Calling dedup against a claim that already has supersedes set → 409.
+/// ClaimRepository::mark_duplicate returns DbError::QueryFailed when
+/// the dup row already has supersedes != NULL → handler maps to ApiError::Conflict → 409.
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_already_superseded_dup_returns_409() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let canonical = common::seed_claim(&pool, "canonical for 409 test").await;
+    // Seed the dup claim, then set ONLY supersedes (the column the handler
+    // actually reads — see ClaimRepository::mark_duplicate). Avoid touching
+    // is_current here so this test pins regression to the precise column.
+    let dup = common::seed_claim(&pool, "dup already superseded").await;
+    sqlx::query("UPDATE claims SET supersedes = $1 WHERE id = $2")
+        .bind(canonical)
+        .bind(dup)
+        .execute(&pool)
+        .await
+        .expect("set up already-superseded claim");
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:admin"]).await;
+
+    let body = serde_json::json!({
+        "canonical_id": canonical,
+        "reason": "test 409",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{dup}/dedup"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        409,
+        "expected 409 for already-superseded dup; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// Calling dedup where dup_id == canonical_id → 400 (handler rejects before DB call).
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_self_dedup_returns_400() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let claim = common::seed_claim(&pool, "self-dedup test claim").await;
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:admin"]).await;
+
+    let body = serde_json::json!({
+        "canonical_id": claim,
+        "reason": "test self-dedup",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{claim}/dedup"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        400,
+        "expected 400 for self-dedup (dup_id == canonical_id); got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}

--- a/crates/epigraph-api/tests/openapi_paths_test.rs
+++ b/crates/epigraph-api/tests/openapi_paths_test.rs
@@ -30,4 +30,171 @@ async fn openapi_documents_in_scope_paths() {
             paths.keys().collect::<Vec<_>>()
         );
     }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/claims/{id}/dedup
+    // -------------------------------------------------------------------------
+    let dedup_post = &paths["/api/v1/claims/{id}/dedup"]["post"];
+    assert!(
+        dedup_post.is_object(),
+        "POST /api/v1/claims/{{id}}/dedup not registered as a path operation"
+    );
+    {
+        let security = dedup_post["security"]
+            .as_array()
+            .expect("POST /api/v1/claims/{id}/dedup: security array missing");
+        let scheme_names: Vec<&str> = security
+            .iter()
+            .flat_map(|obj| obj.as_object().unwrap().keys().map(String::as_str))
+            .collect();
+        assert!(
+            scheme_names.contains(&"ed25519_signature"),
+            "POST /api/v1/claims/{{id}}/dedup missing ed25519_signature: got {:?}",
+            scheme_names
+        );
+    }
+    {
+        let req_body_schema = dedup_post["requestBody"]["content"]["application/json"]["schema"]
+            ["$ref"]
+            .as_str()
+            .expect("POST /api/v1/claims/{id}/dedup: request body schema must be a $ref (typed), not inline");
+        assert!(
+            req_body_schema.ends_with("/DedupRequest"),
+            "POST /api/v1/claims/{{id}}/dedup body should be DedupRequest, got $ref={req_body_schema}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /api/v1/claims/{id}/labels
+    // -------------------------------------------------------------------------
+    let labels_patch = &paths["/api/v1/claims/{id}/labels"]["patch"];
+    assert!(
+        labels_patch.is_object(),
+        "PATCH /api/v1/claims/{{id}}/labels not registered as a path operation"
+    );
+    {
+        let security = labels_patch["security"]
+            .as_array()
+            .expect("PATCH /api/v1/claims/{id}/labels: security array missing");
+        let scheme_names: Vec<&str> = security
+            .iter()
+            .flat_map(|obj| obj.as_object().unwrap().keys().map(String::as_str))
+            .collect();
+        assert!(
+            scheme_names.contains(&"ed25519_signature"),
+            "PATCH /api/v1/claims/{{id}}/labels missing ed25519_signature: got {:?}",
+            scheme_names
+        );
+    }
+    {
+        let req_body_schema = labels_patch["requestBody"]["content"]["application/json"]["schema"]
+            ["$ref"]
+            .as_str()
+            .expect("PATCH /api/v1/claims/{id}/labels: request body schema must be a $ref (typed), not inline");
+        assert!(
+            req_body_schema.ends_with("/UpdateLabelsRequest"),
+            "PATCH /api/v1/claims/{{id}}/labels body should be UpdateLabelsRequest, got $ref={req_body_schema}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/claims/{id}/supersede
+    // -------------------------------------------------------------------------
+    let supersede_post = &paths["/api/v1/claims/{id}/supersede"]["post"];
+    assert!(
+        supersede_post.is_object(),
+        "POST /api/v1/claims/{{id}}/supersede not registered as a path operation"
+    );
+    {
+        let security = supersede_post["security"]
+            .as_array()
+            .expect("POST /api/v1/claims/{id}/supersede: security array missing");
+        let scheme_names: Vec<&str> = security
+            .iter()
+            .flat_map(|obj| obj.as_object().unwrap().keys().map(String::as_str))
+            .collect();
+        assert!(
+            scheme_names.contains(&"ed25519_signature"),
+            "POST /api/v1/claims/{{id}}/supersede missing ed25519_signature: got {:?}",
+            scheme_names
+        );
+    }
+    {
+        let req_body_schema = supersede_post["requestBody"]["content"]["application/json"]
+            ["schema"]["$ref"]
+            .as_str()
+            .expect("POST /api/v1/claims/{id}/supersede: request body schema must be a $ref (typed), not inline");
+        assert!(
+            req_body_schema.ends_with("/SupersedeRequest"),
+            "POST /api/v1/claims/{{id}}/supersede body should be SupersedeRequest, got $ref={req_body_schema}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /api/v1/claims/{id}
+    // -------------------------------------------------------------------------
+    let claim_patch = &paths["/api/v1/claims/{id}"]["patch"];
+    assert!(
+        claim_patch.is_object(),
+        "PATCH /api/v1/claims/{{id}} not registered as a path operation"
+    );
+    {
+        let security = claim_patch["security"]
+            .as_array()
+            .expect("PATCH /api/v1/claims/{id}: security array missing");
+        let scheme_names: Vec<&str> = security
+            .iter()
+            .flat_map(|obj| obj.as_object().unwrap().keys().map(String::as_str))
+            .collect();
+        assert!(
+            scheme_names.contains(&"ed25519_signature"),
+            "PATCH /api/v1/claims/{{id}} missing ed25519_signature: got {:?}",
+            scheme_names
+        );
+    }
+    {
+        let req_body_schema = claim_patch["requestBody"]["content"]["application/json"]["schema"]
+            ["$ref"]
+            .as_str()
+            .expect(
+                "PATCH /api/v1/claims/{id}: request body schema must be a $ref (typed), not inline",
+            );
+        assert!(
+            req_body_schema.ends_with("/PatchClaimRequest"),
+            "PATCH /api/v1/claims/{{id}} body should be PatchClaimRequest, got $ref={req_body_schema}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/workflows/steps/{id}/evolve
+    // -------------------------------------------------------------------------
+    let evolve_post = &paths["/api/v1/workflows/steps/{id}/evolve"]["post"];
+    assert!(
+        evolve_post.is_object(),
+        "POST /api/v1/workflows/steps/{{id}}/evolve not registered as a path operation"
+    );
+    {
+        let security = evolve_post["security"]
+            .as_array()
+            .expect("POST /api/v1/workflows/steps/{id}/evolve: security array missing");
+        let scheme_names: Vec<&str> = security
+            .iter()
+            .flat_map(|obj| obj.as_object().unwrap().keys().map(String::as_str))
+            .collect();
+        assert!(
+            scheme_names.contains(&"ed25519_signature"),
+            "POST /api/v1/workflows/steps/{{id}}/evolve missing ed25519_signature: got {:?}",
+            scheme_names
+        );
+    }
+    {
+        let req_body_schema = evolve_post["requestBody"]["content"]["application/json"]["schema"]
+            ["$ref"]
+            .as_str()
+            .expect("POST /api/v1/workflows/steps/{id}/evolve: request body schema must be a $ref (typed), not inline");
+        assert!(
+            req_body_schema.ends_with("/EvolveStepRequest"),
+            "POST /api/v1/workflows/steps/{{id}}/evolve body should be EvolveStepRequest, got $ref={req_body_schema}"
+        );
+    }
 }

--- a/crates/epigraph-api/tests/patch_claim_http_test.rs
+++ b/crates/epigraph-api/tests/patch_claim_http_test.rs
@@ -1,0 +1,171 @@
+#![cfg(feature = "db")]
+use sqlx::postgres::PgPoolOptions;
+mod common;
+
+/// PATCH /api/v1/claims/:id with a valid claims:write token and a real claim
+/// returns 200 with the updated properties reflected in the response body.
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_claim_happy_path_returns_200() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let claim_id = common::seed_claim(&pool, "patch happy path content").await;
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+
+    // Use add_labels — a successful PATCH returns 200 even if the response body
+    // doesn't reflect labels (get_by_id_conn omits the labels column).
+    // We verify success by checking the HTTP status code only.
+    let body = serde_json::json!({
+        "add_labels": ["test-label"],
+    });
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{claim_id}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(status, 200, "expected 200 OK, got {status} — body={text}");
+}
+
+/// PATCH /api/v1/claims/:id with no Authorization header must return 401.
+/// Auth check fires before any DB lookup, so a random UUID is sufficient.
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_claim_without_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let body = serde_json::json!({
+        "add_labels": ["some-label"],
+    });
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{fake_id}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401 Unauthorized, got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// PATCH /api/v1/claims/:id with a claims:read-only token must return 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_claim_with_read_only_token_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:read"]);
+    let fake_id = uuid::Uuid::new_v4();
+    let body = serde_json::json!({
+        "add_labels": ["some-label"],
+    });
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{fake_id}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 Forbidden, got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// PATCH /api/v1/claims/:id with a valid token but non-existent UUID returns 404.
+/// The handler maps DbError::NotFound → ApiError::NotFound → HTTP 404.
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_claim_nonexistent_claim_returns_404() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+
+    let nonexistent = uuid::Uuid::new_v4();
+    let body = serde_json::json!({
+        "add_labels": ["some-label"],
+    });
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{nonexistent}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        404,
+        "expected 404 for non-existent claim; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// PATCH /api/v1/claims/:id with a body that has no patchable fields returns 400.
+/// The handler checks `request.is_empty()` → 400 before touching the DB.
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_claim_invalid_body_returns_400() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let claim_id = common::seed_claim(&pool, "patch 400 test content").await;
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+
+    // Empty body: no trace_id, no properties, no add_labels, no remove_labels.
+    // The handler's is_empty() check returns true → 400.
+    let body = serde_json::json!({});
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{claim_id}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        400,
+        "expected 400 for empty patch body; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}

--- a/crates/epigraph-api/tests/supersede_scope_check_test.rs
+++ b/crates/epigraph-api/tests/supersede_scope_check_test.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "db")]
 mod common;
+use sqlx::postgres::PgPoolOptions;
 
 /// POST /api/v1/claims/:id/supersede with no Authorization header must return 401.
 /// Auth check fires before any DB lookup, so a non-existent UUID is sufficient.
@@ -55,6 +56,45 @@ async fn supersede_with_read_only_token_returns_403() {
         resp.status(),
         403,
         "expected 403 Forbidden, got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// POST /api/v1/claims/:id/supersede with a valid claims:write token but
+/// a non-existent claim UUID → 404.
+#[tokio::test(flavor = "multi_thread")]
+async fn supersede_nonexistent_claim_returns_404() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+
+    let nonexistent = uuid::Uuid::new_v4();
+    let body = serde_json::json!({
+        "content": "new content",
+        "truth_value": 0.8,
+        "reason": "test reason",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/claims/{nonexistent}/supersede"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        404,
+        "expected 404 for non-existent claim; got {} — body={}",
         resp.status(),
         resp.text().await.unwrap_or_default()
     );

--- a/crates/epigraph-api/tests/workflow_evolve_step_test.rs
+++ b/crates/epigraph-api/tests/workflow_evolve_step_test.rs
@@ -3,6 +3,135 @@ use sqlx::postgres::PgPoolOptions;
 use uuid::Uuid;
 mod common;
 
+// ── negative / error-path tests ──────────────────────────────────────────────
+
+/// No Authorization header → 401.
+#[tokio::test(flavor = "multi_thread")]
+async fn evolve_step_without_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_id = Uuid::new_v4();
+    let body = serde_json::json!({
+        "parent_id": fake_id,
+        "content": "updated step",
+        "edge_type": "supersedes",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/workflows/steps/{fake_id}/evolve"
+        ))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401 without token; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// Token with only `graph:read` (no `claims:write`) → 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn evolve_step_with_read_only_token_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["graph:read"]);
+    let fake_id = Uuid::new_v4();
+    let body = serde_json::json!({
+        "parent_id": fake_id,
+        "content": "updated step",
+        "edge_type": "supersedes",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/workflows/steps/{fake_id}/evolve"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 for graph:read-only token; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// `parent_id` in JSON body differs from `{id}` in path → 400.
+#[tokio::test(flavor = "multi_thread")]
+async fn evolve_step_mismatched_parent_id_returns_400() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:write"]);
+    let path_id = Uuid::new_v4();
+    let body_id = Uuid::new_v4(); // deliberately different
+    let body = serde_json::json!({
+        "parent_id": body_id,
+        "content": "updated step",
+        "edge_type": "supersedes",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/workflows/steps/{path_id}/evolve"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        400,
+        "expected 400 for path/body parent_id mismatch; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// Valid `claims:write` token but parent claim does not exist → 404.
+#[tokio::test(flavor = "multi_thread")]
+async fn evolve_step_nonexistent_parent_returns_404() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:write"]);
+    let nonexistent = Uuid::new_v4();
+    let body = serde_json::json!({
+        "parent_id": nonexistent,
+        "content": "updated step",
+        "edge_type": "supersedes",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/workflows/steps/{nonexistent}/evolve"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        404,
+        "expected 404 for non-existent parent; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn evolve_step_supersedes_creates_new_claim_and_edge() {
     let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");


### PR DESCRIPTION
## Summary

Closes #107 and #108. Bundle B is the test-hardening wave following Bundle A's security fixes (PR #110).

| Issue | Class | Coverage added |
|---|---|---|
| #107 | Tests | 401/403/400/404/409 negative paths for `evolve_step`, `mark_duplicate`, `supersede_claim`, `patch_claim` |
| #108 | Tests | `openapi_paths_test` now asserts method registration, security scheme name, and typed-body `\$ref` per write endpoint |

13 new tests across 5 files; ~636 LoC of test code. No source-code changes.

## Per-endpoint coverage

| Endpoint | Cases added |
|---|---|
| `POST /api/v1/workflows/steps/{id}/evolve` | 401, 403 (claims:read only), 400 (path/body parent_id mismatch), 404 (parent missing) |
| `POST /api/v1/claims/{id}/dedup` | 404 (dup missing), 409 (already superseded), 400 (self-dedup). 401/403 covered by pre-existing `dedup_admin_scope_test.rs`. |
| `POST /api/v1/claims/{id}/supersede` | 404 (claim missing). 401/403 covered by pre-existing `supersede_scope_check_test.rs`. |
| `PATCH /api/v1/claims/{id}` | 200, 400 (empty body), 401, 403, 404 — first HTTP-level integration coverage post the PR #100 refactor |

## OpenAPI coverage (#108)

Per write endpoint, the strengthened `openapi_paths_test` now asserts:
1. \`paths[<path>][<method>].is_object()\` — proves method registration.
2. \`security\` array contains \`ed25519_signature\` — proves the auth requirement isn't accidentally removed.
3. \`requestBody.content."application/json".schema.\$ref\` ends with the typed schema name (\`DedupRequest\`, \`UpdateLabelsRequest\`, \`SupersedeRequest\`, \`PatchClaimRequest\`, \`EvolveStepRequest\`) — proves a future regression to \`serde_json::Value\` would be caught.

The 4 endpoints deferred to issue #106 (\`improve_workflow\`, \`ingest_workflow\`, \`report_hierarchical_outcome\`, \`find_workflow_hierarchical\`) keep their path-existence checks but skip the typed-body assertion, by design.

## Test plan

- [x] All 13 new tests pass locally against \`epigraph_db_repo_test\` with \`postgres://epigraph:epigraph@...\` (sqlx-test's superuser requirement).
- [x] Adjacent existing tests still pass (no flakes introduced): \`dedup_endpoint_test\`, \`dedup_admin_scope_test\`, \`workflow_evolve_step_test::evolve_step_supersedes_creates_new_claim_and_edge\`.
- [x] \`cargo build --workspace\` clean
- [x] \`cargo fmt --check\` clean

## Reviewer feedback applied

Council nit fixed in commit-amend before push: the 409-precondition seed in \`dedup_already_superseded_dup_returns_409\` originally set both \`is_current = false\` and \`supersedes = canonical\`. Tightened to set only \`supersedes\` — the column the handler actually reads — so the test pins regression to the precise gate.

## Out of scope (separate bundles)

- #106 OpenAPI typed schemas — Bundle C
- #109 N+1 in \`find_workflow_hierarchical\` — Bundle D
- Sweeping other write endpoints for admin-only candidates (separate scope-policy review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)