### PR TITLE
perf: PR #100 follow-ups Bundle D — parallelize resolve_to_latest

### DIFF
--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -82,6 +82,7 @@ opentelemetry = { version = "0.27", optional = true }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.27", optional = true }
 tracing-opentelemetry = { version = "0.28", optional = true }
+futures = "0.3"  # For try_join_all in concurrent workflow resolution
 nom = "8.0.0"
 jsonwebtoken = "9"        # JWT creation and validation
 rand = { workspace = true }  # Token generation, nonce generation
@@ -91,7 +92,7 @@ ed25519-dalek = { workspace = true }  # Ed25519 agent assertion verification
 [dev-dependencies]
 axum-test = "14"  # Testing utilities for Axum
 tokio-test = "0.4"  # Async test utilities
-futures = "0.3"  # For concurrent test execution
+# futures moved to [dependencies] (used in handler, not just tests)
 hex = "0.4"  # Hex decoding for signature tests
 http-body-util = "0.1"  # HTTP body utilities for collecting response bodies in tests
 epigraph-embeddings = { workspace = true }  # For embedding integration tests

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -715,15 +715,19 @@ pub async fn find_workflow_hierarchical(
         .collect();
 
     if params.resolve_to_latest {
-        for w in &mut workflows {
-            let resolved = epigraph_db::WorkflowRepository::resolve_steps_to_heads(
-                &state.db_pool,
-                w.workflow_id,
-            )
-            .await
-            .map_err(|e| ApiError::InternalError {
-                message: format!("resolve_to_latest failed: {e}"),
-            })?;
+        let resolution_futures = workflows.iter().map(|w| {
+            let pool = state.db_pool.clone();
+            let workflow_id = w.workflow_id;
+            async move {
+                epigraph_db::WorkflowRepository::resolve_steps_to_heads(&pool, workflow_id)
+                    .await
+                    .map_err(|e| ApiError::InternalError {
+                        message: format!("resolve_to_latest failed: {e}"),
+                    })
+            }
+        });
+        let resolved_per_workflow = futures::future::try_join_all(resolution_futures).await?;
+        for (w, resolved) in workflows.iter_mut().zip(resolved_per_workflow) {
             w.resolved_steps = Some(
                 resolved
                     .into_iter()

--- a/crates/epigraph-db/Cargo.toml
+++ b/crates/epigraph-db/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
+futures = "0.3"
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -3,6 +3,7 @@
 //! Workflows are claims labeled with 'workflow' that represent
 //! reusable research procedures with variant lineages.
 
+use futures::future::try_join_all;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -358,22 +359,32 @@ impl WorkflowRepository {
         .await
         .map_err(DbError::from)?;
 
-        let mut resolved = Vec::with_capacity(step_rows.len());
-        for (step_index, (frozen_claim_id, step_lineage_id)) in step_rows.into_iter().enumerate() {
-            let heads: Vec<LineageHead> = if let Some(lineage_id) = step_lineage_id {
-                ClaimRepository::latest_in_lineage(pool, lineage_id).await?
+        let head_futures = step_rows.iter().map(|(_, step_lineage_id)| async move {
+            if let Some(lineage_id) = *step_lineage_id {
+                ClaimRepository::latest_in_lineage(pool, lineage_id).await
             } else {
-                Vec::new()
-            };
-            let pending_resolution = heads.len() > 1;
-            resolved.push(ResolvedStep {
-                step_index,
-                frozen_claim_id,
-                step_lineage_id,
-                heads,
-                pending_resolution,
-            });
-        }
+                Ok(Vec::new())
+            }
+        });
+        let heads_per_step: Vec<Vec<LineageHead>> = try_join_all(head_futures).await?;
+
+        let resolved = step_rows
+            .into_iter()
+            .enumerate()
+            .zip(heads_per_step)
+            .map(
+                |((step_index, (frozen_claim_id, step_lineage_id)), heads)| {
+                    let pending_resolution = heads.len() > 1;
+                    ResolvedStep {
+                        step_index,
+                        frozen_claim_id,
+                        step_lineage_id,
+                        heads,
+                        pending_resolution,
+                    }
+                },
+            )
+            .collect();
         Ok(resolved)
     }
 


### PR DESCRIPTION
## Summary

Closes #109 (cheap fix). Parallelizes the two N+1 fan-outs in \`find_workflow_hierarchical resolve_to_latest=true\` via \`futures::try_join_all\`.

| Layer | Was | Now |
|---|---|---|
| Handler outer loop | sequential per workflow | concurrent per workflow |
| \`resolve_steps_to_heads\` inner loop | sequential per step | concurrent per step |

Round-trip count is unchanged; wall-clock cut by pool-level concurrency. With \`limit=50\` and average ~3 steps/workflow, that's ~150 round-trips that now overlap instead of serialize.

## Wire format

Unchanged. Verified by re-running the existing wire-format-asserting tests.

## Follow-up filed

The proper fix (option 1 in the issue: single batched CTE, 1 round-trip total) is tracked at https://github.com/epigraph-io/epigraph/issues/114. Cheap fix first; escalate if p99 still misbehaves.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`step_versioning::find_workflow_hierarchical_resolve_walks_lineage\` passes
- [x] \`workflow_find_hierarchical_resolve_test\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)