### PR TITLE
test(engine-integration): wire regression suite to local DB and fix audit findings

### DIFF
--- a/scripts/prepare-engine-integration-db.sh
+++ b/scripts/prepare-engine-integration-db.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Prepare a clean Postgres database for the engine-integration test suite.
+#
+# Usage:   ./scripts/prepare-engine-integration-db.sh [DB_NAME]
+# Default: DB_NAME=epigraph_db_repo_test
+#
+# Connects as the local `epigraph` superuser (required: sqlx::test elsewhere
+# locks pg_namespace; see auto-memory feedback_sqlx_test_uses_superuser.md).
+#
+# After running, export DATABASE_URL exactly as printed at the end and run:
+#   cargo test -p engine-integration-tests -- --ignored
+set -euo pipefail
+
+DB_NAME="${1:-epigraph_db_repo_test}"
+DB_USER="${DB_USER:-epigraph}"
+DB_PASS="${DB_PASS:-epigraph}"
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+ADMIN_DB="${ADMIN_DB:-postgres}"
+
+export PGPASSWORD="$DB_PASS"
+
+echo "→ Dropping and recreating $DB_NAME (existing data will be lost)"
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
+    -c "DROP DATABASE IF EXISTS $DB_NAME" >/dev/null
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
+    -c "CREATE DATABASE $DB_NAME OWNER $DB_USER" >/dev/null
+
+echo "→ Applying migrations from ./migrations"
+for f in migrations/*.sql; do
+    [ -f "$f" ] || continue
+    echo "    $f"
+    psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+        -v ON_ERROR_STOP=1 -q -f "$f"
+done
+
+URL="postgres://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+echo
+echo "✓ Ready. Run:"
+echo "    export DATABASE_URL=\"$URL\""
+echo "    cargo test -p engine-integration-tests -- --ignored --test-threads=1"

--- a/scripts/prepare-engine-integration-db.sh
+++ b/scripts/prepare-engine-integration-db.sh
@@ -20,13 +20,8 @@ ADMIN_DB="${ADMIN_DB:-postgres}"
 
 export PGPASSWORD="$DB_PASS"
 
-echo "→ Dropping and recreating $DB_NAME (existing data will be lost)"
-psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
-    -c "DROP DATABASE IF EXISTS \"$DB_NAME\"" >/dev/null
-psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
-    -c "CREATE DATABASE \"$DB_NAME\" OWNER \"$DB_USER\"" >/dev/null
-
-echo "→ Applying migrations from ./migrations"
+# Locate migrations BEFORE touching the DB — running from the wrong dir
+# must not drop the existing test DB before erroring out.
 shopt -s nullglob
 migration_files=(migrations/*.sql)
 shopt -u nullglob
@@ -34,6 +29,14 @@ if [ ${#migration_files[@]} -eq 0 ]; then
     echo "ERROR: no migrations/*.sql found. Run from repo root." >&2
     exit 1
 fi
+
+echo "→ Dropping and recreating $DB_NAME (existing data will be lost)"
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
+    -c "DROP DATABASE IF EXISTS \"$DB_NAME\"" >/dev/null
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
+    -c "CREATE DATABASE \"$DB_NAME\" OWNER \"$DB_USER\"" >/dev/null
+
+echo "→ Applying ${#migration_files[@]} migrations from ./migrations"
 for f in "${migration_files[@]}"; do
     echo "    $f"
     psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \

--- a/scripts/prepare-engine-integration-db.sh
+++ b/scripts/prepare-engine-integration-db.sh
@@ -22,13 +22,19 @@ export PGPASSWORD="$DB_PASS"
 
 echo "→ Dropping and recreating $DB_NAME (existing data will be lost)"
 psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
-    -c "DROP DATABASE IF EXISTS $DB_NAME" >/dev/null
+    -c "DROP DATABASE IF EXISTS \"$DB_NAME\"" >/dev/null
 psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$ADMIN_DB" \
-    -c "CREATE DATABASE $DB_NAME OWNER $DB_USER" >/dev/null
+    -c "CREATE DATABASE \"$DB_NAME\" OWNER \"$DB_USER\"" >/dev/null
 
 echo "→ Applying migrations from ./migrations"
-for f in migrations/*.sql; do
-    [ -f "$f" ] || continue
+shopt -s nullglob
+migration_files=(migrations/*.sql)
+shopt -u nullglob
+if [ ${#migration_files[@]} -eq 0 ]; then
+    echo "ERROR: no migrations/*.sql found. Run from repo root." >&2
+    exit 1
+fi
+for f in "${migration_files[@]}"; do
     echo "    $f"
     psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
         -v ON_ERROR_STOP=1 -q -f "$f"

--- a/tests/engine-integration/src/harness.rs
+++ b/tests/engine-integration/src/harness.rs
@@ -150,8 +150,8 @@ impl Drop for PrefixGuard {
         // the pool, and that runtime may be partially unwound or blocked when
         // Drop runs. Instead we spawn a fresh OS thread with its own runtime
         // and a brand-new pool so cleanup always succeeds.
-        let database_url = std::env::var("DATABASE_URL")
-            .expect("DATABASE_URL must be set (PrefixGuard::drop)");
+        let database_url =
+            std::env::var("DATABASE_URL").expect("DATABASE_URL must be set (PrefixGuard::drop)");
         let prefix = self.prefix.clone();
         std::thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
@@ -235,13 +235,12 @@ pub async fn load_orchestrator_from_db(
 
     let mut orch = PropagationOrchestrator::new();
 
-    let claim_rows = sqlx::query(
-        "SELECT id, content, agent_id, truth_value FROM claims WHERE content LIKE $1",
-    )
-    .bind(format!("{prefix}%"))
-    .fetch_all(pool)
-    .await
-    .expect("load claims");
+    let claim_rows =
+        sqlx::query("SELECT id, content, agent_id, truth_value FROM claims WHERE content LIKE $1")
+            .bind(format!("{prefix}%"))
+            .fetch_all(pool)
+            .await
+            .expect("load claims");
 
     for row in &claim_rows {
         let id: Uuid = row.get("id");
@@ -329,13 +328,11 @@ mod tests {
 
         // PrefixGuard::drop blocks until cleanup_test_data completes, so by
         // the time we reach here the rows are gone.
-        let count: i64 = sqlx::query_scalar(
-            "SELECT count(*) FROM claims WHERE content LIKE $1",
-        )
-        .bind(format!("{PREFIX}%"))
-        .fetch_one(&db.pool)
-        .await
-        .unwrap();
+        let count: i64 = sqlx::query_scalar("SELECT count(*) FROM claims WHERE content LIKE $1")
+            .bind(format!("{PREFIX}%"))
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
 
         assert_eq!(
             count, 0,

--- a/tests/engine-integration/src/harness.rs
+++ b/tests/engine-integration/src/harness.rs
@@ -207,9 +207,10 @@ pub async fn cleanup_test_data(pool: &PgPool, content_prefix: &str) {
 /// - Reads `claims` rows with `content LIKE prefix%` and registers each as a
 ///   `Claim` (with the DB-assigned id and truth_value).
 /// - Reads `edges` joining those claims and converts:
-///     `relationship = 'supports'`   → `is_supporting = true`,  EvidenceType::Empirical
-///     `relationship = 'contradicts'`→ `is_supporting = false`, EvidenceType::Empirical
-///   All edges use `strength = 0.8`, `age_days = 0.0` (test defaults).
+///   `relationship = 'supports'` → `is_supporting = true`,
+///   `relationship = 'contradicts' | 'refutes'` → `is_supporting = false`,
+///   everything else maps to `is_supporting = true`. Evidence type is
+///   `EvidenceType::Empirical`; `strength = 0.8`; `age_days = 0.0`.
 ///
 /// Anything more elaborate (loading strength from edges.properties,
 /// mapping evidence_type from a column, etc.) belongs in a production loader

--- a/tests/engine-integration/src/harness.rs
+++ b/tests/engine-integration/src/harness.rs
@@ -111,6 +111,61 @@ pub async fn create_test_factor(
     factor_id
 }
 
+/// RAII guard that cleans up test data on drop, even if the test panics.
+///
+/// Stores the content prefix; on `Drop`, opens a fresh DB connection (via
+/// `DATABASE_URL`) on a new OS thread with its own tokio runtime and deletes
+/// all claims/edges/factors whose content starts with the prefix. This avoids
+/// the cross-runtime I/O-driver issue that arises when reusing a pool that was
+/// created on a different runtime.
+///
+/// Tests should construct one at the top of the test body:
+/// `let _guard = PrefixGuard::new(&db.pool, "[test-foo]");`
+pub struct PrefixGuard {
+    // The pool passed to `new` is kept alive for the test's duration but Drop
+    // opens a fresh connection on its own runtime to avoid cross-runtime I/O
+    // driver issues. Field name prefix _ suppresses the dead_code lint.
+    _pool: PgPool,
+    prefix: String,
+}
+
+impl PrefixGuard {
+    #[must_use]
+    pub fn new(pool: &PgPool, prefix: &str) -> Self {
+        Self {
+            _pool: pool.clone(),
+            prefix: prefix.to_string(),
+        }
+    }
+}
+
+impl Drop for PrefixGuard {
+    fn drop(&mut self) {
+        // We cannot reuse the existing PgPool here: its connections are
+        // registered with the tokio I/O driver of whichever runtime created
+        // the pool, and that runtime may be partially unwound or blocked when
+        // Drop runs. Instead we spawn a fresh OS thread with its own runtime
+        // and a brand-new pool so cleanup always succeeds.
+        let database_url = std::env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set (PrefixGuard::drop)");
+        let prefix = self.prefix.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("PrefixGuard::drop tokio runtime");
+            rt.block_on(async move {
+                let pool = sqlx::PgPool::connect(&database_url)
+                    .await
+                    .expect("PrefixGuard::drop db connect");
+                cleanup_test_data(&pool, &prefix).await;
+            });
+        })
+        .join()
+        .expect("PrefixGuard::drop thread");
+    }
+}
+
 /// Clean up test data by prefix. Deletes claims whose content starts with the given prefix
 /// and all edges/factors referencing them.
 pub async fn cleanup_test_data(pool: &PgPool, content_prefix: &str) {
@@ -144,4 +199,44 @@ pub async fn cleanup_test_data(pool: &PgPool, content_prefix: &str) {
         .bind(&ids)
         .execute(pool)
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore] // Requires DATABASE_URL
+    async fn prefix_guard_cleans_up_after_panic() {
+        const PREFIX: &str = "[test-prefix-guard]";
+        let db = TestDb::setup().await;
+        let agent = create_test_agent(&db.pool).await;
+
+        // Spawn a task that inserts a marker row then panics.
+        // tokio::spawn catches the panic, unwinds the task (running Drop on
+        // PrefixGuard), then resolves the JoinHandle to Err(JoinError).
+        let pool = db.pool.clone();
+        let handle = tokio::spawn(async move {
+            let _guard = PrefixGuard::new(&pool, PREFIX);
+            create_test_claim(&pool, agent, &format!("{PREFIX} marker"), 0.5).await;
+            panic!("simulated test failure");
+        });
+        let join_result = handle.await;
+        assert!(join_result.is_err(), "task should have panicked");
+
+        // PrefixGuard::drop blocks until cleanup_test_data completes, so by
+        // the time we reach here the rows are gone.
+        let count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM claims WHERE content LIKE $1",
+        )
+        .bind(format!("{PREFIX}%"))
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count, 0,
+            "PrefixGuard::drop should have cleaned up rows even after panic"
+        );
+    }
 }

--- a/tests/engine-integration/src/harness.rs
+++ b/tests/engine-integration/src/harness.rs
@@ -1,7 +1,7 @@
 //! Shared test harness for engine integration tests.
 //! Provides TestDb, helper functions for creating test entities in PostgreSQL.
 
-use sqlx::PgPool;
+use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
 /// Wrapper around PgPool for integration tests.
@@ -199,6 +199,98 @@ pub async fn cleanup_test_data(pool: &PgPool, content_prefix: &str) {
         .bind(&ids)
         .execute(pool)
         .await;
+}
+
+/// Load all claims and edges matching `prefix` into a fresh
+/// `PropagationOrchestrator`.
+///
+/// - Reads `claims` rows with `content LIKE prefix%` and registers each as a
+///   `Claim` (with the DB-assigned id and truth_value).
+/// - Reads `edges` joining those claims and converts:
+///     `relationship = 'supports'`   → `is_supporting = true`,  EvidenceType::Empirical
+///     `relationship = 'contradicts'`→ `is_supporting = false`, EvidenceType::Empirical
+///   All edges use `strength = 0.8`, `age_days = 0.0` (test defaults).
+///
+/// Anything more elaborate (loading strength from edges.properties,
+/// mapping evidence_type from a column, etc.) belongs in a production loader
+/// — this is a test helper that exists to make the regression test exercise
+/// real DB→engine flow rather than reconstructing state by hand.
+pub async fn load_orchestrator_from_db(
+    pool: &PgPool,
+    prefix: &str,
+) -> epigraph_engine::PropagationOrchestrator {
+    use epigraph_core::{AgentId, Claim, ClaimId, TruthValue};
+    use epigraph_engine::{EvidenceType, PropagationOrchestrator};
+
+    let mut orch = PropagationOrchestrator::new();
+
+    let claim_rows = sqlx::query(
+        "SELECT id, content, agent_id, truth_value FROM claims WHERE content LIKE $1",
+    )
+    .bind(format!("{prefix}%"))
+    .fetch_all(pool)
+    .await
+    .expect("load claims");
+
+    for row in &claim_rows {
+        let id: Uuid = row.get("id");
+        let agent_id: Uuid = row.get("agent_id");
+        let content: String = row.get("content");
+        let truth: f64 = row.get("truth_value");
+
+        // Reconstruct a Claim with the DB-assigned id. Public key is
+        // synthetic — we never sign anything; the orchestrator doesn't verify.
+        let mut public_key = [0u8; 32];
+        public_key[..16].copy_from_slice(agent_id.as_bytes());
+        let claim_proto = Claim::new(
+            content,
+            AgentId::from_uuid(agent_id),
+            public_key,
+            TruthValue::new(truth).unwrap(),
+        );
+        let claim = Claim::with_id(
+            ClaimId::from_uuid(id),
+            claim_proto.content,
+            claim_proto.agent_id,
+            claim_proto.public_key,
+            claim_proto.content_hash,
+            claim_proto.trace_id,
+            claim_proto.signature,
+            claim_proto.truth_value,
+            claim_proto.created_at,
+            claim_proto.updated_at,
+        );
+        orch.register_claim(claim).expect("register");
+    }
+
+    let edge_rows = sqlx::query(
+        "SELECT e.source_id, e.target_id, e.relationship \
+         FROM edges e \
+         JOIN claims cs ON cs.id = e.source_id \
+         WHERE cs.content LIKE $1",
+    )
+    .bind(format!("{prefix}%"))
+    .fetch_all(pool)
+    .await
+    .expect("load edges");
+
+    for row in &edge_rows {
+        let src: Uuid = row.get("source_id");
+        let tgt: Uuid = row.get("target_id");
+        let rel: String = row.get("relationship");
+        let is_supporting = !matches!(rel.to_lowercase().as_str(), "contradicts" | "refutes");
+        orch.add_dependency(
+            ClaimId::from_uuid(src),
+            ClaimId::from_uuid(tgt),
+            is_supporting,
+            0.8,
+            EvidenceType::Empirical,
+            0.0,
+        )
+        .expect("add_dependency");
+    }
+
+    orch
 }
 
 #[cfg(test)]

--- a/tests/engine-integration/src/harness.rs
+++ b/tests/engine-integration/src/harness.rs
@@ -121,6 +121,10 @@ pub async fn create_test_factor(
 ///
 /// Tests should construct one at the top of the test body:
 /// `let _guard = PrefixGuard::new(&db.pool, "[test-foo]");`
+///
+/// Note: `Drop` reads `DATABASE_URL` from the environment at drop time.
+/// Tests must not mutate that variable mid-test or cleanup will run against
+/// the wrong database.
 pub struct PrefixGuard {
     // The pool passed to `new` is kept alive for the test's duration but Drop
     // opens a fresh connection on its own runtime to avoid cross-runtime I/O
@@ -216,6 +220,12 @@ pub async fn cleanup_test_data(pool: &PgPool, content_prefix: &str) {
 /// mapping evidence_type from a column, etc.) belongs in a production loader
 /// — this is a test helper that exists to make the regression test exercise
 /// real DB→engine flow rather than reconstructing state by hand.
+///
+/// Limitation: the edge SELECT filters on `cs.content LIKE prefix%` for the
+/// source side only. Tests must use the same prefix for both endpoints of
+/// every edge — an edge to an out-of-prefix target is still added to the
+/// DAG via `add_dependency`, but the target claim is never `register_claim`'d,
+/// and `update_and_propagate` silently skips propagation through it.
 pub async fn load_orchestrator_from_db(
     pool: &PgPool,
     prefix: &str,

--- a/tests/engine-integration/tests/bp_factors.rs
+++ b/tests/engine-integration/tests/bp_factors.rs
@@ -1,10 +1,13 @@
 //! Integration test: auto-factor trigger + BP round-trip.
 //!
-//! Test 1: CORROBORATES edge insertion triggers auto_create_factor_from_edge (migration 044),
-//!          factor is loaded from PG, run_bp() runs over it, beliefs update correctly.
+//! Test 1: CORROBORATES edge insertion triggers auto_create_factor_from_edge
+//!          (`migrations/001_initial_schema.sql:67`), factor is loaded from
+//!          PG with strength = 0.85 (`migrations/011_derived_from_uppercase_factor.sql:34`),
+//!          run_bp() runs over it, beliefs update correctly.
 //!
-//! Test 2: Migration 068 supersession guard — inserting a CORROBORATES edge where one claim
-//!          has is_current=false must NOT create a factor.
+//! Test 2: supersession guard (`migrations/001_initial_schema.sql:82-85`) —
+//!          inserting a CORROBORATES edge where one claim has is_current=false
+//!          must NOT create a factor.
 
 use engine_integration_tests::harness::*;
 use epigraph_engine::{run_bp, BpConfig, FactorPotential};
@@ -13,19 +16,33 @@ use uuid::Uuid;
 
 const PREFIX: &str = "[test-bp-factors]";
 
+/// Trigger creates a CORROBORATES factor with strength == 0.85 and BP runs
+/// over it without collapsing.
+///
+/// Setup: insert CORROBORATES edge between two `is_current = true` claims.
+/// Migration `001_initial_schema.sql:67` (`auto_create_factor_from_edge`)
+/// must fire and write a single `evidential_support` factor with
+/// `potential.strength = 0.85` (per `edge_to_factor_type` row at
+/// `migrations/011_derived_from_uppercase_factor.sql:34`).
+///
+/// Asserts:
+/// 1. Exactly one factor created.
+/// 2. factor_type == "evidential_support".
+/// 3. potential.strength == 0.85 exactly (catches drift in
+///    `edge_to_factor_type`'s CORROBORATES row).
+/// 4. `run_bp` converges, beliefs stay near priors, both variables agree.
 #[tokio::test]
 #[ignore] // Requires DATABASE_URL pointing to live PostgreSQL
 async fn auto_factor_trigger_creates_factors_for_corroborates() {
     let db = TestDb::setup().await;
+    let _guard = PrefixGuard::new(&db.pool, PREFIX);
     let agent = create_test_agent(&db.pool).await;
 
     let claim_a = create_test_claim(&db.pool, agent, &format!("{PREFIX} claim A"), 0.6).await;
     let claim_b = create_test_claim(&db.pool, agent, &format!("{PREFIX} claim B"), 0.6).await;
 
-    // Insert CORROBORATES edge — trigger should auto-create an evidential_support factor
     create_test_edge(&db.pool, claim_a, claim_b, "CORROBORATES").await;
 
-    // Trigger stores variable_ids in sorted (smaller UUID first) order
     let (smaller, larger) = if claim_a < claim_b {
         (claim_a, claim_b)
     } else {
@@ -38,33 +55,27 @@ async fn auto_factor_trigger_creates_factors_for_corroborates() {
             .fetch_one(&db.pool)
             .await
             .unwrap();
+    assert_eq!(factor_count, 1, "trigger must create exactly one factor");
 
-    assert_eq!(
-        factor_count, 1,
-        "Auto-factor trigger should create exactly one factor for CORROBORATES edge"
-    );
-
-    // Load the factor row to feed into run_bp
     let row: (String, serde_json::Value) =
         sqlx::query_as("SELECT factor_type, potential FROM factors WHERE variable_ids @> $1")
             .bind(&[smaller, larger][..])
             .fetch_one(&db.pool)
             .await
             .unwrap();
+    assert_eq!(row.0, "evidential_support");
 
-    assert_eq!(
-        row.0, "evidential_support",
-        "CORROBORATES edge should produce evidential_support factor, got: {}",
-        row.0
-    );
-
-    // Migration 044 sets strength = 0.85 for CORROBORATES
     let strength = row
         .1
         .get("strength")
         .and_then(|s| s.as_f64())
-        .unwrap_or(0.8);
+        .expect("trigger must write strength field");
+    assert!(
+        (strength - 0.85).abs() < 1e-9,
+        "CORROBORATES strength must be 0.85 (per migrations/011_derived_from_uppercase_factor.sql:34), got {strength}"
+    );
 
+    // Run scalar BP over the loaded factor and verify it converges sensibly.
     let mut priors = HashMap::new();
     priors.insert(claim_a, 0.6);
     priors.insert(claim_b, 0.6);
@@ -79,37 +90,38 @@ async fn auto_factor_trigger_creates_factors_for_corroborates() {
     let config = BpConfig::default();
     let result = run_bp(&factors, &priors, &config);
 
-    // Collect into HashMap for easy lookup
+    assert!(
+        result.converged,
+        "BP must converge for a single symmetric factor (got {} iterations, max_change={})",
+        result.iterations, result.max_change
+    );
+
     let beliefs: HashMap<Uuid, f64> = result.updated_beliefs.into_iter().collect();
+    let belief_a = *beliefs.get(&claim_a).expect("A belief");
+    let belief_b = *beliefs.get(&claim_b).expect("B belief");
 
-    let belief_a = *beliefs.get(&claim_a).unwrap_or(&0.0);
-    let belief_b = *beliefs.get(&claim_b).unwrap_or(&0.0);
-
-    // With symmetric CORROBORATES, beliefs converge to a common fixed point.
-    // The BP blending formula (50% prior + 50% factor signal) means the fixed point
-    // is slightly below 0.6 when strength < 1.0. We assert beliefs stay in (0.4, 0.8)
-    // — i.e., BP does not collapse or explode them.
+    // Symmetric inputs → symmetric outputs (tightened from 0.05 to 1e-6).
     assert!(
-        belief_a > 0.4 && belief_a < 0.8,
-        "Claim A belief should converge within (0.4, 0.8), got: {belief_a}"
-    );
-    assert!(
-        belief_b > 0.4 && belief_b < 0.8,
-        "Claim B belief should converge within (0.4, 0.8), got: {belief_b}"
-    );
-    // The two claims should end at the same belief (symmetric factor, identical priors)
-    assert!(
-        (belief_a - belief_b).abs() < 0.05,
-        "Symmetric CORROBORATES should yield equal beliefs: a={belief_a}, b={belief_b}"
+        (belief_a - belief_b).abs() < 1e-6,
+        "symmetric CORROBORATES must yield equal beliefs (a={belief_a}, b={belief_b})"
     );
 
-    cleanup_test_data(&db.pool, PREFIX).await;
+    // Beliefs should stay reasonably near the 0.6 prior — catches collapse
+    // (→0) or explosion (→1), without back-deriving the exact fixed point.
+    assert!(
+        (belief_a - 0.6).abs() < 0.2,
+        "belief drifted too far from prior 0.6: {belief_a}"
+    );
 }
 
+/// supersession guard (`migrations/001_initial_schema.sql:82-85`) — inserting
+/// a CORROBORATES edge where one claim has `is_current=false` must NOT
+/// create a factor.
 #[tokio::test]
 #[ignore] // Requires DATABASE_URL pointing to live PostgreSQL
 async fn superseded_claim_excluded_from_auto_factor() {
     let db = TestDb::setup().await;
+    let _guard = PrefixGuard::new(&db.pool, PREFIX);
     let agent = create_test_agent(&db.pool).await;
 
     let claim_a = create_test_claim(&db.pool, agent, &format!("{PREFIX} current-claim"), 0.6).await;
@@ -123,7 +135,7 @@ async fn superseded_claim_excluded_from_auto_factor() {
         .await
         .unwrap();
 
-    // Insert CORROBORATES edge — migration 068 guard should skip factor creation
+    // Insert CORROBORATES edge — supersession guard should skip factor creation
     // because claim_b has is_current = false
     create_test_edge(&db.pool, claim_a, claim_b, "CORROBORATES").await;
 
@@ -136,8 +148,6 @@ async fn superseded_claim_excluded_from_auto_factor() {
 
     assert_eq!(
         factor_count, 0,
-        "Migration 068 guard should prevent factor creation for superseded claim"
+        "supersession guard must prevent factor creation for superseded claim"
     );
-
-    cleanup_test_data(&db.pool, PREFIX).await;
 }

--- a/tests/engine-integration/tests/propagation_db.rs
+++ b/tests/engine-integration/tests/propagation_db.rs
@@ -23,18 +23,12 @@ async fn propagation_persists_updated_truth_values() {
 
     // --- Setup: 3-claim chain A → B → C in DB ---
     let agent_uuid = create_test_agent(&db.pool).await;
-    let claim_a_uuid = create_test_claim(
-        &db.pool, agent_uuid, &format!("{PREFIX} root A"), 0.8,
-    )
-    .await;
-    let claim_b_uuid = create_test_claim(
-        &db.pool, agent_uuid, &format!("{PREFIX} mid B"), 0.5,
-    )
-    .await;
-    let claim_c_uuid = create_test_claim(
-        &db.pool, agent_uuid, &format!("{PREFIX} leaf C"), 0.5,
-    )
-    .await;
+    let claim_a_uuid =
+        create_test_claim(&db.pool, agent_uuid, &format!("{PREFIX} root A"), 0.8).await;
+    let claim_b_uuid =
+        create_test_claim(&db.pool, agent_uuid, &format!("{PREFIX} mid B"), 0.5).await;
+    let claim_c_uuid =
+        create_test_claim(&db.pool, agent_uuid, &format!("{PREFIX} leaf C"), 0.5).await;
 
     create_test_edge(&db.pool, claim_a_uuid, claim_b_uuid, "supports").await;
     create_test_edge(&db.pool, claim_b_uuid, claim_c_uuid, "supports").await;
@@ -76,7 +70,10 @@ async fn propagation_persists_updated_truth_values() {
     );
 
     // --- Write back and verify persistence ---
-    for (uuid, value) in [(claim_b_uuid, truth_b.value()), (claim_c_uuid, truth_c.value())] {
+    for (uuid, value) in [
+        (claim_b_uuid, truth_b.value()),
+        (claim_c_uuid, truth_c.value()),
+    ] {
         sqlx::query("UPDATE claims SET truth_value = $1 WHERE id = $2")
             .bind(value)
             .bind(uuid)
@@ -85,7 +82,10 @@ async fn propagation_persists_updated_truth_values() {
             .expect("write back");
     }
 
-    for (uuid, expected) in [(claim_b_uuid, truth_b.value()), (claim_c_uuid, truth_c.value())] {
+    for (uuid, expected) in [
+        (claim_b_uuid, truth_b.value()),
+        (claim_c_uuid, truth_c.value()),
+    ] {
         let row = sqlx::query("SELECT truth_value FROM claims WHERE id = $1")
             .bind(uuid)
             .fetch_one(&db.pool)

--- a/tests/engine-integration/tests/propagation_db.rs
+++ b/tests/engine-integration/tests/propagation_db.rs
@@ -1,13 +1,16 @@
-//! Integration test: DB -> PropagationOrchestrator -> verify updated truth values.
+//! Integration test: DB → PropagationOrchestrator → propagate → DB.
 //!
-//! Exercises the full round-trip: insert claims and edges into PostgreSQL,
-//! load them into the in-memory PropagationOrchestrator, propagate a truth
-//! update through a 3-claim chain, then write the results back and verify
-//! persistence via SELECT.
+//! Inserts 3 claims (A supports B, B supports C) into Postgres, loads them
+//! into a `PropagationOrchestrator` via `load_orchestrator_from_db`, runs
+//! `update_and_propagate` against the loaded state, writes the resulting
+//! truth values back, and verifies persistence via SELECT.
+//!
+//! This is a real DB→engine→DB round-trip: if the loader stops reading
+//! truth_value (or stops creating dependents), the assertions on
+//! orch state pre-propagation will catch it.
 
 use engine_integration_tests::harness::*;
-use epigraph_core::{AgentId, Claim, ClaimId, TruthValue};
-use epigraph_engine::{EvidenceType, PropagationOrchestrator};
+use epigraph_core::{ClaimId, TruthValue};
 use sqlx::Row;
 
 const PREFIX: &str = "[test-prop-db]";
@@ -16,183 +19,82 @@ const PREFIX: &str = "[test-prop-db]";
 #[ignore] // Requires DATABASE_URL pointing to live PostgreSQL
 async fn propagation_persists_updated_truth_values() {
     let db = TestDb::setup().await;
+    let _guard = PrefixGuard::new(&db.pool, PREFIX);
 
-    // --- Setup: create agent + 3 claims forming a chain: A supports B supports C ---
+    // --- Setup: 3-claim chain A → B → C in DB ---
     let agent_uuid = create_test_agent(&db.pool).await;
-    let claim_a_uuid =
-        create_test_claim(&db.pool, agent_uuid, &format!("{PREFIX} root claim A"), 0.8).await;
-    let claim_b_uuid = create_test_claim(
-        &db.pool,
-        agent_uuid,
-        &format!("{PREFIX} dependent claim B"),
-        0.5,
+    let claim_a_uuid = create_test_claim(
+        &db.pool, agent_uuid, &format!("{PREFIX} root A"), 0.8,
     )
     .await;
-    let claim_c_uuid =
-        create_test_claim(&db.pool, agent_uuid, &format!("{PREFIX} leaf claim C"), 0.5).await;
+    let claim_b_uuid = create_test_claim(
+        &db.pool, agent_uuid, &format!("{PREFIX} mid B"), 0.5,
+    )
+    .await;
+    let claim_c_uuid = create_test_claim(
+        &db.pool, agent_uuid, &format!("{PREFIX} leaf C"), 0.5,
+    )
+    .await;
 
     create_test_edge(&db.pool, claim_a_uuid, claim_b_uuid, "supports").await;
     create_test_edge(&db.pool, claim_b_uuid, claim_c_uuid, "supports").await;
 
-    // --- Load claims from DB into orchestrator ---
-    let agent_id = AgentId::from_uuid(agent_uuid);
-    let public_key = [0u8; 32]; // matches harness create_test_agent padding
+    // --- Load orchestrator FROM DB (the actual integration point) ---
+    let mut orch = load_orchestrator_from_db(&db.pool, PREFIX).await;
 
     let claim_a_id = ClaimId::from_uuid(claim_a_uuid);
     let claim_b_id = ClaimId::from_uuid(claim_b_uuid);
     let claim_c_id = ClaimId::from_uuid(claim_c_uuid);
 
-    let claim_a = Claim::new(
-        format!("{PREFIX} root claim A"),
-        agent_id,
-        public_key,
-        TruthValue::new(0.8).unwrap(),
+    // Pre-propagation sanity: orchestrator reflects DB state.
+    // If the loader silently fails to read truth_value, this catches it.
+    assert_eq!(
+        orch.get_truth(claim_a_id).expect("A loaded").value(),
+        0.8,
+        "loader must read truth_value for A from DB"
     );
-    // Override the auto-generated id to match the DB row
-    let claim_a = rebuild_claim_with_id(claim_a_id, claim_a);
-
-    let claim_b = Claim::new(
-        format!("{PREFIX} dependent claim B"),
-        agent_id,
-        public_key,
-        TruthValue::new(0.5).unwrap(),
+    assert_eq!(
+        orch.get_truth(claim_b_id).expect("B loaded").value(),
+        0.5,
+        "loader must read truth_value for B from DB"
     );
-    let claim_b = rebuild_claim_with_id(claim_b_id, claim_b);
 
-    let claim_c = Claim::new(
-        format!("{PREFIX} leaf claim C"),
-        agent_id,
-        public_key,
-        TruthValue::new(0.5).unwrap(),
-    );
-    let claim_c = rebuild_claim_with_id(claim_c_id, claim_c);
-
-    let mut orch = PropagationOrchestrator::new();
-    orch.register_claim(claim_a).expect("register claim A");
-    orch.register_claim(claim_b).expect("register claim B");
-    orch.register_claim(claim_c).expect("register claim C");
-
-    // A supports B, B supports C
-    orch.add_dependency(
-        claim_a_id,
-        claim_b_id,
-        true, // supporting
-        0.8,  // strength
-        EvidenceType::Empirical,
-        0.0, // age_days (fresh evidence)
-    )
-    .expect("add A->B dependency");
-
-    orch.add_dependency(
-        claim_b_id,
-        claim_c_id,
-        true,
-        0.7,
-        EvidenceType::Logical,
-        0.0,
-    )
-    .expect("add B->C dependency");
-
-    // --- Propagate: boost A's truth to 0.95 ---
+    // --- Propagate: boost A's truth ---
     let updated = orch
         .update_and_propagate(claim_a_id, TruthValue::new(0.95).unwrap())
         .expect("propagation should succeed");
+    assert!(updated.contains(&claim_b_id), "B updated");
+    assert!(updated.contains(&claim_c_id), "C updated");
 
-    // Both B and C should have been updated
-    assert!(
-        updated.contains(&claim_b_id),
-        "Claim B should be in the updated set"
-    );
-    assert!(
-        updated.contains(&claim_c_id),
-        "Claim C should be in the updated set"
-    );
-
-    // Truth values should have increased from their initial 0.5
-    let truth_b = orch.get_truth(claim_b_id).expect("claim B should exist");
-    let truth_c = orch.get_truth(claim_c_id).expect("claim C should exist");
-
-    assert!(
-        truth_b.value() > 0.5,
-        "Claim B truth should have increased from 0.5, got {}",
-        truth_b.value()
-    );
-    assert!(
-        truth_c.value() > 0.5,
-        "Claim C truth should have increased from 0.5, got {}",
-        truth_c.value()
-    );
-
-    // B should be >= C (closer to the high-truth source)
+    let truth_b = orch.get_truth(claim_b_id).expect("B exists");
+    let truth_c = orch.get_truth(claim_c_id).expect("C exists");
+    assert!(truth_b.value() > 0.5, "B raised");
+    assert!(truth_c.value() > 0.5, "C raised");
     assert!(
         truth_b.value() >= truth_c.value(),
-        "B ({}) should be >= C ({}): closer to high-truth source",
-        truth_b.value(),
-        truth_c.value()
+        "B (closer to source) >= C"
     );
 
-    // --- Write updated truths back to DB ---
-    sqlx::query("UPDATE claims SET truth_value = $1 WHERE id = $2")
-        .bind(truth_b.value())
-        .bind(claim_b_uuid)
-        .execute(&db.pool)
-        .await
-        .expect("write back truth B");
+    // --- Write back and verify persistence ---
+    for (uuid, value) in [(claim_b_uuid, truth_b.value()), (claim_c_uuid, truth_c.value())] {
+        sqlx::query("UPDATE claims SET truth_value = $1 WHERE id = $2")
+            .bind(value)
+            .bind(uuid)
+            .execute(&db.pool)
+            .await
+            .expect("write back");
+    }
 
-    sqlx::query("UPDATE claims SET truth_value = $1 WHERE id = $2")
-        .bind(truth_c.value())
-        .bind(claim_c_uuid)
-        .execute(&db.pool)
-        .await
-        .expect("write back truth C");
-
-    // --- Verify persistence via SELECT ---
-    let row_b = sqlx::query("SELECT truth_value FROM claims WHERE id = $1")
-        .bind(claim_b_uuid)
-        .fetch_one(&db.pool)
-        .await
-        .expect("fetch claim B");
-    let persisted_b: f64 = row_b.get("truth_value");
-
-    let row_c = sqlx::query("SELECT truth_value FROM claims WHERE id = $1")
-        .bind(claim_c_uuid)
-        .fetch_one(&db.pool)
-        .await
-        .expect("fetch claim C");
-    let persisted_c: f64 = row_c.get("truth_value");
-
-    assert!(
-        (persisted_b - truth_b.value()).abs() < 1e-9,
-        "Persisted B ({}) should match orchestrator B ({})",
-        persisted_b,
-        truth_b.value()
-    );
-    assert!(
-        (persisted_c - truth_c.value()).abs() < 1e-9,
-        "Persisted C ({}) should match orchestrator C ({})",
-        persisted_c,
-        truth_c.value()
-    );
-
-    // --- Cleanup ---
-    cleanup_test_data(&db.pool, PREFIX).await;
-}
-
-/// Rebuild a `Claim` with a specific `ClaimId` (the DB-assigned UUID).
-///
-/// `Claim::new` auto-generates an ID. We need the ID to match the row
-/// already inserted by `create_test_claim`, so we reconstruct via `with_id`.
-fn rebuild_claim_with_id(id: ClaimId, src: Claim) -> Claim {
-    Claim::with_id(
-        id,
-        src.content,
-        src.agent_id,
-        src.public_key,
-        src.content_hash,
-        src.trace_id,
-        src.signature,
-        src.truth_value,
-        src.created_at,
-        src.updated_at,
-    )
+    for (uuid, expected) in [(claim_b_uuid, truth_b.value()), (claim_c_uuid, truth_c.value())] {
+        let row = sqlx::query("SELECT truth_value FROM claims WHERE id = $1")
+            .bind(uuid)
+            .fetch_one(&db.pool)
+            .await
+            .expect("fetch");
+        let persisted: f64 = row.get("truth_value");
+        assert!(
+            (persisted - expected).abs() < 1e-9,
+            "persisted {persisted} matches orchestrator {expected}"
+        );
+    }
 }

--- a/tests/engine-integration/tests/reasoning_db.rs
+++ b/tests/engine-integration/tests/reasoning_db.rs
@@ -13,6 +13,7 @@ const PREFIX: &str = "[test-reasoning-db]";
 #[ignore] // Requires DATABASE_URL pointing to live PostgreSQL
 async fn transitive_support_detected_from_db() {
     let db = TestDb::setup().await;
+    let _guard = PrefixGuard::new(&db.pool, PREFIX);
     let agent = create_test_agent(&db.pool).await;
 
     // Create 3 claims forming a support chain: A → B → C
@@ -106,6 +107,4 @@ async fn transitive_support_detected_from_db() {
             .any(|ts| ts.source == claim_b && ts.target == claim_c),
         "Direct support B→C should be in transitive_supports"
     );
-
-    cleanup_test_data(&db.pool, PREFIX).await;
 }

--- a/tests/engine-integration/tests/sheaf_db.rs
+++ b/tests/engine-integration/tests/sheaf_db.rs
@@ -13,6 +13,7 @@ const PREFIX: &str = "[test-sheaf-db]";
 #[ignore] // Requires DATABASE_URL pointing to live PostgreSQL
 async fn sheaf_consistency_from_db_neighborhood() {
     let db = TestDb::setup().await;
+    let _guard = PrefixGuard::new(&db.pool, PREFIX);
     let agent = create_test_agent(&db.pool).await;
 
     // Create center claim + 3 neighbors
@@ -87,6 +88,4 @@ async fn sheaf_consistency_from_db_neighborhood() {
         (betp - expected_approx).abs() < 1e-9,
         "Expected BetP ≈ {expected_approx}, got: {betp}"
     );
-
-    cleanup_test_data(&db.pool, PREFIX).await;
 }

--- a/tests/engine-integration/tests/trust_db.rs
+++ b/tests/engine-integration/tests/trust_db.rs
@@ -17,12 +17,16 @@ const PREFIX: &str = "[test-trust-db]";
 /// expected reputation derived from `ReputationConfig::default()`.
 ///
 /// With 5 claims of truth 0.80..0.88, age_days=5.0, was_refuted=false:
-/// - recency factor per claim: 1/(1+5/30) = 6/7 (identical → weighted mean = arith mean = 0.84)
-/// - combined = 0.84 (no historical claims)
-/// - stability factor for n=5 < min_claims_for_stability=10:
+/// - All age_days <= 30 → all "recent", `historical` is empty.
+/// - Per-claim recency factor: 1/(1+5/30) = 6/7 ≈ 0.857 (identical for all 5).
+/// - Identical weights → weighted mean of truth values = arith mean = 0.84.
+/// - `historical.is_empty()` → combined = recent_score = 0.84
+///   (the `recency_weight` default is NOT used here; it only kicks in
+///   when both recent and historical groups are non-empty).
+/// - n=5 < min_claims_for_stability=10 → stability factor applied:
 ///     progress = 5/10 = 0.5
-///     stability = 0.5*0.84 + 0.5*0.5 = 0.67
-/// - clamped to (0.1, 0.95) → 0.67
+///     stability = 0.5*0.84 + 0.5*initial_reputation(0.5) = 0.67
+/// - clamped to (min_reputation=0.1, max_reputation=0.95) → 0.67
 ///
 /// This locks the result; any change to ReputationConfig defaults or the
 /// reputation algorithm trips this assertion.
@@ -118,6 +122,9 @@ async fn conflict_classified_from_db_contradicts_edge() {
             source_id: row.get("source_id"),
             target_id: row.get("target_id"),
             relationship: row.get::<String, _>("relationship").to_lowercase(),
+            // Must be > 0.3: the contradiction rule at reasoning.rs:166 gates on
+            // `s1.0 > 0.3 && s2.0 > 0.3`. Below threshold, the contradiction
+            // is silently dropped and the len() == 1 assertion would fail.
             strength: 0.8,
         })
         .collect();

--- a/tests/engine-integration/tests/trust_db.rs
+++ b/tests/engine-integration/tests/trust_db.rs
@@ -146,7 +146,8 @@ async fn conflict_classified_from_db_contradicts_edge() {
     let expected = std::collections::BTreeSet::from([claim_a, claim_b]);
     assert_eq!(
         observed, expected,
-        "contradiction must name claim_a and claim_b (got {:?})", c
+        "contradiction must name claim_a and claim_b (got {:?})",
+        c
     );
     assert_eq!(c.target, target, "target must match");
 }

--- a/tests/engine-integration/tests/trust_db.rs
+++ b/tests/engine-integration/tests/trust_db.rs
@@ -1,10 +1,10 @@
 //! Integration tests: DB claims → ReputationCalculator → verify trust scores.
 //!
 //! Test 1: Load 5 claims from DB, build ClaimOutcome vector, compute reputation,
-//!         verify trust > 0.5 for an agent with high-truth claims.
+//!         verify trust == 0.67 (deterministic from ReputationConfig::default()).
 //!
 //! Test 2: Create 2 claims with CONTRADICTS edge, verify ReasoningEngine detects
-//!         the contradiction (conflict classification from DB data).
+//!         exactly one contradiction naming the specific claim pair and target.
 
 use engine_integration_tests::harness::*;
 use epigraph_engine::reputation::{ClaimOutcome, ReputationCalculator};
@@ -13,88 +13,88 @@ use sqlx::Row;
 
 const PREFIX: &str = "[test-trust-db]";
 
+/// Trust computation from 5 high-truth recent claims yields a specific
+/// expected reputation derived from `ReputationConfig::default()`.
+///
+/// With 5 claims of truth 0.80..0.88, age_days=5.0, was_refuted=false:
+/// - recency factor per claim: 1/(1+5/30) = 6/7 (identical → weighted mean = arith mean = 0.84)
+/// - combined = 0.84 (no historical claims)
+/// - stability factor for n=5 < min_claims_for_stability=10:
+///     progress = 5/10 = 0.5
+///     stability = 0.5*0.84 + 0.5*0.5 = 0.67
+/// - clamped to (0.1, 0.95) → 0.67
+///
+/// This locks the result; any change to ReputationConfig defaults or the
+/// reputation algorithm trips this assertion.
 #[tokio::test]
 #[ignore] // Requires DATABASE_URL pointing to live PostgreSQL
 async fn trust_computed_from_db_claims() {
     let db = TestDb::setup().await;
+    let _guard = PrefixGuard::new(&db.pool, PREFIX);
     let agent = create_test_agent(&db.pool).await;
 
-    // Insert 5 high-truth claims
     let mut claim_ids = Vec::new();
     for i in 0..5 {
         let id = create_test_claim(
             &db.pool,
             agent,
             &format!("{PREFIX} trust-claim-{i}"),
-            0.8 + (i as f64) * 0.02, // 0.80, 0.82, 0.84, 0.86, 0.88
+            0.8 + (i as f64) * 0.02,
         )
         .await;
         claim_ids.push(id);
     }
 
-    // Load truth values from DB, build ClaimOutcome vector
     let rows = sqlx::query("SELECT truth_value FROM claims WHERE content LIKE $1 ORDER BY content")
         .bind(format!("{PREFIX} trust-claim-%"))
         .fetch_all(&db.pool)
         .await
-        .expect("Failed to load claims from DB");
-
-    assert_eq!(rows.len(), 5, "Should have loaded 5 claims from DB");
+        .expect("load claims");
+    assert_eq!(rows.len(), 5);
 
     let outcomes: Vec<ClaimOutcome> = rows
         .iter()
-        .map(|row| {
-            let truth_value: f64 = row.get("truth_value");
-            ClaimOutcome {
-                truth_value,
-                age_days: 5.0, // recent claims
-                was_refuted: false,
-            }
+        .map(|row| ClaimOutcome {
+            truth_value: row.get::<f64, _>("truth_value"),
+            age_days: 5.0,
+            was_refuted: false,
         })
         .collect();
 
-    let calc = ReputationCalculator::new();
-    let trust = calc.calculate(&outcomes).expect("reputation calculation");
+    let trust = ReputationCalculator::new()
+        .calculate(&outcomes)
+        .expect("reputation");
 
-    // 5 claims with truth 0.80..0.88, all recent, none refuted → trust > 0.5
+    let expected = 0.67;
     assert!(
-        trust > 0.5,
-        "Agent with high-truth claims should have trust > 0.5, got: {trust}"
+        (trust - expected).abs() < 1e-9,
+        "expected reputation == {expected} from defaults + hand-calculation; got {trust}. \
+         If ReputationConfig defaults changed, update this expected value and \
+         the doc-comment derivation."
     );
-
-    // Also verify it's bounded below max (0.95) — only 5 claims, stability penalty applies
-    assert!(
-        trust <= 0.95,
-        "Trust should be bounded by max_reputation, got: {trust}"
-    );
-
-    cleanup_test_data(&db.pool, PREFIX).await;
 }
 
+/// CONTRADICTS edge in DB produces a Contradiction record that names the
+/// specific supporting + refuting claims and the shared target.
 #[tokio::test]
 #[ignore] // Requires DATABASE_URL pointing to live PostgreSQL
 async fn conflict_classified_from_db_contradicts_edge() {
     let db = TestDb::setup().await;
+    let _guard = PrefixGuard::new(&db.pool, PREFIX);
     let agent = create_test_agent(&db.pool).await;
 
-    // Create two claims with an imbalance in truth values
-    let claim_a = create_test_claim(&db.pool, agent, &format!("{PREFIX} strong-claim"), 0.9).await;
-    let claim_b = create_test_claim(&db.pool, agent, &format!("{PREFIX} weak-claim"), 0.3).await;
+    let claim_a = create_test_claim(&db.pool, agent, &format!("{PREFIX} strong"), 0.9).await;
+    let claim_b = create_test_claim(&db.pool, agent, &format!("{PREFIX} weak"), 0.3).await;
+    let target = create_test_claim(&db.pool, agent, &format!("{PREFIX} target"), 0.6).await;
 
-    // Create a target claim that both relate to
-    let target = create_test_claim(&db.pool, agent, &format!("{PREFIX} target-claim"), 0.6).await;
-
-    // A supports target, B contradicts target
     create_test_edge(&db.pool, claim_a, target, "supports").await;
     create_test_edge(&db.pool, claim_b, target, "contradicts").await;
 
-    // Load claims and edges from DB
     let claim_rows = sqlx::query("SELECT id, truth_value FROM claims WHERE content LIKE $1")
         .bind(format!("{PREFIX}%"))
         .fetch_all(&db.pool)
         .await
         .expect("load claims");
-
     let claims: Vec<ReasoningClaim> = claim_rows
         .iter()
         .map(|row| ReasoningClaim {
@@ -105,39 +105,41 @@ async fn conflict_classified_from_db_contradicts_edge() {
 
     let edge_rows = sqlx::query(
         "SELECT e.source_id, e.target_id, e.relationship \
-         FROM edges e \
-         JOIN claims cs ON cs.id = e.source_id \
+         FROM edges e JOIN claims cs ON cs.id = e.source_id \
          WHERE cs.content LIKE $1",
     )
     .bind(format!("{PREFIX}%"))
     .fetch_all(&db.pool)
     .await
     .expect("load edges");
-
     let edges: Vec<ReasoningEdge> = edge_rows
         .iter()
-        .map(|row| {
-            let rel: String = row.get("relationship");
-            ReasoningEdge {
-                source_id: row.get("source_id"),
-                target_id: row.get("target_id"),
-                relationship: rel.to_lowercase(),
-                strength: 0.8, // default strength for DB edges
-            }
+        .map(|row| ReasoningEdge {
+            source_id: row.get("source_id"),
+            target_id: row.get("target_id"),
+            relationship: row.get::<String, _>("relationship").to_lowercase(),
+            strength: 0.8,
         })
         .collect();
 
     let result = ReasoningEngine::analyze(&claims, &edges);
 
-    // Should detect at least one contradiction: A supports target while B refutes it
-    assert!(
-        !result.contradictions.is_empty(),
-        "ReasoningEngine should detect contradiction from CONTRADICTS edge, got 0 contradictions"
+    // Exactly one contradiction, naming (claim_a as supporter, claim_b as refuter, target).
+    // Contradiction.claim_a/claim_b ordering is not guaranteed by the engine, so
+    // accept either order but require the *set* to match.
+    assert_eq!(
+        result.contradictions.len(),
+        1,
+        "expected exactly one contradiction, got {} ({:?})",
+        result.contradictions.len(),
+        result.contradictions
     );
-
-    // Verify the contradiction involves our target claim
-    let found = result.contradictions.iter().any(|c| c.target == target);
-    assert!(found, "Contradiction should involve the target claim");
-
-    cleanup_test_data(&db.pool, PREFIX).await;
+    let c = &result.contradictions[0];
+    let observed = std::collections::BTreeSet::from([c.claim_a, c.claim_b]);
+    let expected = std::collections::BTreeSet::from([claim_a, claim_b]);
+    assert_eq!(
+        observed, expected,
+        "contradiction must name claim_a and claim_b (got {:?})", c
+    );
+    assert_eq!(c.target, target, "target must match");
 }

--- a/tests/engine-integration/tests/update_math_regression.rs
+++ b/tests/engine-integration/tests/update_math_regression.rs
@@ -40,57 +40,64 @@ fn contradiction_bba(frame: FrameOfDiscernment, mass: f64) -> MassFunction {
 // C1: evidence_type weighting
 // ---------------------------------------------------------------------------
 
-/// C1 regression: evidence_type must produce different BBA masses.
+/// C1 regression: evidence_type weighting must change BBA output.
 ///
-/// Empirical evidence (type_weight = 1.0) should produce a more informative
-/// BBA than circumstantial evidence (type_weight = 0.4) at the same raw
-/// confidence level.
+/// Real test: call `build_bba_directed` (the actual production code in
+/// `crates/epigraph-engine/src/bba.rs`) with two different `evidence_type`
+/// values and identical everything else. The resulting pignistic BetP on
+/// {supported} must differ — empirical evidence (type_weight = 1.0) must produce
+/// higher BetP(supported) than circumstantial (type_weight = 0.4).
 ///
-/// This test validates that the mass computation `confidence * type_weight`
-/// in bba.rs produces meaningfully different BBAs and that the difference
-/// propagates through to pignistic probability.
+/// This catches the C1 bug class: any change in `bba.rs` that loses the
+/// evidence-type signal (e.g. removing the `* type_weight` multiplication,
+/// or replacing the weight lookup with a constant) breaks this assertion.
 #[tokio::test]
 async fn test_c1_evidence_type_produces_different_weights() {
-    let frame = binary_frame();
-    let confidence = 0.7_f64;
+    use epigraph_engine::bba::{build_bba_directed, BbaParams};
+    use epigraph_engine::calibration::CalibrationConfig;
 
-    // Empirical: type_weight = 1.0
-    let empirical_mass = confidence * 1.0;
-    let empirical_bba = support_bba(frame.clone(), empirical_mass);
+    let cfg = CalibrationConfig::load(std::path::Path::new(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../../calibration.toml"),
+    ))
+    .expect("load calibration.toml");
 
-    // Circumstantial: type_weight = 0.4
-    let circumstantial_mass = confidence * 0.4;
-    let circumstantial_bba = support_bba(frame.clone(), circumstantial_mass);
+    let base_params = BbaParams {
+        evidence_type: "empirical".to_string(),
+        methodology: "instrumental".to_string(),
+        confidence: 0.7,
+        supports: true,
+        section_tier: None,
+        journal_reliability: None,
+        open_world_fraction: 0.0,
+        uncertainty: None,
+    };
 
-    // Both discounted by same reliability (source is equally reliable)
-    let reliability = 0.8_f64;
-    let empirical_disc = discount(&empirical_bba, reliability).unwrap();
-    let circumstantial_disc = discount(&circumstantial_bba, reliability).unwrap();
+    let empirical = build_bba_directed(&base_params, &cfg).expect("empirical bba");
+    let circumstantial = build_bba_directed(
+        &BbaParams {
+            evidence_type: "circumstantial".to_string(),
+            ..base_params.clone()
+        },
+        &cfg,
+    )
+    .expect("circumstantial bba");
 
-    let betp_empirical = measures::pignistic_probability(&empirical_disc, 0);
-    let betp_circumstantial = measures::pignistic_probability(&circumstantial_disc, 0);
+    // The mass functions use frame ["supported", "unsupported"]; index 0 = supported.
+    let betp_emp = measures::pignistic_probability(&empirical, 0);
+    let betp_circ = measures::pignistic_probability(&circumstantial, 0);
 
-    println!(
-        "C1: BetP(TRUE) empirical={betp_empirical:.4}, circumstantial={betp_circumstantial:.4}"
-    );
+    println!("C1: BetP(supported) empirical={betp_emp:.4}, circumstantial={betp_circ:.4}");
 
-    // Empirical evidence should produce higher BetP(TRUE)
     assert!(
-        betp_empirical > betp_circumstantial,
-        "C1 FAILED: empirical BBA ({betp_empirical:.4}) should dominate circumstantial ({betp_circumstantial:.4})"
+        betp_emp > betp_circ,
+        "C1 FAILED: empirical BBA BetP({betp_emp:.4}) must exceed circumstantial ({betp_circ:.4}); \
+         bba.rs has stopped honouring evidence_type"
     );
-
-    // The gap should be substantial — empirical is 2.5× more informative
-    let gap = betp_empirical - betp_circumstantial;
     assert!(
-        gap > 0.05,
-        "C1 FAILED: gap between empirical and circumstantial too small ({gap:.4}), expected > 0.05"
-    );
-
-    // Empirical BBA should push BetP well above 0.5
-    assert!(
-        betp_empirical > 0.55,
-        "C1 FAILED: empirical BBA should push BetP(TRUE) > 0.55, got {betp_empirical:.4}"
+        (betp_emp - betp_circ) > 0.05,
+        "C1 FAILED: gap between empirical and circumstantial ({:.4}) too small (< 0.05); \
+         evidence_type weighting has been diluted",
+        betp_emp - betp_circ
     );
 }
 

--- a/tests/engine-integration/tests/update_math_regression.rs
+++ b/tests/engine-integration/tests/update_math_regression.rs
@@ -56,9 +56,10 @@ async fn test_c1_evidence_type_produces_different_weights() {
     use epigraph_engine::bba::{build_bba_directed, BbaParams};
     use epigraph_engine::calibration::CalibrationConfig;
 
-    let cfg = CalibrationConfig::load(std::path::Path::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/../../calibration.toml"),
-    ))
+    let cfg = CalibrationConfig::load(std::path::Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../calibration.toml"
+    )))
     .expect("load calibration.toml");
 
     let base_params = BbaParams {


### PR DESCRIPTION
## Summary

Motivated by `test-results/regression-audit-2026-05-16.md`, which found the engine-integration regression suite was 60% inert in CI and the running 40% had several tests that didn't actually exercise what their doc-comments claimed.

- **Local DB wiring:** New `scripts/prepare-engine-integration-db.sh` recreates `epigraph_db_repo_test` and applies migrations in one command. After running it, `cargo test -p engine-integration-tests -- --ignored --test-threads=1` now passes 7 previously-dark DB tests.
- **Panic-safe cleanup:** All 5 DB tests adopt a new `PrefixGuard` RAII type (replaces end-of-test `cleanup_test_data` calls).
- **Real test fixes:**
  - **C1** (`test_c1_evidence_type_produces_different_weights`) — was reconstructing math in the test body; now calls `epigraph_engine::bba::build_bba_directed` for real. Mutation-verified by removing `* type_weight` from `bba.rs:102`.
  - **`propagation_db`** — was building the orchestrator in-memory; now uses a new `load_orchestrator_from_db(pool, prefix)` helper that actually reads claims/edges from PG and asserts pre-propagation state matches the DB.
  - **`bp_factors`** — `.unwrap_or(0.8)` → `.expect()` + `(strength - 0.85).abs() < 1e-9`; BP belief symmetry tightened from 0.05 to 1e-6. Stale `migration 044`/`068` doc references updated to consolidated `001_initial_schema.sql:67/82-85/172` and `011_derived_from_uppercase_factor.sql:34`.
  - **`trust_db`** — replaced loose ranges (`0.5 < trust <= 0.95`, `!contradictions.is_empty()`) with deterministic assertions: `trust == 0.67` exactly (hand-derived in doc-comment); exactly one contradiction with `{claim_a, claim_b}` set match. Mutation-verified by changing `initial_reputation: 0.5 → 0.4`.

CI integration is intentionally **not** included — the existing `cargo test --workspace` job in `.github/workflows/ci.yml` still skips `--ignored` tests, so this PR doesn't change CI behaviour. A follow-up PR can add a Postgres service container.

## Test Plan

- [ ] Pull this branch, run `./scripts/prepare-engine-integration-db.sh`
- [ ] `DATABASE_URL="postgres://epigraph:epigraph@localhost:5432/epigraph_db_repo_test" cargo test -p engine-integration-tests -- --include-ignored --test-threads=1` → **12 passed, 0 failed**
- [ ] `cargo test -p engine-integration-tests` (no DB env) → **4 passed, 8 ignored** (CI baseline preserved)
- [ ] `cargo clippy -p engine-integration-tests --tests -- -D warnings` → clean
- [ ] Spot-check that the new C1 test actually fails when `* type_weight` is removed from `crates/epigraph-engine/src/bba.rs:102`