### PR TITLE
fix(api): scope + ownership gates on webhooks and agent mutations

### DIFF
--- a/crates/epigraph-api/src/routes/agent_keys.rs
+++ b/crates/epigraph-api/src/routes/agent_keys.rs
@@ -284,7 +284,14 @@ pub async fn rotate_agent_key(
 ///
 /// Marks the given key as `revoked` with the provided reason.
 /// A revoked key cannot be used for signing or verification.
-/// Requires `agents:write` scope.
+/// Requires `agents:write` scope. Caller must be the target agent
+/// (auth.agent_id == :id) or have `claims:admin`.
+///
+/// # Errors
+///
+/// - 401 Unauthorized: Missing or invalid Bearer token
+/// - 403 Forbidden: Missing scope or caller is not the target agent
+/// - 404 Not Found: Agent or key does not exist
 #[cfg(feature = "db")]
 pub async fn revoke_agent_key(
     State(state): State<AppState>,
@@ -295,6 +302,12 @@ pub async fn revoke_agent_key(
     // Enforce scope when OAuth2-authenticated
     if let Some(axum::Extension(ref auth)) = auth_ctx {
         crate::middleware::scopes::check_scopes(auth, &["agents:write"])?;
+        // Caller must be the target agent OR have claims:admin
+        if !auth.has_scope("claims:admin") && auth.agent_id != Some(id) {
+            return Err(ApiError::Forbidden {
+                reason: "can only mutate your own agent record".into(),
+            });
+        }
     }
 
     // Look up the key to verify it belongs to this agent

--- a/crates/epigraph-api/src/routes/agents.rs
+++ b/crates/epigraph-api/src/routes/agents.rs
@@ -576,6 +576,13 @@ pub struct UpdateAgentRequest {
 /// PUT /api/v1/agents/:id
 ///
 /// Updates mutable fields on an agent. The public key is immutable.
+/// Caller must be the target agent (auth.agent_id == :id) or have `claims:admin`.
+///
+/// # Errors
+///
+/// - 401 Unauthorized: Missing or invalid Bearer token
+/// - 403 Forbidden: Missing scope or caller is not the target agent
+/// - 404 Not Found: Agent does not exist
 #[cfg(feature = "db")]
 pub async fn update_agent(
     State(state): State<AppState>,
@@ -586,6 +593,12 @@ pub async fn update_agent(
     // Enforce scope when OAuth2-authenticated
     if let Some(axum::Extension(ref auth)) = auth_ctx {
         crate::middleware::scopes::check_scopes(auth, &["agents:write"])?;
+        // Caller must be the target agent OR have claims:admin
+        if !auth.has_scope("claims:admin") && auth.agent_id != Some(id) {
+            return Err(ApiError::Forbidden {
+                reason: "can only mutate your own agent record".into(),
+            });
+        }
     }
 
     let agent_id = AgentId::from_uuid(id);

--- a/crates/epigraph-api/src/routes/webhooks.rs
+++ b/crates/epigraph-api/src/routes/webhooks.rs
@@ -76,19 +76,26 @@ pub fn sign_webhook_payload(secret: &str, payload: &[u8]) -> String {
 ///
 /// POST /api/v1/webhooks
 ///
-/// This is a protected endpoint requiring Ed25519 signature verification.
-/// The caller must provide a valid URL, event type filters, and a secret
-/// of at least 32 characters for HMAC-SHA256 payload signing.
+/// Requires `webhooks:write` scope. The caller must provide a valid URL,
+/// event type filters, and a secret of at least 32 characters for
+/// HMAC-SHA256 payload signing.
 ///
 /// # Errors
 ///
 /// - 400 Bad Request: Empty URL or secret shorter than 32 characters
-/// - 401 Unauthorized: Missing or invalid signature (handled by middleware)
+/// - 401 Unauthorized: Missing or invalid Bearer token
+/// - 403 Forbidden: Missing `webhooks:write` scope
 /// - 201 Created: Webhook subscription registered successfully
 pub async fn register_webhook(
     State(state): State<AppState>,
+    auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>,
     Json(registration): Json<WebhookRegistration>,
 ) -> Result<(StatusCode, Json<WebhookSubscription>), ApiError> {
+    // Enforce scope when OAuth2-authenticated
+    if let Some(axum::Extension(ref auth)) = auth_ctx {
+        crate::middleware::scopes::check_scopes(auth, &["webhooks:write"])?;
+    }
+
     // 1. Validate URL is not empty
     if registration.url.trim().is_empty() {
         return Err(ApiError::BadRequest {
@@ -107,7 +114,12 @@ pub async fn register_webhook(
         });
     }
 
-    // 3. Create the subscription
+    // 3. Determine owner principal from auth context
+    let owner_id = auth_ctx
+        .as_ref()
+        .map(|axum::Extension(auth)| auth.owner_id.unwrap_or(auth.client_id));
+
+    // 4. Create the subscription
     let subscription = WebhookSubscription {
         id: Uuid::new_v4(),
         url: registration.url,
@@ -115,9 +127,10 @@ pub async fn register_webhook(
         created_at: Utc::now(),
         active: true,
         secret: registration.secret,
+        owner_id,
     };
 
-    // 4. Store the subscription
+    // 5. Store the subscription
     {
         let mut store = state.webhook_store.write().await;
         store.insert(subscription.id, subscription.clone());
@@ -164,25 +177,44 @@ pub async fn get_webhook(
 ///
 /// DELETE /api/v1/webhooks/:id
 ///
-/// This is a protected endpoint requiring Ed25519 signature verification.
-/// Removes the subscription entirely from the store.
+/// Requires `webhooks:write` scope. The caller must own the webhook
+/// or have `claims:admin` scope.
 ///
 /// # Errors
 ///
+/// - 401 Unauthorized: Missing or invalid Bearer token
+/// - 403 Forbidden: Missing scope or caller is not the webhook owner
 /// - 404 Not Found: No subscription with the given ID
 pub async fn delete_webhook(
     State(state): State<AppState>,
+    auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
-    let mut store = state.webhook_store.write().await;
-    if store.remove(&id).is_some() {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err(ApiError::NotFound {
-            entity: "Webhook".to_string(),
-            id: id.to_string(),
-        })
+    // Enforce scope when OAuth2-authenticated
+    if let Some(axum::Extension(ref auth)) = auth_ctx {
+        crate::middleware::scopes::check_scopes(auth, &["webhooks:write"])?;
     }
+
+    let mut store = state.webhook_store.write().await;
+    let webhook = store.get(&id).ok_or_else(|| ApiError::NotFound {
+        entity: "Webhook".to_string(),
+        id: id.to_string(),
+    })?;
+
+    // Ownership check: caller must be the owner OR have claims:admin
+    if let Some(axum::Extension(ref auth)) = auth_ctx {
+        if !auth.has_scope("claims:admin") {
+            let principal = auth.owner_id.unwrap_or(auth.client_id);
+            if webhook.owner_id != Some(principal) {
+                return Err(ApiError::Forbidden {
+                    reason: "webhook is owned by another principal".into(),
+                });
+            }
+        }
+    }
+
+    store.remove(&id);
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // =============================================================================
@@ -449,6 +481,7 @@ mod tests {
             created_at: Utc::now(),
             active: true,
             secret: "this-should-not-appear-in-json-output-ever".to_string(),
+            owner_id: None,
         };
 
         let json = serde_json::to_string(&sub).unwrap();
@@ -502,6 +535,7 @@ mod tests {
             created_at: Utc::now(),
             active: true,
             secret: "x".repeat(32),
+            owner_id: None,
         };
 
         let sub_filtered = WebhookSubscription {
@@ -511,6 +545,7 @@ mod tests {
             created_at: Utc::now(),
             active: true,
             secret: "x".repeat(32),
+            owner_id: None,
         };
 
         // Empty event_types matches all
@@ -611,6 +646,7 @@ mod tests {
                     created_at: Utc::now(),
                     active: true,
                     secret: "x".repeat(32),
+                    owner_id: None,
                 },
             );
         }
@@ -651,6 +687,7 @@ mod tests {
                     created_at: Utc::now(),
                     active: true,
                     secret: "x".repeat(32),
+                    owner_id: None,
                 },
             );
         }
@@ -690,6 +727,7 @@ mod tests {
                     created_at: Utc::now(),
                     active: false, // INACTIVE
                     secret: "x".repeat(32),
+                    owner_id: None,
                 },
             );
         }

--- a/crates/epigraph-api/src/state.rs
+++ b/crates/epigraph-api/src/state.rs
@@ -90,6 +90,11 @@ pub struct WebhookSubscription {
     /// HMAC-SHA256 secret for payload signing (redacted in API responses)
     #[serde(skip_serializing, default)]
     pub secret: String,
+    /// The principal that created this subscription (client_id or owner_id from auth).
+    /// Used for ownership enforcement on delete.
+    /// None only for subscriptions created before auth was enforced.
+    #[serde(skip_serializing, default)]
+    pub owner_id: Option<Uuid>,
 }
 
 /// Thread-safe in-memory webhook subscription store

--- a/crates/epigraph-api/tests/agent_mutation_auth_test.rs
+++ b/crates/epigraph-api/tests/agent_mutation_auth_test.rs
@@ -1,0 +1,354 @@
+#![cfg(feature = "db")]
+mod common;
+
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+/// Seed an agent row and one active agent_key row.
+/// Returns (agent_id, key_id).
+async fn seed_agent_with_key(pool: &sqlx::PgPool) -> (Uuid, Uuid) {
+    let agent_id = Uuid::new_v4();
+    // Derive a unique 32-byte public key from agent_id
+    let pk: Vec<u8> = agent_id
+        .as_bytes()
+        .iter()
+        .copied()
+        .cycle()
+        .take(32)
+        .collect();
+
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, agent_type) \
+         VALUES ($1, $2, 'system') ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(agent_id)
+    .bind(&pk)
+    .execute(pool)
+    .await
+    .expect("seed agent");
+
+    let key_id = Uuid::new_v4();
+    // Use a distinct 32-byte public key for the key row
+    let key_pk: Vec<u8> = key_id.as_bytes().iter().copied().cycle().take(32).collect();
+
+    sqlx::query(
+        "INSERT INTO agent_keys (id, agent_id, public_key, key_type, status, valid_from) \
+         VALUES ($1, $2, $3, 'signing', 'active', now())",
+    )
+    .bind(key_id)
+    .bind(agent_id)
+    .bind(&key_pk)
+    .execute(pool)
+    .await
+    .expect("seed agent_key");
+
+    (agent_id, key_id)
+}
+
+/// Issue a JWT where agent_id claim == target_agent_id (caller IS the agent).
+fn token_as_agent(agent_id: Uuid, scopes: &[&str]) -> String {
+    let secret = std::env::var("EPIGRAPH_JWT_SECRET")
+        .unwrap_or_else(|_| "epigraph-dev-secret-change-in-production!!".to_string());
+    let cfg = epigraph_api::oauth::JwtConfig::from_secret(secret.as_bytes());
+    let (token, _) = cfg
+        .issue_access_token(
+            Uuid::new_v4(), // client_id (distinct from agent_id)
+            scopes.iter().map(|s| s.to_string()).collect(),
+            "agent",
+            None,
+            Some(agent_id), // agent_id claim = target agent
+            chrono::Duration::minutes(60),
+        )
+        .expect("test JWT issued");
+    token
+}
+
+// ---------------------------------------------------------------------------
+// update_agent — 401
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_agent_no_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_id = Uuid::new_v4();
+    let body = serde_json::json!({"display_name": "x"});
+
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/agents/{fake_id}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// update_agent — 403 (wrong agent_id)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_agent_wrong_agent_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    // Seed the target agent
+    let (agent_id, _) = seed_agent_with_key(&pool).await;
+
+    // Token claims a DIFFERENT agent_id
+    let different_agent_id = Uuid::new_v4();
+    let token = token_as_agent(different_agent_id, &["agents:write"]);
+
+    let body = serde_json::json!({"display_name": "new name"});
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/agents/{agent_id}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// update_agent — 200 (caller == target_agent_id)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_agent_self_returns_200() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let (agent_id, _) = seed_agent_with_key(&pool).await;
+
+    // Token: agent_id claim == target agent
+    let token = token_as_agent(agent_id, &["agents:write"]);
+
+    let body = serde_json::json!({"display_name": "updated name"});
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/agents/{agent_id}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "expected 200, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// update_agent — 200 (admin override)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_agent_admin_override_returns_200() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let (agent_id, _) = seed_agent_with_key(&pool).await;
+
+    // Admin token with a DIFFERENT agent_id (or None), but has claims:admin
+    let token = common::test_bearer_token_with_scopes(&["agents:write", "claims:admin"]);
+
+    let body = serde_json::json!({"display_name": "admin updated"});
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/agents/{agent_id}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "expected 200 for admin override, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// revoke_agent_key — 401
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_agent_key_no_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_agent = Uuid::new_v4();
+    let fake_key = Uuid::new_v4();
+    let body = serde_json::json!({"reason": "test"});
+
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/agents/{fake_agent}/keys/{fake_key}/revoke"
+        ))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// revoke_agent_key — 403 (wrong agent_id)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_agent_key_wrong_agent_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let (agent_id, key_id) = seed_agent_with_key(&pool).await;
+
+    // Token claims a different agent_id
+    let different_agent_id = Uuid::new_v4();
+    let token = token_as_agent(different_agent_id, &["agents:write"]);
+
+    let body = serde_json::json!({"reason": "test revocation"});
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/agents/{agent_id}/keys/{key_id}/revoke"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// revoke_agent_key — 200 (caller == target_agent_id)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_agent_key_self_returns_200() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let (agent_id, key_id) = seed_agent_with_key(&pool).await;
+
+    // Token with agent_id == target agent
+    let token = token_as_agent(agent_id, &["agents:write"]);
+
+    let body = serde_json::json!({"reason": "self-revocation test"});
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/agents/{agent_id}/keys/{key_id}/revoke"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "expected 200 for self-revocation, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// revoke_agent_key — 200 (admin override)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_agent_key_admin_override_returns_200() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let (agent_id, key_id) = seed_agent_with_key(&pool).await;
+
+    // Admin token — different agent_id but has claims:admin
+    let token = common::test_bearer_token_with_scopes(&["agents:write", "claims:admin"]);
+
+    let body = serde_json::json!({"reason": "admin revocation test"});
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{addr}/api/v1/agents/{agent_id}/keys/{key_id}/revoke"
+        ))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "expected 200 for admin revocation, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}

--- a/crates/epigraph-api/tests/webhooks_auth_test.rs
+++ b/crates/epigraph-api/tests/webhooks_auth_test.rs
@@ -1,0 +1,192 @@
+#![cfg(feature = "db")]
+mod common;
+
+const VALID_SECRET: &str = "Xk9mP2qL7vN8wBjH5cT0yDrF3gU6eA1s"; // 32 chars
+
+fn webhook_body() -> serde_json::Value {
+    serde_json::json!({
+        "url": "https://example.com/webhook",
+        "event_types": ["ClaimSubmitted"],
+        "secret": VALID_SECRET
+    })
+}
+
+// ---------------------------------------------------------------------------
+// 401 — no token
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/webhooks without a Bearer token → 401
+#[tokio::test(flavor = "multi_thread")]
+async fn register_webhook_no_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/webhooks"))
+        .json(&webhook_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// DELETE /api/v1/webhooks/:id without a Bearer token → 401
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_webhook_no_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let resp = reqwest::Client::new()
+        .delete(format!("http://{addr}/api/v1/webhooks/{fake_id}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 403 — wrong scope on register
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/webhooks with token lacking `webhooks:write` → 403
+#[tokio::test(flavor = "multi_thread")]
+async fn register_webhook_missing_scope_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    // Token with claims:read but NOT webhooks:write
+    let token = common::test_bearer_token_with_scopes(&["claims:read"]);
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/webhooks"))
+        .bearer_auth(&token)
+        .json(&webhook_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 200 register, then delete by another caller → 403
+// ---------------------------------------------------------------------------
+
+/// Owner registers a webhook; a different principal with webhooks:write tries to
+/// delete it → 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_webhook_by_different_caller_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    // Token for caller A (owner)
+    let owner_token = common::test_bearer_token_with_scopes(&["webhooks:write"]);
+    // Token for caller B (different client_id, also has webhooks:write)
+    let other_token = common::test_bearer_token_with_scopes(&["webhooks:write"]);
+
+    // Register webhook as caller A
+    let reg_resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/webhooks"))
+        .bearer_auth(&owner_token)
+        .json(&webhook_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        reg_resp.status(),
+        201,
+        "register failed: {} — {}",
+        reg_resp.status(),
+        reg_resp.text().await.unwrap_or_default()
+    );
+
+    let sub: serde_json::Value = reg_resp.json().await.unwrap();
+    let webhook_id = sub["id"].as_str().unwrap();
+
+    // Caller B attempts to delete
+    let del_resp = reqwest::Client::new()
+        .delete(format!("http://{addr}/api/v1/webhooks/{webhook_id}"))
+        .bearer_auth(&other_token)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        del_resp.status(),
+        403,
+        "expected 403 for cross-owner delete, got {} — {}",
+        del_resp.status(),
+        del_resp.text().await.unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 204 register then delete by same caller
+// ---------------------------------------------------------------------------
+
+/// Owner registers a webhook; same principal deletes it → 204.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_webhook_by_owner_returns_204() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["webhooks:write"]);
+
+    // Register
+    let reg_resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/webhooks"))
+        .bearer_auth(&token)
+        .json(&webhook_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        reg_resp.status(),
+        201,
+        "register failed: {} — {}",
+        reg_resp.status(),
+        reg_resp.text().await.unwrap_or_default()
+    );
+
+    let sub: serde_json::Value = reg_resp.json().await.unwrap();
+    let webhook_id = sub["id"].as_str().unwrap();
+
+    // Same caller deletes
+    let del_resp = reqwest::Client::new()
+        .delete(format!("http://{addr}/api/v1/webhooks/{webhook_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        del_resp.status(),
+        204,
+        "expected 204 for owner delete, got {} — {}",
+        del_resp.status(),
+        del_resp.text().await.unwrap_or_default()
+    );
+}

--- a/crates/epigraph-core/src/canonical_scopes.rs
+++ b/crates/epigraph-core/src/canonical_scopes.rs
@@ -46,6 +46,7 @@ pub const WRITE_SCOPES: &[&str] = &[
     "tasks:write",
     "ingest:write",
     "policy:challenge",
+    "webhooks:write",
 ];
 
 /// `epigraph-admin`: admin-superset.
@@ -135,5 +136,25 @@ mod tests {
             assert!(scopes_for(name).is_some(), "{name} should resolve");
         }
         assert!(scopes_for("not-a-canonical-name").is_none());
+    }
+
+    #[test]
+    fn webhooks_write_scope_role_membership() {
+        let ro: HashSet<String> = read_only_scopes().into_iter().collect();
+        let wo: HashSet<String> = read_write_scopes().into_iter().collect();
+        let admin: HashSet<String> = admin_scopes().into_iter().collect();
+
+        assert!(
+            !ro.contains("webhooks:write"),
+            "ro must NOT include webhooks:write"
+        );
+        assert!(
+            wo.contains("webhooks:write"),
+            "wo must include webhooks:write"
+        );
+        assert!(
+            admin.contains("webhooks:write"),
+            "admin must include webhooks:write"
+        );
     }
 }


### PR DESCRIPTION
Closes #121.

New `webhooks:write` scope (added to epigraph-core canonical_scopes; flows to wo + admin). Webhooks now require it; delete also requires owner-or-admin. update_agent and revoke_agent_key now require caller is the target agent or has claims:admin.

## Changes

- **H.1** `crates/epigraph-core/src/canonical_scopes.rs`: Added `"webhooks:write"` to `WRITE_SCOPES`. New unit test confirms `wo` and `admin` include it, `ro` does not.
- **H.2** `crates/epigraph-api/src/state.rs`: Added `owner_id: Option<Uuid>` to `WebhookSubscription` (in-memory store — no migration needed). `register_webhook` requires `webhooks:write` and persists caller principal as `owner_id`. `delete_webhook` requires `webhooks:write` and enforces owner-or-`claims:admin`.
- **H.3** `update_agent` and `revoke_agent_key`: After `agents:write` scope check, require `auth.agent_id == Some(target_id)` or `claims:admin`.
- **Tests**: 5 webhook auth tests + 8 agent mutation auth tests — all pass. OpenAPI: no utoipa annotations existed on these handlers; no annotation changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)