### PR TITLE
fix(mcp): McpEmbedder writes to claims.embedding (was no-op on evidence)

### DIFF
--- a/crates/epigraph-mcp/src/embed.rs
+++ b/crates/epigraph-mcp/src/embed.rs
@@ -78,10 +78,15 @@ impl McpEmbedder {
         };
 
         let pgvec = format_pgvector(&embedding);
-        match epigraph_db::EvidenceRepository::store_embedding(&self.pool, claim_id.into(), &pgvec)
-            .await
-        {
-            Ok(_) => true,
+        match epigraph_db::ClaimRepository::store_embedding(&self.pool, claim_id, &pgvec).await {
+            Ok(true) => true,
+            Ok(false) => {
+                tracing::warn!(
+                    claim_id = %claim_id,
+                    "embedding store affected 0 rows (claim missing?)"
+                );
+                false
+            }
             Err(e) => {
                 tracing::warn!("embedding store failed: {e}");
                 false
@@ -149,13 +154,15 @@ impl EmbeddingService for McpEmbedder {
         Ok(results)
     }
 
-    /// Store an embedding for a claim via `EvidenceRepository::store_embedding`.
+    /// Store an embedding on `claims.embedding` via `ClaimRepository::store_embedding`.
     ///
-    /// `McpEmbedder` stores embeddings against *evidence* rows (keyed by claim).
-    /// Here we delegate to that path: format the vector, then call the DB method.
+    /// Per the embedding-policy contract in CLAUDE.md, the canonical storage
+    /// site for claim embeddings is `claims.embedding`. An earlier impl wrote
+    /// to `evidence.embedding` keyed by `claim_id`, which silently no-op'd
+    /// because evidence rows have their own ids.
     async fn store(&self, claim_id: uuid::Uuid, embedding: &[f32]) -> Result<(), EmbeddingError> {
         let pgvec = format_pgvector(embedding);
-        epigraph_db::EvidenceRepository::store_embedding(&self.pool, claim_id.into(), &pgvec)
+        epigraph_db::ClaimRepository::store_embedding(&self.pool, claim_id, &pgvec)
             .await
             .map(|_| ())
             .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))

--- a/crates/epigraph-mcp/tests/embedder_writes_to_claims_table.rs
+++ b/crates/epigraph-mcp/tests/embedder_writes_to_claims_table.rs
@@ -1,0 +1,47 @@
+//! Regression: `McpEmbedder` must persist embeddings on `claims.embedding`,
+//! not `evidence.embedding`. Per the embedding-policy contract in CLAUDE.md
+//! the canonical storage site is `claims.embedding`; an earlier path called
+//! `EvidenceRepository::store_embedding(claim_id.into(), ...)`, which UPDATE-d
+//! a non-existent evidence row (claim_id ≠ evidence.id) and silently no-op'd.
+
+use epigraph_embeddings::EmbeddingService;
+use epigraph_mcp::embed::McpEmbedder;
+use sqlx::PgPool;
+
+mod common;
+use common::seed_claim;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn mcp_embedder_store_writes_to_claims_embedding(pool: PgPool) {
+    let claim_id = seed_claim(&pool, "embedder write target", 0.5).await;
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    let fake_vec = vec![0.1_f32; 1536];
+
+    EmbeddingService::store(&embedder, claim_id, &fake_vec)
+        .await
+        .expect("store should succeed");
+
+    let (claim_has_emb,): (bool,) =
+        sqlx::query_as("SELECT embedding IS NOT NULL FROM claims WHERE id = $1")
+            .bind(claim_id)
+            .fetch_one(&pool)
+            .await
+            .expect("query claim");
+    assert!(
+        claim_has_emb,
+        "claims.embedding must be populated after McpEmbedder::store(); \
+         the storage target is `claims`, not `evidence` (see CLAUDE.md embedding policy)"
+    );
+
+    let evidence_row_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM evidence WHERE id = $1")
+            .bind(claim_id)
+            .fetch_one(&pool)
+            .await
+            .expect("query evidence");
+    assert_eq!(
+        evidence_row_count, 0,
+        "no evidence row should exist at id = claim_id; if this fails the schema \
+         contract changed and the test premise is stale"
+    );
+}


### PR DESCRIPTION
## Summary
- `McpEmbedder::embed_and_store` and `<McpEmbedder as EmbeddingService>::store` both wrote to `evidence.embedding` keyed by a *claim* UUID — but evidence rows carry their own ids, so the UPDATE silently matched zero rows. The wrapper returned `Ok(_) → true` regardless, so memorize/submit_claim/etc. all reported `"embedded": true` while persisting nothing.
- Production audit: `claims.embedding` has 421,146 populated rows; `evidence.embedding` has **0**. The intended target was always `claims.embedding` per [CLAUDE.md "## Embedding policy"](../blob/main/CLAUDE.md#embedding-policy) and the cc34ced consolidation refactor.
- Fix: both call sites now use `ClaimRepository::store_embedding`. `embed_and_store` additionally surfaces a 0-rows warning for the edge case where the claim was deleted between insert and embed.

## Why this slipped past PR #159
PR #159 fixed write-path *callers* (POST `/api/v1/claims`, ingest-executor, etc.) but didn't audit the embedder backend they call. The MCP `memorize` path delegates through `McpEmbedder`, so its embeddings have been silently dropped since the cc34ced consolidation (Mar 12 2026).

## Test plan
- [x] New regression test `embedder_writes_to_claims_table.rs` — seeds claim, calls `EmbeddingService::store`, asserts `claims.embedding IS NOT NULL` and no evidence row exists at that id. Fails before fix, passes after.
- [ ] CI: full workspace tests
- [ ] Post-merge: monitor `live_missing` count (currently 2,531) — should plateau or decline as MCP writes start landing embeddings

## Follow-ups (not in this PR)
- Backfill the 2,531 existing `is_current AND embedding IS NULL` claims — the `backfill_embeddings.py` referenced in `routes/claims.rs:1177` still doesn't exist
- Audit `EvidenceRepository::search_by_embedding` callers — `McpEmbedder::similar` still routes through there; since `evidence.embedding` is empty, recall via that trait method returns nothing. The actual production recall path uses `ClaimRepository::search_by_embedding` (added in 6cc1e25), so this is latent dead code rather than a live bug, but worth cleaning up

🤖 Generated with [Claude Code](https://claude.com/claude-code)