### PR TITLE
feat: PR #100 follow-ups Bundle C — OpenAPI typed schemas

### DIFF
--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["db"]
 
 [dependencies]
 epigraph-interfaces = { workspace = true }  # Extension point traits (EncryptionProvider, PolicyGate, OrchestrationBackend)
-epigraph-ingest = { workspace = true }  # Workflow/document extraction schemas and ingest planners
+epigraph-ingest = { workspace = true, features = ["openapi"] }  # Workflow/document extraction schemas and ingest planners
 epigraph-ingest-executor = { workspace = true, optional = true }  # Persistence executor for workflow ingest (db feature)
 # k-means for /api/v1/themes/build-from-corpus lives in epigraph-engine
 # (theme_kmeans::run_theme_kmeans) — no direct linfa/ndarray dep needed here.

--- a/crates/epigraph-api/src/openapi.rs
+++ b/crates/epigraph-api/src/openapi.rs
@@ -28,7 +28,13 @@ use crate::routes::submit::{
 use crate::routes::versioning::{
     DedupRequest, DedupResponse, SupersedeRequest, SupersessionResponse,
 };
-use crate::routes::workflows::{EvolveStepRequest, EvolveStepResponse};
+use crate::routes::workflows::{
+    EvolveStepRequest, EvolveStepResponse, HierarchicalSearchResponse, HierarchicalWorkflowResult,
+    ImproveWorkflowRequest, LineageHeadResult, ReportOutcomeRequest, ResolvedStepResult,
+    StepExecution,
+};
+use epigraph_ingest::common::schema::{AuthorEntry, ClaimRelationship, ThesisDerivation};
+use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowExtraction, WorkflowSource};
 
 /// EpiGraph API OpenAPI specification
 ///
@@ -101,6 +107,20 @@ use crate::routes::workflows::{EvolveStepRequest, EvolveStepResponse};
             UpdateLabelsResponse,
             EvolveStepRequest,
             EvolveStepResponse,
+            ImproveWorkflowRequest,
+            ReportOutcomeRequest,
+            StepExecution,
+            WorkflowExtraction,
+            WorkflowSource,
+            Phase,
+            Step,
+            AuthorEntry,
+            ClaimRelationship,
+            ThesisDerivation,
+            HierarchicalSearchResponse,
+            HierarchicalWorkflowResult,
+            ResolvedStepResult,
+            LineageHeadResult,
         )
     ),
     modifiers(&SecurityAddon),
@@ -374,7 +394,7 @@ async fn evolve_step_doc() {}
         ("resolve_to_latest" = Option<bool>, Query, description = "Whether to resolve steps to latest versions"),
     ),
     responses(
-        (status = 200, body = serde_json::Value),
+        (status = 200, body = HierarchicalSearchResponse),
         (status = 500),
     ),
     security(("ed25519_signature" = []))
@@ -387,7 +407,7 @@ async fn find_workflow_hierarchical_doc() {}
     path = "/api/v1/workflows/hierarchical/{id}/outcome",
     tag = "workflows",
     params(("id" = uuid::Uuid, Path, description = "UUID of the hierarchical workflow")),
-    request_body = serde_json::Value,
+    request_body = ReportOutcomeRequest,
     responses(
         (status = 200, body = serde_json::Value),
         (status = 404),
@@ -403,7 +423,7 @@ async fn report_hierarchical_outcome_doc() {}
     path = "/api/v1/workflows/{id}/improve",
     tag = "workflows",
     params(("id" = uuid::Uuid, Path, description = "UUID of the workflow to improve")),
-    request_body = serde_json::Value,
+    request_body = ImproveWorkflowRequest,
     responses(
         (status = 200, body = serde_json::Value),
         (status = 404),
@@ -437,7 +457,7 @@ async fn deprecate_workflow_doc() {}
     post,
     path = "/api/v1/workflows/ingest",
     tag = "workflows",
-    request_body = serde_json::Value,
+    request_body = WorkflowExtraction,
     responses(
         (status = 200, body = serde_json::Value),
         (status = 500),

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -57,7 +57,7 @@ pub struct ListWorkflowsQuery {
 }
 
 #[cfg(feature = "db")]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ReportOutcomeRequest {
     pub success: bool,
     pub outcome_details: String,
@@ -67,7 +67,7 @@ pub struct ReportOutcomeRequest {
 }
 
 #[cfg(feature = "db")]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct StepExecution {
     pub step_index: usize,
     pub planned: String,
@@ -77,7 +77,7 @@ pub struct StepExecution {
 }
 
 #[cfg(feature = "db")]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ImproveWorkflowRequest {
     pub goal: Option<String>,
     pub steps: Option<Vec<String>>,
@@ -113,6 +113,47 @@ pub struct RecordBehavioralExecutionRequest {
     pub quality: Option<f64>,
     pub deviation_count: i32,
     pub total_steps: i32,
+}
+
+/// Response body for `GET /api/v1/workflows/hierarchical/search`.
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct HierarchicalSearchResponse {
+    pub workflows: Vec<HierarchicalWorkflowResult>,
+    pub total: usize,
+    pub resolve_to_latest: bool,
+}
+
+/// A single workflow entry within [`HierarchicalSearchResponse`].
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct HierarchicalWorkflowResult {
+    pub workflow_id: uuid::Uuid,
+    pub canonical_name: String,
+    pub generation: i32,
+    pub goal: String,
+    pub parent_id: Option<uuid::Uuid>,
+    pub metadata: serde_json::Value,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_steps: Option<Vec<ResolvedStepResult>>,
+}
+
+/// Per-step resolution result within [`HierarchicalWorkflowResult`].
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct ResolvedStepResult {
+    pub step_index: usize,
+    pub frozen_claim_id: uuid::Uuid,
+    pub step_lineage_id: Option<uuid::Uuid>,
+    pub heads: Vec<LineageHeadResult>,
+    pub pending_resolution: bool,
+}
+
+/// A lineage head within [`ResolvedStepResult`].
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct LineageHeadResult {
+    pub id: uuid::Uuid,
+    pub content: String,
+    pub truth_value: f64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
 // ── Handlers ──
@@ -638,7 +679,7 @@ pub async fn report_outcome(
     path = "/api/v1/workflows/hierarchical/search",
     params(HierarchicalSearchQuery),
     responses(
-        (status = 200, body = serde_json::Value),
+        (status = 200, body = HierarchicalSearchResponse),
         (status = 500),
     ),
     security(("ed25519_signature" = [])),
@@ -647,7 +688,7 @@ pub async fn report_outcome(
 pub async fn find_workflow_hierarchical(
     State(state): State<AppState>,
     Query(params): Query<HierarchicalSearchQuery>,
-) -> Result<Json<serde_json::Value>, ApiError> {
+) -> Result<Json<HierarchicalSearchResponse>, ApiError> {
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
     let rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
         &state.db_pool,
@@ -658,45 +699,61 @@ pub async fn find_workflow_hierarchical(
     .map_err(|e| ApiError::InternalError {
         message: format!("hierarchical search failed: {e}"),
     })?;
-    let mut workflows: Vec<serde_json::Value> = rows
+
+    let mut workflows: Vec<HierarchicalWorkflowResult> = rows
         .into_iter()
-        .map(|r| {
-            serde_json::json!({
-                "workflow_id": r.id,
-                "canonical_name": r.canonical_name,
-                "generation": r.generation,
-                "goal": r.goal,
-                "parent_id": r.parent_id,
-                "metadata": r.metadata,
-                "created_at": r.created_at,
-            })
+        .map(|r| HierarchicalWorkflowResult {
+            workflow_id: r.id,
+            canonical_name: r.canonical_name,
+            generation: r.generation,
+            goal: r.goal,
+            parent_id: r.parent_id,
+            metadata: r.metadata,
+            created_at: r.created_at,
+            resolved_steps: None,
         })
         .collect();
+
     if params.resolve_to_latest {
         for w in &mut workflows {
-            let workflow_id: Uuid = w["workflow_id"].as_str().unwrap().parse().unwrap();
             let resolved = epigraph_db::WorkflowRepository::resolve_steps_to_heads(
                 &state.db_pool,
-                workflow_id,
+                w.workflow_id,
             )
             .await
             .map_err(|e| ApiError::InternalError {
                 message: format!("resolve_to_latest failed: {e}"),
             })?;
-            if let Some(obj) = w.as_object_mut() {
-                obj.insert(
-                    "resolved_steps".to_string(),
-                    serde_json::to_value(resolved).unwrap(),
-                );
-            }
+            w.resolved_steps = Some(
+                resolved
+                    .into_iter()
+                    .map(|s| ResolvedStepResult {
+                        step_index: s.step_index,
+                        frozen_claim_id: s.frozen_claim_id,
+                        step_lineage_id: s.step_lineage_id,
+                        heads: s
+                            .heads
+                            .into_iter()
+                            .map(|h| LineageHeadResult {
+                                id: h.id,
+                                content: h.content,
+                                truth_value: h.truth_value,
+                                created_at: h.created_at,
+                            })
+                            .collect(),
+                        pending_resolution: s.pending_resolution,
+                    })
+                    .collect(),
+            );
         }
     }
 
-    Ok(Json(serde_json::json!({
-        "workflows": workflows,
-        "total": workflows.len(),
-        "resolve_to_latest": params.resolve_to_latest,
-    })))
+    let total = workflows.len();
+    Ok(Json(HierarchicalSearchResponse {
+        workflows,
+        total,
+        resolve_to_latest: params.resolve_to_latest,
+    }))
 }
 
 /// POST /api/v1/workflows/hierarchical/:id/outcome - Report execution outcome

--- a/crates/epigraph-ingest/Cargo.toml
+++ b/crates/epigraph-ingest/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+openapi = ["dep:utoipa"]
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -11,6 +14,7 @@ schemars = { workspace = true }
 uuid = { workspace = true, features = ["v4", "v5"] }
 thiserror = { workspace = true }
 blake3 = "1"  # High-performance hashing for content-addressed atom IDs
+utoipa = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/epigraph-ingest/src/common/schema.rs
+++ b/crates/epigraph-ingest/src/common/schema.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// An author with affiliations and roles. Workflows can be authored by humans,
 /// LLMs, or external systems — same shape as document authors.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AuthorEntry {
     pub name: String,
     #[serde(default)]
@@ -18,6 +19,7 @@ pub struct AuthorEntry {
 /// support / contradict / refute each other across phases just like document
 /// atoms can across paragraphs.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ClaimRelationship {
     pub source_path: String,
     pub target_path: String,
@@ -30,6 +32,7 @@ pub struct ClaimRelationship {
 
 /// Whether the thesis was derived top-down or bottom-up.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ThesisDerivation {
     #[default]
     TopDown,

--- a/crates/epigraph-ingest/src/workflow/schema.rs
+++ b/crates/epigraph-ingest/src/workflow/schema.rs
@@ -11,6 +11,7 @@ use crate::document::schema::default_confidence;
 
 /// Top-level extraction result from a workflow.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkflowExtraction {
     pub source: WorkflowSource,
     #[serde(default)]
@@ -25,6 +26,7 @@ pub struct WorkflowExtraction {
 
 /// Metadata about the workflow.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkflowSource {
     /// Required slug; drives the deterministic root ID.
     pub canonical_name: String,
@@ -46,6 +48,7 @@ pub struct WorkflowSource {
 
 /// A phase within a workflow (analog of `document::schema::Section`).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Phase {
     pub title: String,
     #[serde(default)]
@@ -58,6 +61,7 @@ pub struct Phase {
 /// Paper-specific fields (methodology, evidence_type, page, instruments_used,
 /// reagents_involved, conditions) are intentionally absent.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Step {
     pub compound: String,
     #[serde(default)]


### PR DESCRIPTION
## Summary

Closes #106. Promotes the four workflow endpoints PR #100 left untyped in OpenAPI to proper schemas, so SDK and docs-portal generators can emit compile-time-validated client code.

| Endpoint | Was | Now |
|---|---|---|
| `POST /api/v1/workflows/{id}/improve` | `serde_json::Value` | `ImproveWorkflowRequest` |
| `POST /api/v1/workflows/ingest` | `serde_json::Value` | `WorkflowExtraction` |
| `POST /api/v1/workflows/hierarchical/{id}/outcome` | `serde_json::Value` | `ReportOutcomeRequest` |
| `GET /api/v1/workflows/hierarchical/search` | `serde_json::Value` (response) | `HierarchicalSearchResponse` (new) |

`WorkflowExtraction`'s `utoipa::ToSchema` derive is feature-gated under `epigraph-ingest/openapi` to keep the optional utoipa dep narrow.

## Wire format

Unchanged. `HierarchicalSearchResponse` is a typed mirror of the existing JSON shape. Verified by re-running the existing find_workflow_hierarchical resolve-to-latest tests.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p epigraph-mcp --test step_versioning` passes (asserts wire-format details)

## Relation to Bundle B

Bundle B's strengthened `openapi_paths_test` in PR #112 will, on rebase against main once both land, automatically validate that these four endpoints now have typed `$ref` request/response bodies — closing the regression gap on this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)