### PR TITLE
feat(mcp): unix:/path sockets in --listen (#129)

### DIFF
--- a/crates/epigraph-mcp/src/lib.rs
+++ b/crates/epigraph-mcp/src/lib.rs
@@ -37,11 +37,17 @@ pub async fn serve_with_listener(listen: &str, router: axum::Router) -> std::io:
     #[cfg(unix)]
     if let Some(path) = listen.strip_prefix("unix:") {
         // Best-effort cleanup of a stale socket from a previous run.
+        //
+        // NOTE: AF_UNIX has no SO_REUSEADDR equivalent. If two MCP processes
+        // start concurrently against the same path, the second's remove_file
+        // unlinks the first's just-bound inode and the first listener is
+        // silently orphaned. We rely on systemd (single-instance unit) to
+        // ensure this race never fires in production.
         let _ = std::fs::remove_file(path);
         let listener = tokio::net::UnixListener::bind(path)?;
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o660))?;
-        tracing::info!("EpiGraph MCP server listening on unix:{path}/mcp");
+        tracing::info!("EpiGraph MCP server listening on unix:{path} (HTTP path: /mcp)");
         return axum::serve(listener, router).await;
     }
 

--- a/crates/epigraph-mcp/src/lib.rs
+++ b/crates/epigraph-mcp/src/lib.rs
@@ -18,3 +18,34 @@ pub use server::EpiGraphMcpFull;
 pub fn list_tools() -> serde_json::Value {
     EpiGraphMcpFull::all_tools_json()
 }
+
+/// Serve `router` on the given `listen` spec.
+///
+/// Accepts either a `host:port` TCP address or a `unix:/abs/path` Unix socket spec.
+/// For Unix sockets, the file is removed if stale, then created with `0o660`
+/// permissions (rw for owner+group, nothing for others), so only processes
+/// with filesystem access can connect.
+///
+/// The router is passed in (rather than built here) because the production
+/// router depends on a DB pool, signer, and embedder; tests can pass a trivial
+/// `axum::Router::new()` to exercise only the listener-binding logic.
+///
+/// # Errors
+/// Returns the underlying I/O error from `bind`, `set_permissions`, or `axum::serve`.
+#[allow(clippy::missing_panics_doc)]
+pub async fn serve_with_listener(listen: &str, router: axum::Router) -> std::io::Result<()> {
+    #[cfg(unix)]
+    if let Some(path) = listen.strip_prefix("unix:") {
+        // Best-effort cleanup of a stale socket from a previous run.
+        let _ = std::fs::remove_file(path);
+        let listener = tokio::net::UnixListener::bind(path)?;
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o660))?;
+        tracing::info!("EpiGraph MCP server listening on unix:{path}/mcp");
+        return axum::serve(listener, router).await;
+    }
+
+    let listener = tokio::net::TcpListener::bind(listen).await?;
+    tracing::info!("EpiGraph MCP server listening on http://{listen}/mcp");
+    axum::serve(listener, router).await
+}

--- a/crates/epigraph-mcp/src/main.rs
+++ b/crates/epigraph-mcp/src/main.rs
@@ -14,6 +14,11 @@
 //! # HTTP transport (for curl / remote agents — requires explicit opt-in)
 //! # WARNING: exposes all mutation tools without auth; see issue #122 for proper fix.
 //! epigraph-mcp-full --database-url postgres://user:pass@host/db --listen 127.0.0.1:8080 --allow-unauthenticated-http
+//!
+//! # Unix socket transport (Caddy proxies via reverse_proxy unix://...; eliminates
+//! # the 127.0.0.1 localhost-bypass surface — only processes with filesystem access
+//! # can connect; socket is created with 0660 perms)
+//! epigraph-mcp-full --database-url postgres://user:pass@host/db --listen unix:/run/epigraph/mcp.sock --allow-unauthenticated-http
 //! ```
 
 use std::fmt::Write;
@@ -45,7 +50,9 @@ struct Cli {
     #[arg(long, env = "OPENAI_API_KEY")]
     openai_api_key: Option<String>,
 
-    /// Listen on HTTP address (e.g., 127.0.0.1:8080). If omitted, uses stdio transport.
+    /// Listen on HTTP. Accepts either `host:port` (TCP) or `unix:/abs/path` (Unix socket).
+    /// Unix sockets close the localhost-bypass surface: only processes with filesystem
+    /// access can connect. If omitted, uses stdio transport.
     #[arg(long)]
     listen: Option<String>,
 
@@ -135,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("EpiGraph MCP server running in {mode} mode");
 
     if let Some(addr) = &cli.listen {
-        // ── HTTP transport ──────────────────────────────────────────────
+        // ── HTTP transport (TCP or Unix socket) ────────────────────────
         // (auth gate already enforced above at startup; --allow-unauthenticated-http was checked)
         use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
         use rmcp::transport::streamable_http_server::{
@@ -160,9 +167,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
 
         let router = axum::Router::new().nest_service("/mcp", service);
-        let listener = tokio::net::TcpListener::bind(addr).await?;
-        tracing::info!("EpiGraph MCP server listening on http://{addr}/mcp ({mode})");
-        axum::serve(listener, router).await?;
+        tracing::info!("Starting EpiGraph MCP server in {mode} mode on {addr}");
+        epigraph_mcp::serve_with_listener(addr, router).await?;
     } else {
         // ── Stdio transport (default) ───────────────────────────────────
         let server = EpiGraphMcpFull::new(pool, signer, embedder, cli.read_only);

--- a/crates/epigraph-mcp/tests/unix_socket_test.rs
+++ b/crates/epigraph-mcp/tests/unix_socket_test.rs
@@ -1,0 +1,71 @@
+//! Integration test for `--listen unix:/abs/path` support (issue #129).
+//!
+//! Verifies that `serve_with_listener` binds a Unix-domain socket at the
+//! requested path with 0660 permissions and accepts incoming connections.
+//! Unix sockets eliminate the 127.0.0.1 localhost-bypass surface — only
+//! processes with filesystem access can connect — which is the practical
+//! near-term mitigation paired with Caddy `reverse_proxy unix://...`.
+//!
+//! The full Bearer-auth fix lives in issue #122. This test only exercises
+//! the listener-binding logic; the router is intentionally trivial so the
+//! test runs without a DB / signer / embedder.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_listen_on_unix_socket_binds_and_accepts_connection() {
+    // Unique-per-process path (PID + nanos guards against parallel-test collisions
+    // when this file gains a second test or a re-used PID after rapid restarts).
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let sock_path = format!(
+        "/tmp/epigraph-mcp-test-{}-{nanos}.sock",
+        std::process::id()
+    );
+    let _ = std::fs::remove_file(&sock_path);
+
+    let listen_arg = format!("unix:{sock_path}");
+    let router = axum::Router::new();
+
+    // Spawn the helper. It awaits forever (until aborted) once bound.
+    let listen_arg_clone = listen_arg.clone();
+    let handle = tokio::spawn(async move {
+        epigraph_mcp::serve_with_listener(&listen_arg_clone, router).await
+    });
+
+    // Poll for the socket file to appear (up to 2s).
+    let mut appeared = false;
+    for _ in 0..20 {
+        if std::fs::metadata(&sock_path).is_ok() {
+            appeared = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        appeared,
+        "socket file {sock_path} did not appear within 2s — bind failed"
+    );
+
+    // Verify permissions are 0660 (rw-rw----).
+    let meta = std::fs::metadata(&sock_path).expect("socket should exist");
+    let mode = meta.permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o660,
+        "socket perms should be 0660, got {mode:o} — see issue #129"
+    );
+
+    // Verify it actually accepts a connection (not just a stale file).
+    let _stream = tokio::net::UnixStream::connect(&sock_path)
+        .await
+        .expect("can connect to bound unix socket");
+
+    // Cleanup.
+    handle.abort();
+    let _ = std::fs::remove_file(&sock_path);
+}

--- a/crates/epigraph-mcp/tests/unix_socket_test.rs
+++ b/crates/epigraph-mcp/tests/unix_socket_test.rs
@@ -23,10 +23,7 @@ async fn mcp_listen_on_unix_socket_binds_and_accepts_connection() {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.subsec_nanos())
         .unwrap_or(0);
-    let sock_path = format!(
-        "/tmp/epigraph-mcp-test-{}-{nanos}.sock",
-        std::process::id()
-    );
+    let sock_path = format!("/tmp/epigraph-mcp-test-{}-{nanos}.sock", std::process::id());
     let _ = std::fs::remove_file(&sock_path);
 
     let listen_arg = format!("unix:{sock_path}");
@@ -34,9 +31,10 @@ async fn mcp_listen_on_unix_socket_binds_and_accepts_connection() {
 
     // Spawn the helper. It awaits forever (until aborted) once bound.
     let listen_arg_clone = listen_arg.clone();
-    let handle = tokio::spawn(async move {
-        epigraph_mcp::serve_with_listener(&listen_arg_clone, router).await
-    });
+    let handle =
+        tokio::spawn(
+            async move { epigraph_mcp::serve_with_listener(&listen_arg_clone, router).await },
+        );
 
     // Poll for the socket file to appear (up to 2s).
     let mut appeared = false;


### PR DESCRIPTION
## Summary

Closes #129. Adds Unix-socket support to the MCP server's `--listen` flag so production can route Caddy → MCP via socket and eliminate the 127.0.0.1 localhost-bypass surface (the main concern in #129).

### Usage

```bash
epigraph-mcp-full --listen unix:/run/epiclaw/mcp.sock --allow-unauthenticated-http
```

Caddy then proxies via `reverse_proxy unix:///run/epiclaw/mcp.sock`. Only processes with filesystem access to the socket (= jeremy + root via group, gated by 0660 perms) can connect — TCP localhost bypass is gone.

### What changed

- New `pub async fn serve_with_listener(listen, router)` in `crates/epigraph-mcp/src/lib.rs`. Detects `unix:` prefix → cleans stale socket → `UnixListener::bind` → `set_permissions 0o660` → `axum::serve`. TCP path otherwise (unchanged semantics).
- `main.rs --listen` block now calls the helper; the `--allow-unauthenticated-http` safety gate stays in place and fires for both modes.
- CLI doc comment updated to mention both modes.
- `#[cfg(unix)]`-gated so Windows still compiles.
- Integration test at `crates/epigraph-mcp/tests/unix_socket_test.rs` binds a real socket, asserts `0o660` perms, verifies a `UnixStream::connect` round-trip.

### Issue #122 relationship

Issue #122 (full Bearer auth + per-tool scope gating in MCP HTTP) is the proper long-term fix. This PR is the practical near-term mitigation: socket-only deployment closes the bypass surface immediately even before #122 lands.

### Test plan

- [x] `cargo test -p epigraph-mcp --test unix_socket_test`: 1/1 pass.
- [x] Full `cargo test -p epigraph-mcp` (with `DATABASE_URL` set): no regressions.
- [x] TCP path verified unchanged in code review (same `TcpListener::bind` + `axum::serve` flow, just relocated into the helper).
- [x] `--allow-unauthenticated-http` gate fires for unix mode too (gate at `main.rs:89` checks `cli.listen.is_some()` regardless of prefix).

### Known caveat

AF_UNIX has no `SO_REUSEADDR` equivalent. If two MCP processes start concurrently against the same path, the second's stale-socket cleanup unlinks the first's just-bound inode and silently orphans the first listener. This is fine under the current systemd single-instance unit deployment but is worth noting. A NOTE comment is in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)