### PR TITLE
fix(mcp): use valid default methodology in batch_submit_claims

### DIFF
--- a/crates/epigraph-mcp/src/tools/batch.rs
+++ b/crates/epigraph-mcp/src/tools/batch.rs
@@ -25,7 +25,7 @@ pub async fn batch_submit_claims(
     for (i, entry) in params.claims.iter().enumerate() {
         let claim_params = SubmitClaimParams {
             content: entry.content.clone(),
-            methodology: "batch_submission".to_string(),
+            methodology: "inductive_generalization".to_string(),
             evidence_data: entry.evidence_data.clone(),
             evidence_type: entry.evidence_type.clone(),
             confidence: entry.confidence.unwrap_or(0.5),


### PR DESCRIPTION
## Summary
- `batch_submit_claims` hardcoded `methodology: "batch_submission"`, which `parse_methodology` in `tools/claims.rs` rejects with `unknown methodology`. Every batch entry therefore fails server-side with an invalid-params error.
- Swap to `"inductive_generalization"` (the accepted default the bug report suggested). One-line fix; per-entry methodology can come later if needed.

Closes EpiGraph claim `daf7db58-44e8-4ebd-9ab3-b48ec2411f58` (logged 2026-05-13).

## Test plan
- [x] `cargo check -p epigraph-mcp` (passes locally)
- [x] Manual: `mcp__epigraph__batch_submit_claims` with a 2-entry payload succeeds and returns `status: ok` with claim_ids
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)