### PR TITLE
style(mcp): cargo fmt embedder_writes_to_claims_table test

### DIFF
--- a/crates/epigraph-mcp/tests/embedder_writes_to_claims_table.rs
+++ b/crates/epigraph-mcp/tests/embedder_writes_to_claims_table.rs
@@ -33,12 +33,11 @@ async fn mcp_embedder_store_writes_to_claims_embedding(pool: PgPool) {
          the storage target is `claims`, not `evidence` (see CLAUDE.md embedding policy)"
     );
 
-    let evidence_row_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM evidence WHERE id = $1")
-            .bind(claim_id)
-            .fetch_one(&pool)
-            .await
-            .expect("query evidence");
+    let evidence_row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM evidence WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(&pool)
+        .await
+        .expect("query evidence");
     assert_eq!(
         evidence_row_count, 0,
         "no evidence row should exist at id = claim_id; if this fails the schema \


### PR DESCRIPTION
## Summary
- Fixes red CI on `main` from #162: `cargo fmt --check` failed on `crates/epigraph-mcp/tests/embedder_writes_to_claims_table.rs:33`.
- Pure reformat (single `let` binding); no logic change.

## Test plan
- [x] `cargo fmt --check` clean locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)