### PR TITLE
migration: add claim_themes.properties JSONB column

### DIFF
--- a/migrations/032_claim_themes_properties.sql
+++ b/migrations/032_claim_themes_properties.sql
@@ -1,0 +1,11 @@
+-- migrations/032_claim_themes_properties.sql
+-- Per design 2026-05-18-cross-source-anchor.
+-- Adds free-form metadata to claim_themes so textbook-seeded themes can
+-- record `source_textbook_claim_id` (the L1 section they were derived from)
+-- without inventing a side table. Existing rows default to '{}'::jsonb.
+
+ALTER TABLE claim_themes
+    ADD COLUMN IF NOT EXISTS properties JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_claim_themes_properties
+    ON claim_themes USING gin (properties jsonb_path_ops);


### PR DESCRIPTION
## Summary
- Adds `032_claim_themes_properties.sql` to main — already applied to production DB 2026-05-19 03:27 from `spec/cross-source-anchor` (commit bd88e8a)
- Brings public main in sync with deployed schema so `epigraph-api` can pass startup migration check
- Pure additive migration: `ALTER TABLE claim_themes ADD COLUMN IF NOT EXISTS properties JSONB NOT NULL DEFAULT '{}'::jsonb` + index

## Why now
Production `epigraph-api` was running with the old (pre-32) embedded migrations. Any restart panics with `VersionMissing(32)`. Discovered during stale-binary redeploy. Cherry-pick of the original commit to unblock.

## Test plan
- [x] sqlx checksum will match (file identical to bd88e8a)
- [ ] Rebuild and restart `epigraph-api` — should start cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)