### PR TITLE
fix: backlog-retirement deferred review items (#1, #2, #4)

### DIFF
--- a/crates/epigraph-api/src/routes/claims.rs
+++ b/crates/epigraph-api/src/routes/claims.rs
@@ -1563,6 +1563,11 @@ pub struct ClaimsByLabelsQuery {
     /// Max claims to return (clamped to [`MIN_PAGE_LIMIT`, `MAX_PAGE_LIMIT`]).
     #[serde(default)]
     pub limit: Option<i64>,
+    /// Skip the first N matching claims (default 0; negative values clamped to 0).
+    /// Combine with `limit` to page through large result sets — claims are
+    /// ordered by `created_at DESC`.
+    #[serde(default)]
+    pub offset: Option<i64>,
 }
 
 /// Response row for `GET /api/v1/claims/by-labels`.
@@ -1619,6 +1624,7 @@ pub async fn list_by_labels(
         .limit
         .unwrap_or(DEFAULT_PAGE_LIMIT)
         .clamp(MIN_PAGE_LIMIT, MAX_PAGE_LIMIT);
+    let offset = q.offset.unwrap_or(0).max(0);
 
     let rows = ClaimRepository::list_by_labels(
         &state.db_pool,
@@ -1627,6 +1633,7 @@ pub async fn list_by_labels(
         current_only,
         min_truth,
         limit,
+        offset,
     )
     .await
     .map_err(|e| ApiError::InternalError {

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -908,6 +908,7 @@ impl ClaimRepository {
         current_only: bool,
         min_truth: f64,
         limit: i64,
+        offset: i64,
     ) -> Result<Vec<(Claim, Vec<String>)>, DbError> {
         #[derive(sqlx::FromRow)]
         struct Row {
@@ -924,6 +925,7 @@ impl ClaimRepository {
         }
 
         let limit = limit.clamp(1, 1000);
+        let offset = offset.max(0);
         let rows = sqlx::query_as::<_, Row>(
             r#"
             SELECT id, content, truth_value, agent_id, trace_id,
@@ -935,6 +937,7 @@ impl ClaimRepository {
               AND ($4 = false OR COALESCE(is_current, true) = true)
             ORDER BY created_at DESC
             LIMIT $5
+            OFFSET $6
             "#,
         )
         .bind(labels)
@@ -942,6 +945,7 @@ impl ClaimRepository {
         .bind(exclude_labels)
         .bind(current_only)
         .bind(limit)
+        .bind(offset)
         .fetch_all(pool)
         .await?;
 
@@ -2543,7 +2547,7 @@ mod label_tests {
             .unwrap();
 
         let results =
-            ClaimRepository::list_by_labels(&pool, &["backlog".into()], &[], false, 0.0, 100)
+            ClaimRepository::list_by_labels(&pool, &["backlog".into()], &[], false, 0.0, 100, 0)
                 .await
                 .unwrap();
         assert!(
@@ -2558,6 +2562,7 @@ mod label_tests {
             false,
             0.0,
             100,
+            0,
         )
         .await
         .unwrap();
@@ -2584,6 +2589,7 @@ mod label_tests {
             false,
             0.0,
             100,
+            0,
         )
         .await
         .unwrap();
@@ -2605,7 +2611,7 @@ mod label_tests {
             .unwrap();
 
         let results =
-            ClaimRepository::list_by_labels(&pool, &["truth-test".into()], &[], false, 0.4, 100)
+            ClaimRepository::list_by_labels(&pool, &["truth-test".into()], &[], false, 0.4, 100, 0)
                 .await
                 .unwrap();
         assert!(
@@ -2614,7 +2620,7 @@ mod label_tests {
         );
 
         let results =
-            ClaimRepository::list_by_labels(&pool, &["truth-test".into()], &[], false, 0.9, 100)
+            ClaimRepository::list_by_labels(&pool, &["truth-test".into()], &[], false, 0.9, 100, 0)
                 .await
                 .unwrap();
         assert!(
@@ -2651,7 +2657,7 @@ mod label_tests {
         .unwrap();
 
         let results =
-            ClaimRepository::list_by_labels(&pool, &["limit-test".into()], &[], false, 0.0, 1)
+            ClaimRepository::list_by_labels(&pool, &["limit-test".into()], &[], false, 0.0, 1, 0)
                 .await
                 .unwrap();
         assert_eq!(results.len(), 1, "limit=1 should return exactly 1 result");

--- a/crates/epigraph-db/tests/list_by_labels.rs
+++ b/crates/epigraph-db/tests/list_by_labels.rs
@@ -34,6 +34,7 @@ async fn list_by_labels_returns_labels_is_current_supersedes(pool: PgPool) {
         false, // current_only
         0.0,
         50,
+        0, // offset
     )
     .await
     .unwrap();
@@ -61,6 +62,7 @@ async fn list_by_labels_returns_labels_is_current_supersedes(pool: PgPool) {
         false,
         0.0,
         50,
+        0,
     )
     .await
     .unwrap();
@@ -69,7 +71,7 @@ async fn list_by_labels_returns_labels_is_current_supersedes(pool: PgPool) {
 
     // current_only=true drops the superseded one
     let current =
-        ClaimRepository::list_by_labels(&pool, &["backlog".to_string()], &[], true, 0.0, 50)
+        ClaimRepository::list_by_labels(&pool, &["backlog".to_string()], &[], true, 0.0, 50, 0)
             .await
             .unwrap();
     assert_eq!(current.len(), 2);
@@ -83,11 +85,119 @@ async fn list_by_labels_returns_labels_is_current_supersedes(pool: PgPool) {
         true,
         0.0,
         50,
+        0,
     )
     .await
     .unwrap();
     assert_eq!(open.len(), 1);
     assert_eq!(open[0].0.id, backlog_open);
+}
+
+/// Pagination contract for [`ClaimRepository::list_by_labels`]: with
+/// `ORDER BY created_at DESC`, `limit=N offset=K` must return rows K..K+N
+/// and disjoint pages must cover every row exactly once. Seeds 5 claims
+/// with deterministic `created_at` ordering by inserting one at a time —
+/// `DEFAULT now()` plus the per-row INSERT roundtrip guarantees strict
+/// monotonicity (and we sort our local truth list the same way to avoid
+/// timestamp races).
+#[sqlx::test(migrations = "../../migrations")]
+async fn list_by_labels_pagination(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+
+    // Seed 5 claims one-at-a-time; collect in insertion order. created_at
+    // strictly increases per insert, so DESC order is the reverse of this
+    // vector.
+    let mut seeded: Vec<ClaimId> = Vec::with_capacity(5);
+    for _ in 0..5 {
+        let id = seed_claim(&pool, agent, &["page-test"], true, None).await;
+        seeded.push(id);
+    }
+    // Newest first (matches the SQL ORDER BY created_at DESC).
+    let expected_desc: Vec<ClaimId> = seeded.into_iter().rev().collect();
+
+    // Page 1: limit=2 offset=0 — first 2 newest.
+    let page1 = ClaimRepository::list_by_labels(
+        &pool,
+        &["page-test".to_string()],
+        &[],
+        false,
+        0.0,
+        2,
+        0,
+    )
+    .await
+    .unwrap();
+    assert_eq!(page1.len(), 2, "page1 len");
+    let page1_ids: Vec<ClaimId> = page1.iter().map(|(c, _)| c.id).collect();
+    assert_eq!(page1_ids, expected_desc[0..2]);
+
+    // Page 2: limit=2 offset=2 — next 2.
+    let page2 = ClaimRepository::list_by_labels(
+        &pool,
+        &["page-test".to_string()],
+        &[],
+        false,
+        0.0,
+        2,
+        2,
+    )
+    .await
+    .unwrap();
+    assert_eq!(page2.len(), 2, "page2 len");
+    let page2_ids: Vec<ClaimId> = page2.iter().map(|(c, _)| c.id).collect();
+    assert_eq!(page2_ids, expected_desc[2..4]);
+
+    // Page 3: limit=2 offset=4 — only 1 remaining (5 total).
+    let page3 = ClaimRepository::list_by_labels(
+        &pool,
+        &["page-test".to_string()],
+        &[],
+        false,
+        0.0,
+        2,
+        4,
+    )
+    .await
+    .unwrap();
+    assert!(
+        page3.len() <= 1,
+        "page3 should have <=1 row (got {})",
+        page3.len()
+    );
+    let page3_ids: Vec<ClaimId> = page3.iter().map(|(c, _)| c.id).collect();
+    assert_eq!(page3_ids, expected_desc[4..]);
+
+    // No overlap across pages.
+    let all_ids: Vec<ClaimId> = page1_ids
+        .iter()
+        .chain(page2_ids.iter())
+        .chain(page3_ids.iter())
+        .copied()
+        .collect();
+    let unique: std::collections::HashSet<ClaimId> = all_ids.iter().copied().collect();
+    assert_eq!(
+        all_ids.len(),
+        unique.len(),
+        "no claim should appear on more than one page"
+    );
+
+    // Negative offset must clamp to 0 (matches the implementation contract).
+    let clamped = ClaimRepository::list_by_labels(
+        &pool,
+        &["page-test".to_string()],
+        &[],
+        false,
+        0.0,
+        2,
+        -100,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        clamped.iter().map(|(c, _)| c.id).collect::<Vec<_>>(),
+        expected_desc[0..2],
+        "negative offset should behave like offset=0"
+    );
 }
 
 async fn seed_agent(pool: &PgPool) -> Uuid {

--- a/crates/epigraph-db/tests/list_by_labels.rs
+++ b/crates/epigraph-db/tests/list_by_labels.rs
@@ -116,49 +116,28 @@ async fn list_by_labels_pagination(pool: PgPool) {
     let expected_desc: Vec<ClaimId> = seeded.into_iter().rev().collect();
 
     // Page 1: limit=2 offset=0 — first 2 newest.
-    let page1 = ClaimRepository::list_by_labels(
-        &pool,
-        &["page-test".to_string()],
-        &[],
-        false,
-        0.0,
-        2,
-        0,
-    )
-    .await
-    .unwrap();
+    let page1 =
+        ClaimRepository::list_by_labels(&pool, &["page-test".to_string()], &[], false, 0.0, 2, 0)
+            .await
+            .unwrap();
     assert_eq!(page1.len(), 2, "page1 len");
     let page1_ids: Vec<ClaimId> = page1.iter().map(|(c, _)| c.id).collect();
     assert_eq!(page1_ids, expected_desc[0..2]);
 
     // Page 2: limit=2 offset=2 — next 2.
-    let page2 = ClaimRepository::list_by_labels(
-        &pool,
-        &["page-test".to_string()],
-        &[],
-        false,
-        0.0,
-        2,
-        2,
-    )
-    .await
-    .unwrap();
+    let page2 =
+        ClaimRepository::list_by_labels(&pool, &["page-test".to_string()], &[], false, 0.0, 2, 2)
+            .await
+            .unwrap();
     assert_eq!(page2.len(), 2, "page2 len");
     let page2_ids: Vec<ClaimId> = page2.iter().map(|(c, _)| c.id).collect();
     assert_eq!(page2_ids, expected_desc[2..4]);
 
     // Page 3: limit=2 offset=4 — only 1 remaining (5 total).
-    let page3 = ClaimRepository::list_by_labels(
-        &pool,
-        &["page-test".to_string()],
-        &[],
-        false,
-        0.0,
-        2,
-        4,
-    )
-    .await
-    .unwrap();
+    let page3 =
+        ClaimRepository::list_by_labels(&pool, &["page-test".to_string()], &[], false, 0.0, 2, 4)
+            .await
+            .unwrap();
     assert!(
         page3.len() <= 1,
         "page3 should have <=1 row (got {})",

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -433,10 +433,43 @@ pub async fn resolve_backlog_item(
     // Confirm the target exists; we do NOT require the "backlog" label —
     // a stricter precondition belongs to the call site (HTTP filters /
     // operator UI) rather than the verb.
-    let _original = ClaimRepository::get_by_id(&server.pool, original_claim_id)
+    let original = ClaimRepository::get_by_id(&server.pool, original_claim_id)
         .await
         .map_err(internal_error)?
         .ok_or_else(|| invalid_params(format!("claim {original_id} not found")))?;
+
+    // Authorization: mirror PATCH /api/v1/claims/:id/labels'
+    // `require_owner_or_admin` middleware. The HTTP route's check is
+    // (claims:admin OR auth.owner_id/client_id == claim.agent_id). The
+    // rmcp tool_router macro does NOT forward the request's `AuthContext`
+    // into per-tool handlers — only `Parameters<T>` is passed. So we
+    // cannot read the caller's scopes here (admin override) or their
+    // owner/client UUID. Per Component 2 of the backlog-retirement spec
+    // ("Calls existing HTTP routes…"), HTTP forwarding would be cleaner
+    // but requires a bearer token the MCP server doesn't hold unless the
+    // caller passes one.
+    //
+    // Coarse fallback: compare the claim's author against the server's
+    // own signer agent. This blocks the most common abuse (a token with
+    // claims:write retiring a claim authored by a different signer) but
+    // it does NOT distinguish multiple human/agent callers that share
+    // the same MCP-server signer. Follow-up: plumb AuthContext through
+    // rmcp's Extension<T> pattern at the tool-handler boundary so this
+    // can check has_scope("claims:admin") and auth.owner_id properly.
+    let caller_agent = server.agent_id().await?;
+    let target_agent = original.agent_id.as_uuid();
+    if caller_agent != target_agent {
+        return Err(McpError {
+            code: rmcp::model::ErrorCode::INVALID_PARAMS,
+            message: format!(
+                "claim {original_id} is owned by agent {target_agent}; \
+                 caller agent {caller_agent} cannot retire it (claims:admin scope \
+                 override not yet plumbed into MCP tool handlers)"
+            )
+            .into(),
+            data: None,
+        });
+    }
 
     // 1. Submit the resolution claim via the canonical pipeline.
     let methodology = params

--- a/crates/epigraph-mcp/src/tools/paper_queries.rs
+++ b/crates/epigraph-mcp/src/tools/paper_queries.rs
@@ -205,6 +205,7 @@ pub async fn query_claims_by_label(
 ) -> Result<CallToolResult, McpError> {
     let limit = params.limit.unwrap_or(20).clamp(1, 100);
     let min_truth = params.min_truth.unwrap_or(0.0);
+    let offset = params.offset.unwrap_or(0).max(0);
 
     if params.labels.is_empty() {
         return Err(McpError {
@@ -221,6 +222,7 @@ pub async fn query_claims_by_label(
         params.current_only,
         min_truth,
         limit,
+        offset,
     )
     .await
     .map_err(internal_error)?;

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -229,6 +229,12 @@ pub struct QueryClaimsByLabelParams {
 
     #[schemars(description = "Maximum results (default 20)")]
     pub limit: Option<i64>,
+
+    #[schemars(
+        description = "Skip the first N matching claims (default 0). Combine with `limit` to page through large result sets — results are ordered by `created_at DESC`."
+    )]
+    #[serde(default)]
+    pub offset: Option<i64>,
 }
 
 // ── Workflows ──

--- a/crates/epigraph-mcp/tests/query_claims_by_label.rs
+++ b/crates/epigraph-mcp/tests/query_claims_by_label.rs
@@ -37,6 +37,7 @@ async fn query_by_label_returns_labels_and_filters(pool: PgPool) {
             current_only: false,
             min_truth: None,
             limit: Some(10),
+            offset: None,
         },
     )
     .await
@@ -80,6 +81,7 @@ async fn query_by_label_returns_labels_and_filters(pool: PgPool) {
             current_only: false,
             min_truth: None,
             limit: Some(10),
+            offset: None,
         },
     )
     .await
@@ -103,6 +105,7 @@ async fn query_by_label_returns_labels_and_filters(pool: PgPool) {
             current_only: true,
             min_truth: None,
             limit: Some(10),
+            offset: None,
         },
     )
     .await
@@ -126,6 +129,7 @@ async fn query_by_label_returns_labels_and_filters(pool: PgPool) {
             current_only: true,
             min_truth: None,
             limit: Some(10),
+            offset: None,
         },
     )
     .await

--- a/crates/epigraph-mcp/tests/resolve_backlog_item.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item.rs
@@ -130,10 +130,7 @@ fn parse_json(result: &CallToolResult) -> Value {
 /// registered, then return that agent's UUID. We need the server-signer
 /// agent (not a freshly-seeded random agent) because
 /// `resolve_backlog_item` now enforces caller-owns-claim.
-async fn bootstrap_server_agent(
-    server: &epigraph_mcp::EpiGraphMcpFull,
-    pool: &PgPool,
-) -> Uuid {
+async fn bootstrap_server_agent(server: &epigraph_mcp::EpiGraphMcpFull, pool: &PgPool) -> Uuid {
     let result = epigraph_mcp::tools::claims::submit_claim(
         server,
         epigraph_mcp::types::SubmitClaimParams {

--- a/crates/epigraph-mcp/tests/resolve_backlog_item.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item.rs
@@ -25,10 +25,14 @@ use common::build_test_server;
 
 #[sqlx::test(migrations = "../../migrations")]
 async fn resolve_backlog_item_creates_resolution_and_patches_original(pool: PgPool) {
-    let agent = seed_agent(&pool).await;
-    let original = seed_claim(&pool, agent, &["backlog"], true, None).await;
-
     let server = build_test_server(pool.clone());
+
+    // Author the backlog claim through the MCP server's own signer so the
+    // owner-or-admin check inside resolve_backlog_item succeeds. (The
+    // server's signer agent is registered as a side-effect of submit_claim;
+    // we then look up its UUID via the just-created claim.)
+    let server_agent = bootstrap_server_agent(&server, &pool).await;
+    let original = seed_claim(&pool, server_agent, &["backlog"], true, None).await;
 
     let result = resolve_backlog_item(
         &server,
@@ -122,15 +126,41 @@ fn parse_json(result: &CallToolResult) -> Value {
     serde_json::from_str(&text).expect("response is JSON")
 }
 
-async fn seed_agent(pool: &PgPool) -> Uuid {
-    let id = Uuid::new_v4();
-    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
-        .bind(id)
-        .bind("bb".repeat(32))
-        .execute(pool)
+/// Submit a throwaway claim through the server so its signer agent is
+/// registered, then return that agent's UUID. We need the server-signer
+/// agent (not a freshly-seeded random agent) because
+/// `resolve_backlog_item` now enforces caller-owns-claim.
+async fn bootstrap_server_agent(
+    server: &epigraph_mcp::EpiGraphMcpFull,
+    pool: &PgPool,
+) -> Uuid {
+    let result = epigraph_mcp::tools::claims::submit_claim(
+        server,
+        epigraph_mcp::types::SubmitClaimParams {
+            content: "bootstrap claim for resolve_backlog_item test".into(),
+            methodology: "deductive_logic".into(),
+            evidence_data: "ev".into(),
+            evidence_type: "logical".into(),
+            confidence: 0.5,
+            source_url: None,
+            reasoning: None,
+            labels: vec![],
+        },
+    )
+    .await
+    .expect("bootstrap submit_claim");
+    let body = parse_json(&result);
+    let claim_id: Uuid = body["claim_id"]
+        .as_str()
+        .expect("claim_id is string")
+        .parse()
+        .expect("valid UUID");
+    let (agent_id,): (Uuid,) = sqlx::query_as("SELECT agent_id FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
         .await
-        .expect("seed agent");
-    id
+        .expect("fetch agent_id");
+    agent_id
 }
 
 async fn seed_claim(

--- a/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
@@ -1,0 +1,224 @@
+//! Integration test for the owner-or-admin check in
+//! [`resolve_backlog_item`] (deferred-review item #2 of the
+//! backlog-retirement work).
+//!
+//! Background: previously `resolve_backlog_item` called
+//! `ClaimRepository::update_labels` directly on the repo layer, bypassing
+//! the HTTP `PATCH /api/v1/claims/:id/labels` route's
+//! `require_owner_or_admin` middleware. A token with `claims:write`
+//! could retire ANY agent's claim. The fix mirrors the HTTP check inside
+//! the MCP handler.
+//!
+//! Caveat: rmcp's `tool_router` macro does NOT forward `AuthContext` into
+//! per-tool handlers (only `Parameters<T>`), so the MCP handler cannot
+//! read the caller's scopes (`claims:admin` override) or owner UUID. The
+//! check therefore degrades to agent-equality against the server's own
+//! signer agent. This test exercises that check:
+//!
+//! - **Foreign-agent claim → FORBIDDEN.** Seeds a claim authored by a
+//!   freshly-inserted foreign agent UUID. `resolve_backlog_item` must
+//!   refuse with INVALID_PARAMS (the agent-equality fallback maps onto
+//!   that rmcp ErrorCode; see the `claims.rs` impl).
+//! - **Own-signer claim → OK.** Submits a claim through the same MCP
+//!   server (auto-registers the signer agent), then retires it. Must
+//!   succeed.
+//!
+//! The admin-scope override path is intentionally NOT tested here — it
+//! is unreachable without plumbing AuthContext into the tool layer
+//! (tracked as the follow-up in the handler's authz comment).
+
+use epigraph_core::ClaimId;
+use epigraph_db::ClaimRepository;
+use epigraph_mcp::tools::claims::resolve_backlog_item;
+use epigraph_mcp::types::{ResolveBacklogItemParams, SubmitClaimParams};
+use rmcp::model::CallToolResult;
+use serde_json::Value;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+use common::build_test_server;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn resolve_backlog_item_refuses_foreign_agent_claim(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+
+    // Bootstrap the server's signer agent so `resolve_backlog_item`'s
+    // internal `agent_id().await` resolves to a real registered UUID.
+    let _server_agent = bootstrap_server_agent(&server, &pool).await;
+
+    // Seed a backlog claim authored by a DIFFERENT, foreign agent. The
+    // MCP handler should refuse to retire it.
+    let foreign_agent = seed_random_agent(&pool).await;
+    let foreign_claim =
+        seed_claim_with_agent(&pool, foreign_agent, &["backlog"]).await;
+
+    let err = resolve_backlog_item(
+        &server,
+        ResolveBacklogItemParams {
+            original_id: foreign_claim.as_uuid().to_string(),
+            resolution_content: "should be rejected".to_string(),
+            methodology: None,
+        },
+    )
+    .await
+    .expect_err("resolve_backlog_item must refuse a foreign-agent claim");
+
+    // The error should explicitly cite ownership / lack of permission.
+    let msg = err.message.to_string();
+    assert!(
+        msg.contains("owned by") && msg.contains("cannot retire"),
+        "error must explain the ownership refusal, got: {msg:?}"
+    );
+
+    // The foreign claim must NOT have been label-patched as a side effect.
+    let labels = ClaimRepository::get_labels(&pool, foreign_claim)
+        .await
+        .expect("get_labels foreign");
+    assert!(
+        !labels.contains(&"resolved".to_string()),
+        "foreign claim must NOT have been labeled 'resolved' \
+         (side-effect leak past the authz check): {labels:?}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn resolve_backlog_item_permits_own_signer_claim(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+
+    // Submit a backlog claim THROUGH the server (so its agent_id is the
+    // server's own signer). Then retire it: must succeed.
+    let result = epigraph_mcp::tools::claims::submit_claim(
+        &server,
+        SubmitClaimParams {
+            content: "open backlog item authored by server signer".into(),
+            methodology: "deductive_logic".into(),
+            evidence_data: "ev".into(),
+            evidence_type: "logical".into(),
+            confidence: 0.5,
+            source_url: None,
+            reasoning: None,
+            labels: vec!["backlog".into()],
+        },
+    )
+    .await
+    .expect("submit_claim");
+    let body = parse_json(&result);
+    let claim_id: Uuid = body["claim_id"]
+        .as_str()
+        .expect("claim_id is string")
+        .parse()
+        .expect("valid UUID");
+
+    let result = resolve_backlog_item(
+        &server,
+        ResolveBacklogItemParams {
+            original_id: claim_id.to_string(),
+            resolution_content: "retired by own signer".to_string(),
+            methodology: None,
+        },
+    )
+    .await
+    .expect("resolve_backlog_item must permit retirement of own claim");
+
+    let body = parse_json(&result);
+    let labels: Vec<String> = body["original_labels"]
+        .as_array()
+        .expect("original_labels is array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        labels.contains(&"resolved".to_string()),
+        "own claim's label patch must succeed: {labels:?}"
+    );
+}
+
+fn parse_json(result: &CallToolResult) -> Value {
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text content block");
+    serde_json::from_str(&text).expect("response is JSON")
+}
+
+/// Submit a throwaway claim through the server to force registration of
+/// the server's signer agent. The agent UUID returned is unused by
+/// callers that just want the side-effect (registration); the foreign-
+/// agent test path discards it.
+async fn bootstrap_server_agent(
+    server: &epigraph_mcp::EpiGraphMcpFull,
+    pool: &PgPool,
+) -> Uuid {
+    let result = epigraph_mcp::tools::claims::submit_claim(
+        server,
+        SubmitClaimParams {
+            content: "bootstrap claim for ownership test".into(),
+            methodology: "deductive_logic".into(),
+            evidence_data: "ev".into(),
+            evidence_type: "logical".into(),
+            confidence: 0.5,
+            source_url: None,
+            reasoning: None,
+            labels: vec![],
+        },
+    )
+    .await
+    .expect("bootstrap submit_claim");
+    let body = parse_json(&result);
+    let claim_id: Uuid = body["claim_id"]
+        .as_str()
+        .expect("claim_id is string")
+        .parse()
+        .expect("valid UUID");
+    let (agent_id,): (Uuid,) = sqlx::query_as("SELECT agent_id FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
+        .await
+        .expect("fetch agent_id");
+    agent_id
+}
+
+async fn seed_random_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    // Use a unique-per-id public key so we don't collide with the
+    // server-signer's deterministic public_key.
+    let pk: Vec<u8> = id.as_bytes().iter().copied().cycle().take(32).collect();
+    sqlx::query(
+        "INSERT INTO agents (id, public_key) VALUES ($1, $2) \
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(id)
+    .bind(&pk)
+    .execute(pool)
+    .await
+    .expect("seed foreign agent");
+    id
+}
+
+async fn seed_claim_with_agent(pool: &PgPool, agent_id: Uuid, labels: &[&str]) -> ClaimId {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, \
+                             labels, is_current, supersedes) \
+         VALUES ($1, $2, $3, 0.5, $4, $5, true, NULL)",
+    )
+    .bind(id)
+    .bind(format!("foreign claim {id}"))
+    .bind(hash)
+    .bind(agent_id)
+    .bind(labels.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+    .execute(pool)
+    .await
+    .expect("seed foreign claim");
+    ClaimId::from_uuid(id)
+}

--- a/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
@@ -50,8 +50,7 @@ async fn resolve_backlog_item_refuses_foreign_agent_claim(pool: PgPool) {
     // Seed a backlog claim authored by a DIFFERENT, foreign agent. The
     // MCP handler should refuse to retire it.
     let foreign_agent = seed_random_agent(&pool).await;
-    let foreign_claim =
-        seed_claim_with_agent(&pool, foreign_agent, &["backlog"]).await;
+    let foreign_claim = seed_claim_with_agent(&pool, foreign_agent, &["backlog"]).await;
 
     let err = resolve_backlog_item(
         &server,
@@ -148,10 +147,7 @@ fn parse_json(result: &CallToolResult) -> Value {
 /// the server's signer agent. The agent UUID returned is unused by
 /// callers that just want the side-effect (registration); the foreign-
 /// agent test path discards it.
-async fn bootstrap_server_agent(
-    server: &epigraph_mcp::EpiGraphMcpFull,
-    pool: &PgPool,
-) -> Uuid {
+async fn bootstrap_server_agent(server: &epigraph_mcp::EpiGraphMcpFull, pool: &PgPool) -> Uuid {
     let result = epigraph_mcp::tools::claims::submit_claim(
         server,
         SubmitClaimParams {

--- a/scripts/cleanup_backlog_labels.py
+++ b/scripts/cleanup_backlog_labels.py
@@ -50,18 +50,40 @@ KEYWORD_RE = re.compile(
 
 
 def page_claims(base_url: str, labels: list[str], exclude: list[str], current_only: bool) -> list[dict]:
-    """Page through all claims matching the filter (limit=100 per page)."""
-    params = {
-        "labels": ",".join(labels),
-        "limit": 100,
-    }
-    if exclude:
-        params["exclude_labels"] = ",".join(exclude)
-    if current_only:
-        params["current_only"] = "true"
-    r = httpx.get(f"{base_url}/api/v1/claims/by-labels", params=params, timeout=30)
-    r.raise_for_status()
-    return r.json()
+    """Page through all claims matching the filter — loops until a short page.
+
+    Calls `GET /api/v1/claims/by-labels` repeatedly with monotonically
+    increasing `offset` and a fixed `page_size=100`. Stops when a page
+    returns fewer than `page_size` rows (i.e. the result set is exhausted)
+    or the safety belt of 10,000 rows is hit (whichever comes first).
+    """
+    out: list[dict] = []
+    offset = 0
+    page_size = 100
+    while True:
+        params: dict[str, object] = {
+            "labels": ",".join(labels),
+            "limit": page_size,
+            "offset": offset,
+        }
+        if exclude:
+            params["exclude_labels"] = ",".join(exclude)
+        if current_only:
+            params["current_only"] = "true"
+        r = httpx.get(f"{base_url}/api/v1/claims/by-labels", params=params, timeout=30)
+        r.raise_for_status()
+        page = r.json()
+        out.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
+        if offset >= 10_000:  # safety belt
+            print(
+                f"WARN: page_claims hit 10k cap at labels={labels}",
+                file=sys.stderr,
+            )
+            break
+    return out
 
 
 def patch_labels(base_url: str, claim_id: str, add: list[str]) -> dict:

--- a/scripts/reconcile_backlog_labels.py
+++ b/scripts/reconcile_backlog_labels.py
@@ -34,12 +34,38 @@ RECON_WINDOW_DAYS = int(os.environ.get("RECON_WINDOW_DAYS", "7"))
 
 
 def page_claims(base_url: str, labels: list[str], exclude: list[str]) -> list[dict]:
-    params = {"labels": ",".join(labels), "limit": 100}
-    if exclude:
-        params["exclude_labels"] = ",".join(exclude)
-    r = httpx.get(f"{base_url}/api/v1/claims/by-labels", params=params, timeout=30)
-    r.raise_for_status()
-    return r.json()
+    """Page through all claims matching the filter — loops until a short page.
+
+    See `cleanup_backlog_labels.page_claims` for the shared semantics. We
+    keep the parameter list slimmer here (no `current_only`) to minimize
+    collateral with the existing reconciler call sites; pagination is the
+    only behavior change.
+    """
+    out: list[dict] = []
+    offset = 0
+    page_size = 100
+    while True:
+        params: dict[str, object] = {
+            "labels": ",".join(labels),
+            "limit": page_size,
+            "offset": offset,
+        }
+        if exclude:
+            params["exclude_labels"] = ",".join(exclude)
+        r = httpx.get(f"{base_url}/api/v1/claims/by-labels", params=params, timeout=30)
+        r.raise_for_status()
+        page = r.json()
+        out.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
+        if offset >= 10_000:  # safety belt
+            print(
+                f"WARN: page_claims hit 10k cap at labels={labels}",
+                file=sys.stderr,
+            )
+            break
+    return out
 
 
 def patch_labels(base_url: str, claim_id: str, add: list[str]) -> dict:
@@ -67,15 +93,8 @@ def main() -> int:
     for bc in open_backlog:
         backlog_by_prefix.setdefault(bc["id"][:8].lower(), []).append(bc)
 
-    # Page resolved claims; warn if we hit the limit.
+    # Page resolved claims (page_claims now loops until exhaustion or 10k cap).
     resolved_page = page_claims(args.base_url, ["resolved"], [])
-    if len(resolved_page) >= 100:
-        print(
-            f"WARN: resolved page returned {len(resolved_page)} (page cap). "
-            "Older resolution claims may be missed — extend the HTTP route with "
-            "created_after or paginate.",
-            file=sys.stderr,
-        )
     resolved_recent = [
         rc for rc in resolved_page
         if datetime.datetime.fromisoformat(rc["created_at"].replace("Z", "+00:00")) >= cutoff


### PR DESCRIPTION
## Summary

Follow-up to PRs [#152](https://github.com/epigraph-io/epigraph/pull/152) (Tasks 1-6) and [#154](https://github.com/epigraph-io/epigraph/pull/154) (Tasks 7-9). The final code review surfaced two BLOCKER-class issues that were filed as follow-ups; this PR ships both.

### Issue #2 — `resolve_backlog_item` ownership check (`9bbe9f5`)

`resolve_backlog_item` was calling `ClaimRepository::update_labels` directly, bypassing the HTTP `PATCH /api/v1/claims/:id/labels` route's `require_owner_or_admin` middleware. A `claims:write`-scoped MCP token could retire backlog claims authored by any agent.

Added an in-handler owner-equality guard between the `get_by_id` fetch and `submit_claim` delegation. Returns `INVALID_PARAMS` with both UUIDs in the error message if the caller is not the claim author.

**Known limitation (documented in handler comment):** rmcp's `tool_router` macro generates per-tool dispatch that only forwards `Parameters<T>`, not the `RequestContext` or `http::request::Parts` extensions. The MCP server cannot reach the per-request `AuthContext` from inside a tool handler — so the check uses `server.agent_id().await` (the server-signer's UUID), not the per-call auth principal. This blocks the headline abuse (a write-scope token retiring foreign-authored claims) but cannot enforce the `claims:admin` override or distinguish multiple human/agent callers sharing the same MCP server. A proper fix would plumb `AuthContext` through rmcp's `Extension<T>` parameter pattern — out of scope here, filed as a backlog item.

### Issues #1 + #4 — pagination (`6c653d6`)

`ClaimRepository::list_by_labels` had no `OFFSET` parameter, so the cleanup script silently processed only the first 100 of 210 backlog claims; the reconciler had the same risk for `[resolved]` sets larger than 100 in 7 days.

- `ClaimRepository::list_by_labels` gains `offset: i64` (last positional arg), SQL gains `OFFSET $6`, negative-offset clamped to 0.
- MCP `query_claims_by_label` exposes `offset: Option<i64>`.
- HTTP `GET /api/v1/claims/by-labels` exposes `offset` query param.
- Both Python scripts loop `offset += page_size` until a short page (10k safety belt).
- New `list_by_labels_pagination` integration test seeds 5 claims and verifies `limit=2 offset∈{0,2,4}` returns disjoint pages.

## Test plan

- [x] `cargo test -p epigraph-db --test list_by_labels` (2 tests, including new pagination one)
- [x] `cargo test -p epigraph-mcp --test query_claims_by_label`
- [x] `cargo test -p epigraph-mcp --test resolve_backlog_item` (passes after seeding change for ownership)
- [x] `cargo test -p epigraph-mcp --test resolve_backlog_item_ownership` (new — foreign-agent refused, own-signer permitted)
- [x] `cargo test -p epigraph-api --test claims_by_labels`
- [x] `SQLX_OFFLINE=true cargo check --workspace`
- [x] `cargo fmt --all --check`
- [ ] CI green
- [ ] After merge: re-run `python3 scripts/cleanup_backlog_labels.py` to confirm the additional ~110 backlog claims get examined (page 2+). Expect a few more supersedes-retired auto-patches and a fresh needs-review bucket.

## Out of scope (filed for future)

- Plumb `AuthContext` through rmcp's `Extension<T>` pattern so MCP tool handlers see the per-request scopes/owner_id and can enforce the full `claims:admin` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)