### PR TITLE
fix(ds): clamp belief/plausibility and make combine_multiple order-independent

### DIFF
--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -262,6 +262,10 @@ impl MassFunctionRepository {
     /// Update a claim's belief, plausibility, and pignistic probability columns
     ///
     /// Called after combining mass functions to persist the computed interval.
+    /// All numeric values are clamped to [0, 1] at the write boundary so
+    /// floating-point drift accumulated upstream cannot trip the
+    /// `claims_{belief,plausibility,mass_on_empty,mass_on_missing,pignistic_prob}_bounds`
+    /// CHECK constraints.
     ///
     /// # Errors
     /// Returns `DbError::QueryFailed` if the database query fails.
@@ -275,6 +279,12 @@ impl MassFunctionRepository {
         pignistic_prob: Option<f64>,
         mass_on_missing: f64,
     ) -> Result<(), DbError> {
+        let belief = belief.clamp(0.0, 1.0);
+        let plausibility = plausibility.clamp(0.0, 1.0);
+        let mass_on_empty = mass_on_empty.clamp(0.0, 1.0);
+        let mass_on_missing = mass_on_missing.clamp(0.0, 1.0);
+        let pignistic_prob = pignistic_prob.map(|p| p.clamp(0.0, 1.0));
+
         sqlx::query(
             r#"
             UPDATE claims

--- a/crates/epigraph-ds/src/combination.rs
+++ b/crates/epigraph-ds/src/combination.rs
@@ -1797,9 +1797,7 @@ mod tests {
             // And the converse: no extra focal elements in the permutation.
             for fe in combined.masses().keys() {
                 if !baseline.masses().contains_key(fe) {
-                    panic!(
-                        "permutation {i} produced focal element {fe} absent from baseline"
-                    );
+                    panic!("permutation {i} produced focal element {fe} absent from baseline");
                 }
             }
         }

--- a/crates/epigraph-ds/src/combination.rs
+++ b/crates/epigraph-ds/src/combination.rs
@@ -470,6 +470,31 @@ pub fn adaptive_combine(
     }
 }
 
+/// Canonical comparison of two mass functions for deterministic ordering.
+///
+/// Compares the underlying `BTreeMap<FocalElement, f64>` lex-pair-wise. f64
+/// uses `total_cmp` so NaN does not produce ambiguous orderings. This is the
+/// sort key used by [`combine_multiple`] to make the fold order-independent.
+fn canonical_mass_cmp(a: &MassFunction, b: &MassFunction) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let mut ai = a.masses().iter();
+    let mut bi = b.masses().iter();
+    loop {
+        match (ai.next(), bi.next()) {
+            (Some((fa, ma)), Some((fb, mb))) => match fa.cmp(fb) {
+                Ordering::Equal => match ma.total_cmp(mb) {
+                    Ordering::Equal => continue,
+                    o => return o,
+                },
+                o => return o,
+            },
+            (Some(_), None) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            (None, None) => return Ordering::Equal,
+        }
+    }
+}
+
 /// Combine multiple mass functions by pairwise adaptive folding
 ///
 /// For each pairwise step, computes the conflict coefficient K and the
@@ -483,6 +508,12 @@ pub fn adaptive_combine(
 ///
 /// The `_conflict_threshold` parameter is retained for backward compatibility
 /// but is no longer used; rule selection is fully adaptive.
+///
+/// Inputs are sorted via [`canonical_mass_cmp`] before folding so the result
+/// is independent of the caller's iteration order. Without the sort, the
+/// adaptive rule selection (which depends on accumulated state) made the fold
+/// non-commutative: reordering evidence could switch between Dempster,
+/// CdstConjunctive, and Inagaki rules and produce different final masses.
 ///
 /// # Errors
 /// - `DsError::InsufficientSources` if `masses` is empty
@@ -500,10 +531,13 @@ pub fn combine_multiple(
         return Ok((masses[0].clone(), Vec::new()));
     }
 
-    let mut accumulated = masses[0].clone();
-    let mut reports = Vec::with_capacity(masses.len() - 1);
+    let mut sorted: Vec<MassFunction> = masses.to_vec();
+    sorted.sort_by(canonical_mass_cmp);
 
-    for m in &masses[1..] {
+    let mut accumulated = sorted[0].clone();
+    let mut reports = Vec::with_capacity(sorted.len() - 1);
+
+    for m in &sorted[1..] {
         let k = conflict_coefficient(&accumulated, m)?;
         let owf = accumulated.open_world_fraction();
         let rule = select_combination_rule(k, owf);
@@ -1723,5 +1757,51 @@ mod tests {
             pl_after_refutation < 0.5,
             "Pl({pl_after_refutation:.6}) should be well below 0.5 after strong refutation"
         );
+    }
+
+    /// Regression: `combine_multiple` must be order-independent.
+    ///
+    /// Prior to the canonical sort, adaptive rule selection (which depends on
+    /// the *accumulated* fold state) could pick a different `CombinationRule`
+    /// for the same input set when callers reordered evidence. Filed as
+    /// backlog claim `cebb0043` on 2026-05-16 (non-commutativity stress test).
+    #[test]
+    fn combine_multiple_is_order_independent() {
+        let frame = ternary_frame();
+        // Three sources with distinct mass profiles — one supporting, one
+        // partially conflicting, one missing-heavy. This is the kind of mix
+        // that previously triggered rule-switching across permutations.
+        let m_support = MassFunction::simple(frame.clone(), BTreeSet::from([0]), 0.7).unwrap();
+        let m_partial = MassFunction::simple(frame.clone(), BTreeSet::from([0, 1]), 0.6).unwrap();
+        let m_refute = MassFunction::simple(frame.clone(), BTreeSet::from([1]), 0.5).unwrap();
+
+        let permutations = [
+            vec![m_support.clone(), m_partial.clone(), m_refute.clone()],
+            vec![m_refute.clone(), m_support.clone(), m_partial.clone()],
+            vec![m_partial.clone(), m_refute.clone(), m_support.clone()],
+            vec![m_refute.clone(), m_partial.clone(), m_support.clone()],
+            vec![m_support.clone(), m_refute.clone(), m_partial.clone()],
+            vec![m_partial.clone(), m_support.clone(), m_refute.clone()],
+        ];
+
+        let (baseline, _) = combine_multiple(&permutations[0], 0.1).unwrap();
+        for (i, perm) in permutations.iter().enumerate().skip(1) {
+            let (combined, _) = combine_multiple(perm, 0.1).unwrap();
+            for (fe, mass) in baseline.masses() {
+                let other = combined.mass_of(fe);
+                assert!(
+                    (mass - other).abs() < 1e-12,
+                    "permutation {i} diverges on {fe}: baseline={mass}, perm={other}"
+                );
+            }
+            // And the converse: no extra focal elements in the permutation.
+            for fe in combined.masses().keys() {
+                if !baseline.masses().contains_key(fe) {
+                    panic!(
+                        "permutation {i} produced focal element {fe} absent from baseline"
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/epigraph-ds/src/measures.rs
+++ b/crates/epigraph-ds/src/measures.rs
@@ -18,6 +18,9 @@ use epigraph_core::TruthValue;
 /// `Bel(A)` = sum `m(B)` for all B positive with `B.subset` subset of `A.subset`, B non-empty
 ///
 /// Complement elements are excluded — they represent "outside" evidence.
+///
+/// Result is clamped to [0, 1]; without the clamp, repeated folds accumulate
+/// floating-point drift that trips the `claims_belief_bounds` CHECK constraint.
 #[must_use]
 pub fn belief(m: &MassFunction, target: &FocalElement) -> f64 {
     if target.complement {
@@ -25,13 +28,15 @@ pub fn belief(m: &MassFunction, target: &FocalElement) -> f64 {
         // Return 0 — callers should use evaluate_to_classical first
         return 0.0;
     }
-    m.masses()
+    let raw: f64 = m
+        .masses()
         .iter()
         .filter(|(fe, _)| {
             fe.is_positive() && !fe.subset.is_empty() && fe.subset.is_subset(&target.subset)
         })
         .map(|(_, &mass)| mass)
-        .sum()
+        .sum();
+    raw.clamp(0.0, 1.0)
 }
 
 /// Plausibility: sum of masses of all positive focal elements intersecting target
@@ -39,18 +44,23 @@ pub fn belief(m: &MassFunction, target: &FocalElement) -> f64 {
 /// Pl(A) = sum m(B) for all B positive with B.subset intersects A.subset
 ///
 /// Complement elements are excluded.
+///
+/// Result is clamped to [0, 1]; without the clamp, repeated folds accumulate
+/// floating-point drift that trips the `claims_plausibility_bounds` CHECK constraint.
 #[must_use]
 pub fn plausibility(m: &MassFunction, target: &FocalElement) -> f64 {
     if target.complement {
         return 0.0;
     }
-    m.masses()
+    let raw: f64 = m
+        .masses()
         .iter()
         .filter(|(fe, _)| {
             fe.is_positive() && !fe.subset.is_empty() && !fe.subset.is_disjoint(&target.subset)
         })
         .map(|(_, &mass)| mass)
-        .sum()
+        .sum();
+    raw.clamp(0.0, 1.0)
 }
 
 /// Belief interval [Bel(A), Pl(A)]


### PR DESCRIPTION
## Summary
Closes two related belief-math bugs from the 2026-05 backlog:

- **Plausibility bounds CHECK trip** (claims `35ec7aa7`, `8c921f32`, 2026-05-14/13). `measures::plausibility` and `measures::belief` were raw f64 sums; repeated folds drifted slightly past 1.0 and tripped the `claims_plausibility_bounds` CHECK on persist. Clamp in `measures.rs` and again at the DB write boundary in `MassFunctionRepository::update_claim_belief`.
- **`combine_multiple` non-commutative** (claim `cebb0043`, 2026-05-16). The adaptive selector reads `conflict_k` and `open_world_fraction` off accumulated fold state, so reordering inputs could switch rules (Dempster / CdstConjunctive / Inagaki) and produce different final masses. Sort inputs via a canonical comparator (lex over the `BTreeMap`, `f64::total_cmp` for masses) before the fold; result now depends only on the input set.

Regression test `combine_multiple_is_order_independent` exercises all 6 permutations of a 3-source mix and asserts identical focal-mass distributions.

## Test plan
- [x] `cargo test -p epigraph-ds --lib` — 158 passed, 0 failed
- [x] `cargo build -p epigraph-ds -p epigraph-db` — clean
- [ ] Reviewer: confirm the canonical sort matches the desired determinism semantics; an alternative would be `(a as *const _).cmp(b as *const _)` (identity-stable) but I picked content-based so callers passing equal sets in different order get the same result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)