### PR TITLE
feat(mcp): improve_workflow_hierarchy tool (#36)

### DIFF
--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -128,6 +128,25 @@ impl WorkflowRepository {
         Ok(row.map(|(id,)| id))
     }
 
+    /// Return the highest existing `generation` for the given `canonical_name`,
+    /// or `None` if no rows exist. Used by `improve_workflow_hierarchy` to
+    /// pick the next generation for a variant.
+    ///
+    /// # Errors
+    /// Returns `sqlx::Error` if the underlying query fails.
+    pub async fn max_generation_by_canonical(
+        pool: &PgPool,
+        canonical_name: &str,
+    ) -> Result<Option<i32>, sqlx::Error> {
+        let row: Option<(Option<i32>,)> = sqlx::query_as(
+            "SELECT MAX(generation) FROM workflows WHERE canonical_name = $1",
+        )
+        .bind(canonical_name)
+        .fetch_optional(pool)
+        .await?;
+        Ok(row.and_then(|(g,)| g))
+    }
+
     /// Semantic search for workflows by embedding with hybrid scoring.
     pub async fn find_by_embedding(
         pool: &PgPool,
@@ -650,6 +669,45 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn max_generation_by_canonical_returns_highest(pool: sqlx::PgPool) {
+        // Insert two generations of the same canonical_name.
+        WorkflowRepository::insert_root(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "max-gen-test",
+            1,
+            "first",
+            None,
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+        WorkflowRepository::insert_root(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "max-gen-test",
+            3,
+            "third",
+            None,
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+
+        let max = WorkflowRepository::max_generation_by_canonical(&pool, "max-gen-test")
+            .await
+            .unwrap();
+        assert_eq!(max, Some(3));
+
+        // Missing canonical_name returns None.
+        let missing =
+            WorkflowRepository::max_generation_by_canonical(&pool, "does-not-exist-at-all")
+                .await
+                .unwrap();
+        assert_eq!(missing, None);
     }
 
     #[sqlx::test(migrations = "../../migrations")]

--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -141,12 +141,11 @@ impl WorkflowRepository {
         // `SELECT MAX(...)` always returns exactly one row in PostgreSQL —
         // `NULL` when no source rows match. `fetch_one` matches that contract;
         // the inner `Option<i32>` carries the "no matching rows" signal.
-        let (max_gen,): (Option<i32>,) = sqlx::query_as(
-            "SELECT MAX(generation) FROM workflows WHERE canonical_name = $1",
-        )
-        .bind(canonical_name)
-        .fetch_one(pool)
-        .await?;
+        let (max_gen,): (Option<i32>,) =
+            sqlx::query_as("SELECT MAX(generation) FROM workflows WHERE canonical_name = $1")
+                .bind(canonical_name)
+                .fetch_one(pool)
+                .await?;
         Ok(max_gen)
     }
 

--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -138,13 +138,16 @@ impl WorkflowRepository {
         pool: &PgPool,
         canonical_name: &str,
     ) -> Result<Option<i32>, sqlx::Error> {
-        let row: Option<(Option<i32>,)> = sqlx::query_as(
+        // `SELECT MAX(...)` always returns exactly one row in PostgreSQL —
+        // `NULL` when no source rows match. `fetch_one` matches that contract;
+        // the inner `Option<i32>` carries the "no matching rows" signal.
+        let (max_gen,): (Option<i32>,) = sqlx::query_as(
             "SELECT MAX(generation) FROM workflows WHERE canonical_name = $1",
         )
         .bind(canonical_name)
-        .fetch_optional(pool)
+        .fetch_one(pool)
         .await?;
-        Ok(row.and_then(|(g,)| g))
+        Ok(max_gen)
     }
 
     /// Semantic search for workflows by embedding with hybrid scoring.

--- a/crates/epigraph-mcp/src/main.rs
+++ b/crates/epigraph-mcp/src/main.rs
@@ -2,7 +2,7 @@
 
 //! EpiGraph Full-Framework MCP Server — exposes all workspace crates as MCP tools.
 //!
-//! Connects to the EpiGraph PostgreSQL backend and provides 57 MCP tools including
+//! Connects to the EpiGraph PostgreSQL backend and provides 58 MCP tools including
 //! full CDST support (6 combination methods), scoped beliefs, and DS-vs-Bayesian divergence.
 //!
 //! ## Usage
@@ -30,7 +30,7 @@ use epigraph_mcp::EpiGraphMcpFull;
 #[derive(Parser)]
 #[command(
     name = "epigraph-mcp-full",
-    about = "EpiGraph full-framework MCP server — 57 epistemic tools"
+    about = "EpiGraph full-framework MCP server — 58 epistemic tools"
 )]
 struct Cli {
     /// PostgreSQL connection URL
@@ -130,7 +130,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mode = if cli.read_only {
         "read-only (33 tools)"
     } else {
-        "full (57 tools)"
+        "full (58 tools)"
     };
     tracing::info!("EpiGraph MCP server running in {mode} mode");
 

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -402,7 +402,7 @@ impl EpiGraphMcpFull {
         tools::workflows::deprecate_workflow(self, params).await
     }
 
-    // ── Hierarchical Workflows (3 tools) ──
+    // ── Hierarchical Workflows (4 tools) ──
     //
     // Counterparts to the flat `store_workflow` family above. These operate
     // on the `workflows` table where every step is a claim node connected
@@ -418,6 +418,17 @@ impl EpiGraphMcpFull {
     ) -> Result<CallToolResult, McpError> {
         self.reject_if_read_only()?;
         tools::workflow_ingest::ingest_workflow(self, params).await
+    }
+
+    #[tool(
+        description = "Create a generation-incremented hierarchical variant of an existing workflow. Looks up parent by canonical_name, finds its latest generation, and ingests the new extraction with generation = parent + 1 and parent_canonical_name linked. Idempotent."
+    )]
+    async fn improve_workflow_hierarchy(
+        &self,
+        Parameters(params): Parameters<ImproveWorkflowHierarchyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::workflow_ingest::improve_workflow_hierarchy(self, params).await
     }
 
     #[tool(
@@ -776,7 +787,7 @@ impl EpiGraphMcpFull {
 impl ServerHandler for EpiGraphMcpFull {
     fn get_info(&self) -> ServerInfo {
         let mode = if self.read_only { "read-only" } else { "full" };
-        let tool_count = if self.read_only { 33 } else { 57 };
+        let tool_count = if self.read_only { 33 } else { 58 };
         ServerInfo {
             instructions: Some(format!(
                 "EpiGraph {mode} MCP server with {tool_count} epistemic tools."

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -421,7 +421,7 @@ impl EpiGraphMcpFull {
     }
 
     #[tool(
-        description = "Create a generation-incremented hierarchical variant of an existing workflow. Looks up parent by canonical_name, finds its latest generation, and ingests the new extraction with generation = parent + 1 and parent_canonical_name linked. Idempotent."
+        description = "Create a generation-incremented hierarchical variant of an existing workflow. Looks up parent by canonical_name, finds its latest generation, and ingests the new extraction with generation = parent + 1 and parent_canonical_name linked. Same-lineage improvement only: the new variant's canonical_name and parent_canonical_name are both set to the tool's `parent_canonical_name` param; cross-lineage variants are not supported. Each call produces a new generation."
     )]
     async fn improve_workflow_hierarchy(
         &self,

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -126,17 +126,15 @@ pub async fn improve_workflow_hierarchy_via_pool(
     parent_canonical_name: &str,
     mut extraction: WorkflowExtraction,
 ) -> Result<ImproveWorkflowHierarchyResponse, McpError> {
-    let parent_max = epigraph_db::WorkflowRepository::max_generation_by_canonical(
-        pool,
-        parent_canonical_name,
-    )
-    .await
-    .map_err(internal_error)?
-    .ok_or_else(|| {
-        invalid_params(format!(
-            "no workflow with canonical_name={parent_canonical_name}"
-        ))
-    })?;
+    let parent_max =
+        epigraph_db::WorkflowRepository::max_generation_by_canonical(pool, parent_canonical_name)
+            .await
+            .map_err(internal_error)?
+            .ok_or_else(|| {
+                invalid_params(format!(
+                    "no workflow with canonical_name={parent_canonical_name}"
+                ))
+            })?;
 
     let new_generation = parent_max + 1;
 

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -12,9 +12,9 @@
 
 use rmcp::model::*;
 
-use crate::errors::{internal_error, McpError};
+use crate::errors::{internal_error, invalid_params, McpError};
 use crate::server::EpiGraphMcpFull;
-use crate::types::IngestWorkflowParams;
+use crate::types::{ImproveWorkflowHierarchyParams, IngestWorkflowParams};
 
 use epigraph_ingest::workflow::WorkflowExtraction;
 
@@ -84,6 +84,91 @@ pub async fn ingest_workflow(
     params: IngestWorkflowParams,
 ) -> Result<CallToolResult, McpError> {
     do_ingest_workflow(server, &params.extraction).await
+}
+
+// ── improve_workflow_hierarchy ─────────────────────────────────────────────
+//
+// Creates a generation-incremented variant of an existing hierarchical
+// workflow lineage. Idempotent on `(canonical_name, generation)` via the
+// underlying executor's gate: a fully-formed variant at the resolved
+// generation is detected and reported as `already_ingested`. Note that the
+// resolved generation is always `max(generation) + 1` for the canonical
+// lineage, so back-to-back calls each produce a fresh generation rather
+// than no-oping the second call.
+//
+// We do NOT add the `'workflow'` label to the thesis claim. That label is
+// reserved for FLAT workflow claims (the `store_workflow` / `improve_workflow`
+// lineage). Hierarchical workflows live in the `workflows` table and use
+// `kind: workflow_thesis` on the root claim, matching `do_ingest_workflow`'s
+// behavior.
+
+#[derive(Debug, serde::Serialize)]
+pub struct ImproveWorkflowHierarchyResponse {
+    pub parent_canonical_name: String,
+    pub parent_generation: i32,
+    pub new_generation: i32,
+    pub workflow_id: String,
+    pub claims_ingested: usize,
+    pub already_ingested: bool,
+}
+
+/// Pool-only logic for `improve_workflow_hierarchy`. Resolves the max
+/// generation for `parent_canonical_name`, overwrites the caller-supplied
+/// extraction source fields with the resolved variant identity, then calls
+/// `do_ingest_workflow_via_pool` to perform the actual hierarchical ingest.
+///
+/// Caller-supplied values for `extraction.source.canonical_name`,
+/// `extraction.source.generation`, and `extraction.source.parent_canonical_name`
+/// are intentionally OVERWRITTEN so that the variant's identity is dictated
+/// by the resolver, not the caller.
+pub async fn improve_workflow_hierarchy_via_pool(
+    pool: &sqlx::PgPool,
+    parent_canonical_name: &str,
+    mut extraction: WorkflowExtraction,
+) -> Result<ImproveWorkflowHierarchyResponse, McpError> {
+    let parent_max = epigraph_db::WorkflowRepository::max_generation_by_canonical(
+        pool,
+        parent_canonical_name,
+    )
+    .await
+    .map_err(internal_error)?
+    .ok_or_else(|| {
+        invalid_params(format!(
+            "no workflow with canonical_name={parent_canonical_name}"
+        ))
+    })?;
+
+    let new_generation = parent_max + 1;
+
+    extraction.source.canonical_name = parent_canonical_name.to_string();
+    extraction.source.generation = u32::try_from(new_generation)
+        .map_err(|e| internal_error(format!("new_generation does not fit in u32: {e}")))?;
+    extraction.source.parent_canonical_name = Some(parent_canonical_name.to_string());
+
+    let response = do_ingest_workflow_via_pool(pool, &extraction).await?;
+
+    Ok(ImproveWorkflowHierarchyResponse {
+        parent_canonical_name: parent_canonical_name.to_string(),
+        parent_generation: parent_max,
+        new_generation,
+        workflow_id: response.workflow_id,
+        claims_ingested: response.claims_ingested,
+        already_ingested: response.already_ingested,
+    })
+}
+
+/// MCP tool entry point for `improve_workflow_hierarchy`.
+pub async fn improve_workflow_hierarchy(
+    server: &EpiGraphMcpFull,
+    params: ImproveWorkflowHierarchyParams,
+) -> Result<CallToolResult, McpError> {
+    let response = improve_workflow_hierarchy_via_pool(
+        &server.pool,
+        &params.parent_canonical_name,
+        params.extraction,
+    )
+    .await?;
+    success_json(&response)
 }
 
 // ── Integration tests ──────────────────────────────────────────────────────

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -375,7 +375,7 @@ pub struct ImproveWorkflowHierarchyParams {
     pub parent_canonical_name: String,
 
     #[schemars(
-        description = "Hierarchical extraction for the new variant. The tool overwrites `extraction.source.canonical_name`, `generation`, and `parent_canonical_name` with the resolved values, so caller-supplied values for those three fields are ignored."
+        description = "Hierarchical extraction for the new variant. The tool overwrites `extraction.source.canonical_name`, `generation`, and `parent_canonical_name`: canonical_name and parent_canonical_name are both set to the tool's `parent_canonical_name` param (same-lineage improvement only — cross-lineage variants are not supported by this tool), and generation is set to the parent's current max + 1. Caller-supplied values for those three fields are ignored."
     )]
     pub extraction: epigraph_ingest::workflow::WorkflowExtraction,
 }

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -368,6 +368,19 @@ pub struct IngestWorkflowParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ImproveWorkflowHierarchyParams {
+    #[schemars(
+        description = "Canonical name of the existing workflow lineage to variant. The tool resolves the current max generation under this name and creates the new variant at generation = max + 1."
+    )]
+    pub parent_canonical_name: String,
+
+    #[schemars(
+        description = "Hierarchical extraction for the new variant. The tool overwrites `extraction.source.canonical_name`, `generation`, and `parent_canonical_name` with the resolved values, so caller-supplied values for those three fields are ignored."
+    )]
+    pub extraction: epigraph_ingest::workflow::WorkflowExtraction,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct FindWorkflowHierarchicalParams {
     #[schemars(
         description = "Free-text search over hierarchical workflow goal and canonical_name (ILIKE)."

--- a/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
+++ b/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
@@ -1,0 +1,146 @@
+//! Integration test for the `improve_workflow_hierarchy` MCP tool.
+//!
+//! Verifies that calling the tool against an existing canonical workflow
+//! resolves the max generation, ingests the new extraction at generation
+//! `parent_max + 1`, and links it via `parent_canonical_name`. Also
+//! confirms that each call produces a fresh generation (no implicit
+//! idempotent no-op when the new generation hasn't been written yet).
+
+use epigraph_ingest::common::schema::ThesisDerivation;
+use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowSource};
+use epigraph_ingest::workflow::WorkflowExtraction;
+
+fn parent_extraction(canonical: &str) -> WorkflowExtraction {
+    WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: canonical.to_string(),
+            goal: "Original flat-mapped workflow".to_string(),
+            generation: 1,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: None,
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "Body".to_string(),
+            summary: "Flat steps as a single phase".to_string(),
+            steps: vec![Step {
+                compound: "do thing".to_string(),
+                rationale: "because".to_string(),
+                operations: vec!["step 1".to_string()],
+                generality: vec![1],
+                confidence: 0.5,
+            }],
+        }],
+        relationships: vec![],
+    }
+}
+
+fn improved_extraction() -> WorkflowExtraction {
+    // Caller leaves canonical_name / generation / parent_canonical_name
+    // arbitrary; the tool overwrites them.
+    let mut e = parent_extraction("ignored-by-tool");
+    e.source.goal = "Refined hierarchical re-authoring".to_string();
+    e.phases = vec![
+        Phase {
+            title: "Setup".to_string(),
+            summary: "Prepare prerequisites".to_string(),
+            steps: vec![Step {
+                compound: "install deps".to_string(),
+                rationale: "code needs them".to_string(),
+                operations: vec!["pip install".to_string()],
+                generality: vec![2],
+                confidence: 0.9,
+            }],
+        },
+        Phase {
+            title: "Execute".to_string(),
+            summary: "Run the workflow".to_string(),
+            steps: vec![Step {
+                compound: "run".to_string(),
+                rationale: "main work".to_string(),
+                operations: vec!["./run.sh".to_string()],
+                generality: vec![2],
+                confidence: 0.9,
+            }],
+        },
+    ];
+    e
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn improve_workflow_hierarchy_increments_generation(pool: sqlx::PgPool) {
+    let canonical = "test-improve-hier-increments";
+
+    // Ingest parent at generation 1.
+    epigraph_mcp::tools::workflow_ingest::do_ingest_workflow_via_pool(
+        &pool,
+        &parent_extraction(canonical),
+    )
+    .await
+    .expect("parent ingest");
+
+    // First improve: parent_max=1, new_generation=2.
+    let new_gen = epigraph_mcp::tools::workflow_ingest::improve_workflow_hierarchy_via_pool(
+        &pool,
+        canonical,
+        improved_extraction(),
+    )
+    .await
+    .expect("improve");
+
+    assert_eq!(new_gen.parent_generation, 1);
+    assert_eq!(new_gen.new_generation, 2);
+    assert!(!new_gen.already_ingested);
+
+    // Verify the workflows row was created at generation 2 with the parent
+    // linkage in place via the executor's variant_of edge logic.
+    let row: (i32, Option<uuid::Uuid>) =
+        sqlx::query_as("SELECT generation, parent_id FROM workflows WHERE id = $1::uuid")
+            .bind(&new_gen.workflow_id)
+            .fetch_one(&pool)
+            .await
+            .expect("workflows row exists");
+    assert_eq!(row.0, 2);
+    assert!(
+        row.1.is_some(),
+        "variant should have parent_id pointing at gen 1 root"
+    );
+
+    // Second improve: parent_max is now 2, so new_generation=3. Each call
+    // produces a fresh variant; idempotency is on (canonical_name, generation),
+    // not on the tool entrypoint.
+    let new_gen2 = epigraph_mcp::tools::workflow_ingest::improve_workflow_hierarchy_via_pool(
+        &pool,
+        canonical,
+        improved_extraction(),
+    )
+    .await
+    .expect("second improve");
+    assert_eq!(new_gen2.parent_generation, 2);
+    assert_eq!(new_gen2.new_generation, 3);
+    assert!(!new_gen2.already_ingested);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn improve_workflow_hierarchy_errors_when_parent_missing(pool: sqlx::PgPool) {
+    let result = epigraph_mcp::tools::workflow_ingest::improve_workflow_hierarchy_via_pool(
+        &pool,
+        "nonexistent-canonical-name-xyzzy",
+        improved_extraction(),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "improving a non-existent canonical_name should error"
+    );
+    let err_msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_msg.contains("no workflow with canonical_name"),
+        "error message should mention missing canonical_name; got: {err_msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the `improve_workflow_hierarchy` MCP tool — the code primitive that makes the per-workflow re-authoring sweep in #36 cheap. The actual data sweep (re-authoring flat-mapped workflows into real hierarchical form, prioritized by `properties.use_count`) is operational follow-up tracked separately.

### Tool contract

Inputs:
- `parent_canonical_name: String` — the existing workflow lineage to variant
- `extraction: WorkflowExtraction` — the hierarchical re-authoring

Behavior:
1. Look up the parent's current `MAX(generation)` in the `workflows` table.
2. **Overwrite** `extraction.source.canonical_name`, `generation`, and `parent_canonical_name` to enforce same-lineage semantics: `canonical_name = parent_canonical_name`, `generation = max + 1`, `parent_canonical_name = Some(parent_canonical_name)`. Caller-supplied values for those three fields are ignored. Cross-lineage variants are not supported by this tool.
3. Ingest via the existing `do_ingest_workflow_via_pool` (idempotent at the `(canonical_name, generation)` level).
4. Return `{ parent_canonical_name, parent_generation, new_generation, workflow_id, claims_ingested, already_ingested }`.

Returns 404-style error if no workflow exists with the given `parent_canonical_name`.

### What changed

- `crates/epigraph-db/src/repos/workflow.rs`: new `WorkflowRepository::max_generation_by_canonical` using `fetch_one` over `SELECT MAX(generation) FROM workflows WHERE canonical_name = $1`. Unit test covers rows-present (returns `Some(3)`) and no-matching-rows (`MAX` returns `NULL` → `None`).
- `crates/epigraph-mcp/src/tools/workflow_ingest.rs`: `ImproveWorkflowHierarchyResponse`, pool-only `improve_workflow_hierarchy_via_pool`, MCP entry point `improve_workflow_hierarchy`.
- `crates/epigraph-mcp/src/types.rs`: `ImproveWorkflowHierarchyParams` with explicit docstring noting overwrite semantics.
- `crates/epigraph-mcp/src/server.rs`: tool registration alongside `ingest_workflow`. Hierarchical Workflows section header `3 → 4 tools`. Read-only-mode `tool_count` unchanged.
- `crates/epigraph-mcp/src/main.rs`: full-mode tool count `57 → 58` in CLI `about`, startup mode string, and docstring.
- `crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs`: 2 integration tests — generation-increment + each-call-creates-new-variant; parent-missing error path.

### Label decision

The new thesis claim is **not** tagged with the `'workflow'` label. That label belongs to the flat-workflow lineage (`store_workflow` / flat `improve_workflow`). Hierarchical workflows use `'workflow_thesis'` on the root and live in the `workflows` table — consistent with how `do_ingest_workflow` already labels its thesis root.

### Test plan

- [x] `cargo test -p epigraph-db --lib max_generation_by_canonical`: 1/1 pass.
- [x] `cargo test -p epigraph-mcp --test improve_workflow_hierarchy_test`: 2/2 pass.
- [x] `cargo test -p epigraph-mcp --lib`: 15 pass, no regressions.
- [x] `cargo clippy -p epigraph-db -p epigraph-mcp --tests`: clean.
- [x] `cargo check --workspace`: clean.

### Issue #36 status

This PR delivers the **primitive**. Issue #36 stays open to track the **data sweep**: re-author flat-mapped workflows into real hierarchical form, ordered by `properties.use_count` desc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)