### PR TITLE
fix(api): ownership-or-admin gate on claim-mutation endpoints

### DIFF
--- a/crates/epigraph-api/src/middleware/scopes.rs
+++ b/crates/epigraph-api/src/middleware/scopes.rs
@@ -21,6 +21,28 @@ pub fn check_scopes(auth: &AuthContext, required: &[&str]) -> Result<(), ApiErro
     Ok(())
 }
 
+/// Returns `Ok(())` if either:
+/// - `auth` has the `claims:admin` scope, OR
+/// - `auth.owner_id` (or `auth.client_id` when `owner_id` is `None`) matches `target_owner_id`.
+///
+/// Used to gate per-row mutations: admins can edit any row; others can
+/// only edit rows they authored/own.
+pub fn require_owner_or_admin(
+    auth: &AuthContext,
+    target_owner_id: uuid::Uuid,
+) -> Result<(), ApiError> {
+    if auth.has_scope("claims:admin") {
+        return Ok(());
+    }
+    let principal = auth.owner_id.unwrap_or(auth.client_id);
+    if principal == target_owner_id {
+        return Ok(());
+    }
+    Err(ApiError::Forbidden {
+        reason: "row is owned by another principal and caller lacks claims:admin".into(),
+    })
+}
+
 /// Middleware: check that the request has a specific scope.
 /// Use with `axum::middleware::from_fn`.
 pub async fn require_scope(
@@ -42,4 +64,50 @@ pub async fn require_scope(
     }
 
     Ok(next.run(request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::bearer::ClientType;
+    use uuid::Uuid;
+
+    fn make_auth(scopes: &[&str], client_id: Uuid, owner_id: Option<Uuid>) -> AuthContext {
+        AuthContext {
+            client_id,
+            agent_id: None,
+            owner_id,
+            client_type: ClientType::Service,
+            scopes: scopes.iter().map(|s| (*s).to_string()).collect(),
+            jti: Uuid::new_v4(),
+        }
+    }
+
+    #[test]
+    fn admin_scope_passes_regardless_of_owner() {
+        let auth = make_auth(&["claims:admin"], Uuid::new_v4(), None);
+        let target = Uuid::new_v4(); // completely different
+        assert!(require_owner_or_admin(&auth, target).is_ok());
+    }
+
+    #[test]
+    fn matching_owner_passes_without_admin() {
+        let owner_id = Uuid::new_v4();
+        let auth = make_auth(&["claims:write"], Uuid::new_v4(), Some(owner_id));
+        assert!(require_owner_or_admin(&auth, owner_id).is_ok());
+    }
+
+    #[test]
+    fn matching_client_id_passes_when_no_owner_id() {
+        let client_id = Uuid::new_v4();
+        let auth = make_auth(&["claims:write"], client_id, None);
+        assert!(require_owner_or_admin(&auth, client_id).is_ok());
+    }
+
+    #[test]
+    fn non_matching_no_admin_fails() {
+        let auth = make_auth(&["claims:write"], Uuid::new_v4(), None);
+        let target = Uuid::new_v4(); // different from client_id
+        assert!(require_owner_or_admin(&auth, target).is_err());
+    }
 }

--- a/crates/epigraph-api/src/openapi.rs
+++ b/crates/epigraph-api/src/openapi.rs
@@ -344,6 +344,7 @@ async fn mark_duplicate_doc() {}
         (status = 200, body = ClaimResponse),
         (status = 400),
         (status = 401),
+        (status = 403),
         (status = 404),
     ),
     security(("ed25519_signature" = []))
@@ -360,6 +361,8 @@ async fn patch_claim_doc() {}
     responses(
         (status = 200, body = UpdateLabelsResponse),
         (status = 400),
+        (status = 401),
+        (status = 403),
         (status = 404),
     ),
     security(("ed25519_signature" = []))

--- a/crates/epigraph-api/src/routes/claims.rs
+++ b/crates/epigraph-api/src/routes/claims.rs
@@ -1967,25 +1967,29 @@ mod db_tests {
     }
 
     /// Insert a minimal agent + claim directly for test setup.
+    ///
+    /// `owner_id` is used as the claim's `agent_id` so that ownership checks
+    /// pass when the caller's AuthContext carries the same id as `owner_id`.
     async fn insert_test_claim(
         pool: &epigraph_db::PgPool,
         claim_id: Uuid,
+        owner_id: Uuid,
         truth: f64,
         properties: serde_json::Value,
         labels: &[&str],
     ) {
-        // Upsert agent (reuse claim_id as agent_id for simplicity; unique public_key via hash)
+        // Upsert agent for the owner (unique public_key via hash)
         sqlx::query(
             r#"INSERT INTO agents (id, public_key, created_at, updated_at)
                VALUES ($1, sha256($1::text::bytea), NOW(), NOW())
                ON CONFLICT (id) DO NOTHING"#,
         )
-        .bind(claim_id)
+        .bind(owner_id)
         .execute(pool)
         .await
         .expect("upsert agent");
 
-        // Insert claim
+        // Insert claim with agent_id = owner_id so ownership checks pass
         let labels_arr: Vec<String> = labels.iter().map(|s| s.to_string()).collect();
         sqlx::query(
             r#"INSERT INTO claims
@@ -1997,7 +2001,7 @@ mod db_tests {
         )
         .bind(claim_id)
         .bind(format!("test claim {claim_id}"))
-        .bind(claim_id)
+        .bind(owner_id)
         .bind(truth)
         .bind(&properties)
         .bind(&labels_arr)
@@ -2061,7 +2065,15 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.7, serde_json::json!({"a": 1}), &[]).await;
+        insert_test_claim(
+            &pool,
+            claim_id,
+            client_id,
+            0.7,
+            serde_json::json!({"a": 1}),
+            &[],
+        )
+        .await;
 
         let state = AppState::with_db(
             pool.clone(),
@@ -2105,6 +2117,7 @@ mod db_tests {
         insert_test_claim(
             &pool,
             claim_id,
+            client_id,
             0.7,
             serde_json::json!({"status": "pending", "x": 99}),
             &[],
@@ -2153,7 +2166,7 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.5, serde_json::json!({}), &[]).await;
+        insert_test_claim(&pool, claim_id, client_id, 0.5, serde_json::json!({}), &[]).await;
 
         let state = AppState::with_db(
             pool.clone(),
@@ -2212,7 +2225,15 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.7, serde_json::json!({}), &["existing"]).await;
+        insert_test_claim(
+            &pool,
+            claim_id,
+            client_id,
+            0.7,
+            serde_json::json!({}),
+            &["existing"],
+        )
+        .await;
 
         let state = AppState::with_db(
             pool.clone(),
@@ -2257,7 +2278,7 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.5, serde_json::json!({}), &[]).await;
+        insert_test_claim(&pool, claim_id, client_id, 0.5, serde_json::json!({}), &[]).await;
 
         let state = AppState::with_db(
             pool.clone(),
@@ -2302,7 +2323,15 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.7, serde_json::json!({"k": 1}), &[]).await;
+        insert_test_claim(
+            &pool,
+            claim_id,
+            client_id,
+            0.7,
+            serde_json::json!({"k": 1}),
+            &[],
+        )
+        .await;
 
         let state = AppState::with_db(
             pool.clone(),
@@ -2346,7 +2375,7 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.7, serde_json::json!({}), &[]).await;
+        insert_test_claim(&pool, claim_id, client_id, 0.7, serde_json::json!({}), &[]).await;
 
         let state = AppState::with_db(
             pool.clone(),
@@ -2405,7 +2434,7 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.7, serde_json::json!({}), &[]).await;
+        insert_test_claim(&pool, claim_id, client_id, 0.7, serde_json::json!({}), &[]).await;
 
         // Auth is present but lacks claims:write
         let auth = AuthContext {
@@ -2446,7 +2475,7 @@ mod db_tests {
         let client_id = Uuid::new_v4();
         insert_oauth_client(&pool, client_id).await;
         let claim_id = Uuid::new_v4();
-        insert_test_claim(&pool, claim_id, 0.7, serde_json::json!({}), &[]).await;
+        insert_test_claim(&pool, claim_id, client_id, 0.7, serde_json::json!({}), &[]).await;
 
         let state = AppState::with_db(
             pool.clone(),
@@ -2510,6 +2539,7 @@ mod db_tests {
         insert_test_claim(
             &pool,
             claim_id,
+            bad_client_id,
             0.5,
             serde_json::json!({"original": true}),
             &[],

--- a/crates/epigraph-api/src/routes/claims.rs
+++ b/crates/epigraph-api/src/routes/claims.rs
@@ -1136,10 +1136,13 @@ pub async fn update_claim(
     Path(id): Path<Uuid>,
     Json(request): Json<UpdateClaimRequest>,
 ) -> Result<Json<ClaimResponse>, ApiError> {
-    // Enforce scope when OAuth2-authenticated
-    if let Some(axum::Extension(ref auth)) = auth_ctx {
-        crate::middleware::scopes::check_scopes(auth, &["claims:write"])?;
-    }
+    // Require authentication
+    let auth = auth_ctx
+        .ok_or_else(|| ApiError::Unauthorized {
+            reason: "PUT /api/v1/claims/:id requires authentication".into(),
+        })?
+        .0;
+    crate::middleware::scopes::check_scopes(&auth, &["claims:write"])?;
 
     let claim_id = ClaimId::from_uuid(id);
 
@@ -1150,6 +1153,10 @@ pub async fn update_claim(
             entity: "Claim".to_string(),
             id: id.to_string(),
         })?;
+
+    // Ownership / admin gate (after 404 check to avoid leaking existence)
+    let claim_agent_id: Uuid = current.agent_id.into();
+    crate::middleware::scopes::require_owner_or_admin(&auth, claim_agent_id)?;
 
     // Update truth value if provided
     if let Some(tv) = request.truth_value {
@@ -1196,12 +1203,12 @@ pub async fn update_claim(
             })?;
     }
 
-    // Record provenance when OAuth2-authenticated
-    if let Some(axum::Extension(ref auth)) = auth_ctx {
+    // Record provenance
+    {
         let content_hash = blake3::hash(id.as_bytes());
         if let Err(e) = crate::middleware::provenance::record_provenance(
             &state.db_pool,
-            auth,
+            &auth,
             "claim",
             id,
             "update",
@@ -1251,6 +1258,7 @@ pub async fn update_claim(
         (status = 200, body = ClaimResponse),
         (status = 400),
         (status = 401),
+        (status = 403),
         (status = 404),
     ),
     security(("ed25519_signature" = [])),
@@ -1286,6 +1294,21 @@ pub async fn patch_claim(
     }
 
     let claim_id = ClaimId::from_uuid(id);
+
+    // ── 4. Ownership / admin gate ────────────────────────────────────────────
+    // Fetch agent_id before opening the transaction so 404 fires before 403.
+    let claim_agent_id: Uuid = sqlx::query_scalar("SELECT agent_id FROM claims WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("DB error fetching claim owner: {e}"),
+        })?
+        .ok_or_else(|| ApiError::NotFound {
+            entity: "Claim".to_string(),
+            id: id.to_string(),
+        })?;
+    crate::middleware::scopes::require_owner_or_admin(&auth, claim_agent_id)?;
 
     // ── 5. Open transaction — all mutations + provenance are atomic ──────────
     let mut tx = state
@@ -1449,6 +1472,8 @@ pub struct UpdateLabelsResponse {
     responses(
         (status = 200, body = UpdateLabelsResponse),
         (status = 400),
+        (status = 401),
+        (status = 403),
         (status = 404),
     ),
     security(("ed25519_signature" = [])),
@@ -1456,14 +1481,37 @@ pub struct UpdateLabelsResponse {
 )]
 pub async fn update_labels(
     State(state): State<AppState>,
+    auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>,
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateLabelsRequest>,
 ) -> Result<Json<UpdateLabelsResponse>, ApiError> {
+    // Require authentication
+    let auth = auth_ctx
+        .ok_or_else(|| ApiError::Unauthorized {
+            reason: "PATCH /api/v1/claims/:id/labels requires authentication".into(),
+        })?
+        .0;
+    crate::middleware::scopes::check_scopes(&auth, &["claims:write"])?;
+
     if body.add.is_empty() && body.remove.is_empty() {
         return Err(ApiError::BadRequest {
             message: "At least one of 'add' or 'remove' must be non-empty".to_string(),
         });
     }
+
+    // Fetch agent_id — 404 before 403 (don't leak existence via ownership check)
+    let claim_agent_id: Uuid = sqlx::query_scalar("SELECT agent_id FROM claims WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db_pool)
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("DB error fetching claim owner: {e}"),
+        })?
+        .ok_or_else(|| ApiError::NotFound {
+            entity: "Claim".to_string(),
+            id: id.to_string(),
+        })?;
+    crate::middleware::scopes::require_owner_or_admin(&auth, claim_agent_id)?;
 
     let labels = ClaimRepository::update_labels(&state.db_pool, id, &body.add, &body.remove)
         .await

--- a/crates/epigraph-api/src/routes/versioning.rs
+++ b/crates/epigraph-api/src/routes/versioning.rs
@@ -237,6 +237,9 @@ pub async fn supersede_claim(
             id: claim_id.to_string(),
         })?;
 
+    // 6b. Ownership / admin gate
+    crate::middleware::scopes::require_owner_or_admin(&auth, agent_uuid)?;
+
     // 7. Perform supersession in the database (atomic transaction)
     let old_claim_id = ClaimId::from_uuid(claim_id);
     let (new_uuid, _old_uuid) = ClaimRepository::supersede(

--- a/crates/epigraph-api/tests/common/mod.rs
+++ b/crates/epigraph-api/tests/common/mod.rs
@@ -166,6 +166,43 @@ pub async fn seed_claim(pool: &PgPool, content: &str) -> Uuid {
     id
 }
 
+/// Insert a claim whose `agent_id` is the given UUID.
+/// Also inserts an `agents` row for that UUID so the FK is satisfied.
+pub async fn seed_claim_with_agent(pool: &PgPool, content: &str, agent_id: Uuid) -> Uuid {
+    // Ensure the agent row exists (may already exist from a previous call).
+    let pk: Vec<u8> = agent_id
+        .as_bytes()
+        .iter()
+        .copied()
+        .cycle()
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, agent_type) \
+         VALUES ($1, $2, 'system') ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(agent_id)
+    .bind(&pk)
+    .execute(pool)
+    .await
+    .expect("seed agent for claim");
+
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id.as_bytes().iter().copied().cycle().take(32).collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current, labels) \
+         VALUES ($1, $2, $3, 0.5, $4, true, ARRAY[]::text[])",
+    )
+    .bind(id)
+    .bind(content)
+    .bind(&hash)
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("seed claim with agent");
+    id
+}
+
 /// Insert a claim with explicit labels.
 pub async fn seed_claim_with_labels(pool: &PgPool, content: &str, labels: &[&str]) -> Uuid {
     let id = seed_claim(pool, content).await;

--- a/crates/epigraph-api/tests/patch_claim_http_test.rs
+++ b/crates/epigraph-api/tests/patch_claim_http_test.rs
@@ -2,8 +2,8 @@
 use sqlx::postgres::PgPoolOptions;
 mod common;
 
-/// PATCH /api/v1/claims/:id with a valid claims:write token and a real claim
-/// returns 200 with the updated properties reflected in the response body.
+/// PATCH /api/v1/claims/:id with a valid claims:write token (matching owner)
+/// returns 200.
 #[tokio::test(flavor = "multi_thread")]
 async fn patch_claim_happy_path_returns_200() {
     let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
@@ -13,15 +13,14 @@ async fn patch_claim_happy_path_returns_200() {
         .await
         .unwrap();
 
-    let claim_id = common::seed_claim(&pool, "patch happy path content").await;
-
     let (addr, _shutdown) = common::spawn_app(&url).await;
-    let (token, _client_id) =
+    let (token, client_id) =
         common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
 
-    // Use add_labels — a successful PATCH returns 200 even if the response body
-    // doesn't reflect labels (get_by_id_conn omits the labels column).
-    // We verify success by checking the HTTP status code only.
+    // Seed claim whose agent_id == client_id so ownership check passes.
+    let claim_id =
+        common::seed_claim_with_agent(&pool, "patch happy path content", client_id).await;
+
     let body = serde_json::json!({
         "add_labels": ["test-label"],
     });
@@ -37,6 +36,82 @@ async fn patch_claim_happy_path_returns_200() {
     let status = resp.status();
     let text = resp.text().await.unwrap();
     assert_eq!(status, 200, "expected 200 OK, got {status} — body={text}");
+}
+
+/// PATCH /api/v1/claims/:id with a claims:admin token on someone else's claim
+/// returns 200 (admin override).
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_claim_admin_token_overrides_ownership() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    // Admin token — client_id different from claim's agent_id
+    let (admin_token, _) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write", "claims:admin"])
+            .await;
+    // Claim owned by a different agent
+    let claim_id = common::seed_claim(&pool, "admin override target").await;
+
+    let body = serde_json::json!({ "add_labels": ["admin-label"] });
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{claim_id}"))
+        .bearer_auth(&admin_token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "admin should pass ownership check; got {status} — body={text}"
+    );
+}
+
+/// PATCH /api/v1/claims/:id with a claims:write token for a different principal
+/// returns 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_claim_mismatched_owner_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    // Token for principal A
+    let (token_a, _client_a) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    // Claim owned by principal B (different client)
+    let (_, client_b) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    let claim_id = common::seed_claim_with_agent(&pool, "ownership mismatch claim", client_b).await;
+
+    let body = serde_json::json!({ "add_labels": ["forbidden-label"] });
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{claim_id}"))
+        .bearer_auth(&token_a)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 for mismatched owner; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
 }
 
 /// PATCH /api/v1/claims/:id with no Authorization header must return 401.
@@ -143,11 +218,12 @@ async fn patch_claim_invalid_body_returns_400() {
         .await
         .unwrap();
 
-    let claim_id = common::seed_claim(&pool, "patch 400 test content").await;
-
     let (addr, _shutdown) = common::spawn_app(&url).await;
-    let (token, _client_id) =
+    let (token, client_id) =
         common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+
+    // Claim owned by the same client so we reach the is_empty() check.
+    let claim_id = common::seed_claim_with_agent(&pool, "patch 400 test content", client_id).await;
 
     // Empty body: no trace_id, no properties, no add_labels, no remove_labels.
     // The handler's is_empty() check returns true → 400.

--- a/crates/epigraph-api/tests/supersede_scope_check_test.rs
+++ b/crates/epigraph-api/tests/supersede_scope_check_test.rs
@@ -61,6 +61,82 @@ async fn supersede_with_read_only_token_returns_403() {
     );
 }
 
+/// POST /api/v1/claims/:id/supersede with a matching-owner token → 200/201.
+#[tokio::test(flavor = "multi_thread")]
+async fn supersede_matching_owner_returns_success() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    let claim_id = common::seed_claim_with_agent(&pool, "supersede owner match", client_id).await;
+
+    let body = serde_json::json!({
+        "content": "superseded content",
+        "truth_value": 0.7,
+        "reason": "ownership test",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{claim_id}/supersede"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert!(
+        status == 200 || status == 201,
+        "expected 200/201 for matching owner; got {status} — body={text}"
+    );
+}
+
+/// POST /api/v1/claims/:id/supersede with a mismatched owner → 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn supersede_mismatched_owner_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    // Token for principal A
+    let (token_a, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    // Claim owned by principal B
+    let (_, client_b) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    let claim_id = common::seed_claim_with_agent(&pool, "supersede owner mismatch", client_b).await;
+
+    let body = serde_json::json!({
+        "content": "unauthorized supersede",
+        "truth_value": 0.7,
+        "reason": "should fail",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/claims/{claim_id}/supersede"))
+        .bearer_auth(&token_a)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 for mismatched owner; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
 /// POST /api/v1/claims/:id/supersede with a valid claims:write token but
 /// a non-existent claim UUID → 404.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/epigraph-api/tests/update_claim_ownership_test.rs
+++ b/crates/epigraph-api/tests/update_claim_ownership_test.rs
@@ -1,0 +1,131 @@
+#![cfg(feature = "db")]
+mod common;
+use sqlx::postgres::PgPoolOptions;
+
+/// PUT /api/v1/claims/:id with a matching-owner token returns 200.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_claim_matching_owner_returns_200() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    let claim_id =
+        common::seed_claim_with_agent(&pool, "update claim owner match", client_id).await;
+
+    let body = serde_json::json!({ "truth_value": 0.8 });
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/claims/{claim_id}"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "expected 200 for matching owner; got {status} — body={text}"
+    );
+}
+
+/// PUT /api/v1/claims/:id with a claims:admin token on someone else's claim returns 200.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_claim_admin_token_overrides_ownership() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (admin_token, _) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write", "claims:admin"])
+            .await;
+    // Claim owned by a completely different agent
+    let claim_id = common::seed_claim(&pool, "update claim admin override").await;
+
+    let body = serde_json::json!({ "truth_value": 0.6 });
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/claims/{claim_id}"))
+        .bearer_auth(&admin_token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "admin should bypass ownership check; got {status} — body={text}"
+    );
+}
+
+/// PUT /api/v1/claims/:id with a mismatched-owner token returns 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_claim_mismatched_owner_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    // Token for principal A
+    let (token_a, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    // Claim owned by principal B
+    let (_, client_b) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    let claim_id =
+        common::seed_claim_with_agent(&pool, "update claim owner mismatch", client_b).await;
+
+    let body = serde_json::json!({ "truth_value": 0.5 });
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/claims/{claim_id}"))
+        .bearer_auth(&token_a)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 for mismatched owner; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// PUT /api/v1/claims/:id with no token returns 401.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_claim_without_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let body = serde_json::json!({ "truth_value": 0.5 });
+    let resp = reqwest::Client::new()
+        .put(format!("http://{addr}/api/v1/claims/{fake_id}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401 without token; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}

--- a/crates/epigraph-api/tests/update_labels_ownership_test.rs
+++ b/crates/epigraph-api/tests/update_labels_ownership_test.rs
@@ -1,0 +1,131 @@
+#![cfg(feature = "db")]
+mod common;
+use sqlx::postgres::PgPoolOptions;
+
+/// PATCH /api/v1/claims/:id/labels with a matching-owner token returns 200.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_labels_matching_owner_returns_200() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    let claim_id =
+        common::seed_claim_with_agent(&pool, "update labels owner match", client_id).await;
+
+    let body = serde_json::json!({ "add": ["owner-label"] });
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{claim_id}/labels"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "expected 200 for matching owner; got {status} — body={text}"
+    );
+}
+
+/// PATCH /api/v1/claims/:id/labels with a claims:admin token on someone else's claim returns 200.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_labels_admin_token_overrides_ownership() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (admin_token, _) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write", "claims:admin"])
+            .await;
+    // Claim owned by a completely different agent
+    let claim_id = common::seed_claim(&pool, "update labels admin override").await;
+
+    let body = serde_json::json!({ "add": ["admin-label"] });
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{claim_id}/labels"))
+        .bearer_auth(&admin_token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "admin should bypass ownership check; got {status} — body={text}"
+    );
+}
+
+/// PATCH /api/v1/claims/:id/labels with a mismatched-owner token returns 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_labels_mismatched_owner_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    // Token for principal A
+    let (token_a, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    // Claim owned by principal B
+    let (_, client_b) =
+        common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+    let claim_id =
+        common::seed_claim_with_agent(&pool, "update labels owner mismatch", client_b).await;
+
+    let body = serde_json::json!({ "add": ["forbidden-label"] });
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{claim_id}/labels"))
+        .bearer_auth(&token_a)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403 for mismatched owner; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// PATCH /api/v1/claims/:id/labels with no token returns 401.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_labels_without_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let body = serde_json::json!({ "add": ["some-label"] });
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{addr}/api/v1/claims/{fake_id}/labels"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401 without token; got {} — body={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}


### PR DESCRIPTION
Closes #116.

## Summary
- Adds `require_owner_or_admin` helper in `middleware::scopes` — callers must hold `claims:admin` OR be the claim's authoring agent
- Wires the check into `supersede_claim`, `update_claim`, `patch_claim`, and `update_labels` after the 404 existence check (no info leak)
- `update_labels` gains a full auth chain (was previously completely unprotected)
- `update_claim` auth is now required (was previously optional)
- OpenAPI doc stubs updated with 401/403 responses

## Test plan
- [ ] 4 unit tests in `middleware::scopes` (admin passes, matching owner passes, matching client_id passes, non-matching fails)
- [ ] `patch_claim_http_test`: 7 tests including matching owner (200), admin override (200), mismatched owner (403)
- [ ] `supersede_scope_check_test`: 5 tests including matching owner (200), mismatched owner (403)
- [ ] `update_claim_ownership_test` (new): 4 tests covering matching owner, admin, mismatched (403), no auth (401)
- [ ] `update_labels_ownership_test` (new): 4 tests covering same scenarios
- [ ] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)