### PR TITLE
fix(mcp/ingest): per-chapter version gate for chunked DocumentExtraction

### DIFF
--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -32,7 +32,28 @@ fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpErro
 // ingest_document — hierarchical DocumentExtraction → graph
 // ────────────────────────────────────────────────────────────────────────────
 
-const PIPELINE_VERSION: &str = "hierarchical_extraction_v1";
+const PIPELINE_VERSION_BASE: &str = "hierarchical_extraction_v1";
+
+/// Pipeline version stamp used by the `processed_by` edge and the version gate.
+///
+/// For documents ingested whole (papers), this is just `PIPELINE_VERSION_BASE`
+/// so re-ingesting the same paper short-circuits as before. For chunked
+/// ingests where many `DocumentExtraction`s share one paper row (e.g. a
+/// textbook ingested chapter-by-chapter), `source.metadata.chapter_index` is
+/// appended so each chunk is gated independently — without it, the first
+/// chunk's `processed_by` edge would block every subsequent chunk for the
+/// same paper.
+fn effective_pipeline_version(extraction: &DocumentExtraction) -> String {
+    extraction
+        .source
+        .metadata
+        .get("chapter_index")
+        .and_then(serde_json::Value::as_u64)
+        .map_or_else(
+            || PIPELINE_VERSION_BASE.to_string(),
+            |n| format!("{PIPELINE_VERSION_BASE}:ch{n}"),
+        )
+}
 
 pub async fn ingest_document(
     server: &EpiGraphMcpFull,
@@ -72,13 +93,14 @@ pub async fn do_ingest_document(
 
     let paper_title = extraction.source.title.clone();
     let doi = resolve_doi(extraction);
+    let pipeline_version = effective_pipeline_version(extraction);
 
     // ── 1. Version gate: skip if already processed by this pipeline ──
     if let Some(prior) = PaperRepository::find_by_doi(pool, &doi)
         .await
         .map_err(internal_error)?
     {
-        if PaperRepository::has_processed_by_edge(pool, prior.id, PIPELINE_VERSION)
+        if PaperRepository::has_processed_by_edge(pool, prior.id, &pipeline_version)
             .await
             .map_err(internal_error)?
         {
@@ -384,7 +406,12 @@ pub async fn do_ingest_document(
     // models "this paper was processed by this agent at this pipeline
     // version". (Self-loops on paper are blocked by the edges_no_self_loop
     // check constraint, so we cannot point the edge back at the paper.)
-    let (_row, _was_created) = EdgeRepository::create_if_not_exists(
+    // Direct create (not create_if_not_exists): the gate above guarantees no
+    // edge with this exact `pipeline` value exists yet for this paper. Using
+    // create_if_not_exists here would dedupe on (paper, agent, "processed_by")
+    // alone and silently retain a prior chapter's pipeline marker, breaking
+    // the per-chapter gate on re-ingest.
+    let _edge_id = EdgeRepository::create(
         pool,
         paper_id,
         "paper",
@@ -392,7 +419,7 @@ pub async fn do_ingest_document(
         "agent",
         "processed_by",
         Some(serde_json::json!({
-            "pipeline": PIPELINE_VERSION,
+            "pipeline": pipeline_version,
             "tool": "ingest_document",
         })),
         None,

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -170,6 +170,93 @@ async fn re_ingest_hits_version_gate(pool: PgPool) {
     assert_eq!(json["relationships_created"], serde_json::json!(0));
 }
 
+/// Per-chapter version gating: a textbook ingested chapter-by-chapter shares
+/// one paper row across many `DocumentExtraction`s. With `source.metadata.
+/// chapter_index` set, each chunk's `processed_by` edge carries
+/// `pipeline=hierarchical_extraction_v1:ch<N>` so chapter 2 isn't blocked by
+/// the edge chapter 1 left behind. Re-ingesting the *same* chapter still hits
+/// the gate.
+#[sqlx::test(migrations = "../../migrations")]
+async fn per_chapter_version_gate_isolates_chunks(pool: PgPool) {
+    let server = make_server(pool.clone());
+
+    let make_chapter = |idx: u64| -> DocumentExtraction {
+        let json = format!(
+            r#"{{
+              "source": {{
+                "title": "Test Textbook — Chapter {idx}",
+                "doi": "10.1234/textbook-chunked",
+                "source_type": "Textbook",
+                "authors": [{{"name": "Alice Author", "affiliations": [], "roles": ["author"]}}],
+                "metadata": {{"chapter_index": {idx}}}
+              }},
+              "thesis": "Chapter {idx} thesis",
+              "thesis_derivation": "TopDown",
+              "sections": [{{
+                "title": "Sec",
+                "summary": "Chapter {idx} section summary",
+                "paragraphs": [{{
+                  "compound": "Chapter {idx} compound claim",
+                  "supporting_text": "Chapter {idx} support",
+                  "atoms": ["Chapter {idx} atom one"],
+                  "generality": [3],
+                  "confidence": 0.8
+                }}]
+              }}],
+              "relationships": []
+            }}"#
+        );
+        serde_json::from_str(&json).expect("fixture parses")
+    };
+
+    let ch1 = do_ingest_document(&server, &make_chapter(1))
+        .await
+        .expect("ch1 ingest");
+    let ch1_json: serde_json::Value =
+        serde_json::from_str(&result_text(&ch1)).unwrap();
+    assert_eq!(ch1_json["already_ingested"], serde_json::json!(false));
+    let paper_id = uuid::Uuid::parse_str(ch1_json["paper_id"].as_str().unwrap()).unwrap();
+
+    let ch2 = do_ingest_document(&server, &make_chapter(2))
+        .await
+        .expect("ch2 ingest");
+    let ch2_json: serde_json::Value =
+        serde_json::from_str(&result_text(&ch2)).unwrap();
+    assert_eq!(
+        ch2_json["already_ingested"],
+        serde_json::json!(false),
+        "chapter 2 must not be blocked by chapter 1's processed_by edge"
+    );
+    assert_eq!(ch2_json["paper_id"], ch1_json["paper_id"], "same paper row reused");
+
+    let ch2_repeat = do_ingest_document(&server, &make_chapter(2))
+        .await
+        .expect("ch2 re-ingest");
+    let repeat_json: serde_json::Value =
+        serde_json::from_str(&result_text(&ch2_repeat)).unwrap();
+    assert_eq!(
+        repeat_json["already_ingested"],
+        serde_json::json!(true),
+        "re-ingesting the same chapter must still hit the per-chapter gate"
+    );
+
+    // Both per-chapter processed_by edges must coexist on the paper.
+    let count: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*) FROM edges
+        WHERE source_id = $1 AND source_type = 'paper'
+          AND relationship = 'processed_by'
+          AND properties ->> 'pipeline' IN
+              ('hierarchical_extraction_v1:ch1', 'hierarchical_extraction_v1:ch2')
+        "#,
+    )
+    .bind(paper_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count.0, 2, "one processed_by edge per chapter");
+}
+
 /// A second fixture sharing one atom and the same author with the primary
 /// fixture. Validates cross-paper atom convergence and author dedup.
 const FIXTURE_OVERLAP: &str = r#"{

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -212,28 +212,28 @@ async fn per_chapter_version_gate_isolates_chunks(pool: PgPool) {
     let ch1 = do_ingest_document(&server, &make_chapter(1))
         .await
         .expect("ch1 ingest");
-    let ch1_json: serde_json::Value =
-        serde_json::from_str(&result_text(&ch1)).unwrap();
+    let ch1_json: serde_json::Value = serde_json::from_str(&result_text(&ch1)).unwrap();
     assert_eq!(ch1_json["already_ingested"], serde_json::json!(false));
     let paper_id = uuid::Uuid::parse_str(ch1_json["paper_id"].as_str().unwrap()).unwrap();
 
     let ch2 = do_ingest_document(&server, &make_chapter(2))
         .await
         .expect("ch2 ingest");
-    let ch2_json: serde_json::Value =
-        serde_json::from_str(&result_text(&ch2)).unwrap();
+    let ch2_json: serde_json::Value = serde_json::from_str(&result_text(&ch2)).unwrap();
     assert_eq!(
         ch2_json["already_ingested"],
         serde_json::json!(false),
         "chapter 2 must not be blocked by chapter 1's processed_by edge"
     );
-    assert_eq!(ch2_json["paper_id"], ch1_json["paper_id"], "same paper row reused");
+    assert_eq!(
+        ch2_json["paper_id"], ch1_json["paper_id"],
+        "same paper row reused"
+    );
 
     let ch2_repeat = do_ingest_document(&server, &make_chapter(2))
         .await
         .expect("ch2 re-ingest");
-    let repeat_json: serde_json::Value =
-        serde_json::from_str(&result_text(&ch2_repeat)).unwrap();
+    let repeat_json: serde_json::Value = serde_json::from_str(&result_text(&ch2_repeat)).unwrap();
     assert_eq!(
         repeat_json["already_ingested"],
         serde_json::json!(true),


### PR DESCRIPTION
## Summary

The `ingest_document` version gate (`crates/epigraph-mcp/src/tools/ingestion.rs`) fired per-paper. Any second `DocumentExtraction` sharing a paper DOI returned `already_ingested=true` with zero claims — correct for whole-paper ingest, broken for chunked flows where one paper row spans many chapters (OpenStax textbook hierarchical re-ingest, plan in `docs/superpowers/plans/2026-05-17-openstax-hierarchical-reingest.md`).

Hit this exact bug live: chapter 1 ingested cleanly, then chapter 2 of the same physics book short-circuited at the gate.

## Changes

1. **`effective_pipeline_version(extraction)`** — derives the gate marker from `source.metadata.chapter_index`. With it present, the pipeline value becomes `hierarchical_extraction_v1:ch<N>` so each chapter is gated independently. Without it (whole-paper ingest), behavior is unchanged.
2. **`processed_by` edge write changed from `create_if_not_exists` to `create`**. The dedup-by-triple check keyed only on `(source, target, relationship)`, so for a shared `paper → system_agent` target the first chapter's pipeline marker was silently retained. The gate above already guarantees no edge with this exact pipeline value exists at write time, so a direct insert is safe.

## Test plan

- [x] `cargo test -p epigraph-mcp --test ingest_document_smoke` — all 6 tests pass:
  - existing `re_ingest_hits_version_gate` (whole-paper path) ✅
  - new `per_chapter_version_gate_isolates_chunks` ✅ asserts ch1 ingests, ch2 ingests under same DOI, ch2 re-ingest is blocked, both `processed_by` edges coexist
  - 4 other smoke tests unchanged ✅
- [x] sqlx-prepare clean against `epigraph_db_repo_test`

## Deploy note

After merge: the running `epigraph-mcp` binary needs a rebuild + restart to pick up the new gate logic. Three OpenStax physics chapter extractions (`/home/jeremy/tmp/extractions/physics_ch0{2,3,4}.json`) are queued and ready to ingest the moment the new binary is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)