### PR TITLE
feat: link_hierarchical API endpoint + MCP tool for cross-tier structural edges

### DIFF
--- a/crates/epigraph-api/src/openapi.rs
+++ b/crates/epigraph-api/src/openapi.rs
@@ -19,6 +19,7 @@ use crate::routes::challenge::{ChallengeResponse, SubmitChallengeRequest};
 use crate::routes::claims::{
     ClaimResponse, PatchClaimRequest, UpdateLabelsRequest, UpdateLabelsResponse,
 };
+use crate::routes::edges::{LinkHierarchicalRequest, LinkHierarchicalResponse};
 use crate::routes::health::HealthResponse;
 use crate::routes::rag::{RagContextResponse, RagContextResult, RagQueryParams};
 use crate::routes::submit::{
@@ -69,6 +70,7 @@ use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowExtraction, Workflo
         report_hierarchical_outcome_doc,
         deprecate_workflow_doc,
         ingest_workflow_doc,
+        create_hierarchical_edge_doc,
     ),
     components(
         schemas(
@@ -118,6 +120,8 @@ use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowExtraction, Workflo
             HierarchicalWorkflowResult,
             ResolvedStepResult,
             LineageHeadResult,
+            LinkHierarchicalRequest,
+            LinkHierarchicalResponse,
         )
     ),
     modifiers(&SecurityAddon),
@@ -129,6 +133,7 @@ use epigraph_ingest::workflow::schema::{Phase, Step, WorkflowExtraction, Workflo
         (name = "admin", description = "Administrative endpoints"),
         (name = "claims", description = "Claim management endpoints"),
         (name = "workflows", description = "Workflow management endpoints"),
+        (name = "edges", description = "Edge creation and management"),
     )
 )]
 pub struct ApiDoc;
@@ -449,6 +454,29 @@ async fn deprecate_workflow_doc() {}
     security(("ed25519_signature" = []))
 )]
 async fn ingest_workflow_doc() {}
+
+/// Create a cross-tier hierarchical structural edge between two claims (doc stub).
+///
+/// Tight-contract sibling of the generic POST /api/v1/edges: locked to the
+/// three structural relationships (`decomposes_to`, `section_follows`,
+/// `continues_argument`), both endpoints must be existing claims, and
+/// `(source, target, relationship)` is idempotent so per-chapter wire-ups
+/// can retry safely.
+#[utoipa::path(
+    post,
+    path = "/api/v1/edges/hierarchical",
+    tag = "edges",
+    request_body = LinkHierarchicalRequest,
+    responses(
+        (status = 200, description = "Edge created or already present", body = LinkHierarchicalResponse),
+        (status = 400, description = "Invalid relationship or self-loop", body = ErrorResponse),
+        (status = 401, description = "Missing or invalid token", body = ErrorResponse),
+        (status = 403, description = "Token missing edges:write scope", body = ErrorResponse),
+        (status = 404, description = "Source or target claim does not exist", body = ErrorResponse),
+    ),
+    security(("ed25519_signature" = []))
+)]
+async fn create_hierarchical_edge_doc() {}
 
 /// Generate the OpenAPI JSON specification.
 ///

--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -962,6 +962,164 @@ pub async fn delete_edge(
 }
 
 // =============================================================================
+// CROSS-TIER HIERARCHICAL EDGE (purpose-built single-edge endpoint)
+// =============================================================================
+
+/// Allowed relationship strings for `POST /api/v1/edges/hierarchical`.
+///
+/// Deliberately tighter than the generic `VALID_RELATIONSHIPS` allow-list: this
+/// endpoint exists to wire chapters / sections / paragraphs across ingest
+/// boundaries, not to insert arbitrary edge types. New entries here must be
+/// claim-claim structural relationships emitted by the hierarchical ingest
+/// builder (see `epigraph-ingest/src/document/builder.rs`).
+pub const HIERARCHICAL_RELATIONSHIPS: &[&str] =
+    &["decomposes_to", "section_follows", "continues_argument"];
+
+fn is_hierarchical_relationship(s: &str) -> bool {
+    HIERARCHICAL_RELATIONSHIPS.contains(&s)
+}
+
+/// Request body for `POST /api/v1/edges/hierarchical`.
+///
+/// Both endpoints (`source_claim_id`, `target_claim_id`) are claim UUIDs;
+/// `source_type` and `target_type` are implicitly `"claim"` and the caller
+/// cannot override them. `properties` is an arbitrary JSON object the
+/// caller can attach to the edge (e.g. `{"sibling_order": 2}` for chapter
+/// chains). `relationship` must be one of `HIERARCHICAL_RELATIONSHIPS`.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct LinkHierarchicalRequest {
+    pub source_claim_id: Uuid,
+    pub target_claim_id: Uuid,
+    pub relationship: String,
+    #[schema(value_type = Option<serde_json::Value>)]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// Response body for `POST /api/v1/edges/hierarchical`.
+///
+/// `created=true` means a new edge row was inserted; `created=false` means
+/// `(source, target, relationship)` already existed and the existing edge_id
+/// is returned. Both cases return 200 OK so retried per-chapter wire-ups
+/// stay idempotent without the caller having to inspect status codes.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct LinkHierarchicalResponse {
+    pub edge_id: Uuid,
+    pub created: bool,
+}
+
+/// Create a cross-tier hierarchical structural edge between two claims.
+///
+/// `POST /api/v1/edges/hierarchical`
+///
+/// Purpose-built sibling of the generic `POST /api/v1/edges`: locked down to
+/// the three structural edge types emitted by hierarchical ingest
+/// (`decomposes_to`, `section_follows`, `continues_argument`), both endpoints
+/// must be existing claims, and `(source, target, relationship)` is
+/// deduplicated so per-chapter wire-ups can re-run idempotently. Intentionally
+/// side-effect-free vs the generic POST: no DS recomputation, no factor
+/// inserts, no edge.added event, no provenance — these structural edges carry
+/// no evidential semantics and the matching `ingest_document` path treats
+/// them the same way.
+///
+/// Returns 200 OK in both the freshly-inserted and dedup-hit cases so
+/// retried wiring calls don't need to distinguish status codes.
+#[cfg(feature = "db")]
+pub async fn create_hierarchical_edge(
+    State(state): State<AppState>,
+    auth_ctx: Option<axum::Extension<crate::middleware::bearer::AuthContext>>,
+    Json(request): Json<LinkHierarchicalRequest>,
+) -> Result<(StatusCode, Json<LinkHierarchicalResponse>), ApiError> {
+    // Enforce scope when OAuth2-authenticated (mirrors generic POST /api/v1/edges).
+    if let Some(axum::Extension(ref auth)) = auth_ctx {
+        crate::middleware::scopes::check_scopes(auth, &["edges:write"])?;
+    }
+
+    // Tight relationship allow-list — narrower than VALID_RELATIONSHIPS by design.
+    if !is_hierarchical_relationship(&request.relationship) {
+        return Err(ApiError::ValidationError {
+            field: "relationship".to_string(),
+            reason: format!(
+                "Invalid relationship '{}'. Valid hierarchical types: {}",
+                request.relationship,
+                HIERARCHICAL_RELATIONSHIPS.join(", ")
+            ),
+        });
+    }
+
+    // No self-loops: source and target are both claims, so equal UUIDs always loop.
+    if request.source_claim_id == request.target_claim_id {
+        return Err(ApiError::ValidationError {
+            field: "target_claim_id".to_string(),
+            reason: "Self-loops are not allowed (source and target are the same claim)".to_string(),
+        });
+    }
+
+    let pool = &state.db_pool;
+
+    // Verify both claims exist via the repo layer (no inline SQL — CLAUDE.md
+    // requires SQL stays in epigraph-db). Disambiguate which side is missing
+    // so callers can fix the right end of the link.
+    if epigraph_db::ClaimRepository::get_by_id(
+        pool,
+        epigraph_core::ClaimId::from_uuid(request.source_claim_id),
+    )
+    .await?
+    .is_none()
+    {
+        return Err(ApiError::NotFound {
+            entity: "source_claim".to_string(),
+            id: request.source_claim_id.to_string(),
+        });
+    }
+    if epigraph_db::ClaimRepository::get_by_id(
+        pool,
+        epigraph_core::ClaimId::from_uuid(request.target_claim_id),
+    )
+    .await?
+    .is_none()
+    {
+        return Err(ApiError::NotFound {
+            entity: "target_claim".to_string(),
+            id: request.target_claim_id.to_string(),
+        });
+    }
+
+    // Idempotent on (source, target, relationship) so per-chapter wire-ups
+    // can re-run safely. source_type / target_type are always "claim" here.
+    let (edge_row, was_created) = EdgeRepository::create_if_not_exists(
+        pool,
+        request.source_claim_id,
+        "claim",
+        request.target_claim_id,
+        "claim",
+        &request.relationship,
+        request.properties.clone(),
+        None,
+        None,
+    )
+    .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(LinkHierarchicalResponse {
+            edge_id: edge_row.id,
+            created: was_created,
+        }),
+    ))
+}
+
+/// Cross-tier hierarchical edge endpoint (placeholder - no database).
+#[cfg(not(feature = "db"))]
+pub async fn create_hierarchical_edge(
+    State(_state): State<AppState>,
+    Json(_request): Json<LinkHierarchicalRequest>,
+) -> Result<(StatusCode, Json<LinkHierarchicalResponse>), ApiError> {
+    Err(ApiError::ServiceUnavailable {
+        service: "database".to_string(),
+    })
+}
+
+// =============================================================================
 // PATCH EDGE
 // =============================================================================
 

--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -233,6 +233,10 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/v1/papers", post(papers::create_paper))
         .route("/api/v1/edges", post(edges::create_edge))
         .route(
+            "/api/v1/edges/hierarchical",
+            post(edges::create_hierarchical_edge),
+        )
+        .route(
             "/api/v1/analyze/unconstrained",
             post(analyze::unconstrained_analysis),
         )
@@ -867,6 +871,10 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/v1/ingest/paper-url", post(ingest::ingest_paper))
         .route("/api/v1/papers", post(papers::create_paper))
         .route("/api/v1/edges", post(edges::create_edge))
+        .route(
+            "/api/v1/edges/hierarchical",
+            post(edges::create_hierarchical_edge),
+        )
         .route(
             "/api/v1/analyze/unconstrained",
             post(analyze::unconstrained_analysis),

--- a/crates/epigraph-api/tests/link_hierarchical_test.rs
+++ b/crates/epigraph-api/tests/link_hierarchical_test.rs
@@ -1,0 +1,276 @@
+//! HTTP integration tests for `POST /api/v1/edges/hierarchical`.
+//!
+//! Mirrors the MCP smoke test (crates/epigraph-mcp/tests/link_hierarchical_smoke.rs)
+//! through the auth+route stack: validation, 404 disambiguation, idempotency,
+//! and the tight relationship allow-list.
+
+#![cfg(feature = "db")]
+
+use sqlx::postgres::PgPoolOptions;
+mod common;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn link_hierarchical_happy_path_is_idempotent() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["edges:write"]).await;
+
+    let source_id = common::seed_claim(&pool, "link_hierarchical happy source").await;
+    let target_id = common::seed_claim(&pool, "link_hierarchical happy target").await;
+
+    let body = serde_json::json!({
+        "source_claim_id": source_id,
+        "target_claim_id": target_id,
+        "relationship": "decomposes_to",
+        "properties": { "chapter": 1 },
+    });
+
+    let client = reqwest::Client::new();
+
+    // First call — fresh insert.
+    let resp = client
+        .post(format!("http://{addr}/api/v1/edges/hierarchical"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "first call should 200 OK");
+    let first: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(first["created"], serde_json::json!(true));
+    let edge_id = first["edge_id"].as_str().unwrap().to_string();
+
+    // Second call — dedup hit, same edge_id, created=false, still 200.
+    let resp2 = client
+        .post(format!("http://{addr}/api/v1/edges/hierarchical"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        200,
+        "idempotent re-run should also 200 OK (not 201)"
+    );
+    let second: serde_json::Value = resp2.json().await.unwrap();
+    assert_eq!(second["created"], serde_json::json!(false));
+    assert_eq!(second["edge_id"].as_str().unwrap(), edge_id);
+
+    // DB has exactly one edge row.
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges \
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'",
+    )
+    .bind(source_id)
+    .bind(target_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count.0, 1, "must have exactly one edge after re-run");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn link_hierarchical_rejects_non_structural_relationship() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["edges:write"]).await;
+
+    let source_id = common::seed_claim(&pool, "link_hierarchical bad-rel source").await;
+    let target_id = common::seed_claim(&pool, "link_hierarchical bad-rel target").await;
+
+    // `supports` is valid for the generic POST /api/v1/edges but must be
+    // rejected by this tight endpoint.
+    let body = serde_json::json!({
+        "source_claim_id": source_id,
+        "target_claim_id": target_id,
+        "relationship": "supports",
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/edges/hierarchical"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 400,
+        "non-structural relationship must 400; got {status} — body={text}"
+    );
+    assert!(
+        text.contains("decomposes_to"),
+        "error body should list valid types; got: {text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn link_hierarchical_missing_source_returns_404() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["edges:write"]).await;
+
+    let target_id = common::seed_claim(&pool, "link_hierarchical 404-source target").await;
+    let bogus = uuid::Uuid::new_v4();
+
+    let body = serde_json::json!({
+        "source_claim_id": bogus,
+        "target_claim_id": target_id,
+        "relationship": "section_follows",
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/edges/hierarchical"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 404,
+        "missing source must 404; got {status} — body={text}"
+    );
+    assert!(
+        text.contains("source_claim"),
+        "error body should disambiguate which side is missing; got: {text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn link_hierarchical_missing_target_returns_404() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["edges:write"]).await;
+
+    let source_id = common::seed_claim(&pool, "link_hierarchical 404-target source").await;
+    let bogus = uuid::Uuid::new_v4();
+
+    let body = serde_json::json!({
+        "source_claim_id": source_id,
+        "target_claim_id": bogus,
+        "relationship": "continues_argument",
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/edges/hierarchical"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 404,
+        "missing target must 404; got {status} — body={text}"
+    );
+    assert!(
+        text.contains("target_claim"),
+        "error body should disambiguate which side is missing; got: {text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn link_hierarchical_rejects_self_loop() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _client_id) =
+        common::test_bearer_token_with_seeded_client(&pool, &["edges:write"]).await;
+
+    let claim_id = common::seed_claim(&pool, "link_hierarchical self-loop").await;
+
+    let body = serde_json::json!({
+        "source_claim_id": claim_id,
+        "target_claim_id": claim_id,
+        "relationship": "decomposes_to",
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/edges/hierarchical"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 400,
+        "self-loops must 400 before hitting the DB CHECK; got {status} — body={text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn link_hierarchical_requires_edges_write_scope() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    // Token has graph:read only — must be rejected by the scope guard.
+    let token = common::test_bearer_token_with_scopes(&["graph:read"]);
+
+    let source_id = common::seed_claim(&pool, "link_hierarchical scope source").await;
+    let target_id = common::seed_claim(&pool, "link_hierarchical scope target").await;
+
+    let body = serde_json::json!({
+        "source_claim_id": source_id,
+        "target_claim_id": target_id,
+        "relationship": "decomposes_to",
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/edges/hierarchical"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 403,
+        "missing edges:write scope must 403; got {status} — body={text}"
+    );
+}

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -66,6 +66,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("improve_workflow_hierarchy", "claims:write"),
     ("ingest_document", "claims:write"),
     ("ingest_workflow", "claims:write"),
+    ("link_hierarchical", "claims:write"),
     ("memorize", "claims:write"),
     ("patch_claim", "claims:write"),
     ("publish_event", "claims:write"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -360,6 +360,17 @@ impl EpiGraphMcpFull {
         tools::ingestion::ingest_document(self, params).await
     }
 
+    #[tool(
+        description = "Create a cross-tier structural edge between two existing claims (decomposes_to, section_follows, or continues_argument). Purpose-built for per-chapter ingest wire-ups (chapter thesis -> book thesis, chapter[N] -> chapter[N+1]). Idempotent on (source, target, relationship): re-runs return the existing edge_id with created=false. Bypasses HTTP and goes straight through the repo layer."
+    )]
+    async fn link_hierarchical(
+        &self,
+        Parameters(params): Parameters<LinkHierarchicalParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::link_hierarchical::link_hierarchical(self, params).await
+    }
+
     // ── Paper Queries (3 tools) ──
 
     #[tool(description = "Look up a paper by its DOI, returning title, authors, and claims.")]
@@ -850,7 +861,7 @@ impl EpiGraphMcpFull {
 impl ServerHandler for EpiGraphMcpFull {
     fn get_info(&self) -> ServerInfo {
         let mode = if self.read_only { "read-only" } else { "full" };
-        let tool_count = if self.read_only { 33 } else { 59 };
+        let tool_count = if self.read_only { 33 } else { 60 };
         ServerInfo {
             instructions: Some(format!(
                 "EpiGraph {mode} MCP server with {tool_count} epistemic tools."

--- a/crates/epigraph-mcp/src/tools/link_hierarchical.rs
+++ b/crates/epigraph-mcp/src/tools/link_hierarchical.rs
@@ -1,0 +1,121 @@
+//! `link_hierarchical` — cross-tier structural edge creation between claims.
+//!
+//! Counterpart to the new `POST /api/v1/edges/hierarchical` HTTP endpoint.
+//! Bypasses HTTP and goes directly through `EdgeRepository::create_if_not_exists`
+//! so per-chapter ingest wiring (e.g. chapter thesis → book thesis,
+//! chapter[N] → chapter[N+1]) can continue from a Claude Code session even
+//! when the API binary is unavailable.
+//!
+//! Tight contract — narrower than the generic `POST /api/v1/edges` route:
+//! - both endpoints must be existing claims (`source_type` / `target_type`
+//!   are always `"claim"` and not caller-controllable),
+//! - `relationship` must be one of `HIERARCHICAL_RELATIONSHIPS`,
+//! - the call is idempotent on `(source, target, relationship)`.
+//!
+//! Intentionally side-effect-free vs the generic POST: no DS recomputation,
+//! no factor inserts, no `edge.added` event, no provenance. These structural
+//! edges carry no evidential semantics and the matching `ingest_document`
+//! flow treats them the same way.
+
+use rmcp::model::*;
+
+use crate::errors::{internal_error, invalid_params, parse_uuid, McpError};
+use crate::server::EpiGraphMcpFull;
+use crate::types::{LinkHierarchicalParams, LinkHierarchicalResponse};
+
+use epigraph_core::ClaimId;
+use epigraph_db::{ClaimRepository, EdgeRepository};
+
+/// Allowed relationship strings — mirror of
+/// `epigraph_api::routes::edges::HIERARCHICAL_RELATIONSHIPS`. Kept as a local
+/// constant so the MCP crate does not take a code dep on the API crate.
+pub const HIERARCHICAL_RELATIONSHIPS: &[&str] =
+    &["decomposes_to", "section_follows", "continues_argument"];
+
+fn is_hierarchical_relationship(s: &str) -> bool {
+    HIERARCHICAL_RELATIONSHIPS.contains(&s)
+}
+
+fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(value).map_err(internal_error)?,
+    )]))
+}
+
+pub async fn link_hierarchical(
+    server: &EpiGraphMcpFull,
+    params: LinkHierarchicalParams,
+) -> Result<CallToolResult, McpError> {
+    do_link_hierarchical(server, params).await
+}
+
+/// Core wiring logic factored out so integration tests can call it directly
+/// without round-tripping through the rmcp dispatch layer. Mirrors the
+/// `do_ingest_document` factoring in `tools/ingestion.rs`.
+pub async fn do_link_hierarchical(
+    server: &EpiGraphMcpFull,
+    params: LinkHierarchicalParams,
+) -> Result<CallToolResult, McpError> {
+    let source_id = parse_uuid(&params.source_claim_id)?;
+    let target_id = parse_uuid(&params.target_claim_id)?;
+
+    // Tight allow-list — narrower than VALID_RELATIONSHIPS on purpose. New
+    // entries must come from `HIERARCHICAL_RELATIONSHIPS`.
+    if !is_hierarchical_relationship(&params.relationship) {
+        return Err(invalid_params(format!(
+            "invalid relationship '{}'. Valid hierarchical types: {}",
+            params.relationship,
+            HIERARCHICAL_RELATIONSHIPS.join(", "),
+        )));
+    }
+
+    // No self-loops — both endpoints are claims so equal UUIDs always loop.
+    if source_id == target_id {
+        return Err(invalid_params(
+            "self-loops are not allowed (source and target are the same claim)",
+        ));
+    }
+
+    let pool = &server.pool;
+
+    // Verify both claims exist via the repo layer (per CLAUDE.md, SQL stays
+    // in epigraph-db). Disambiguate which side is missing so the caller can
+    // fix the right end of the link.
+    if ClaimRepository::get_by_id(pool, ClaimId::from_uuid(source_id))
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err(invalid_params(format!(
+            "source_claim_id {source_id} not found"
+        )));
+    }
+    if ClaimRepository::get_by_id(pool, ClaimId::from_uuid(target_id))
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err(invalid_params(format!(
+            "target_claim_id {target_id} not found"
+        )));
+    }
+
+    let (edge_row, was_created) = EdgeRepository::create_if_not_exists(
+        pool,
+        source_id,
+        "claim",
+        target_id,
+        "claim",
+        &params.relationship,
+        params.properties.clone(),
+        None,
+        None,
+    )
+    .await
+    .map_err(internal_error)?;
+
+    success_json(&LinkHierarchicalResponse {
+        edge_id: edge_row.id.to_string(),
+        created: was_created,
+    })
+}

--- a/crates/epigraph-mcp/src/tools/mod.rs
+++ b/crates/epigraph-mcp/src/tools/mod.rs
@@ -7,6 +7,7 @@ pub mod events;
 pub mod evolve_step;
 pub mod graph;
 pub mod ingestion;
+pub mod link_hierarchical;
 pub mod memory;
 pub mod paper_queries;
 pub mod perspectives;

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -679,6 +679,43 @@ pub struct IngestDocumentParams {
     pub file_path: String,
 }
 
+/// Parameters for the `link_hierarchical` MCP tool.
+///
+/// Wires two existing claims with one of the structural relationships emitted
+/// by the hierarchical ingest pipeline (`decomposes_to`, `section_follows`,
+/// `continues_argument`). Mirrors the contract of
+/// `POST /api/v1/edges/hierarchical` but bypasses HTTP and goes directly
+/// through the repo layer, which keeps per-chapter chapter-to-book wiring
+/// working when the HTTP API binary is unavailable.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LinkHierarchicalParams {
+    #[schemars(description = "UUID of the source claim")]
+    pub source_claim_id: String,
+
+    #[schemars(description = "UUID of the target claim")]
+    pub target_claim_id: String,
+
+    #[schemars(
+        description = "Structural relationship type. One of: decomposes_to, section_follows, continues_argument."
+    )]
+    pub relationship: String,
+
+    #[schemars(description = "Optional arbitrary JSON object attached to the edge.")]
+    #[serde(default)]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// Response for the `link_hierarchical` MCP tool.
+///
+/// `created=true` means a new edge row was inserted; `created=false` means an
+/// edge with the same `(source, target, relationship)` triple already
+/// existed and the existing edge_id is returned (idempotent re-runs).
+#[derive(Debug, Serialize)]
+pub struct LinkHierarchicalResponse {
+    pub edge_id: String,
+    pub created: bool,
+}
+
 #[derive(Debug, Serialize)]
 pub struct IngestDocumentResponse {
     pub paper_id: String,

--- a/crates/epigraph-mcp/tests/link_hierarchical_smoke.rs
+++ b/crates/epigraph-mcp/tests/link_hierarchical_smoke.rs
@@ -1,0 +1,265 @@
+//! End-to-end smoke test for the `link_hierarchical` MCP tool.
+//!
+//! Drives `do_link_hierarchical` directly against a sqlx::test pool so the
+//! happy / idempotent / validation / 404-equivalent paths all exercise the
+//! same repo layer the production rmcp dispatcher uses.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_mcp::embed::McpEmbedder;
+use epigraph_mcp::server::EpiGraphMcpFull;
+use epigraph_mcp::tools::link_hierarchical::do_link_hierarchical;
+use epigraph_mcp::types::LinkHierarchicalParams;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Lightweight mirror of `LinkHierarchicalResponse` for test deserialization.
+/// (The production struct is Serialize-only — adding Deserialize purely to make
+/// tests easier is gold-plating; parsing into a local mirror keeps the prod
+/// type focused on its one direction of the wire contract.)
+#[derive(serde::Deserialize)]
+struct LinkHierarchicalResponse {
+    edge_id: String,
+    created: bool,
+}
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::generate();
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+/// Minimal seeded claim — bypasses the full submit_claim pipeline because
+/// this test cares about the edge-wiring code path, not claim ingestion.
+async fn seed_claim(pool: &PgPool, content: &str) -> Uuid {
+    // Each claim needs a unique agent (unique public_key) and unique content_hash.
+    let agent_id = Uuid::new_v4();
+    let agent_pk: Vec<u8> = agent_id
+        .as_bytes()
+        .iter()
+        .copied()
+        .cycle()
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, agent_type) \
+         VALUES ($1, $2, 'system') ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(agent_id)
+    .bind(&agent_pk)
+    .execute(pool)
+    .await
+    .expect("seed agent");
+
+    let claim_id = Uuid::new_v4();
+    // content_hash must be unique per claim row — derive from the claim UUID
+    // so concurrent sqlx::test pools don't collide.
+    let hash: Vec<u8> = claim_id
+        .as_bytes()
+        .iter()
+        .copied()
+        .cycle()
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current, labels) \
+         VALUES ($1, $2, $3, 0.5, $4, true, ARRAY[]::text[])",
+    )
+    .bind(claim_id)
+    .bind(content)
+    .bind(&hash)
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("seed claim");
+    claim_id
+}
+
+fn parse_response(result: &rmcp::model::CallToolResult) -> LinkHierarchicalResponse {
+    let text = result
+        .content
+        .first()
+        .expect("at least one content block")
+        .as_text()
+        .expect("text content")
+        .text
+        .clone();
+    serde_json::from_str(&text).expect("LinkHierarchicalResponse JSON")
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn happy_path_creates_edge_and_is_idempotent(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let source = seed_claim(&pool, "chapter 1 thesis").await;
+    let target = seed_claim(&pool, "book thesis").await;
+
+    // First call — fresh insert.
+    let first = do_link_hierarchical(
+        &server,
+        LinkHierarchicalParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "decomposes_to".to_string(),
+            properties: Some(serde_json::json!({"chapter": 1})),
+        },
+    )
+    .await
+    .expect("happy path succeeds");
+    let first_resp = parse_response(&first);
+    assert!(first_resp.created, "first call must report created=true");
+
+    // Edge exists in DB with the expected triple and properties.
+    let row: (Uuid, serde_json::Value) = sqlx::query_as(
+        "SELECT id, properties FROM edges \
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to' \
+           AND source_type = 'claim' AND target_type = 'claim'",
+    )
+    .bind(source)
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .expect("edge row");
+    assert_eq!(row.0.to_string(), first_resp.edge_id);
+    assert_eq!(row.1, serde_json::json!({"chapter": 1}));
+
+    // Second call with the same args — dedup hit, no new edge row.
+    let second = do_link_hierarchical(
+        &server,
+        LinkHierarchicalParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "decomposes_to".to_string(),
+            properties: Some(serde_json::json!({"chapter": 1})),
+        },
+    )
+    .await
+    .expect("idempotent re-run succeeds");
+    let second_resp = parse_response(&second);
+    assert!(
+        !second_resp.created,
+        "second call must report created=false (dedup hit)"
+    );
+    assert_eq!(
+        second_resp.edge_id, first_resp.edge_id,
+        "dedup hit must return the existing edge_id"
+    );
+
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges \
+         WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'",
+    )
+    .bind(source)
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count.0, 1, "must have exactly one edge after re-run");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn invalid_relationship_is_rejected(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let source = seed_claim(&pool, "atomA").await;
+    let target = seed_claim(&pool, "atomB").await;
+
+    let err = do_link_hierarchical(
+        &server,
+        LinkHierarchicalParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "supports".to_string(), // valid for generic POST, rejected here
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("supports must be rejected by the tight allow-list");
+    let msg = err.message.to_string();
+    assert!(
+        msg.contains("invalid relationship"),
+        "error should name the relationship problem; got: {msg}"
+    );
+    assert!(
+        msg.contains("decomposes_to"),
+        "error should list the valid types; got: {msg}"
+    );
+
+    // No edge written.
+    let count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM edges WHERE source_id = $1 AND target_id = $2")
+            .bind(source)
+            .bind(target)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count.0, 0);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn missing_source_claim_returns_404_equivalent(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let target = seed_claim(&pool, "real target").await;
+    let bogus = Uuid::new_v4();
+
+    let err = do_link_hierarchical(
+        &server,
+        LinkHierarchicalParams {
+            source_claim_id: bogus.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "section_follows".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("missing source claim must error");
+    let msg = err.message.to_string();
+    assert!(
+        msg.contains("source_claim_id") && msg.contains(&bogus.to_string()),
+        "error should identify the missing side and its UUID; got: {msg}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn missing_target_claim_returns_404_equivalent(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let source = seed_claim(&pool, "real source").await;
+    let bogus = Uuid::new_v4();
+
+    let err = do_link_hierarchical(
+        &server,
+        LinkHierarchicalParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: bogus.to_string(),
+            relationship: "continues_argument".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("missing target claim must error");
+    let msg = err.message.to_string();
+    assert!(
+        msg.contains("target_claim_id") && msg.contains(&bogus.to_string()),
+        "error should identify the missing side and its UUID; got: {msg}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn self_loop_is_rejected(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let claim = seed_claim(&pool, "loop").await;
+
+    let err = do_link_hierarchical(
+        &server,
+        LinkHierarchicalParams {
+            source_claim_id: claim.to_string(),
+            target_claim_id: claim.to_string(),
+            relationship: "decomposes_to".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("self-loops must be rejected before hitting the DB CHECK");
+    let msg = err.message.to_string();
+    assert!(
+        msg.to_lowercase().contains("self-loop"),
+        "error should mention self-loops; got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a purpose-built single-edge surface for cross-tier hierarchical wiring between existing claims, with parallel HTTP + MCP entrypoints backed by the same repo layer.

**Motivation:** per-chapter `ingest_document` runs each chapter as its own `DocumentExtraction` and emits structural edges (`decomposes_to`, `section_follows`, `continues_argument`) only *within* an extraction. Wiring across extractions — e.g. each chapter's thesis up to the book-level thesis, or chapter[N] → chapter[N+1] — needs a separate edge-creation call. The generic `POST /api/v1/edges` accepts these relationship strings (since PR #153) but is locked behind OAuth and currently unresponsive due to an unrelated job-runner deadlock. We also want a tighter, first-class contract for this specific operation so future plans can declare cross-tier wiring as a named step rather than a generic edge insert.

- `POST /api/v1/edges/hierarchical` — tight allow-list (3 structural relationship types), both endpoints must be existing claims (`source_type` / `target_type` pinned to `"claim"` and not caller-controllable), scoped on `edges:write`, idempotent on `(source, target, relationship)`, 200 OK in both fresh-insert and dedup-hit cases. Intentionally side-effect-free vs the generic POST (no DS recomputation, no factor inserts, no `edge.added` event, no provenance) — these structural edges carry no evidential semantics and the matching `ingest_document` flow treats them the same way.
- `link_hierarchical` MCP tool — same contract, bypasses HTTP and goes directly through `EdgeRepository::create_if_not_exists` so per-chapter wire-ups work from Claude Code sessions even when the HTTP API binary is unhappy. Gated on `claims:write` to match `ingest_document` per the existing MCP scope-map convention (we don't add an `edges:write` MCP scope; that's the one judgment call worth flagging).
- OpenAPI doc stub + schema registration so the new path shows up in `/api/v1/openapi.json` alongside the rest of the curated spec.

## Test plan

- [x] `DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph_db_repo_test cargo test -p epigraph-mcp --test link_hierarchical_smoke` — 5/5 passing (happy + idempotent, invalid relationship, missing source 404, missing target 404, self-loop reject)
- [x] `DATABASE_URL=... cargo test -p epigraph-api --test link_hierarchical_test` — 6/6 passing (the 5 above + scope enforcement)
- [x] `cargo test -p epigraph-mcp --lib` — 22 passing (scope_map coverage tests confirm `link_hierarchical` is registered)
- [x] `cargo test -p epigraph-api --lib routes::edges` — 27 passing (no regression in existing edges handlers)
- [x] `cargo test -p epigraph-api --test openapi_paths_test` — 1 passing (existing curated-paths check still happy)
- [x] `cargo build --release -p epigraph-mcp -p epigraph-api` — clean
- [x] `cargo fmt -p epigraph-mcp -p epigraph-api` — clean
- [ ] User to rebuild + reinstall MCP server / API binary before live use; not merged here per task instructions

## Notes for review

- No new `sqlx::query!` calls — both surfaces route through `EdgeRepository::create_if_not_exists` and `ClaimRepository::get_by_id`. `.sqlx/` untouched.
- No new MCP scope category. MCP `link_hierarchical` → `claims:write` (mirrors `ingest_document`); HTTP route stays on `edges:write` (mirrors generic POST `/api/v1/edges`). Open to splitting into a new `edges:write` MCP scope if the broader project wants to align them, but that's a separate refactor.
- `LinkHierarchicalResponse` is Serialize-only on the production side; the MCP smoke test parses into a local Deserialize mirror to avoid widening the prod type's contract just for tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)