### PR TITLE
fix(api): skip embedding for epiclaw-host provenance telemetry

### DIFF
--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -185,3 +185,7 @@ path = "tests/events/staleness_events_test.rs"
 [[test]]
 name = "embed_on_create_claim"
 path = "tests/integration/embed_on_create_claim.rs"
+
+[[test]]
+name = "skip_embed_host_telemetry"
+path = "tests/integration/skip_embed_host_telemetry.rs"

--- a/crates/epigraph-api/src/routes/submit.rs
+++ b/crates/epigraph-api/src/routes/submit.rs
@@ -1473,8 +1473,38 @@ pub async fn submit_packet(
     // This enables semantic search to find this claim based on meaning.
     // Embedding generation is non-blocking: if the service is unavailable
     // or fails, the claim submission still succeeds.
+    //
+    // Skip host-provenance telemetry (epiclaw-host signs every observable
+    // event as a signed claim for tamper-evidence; embedding sentence-shaped
+    // operational events like "Container X exited code 0 after Yms" has no
+    // semantic value and costs an OpenAI call per event).
+    let is_host_telemetry = packet
+        .claim
+        .properties
+        .as_ref()
+        .and_then(|p| p.get("event"))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|e| {
+            matches!(
+                e,
+                "container_spawned"
+                    | "container_exited"
+                    | "agent_output"
+                    | "task_scheduled"
+                    | "task_executed"
+                    | "message_received"
+                    | "message_sent"
+            )
+        });
+
     #[cfg(feature = "db")]
     if let Some(ref embedding_service) = state.embedding_service {
+        if is_host_telemetry {
+            tracing::debug!(
+                claim_id = %claim_id,
+                "Skipping embedding for host-provenance telemetry claim"
+            );
+        } else {
         match embedding_service.generate(&packet.claim.content).await {
             Ok(embedding) => {
                 // Store directly via SQL (provider-agnostic — works with Jina, OpenAI, etc.)
@@ -1515,17 +1545,25 @@ pub async fn submit_packet(
                 // Continue anyway - claim submission shouldn't fail due to embedding issues
             }
         }
+        }
     }
     #[cfg(not(feature = "db"))]
     if let Some(ref embedding_service) = state.embedding_service {
-        match embedding_service.generate(&packet.claim.content).await {
-            Ok(embedding) => {
-                if let Err(e) = embedding_service.store(claim_id, &embedding).await {
-                    tracing::warn!(claim_id = %claim_id, error = %e, "Failed to store claim embedding");
+        if is_host_telemetry {
+            tracing::debug!(
+                claim_id = %claim_id,
+                "Skipping embedding for host-provenance telemetry claim"
+            );
+        } else {
+            match embedding_service.generate(&packet.claim.content).await {
+                Ok(embedding) => {
+                    if let Err(e) = embedding_service.store(claim_id, &embedding).await {
+                        tracing::warn!(claim_id = %claim_id, error = %e, "Failed to store claim embedding");
+                    }
                 }
-            }
-            Err(e) => {
-                tracing::warn!(claim_id = %claim_id, error = %e, "Failed to generate embedding for claim");
+                Err(e) => {
+                    tracing::warn!(claim_id = %claim_id, error = %e, "Failed to generate embedding for claim");
+                }
             }
         }
     }

--- a/crates/epigraph-api/tests/integration/skip_embed_host_telemetry.rs
+++ b/crates/epigraph-api/tests/integration/skip_embed_host_telemetry.rs
@@ -1,0 +1,228 @@
+//! POST /api/v1/submit/packet must NOT embed claims whose
+//! `properties.event` marks them as host-provenance telemetry from
+//! `epiclaw-host`. Embedding sentence-shaped operational events like
+//! "Container X exited code 0 after Yms" has no semantic value and costs an
+//! OpenAI call per event; the host signs them only for tamper-evidence on
+//! container lifecycle.
+//!
+//! Regression guard: removing the skip-check in `submit.rs` would resume
+//! ~thousands of wasted embedding calls per day from the epiclaw orchestrator.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use epigraph_api::{create_router, state::AppState, ApiConfig};
+use epigraph_embeddings::{EmbeddingConfig, EmbeddingService, MockProvider};
+use http_body_util::BodyExt;
+use serde_json::json;
+use sqlx::PgPool;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn test_bearer_token() -> String {
+    use epigraph_api::oauth::JwtConfig;
+    let jwt_config = JwtConfig::from_secret(b"epigraph-dev-secret-change-in-production!!");
+    let (token, _) = jwt_config
+        .issue_access_token(
+            Uuid::new_v4(),
+            vec!["claims:write".to_string(), "epigraph:write".to_string()],
+            "service",
+            None,
+            None,
+            chrono::Duration::seconds(300),
+        )
+        .expect("issue_access_token");
+    token
+}
+
+async fn submit_packet_with_properties(
+    pool: PgPool,
+    content: &str,
+    properties: Option<serde_json::Value>,
+) -> Uuid {
+    let provider = MockProvider::new(EmbeddingConfig::local(1536));
+    let service: Arc<dyn EmbeddingService> = Arc::new(provider);
+    let state = AppState::with_db(pool.clone(), ApiConfig::default())
+        .with_embedding_service(service.clone());
+    let app = create_router(state);
+
+    let agent_id = Uuid::new_v4();
+    // Public key must be unique across agents — derive from the UUID so each
+    // call to this helper inserts a distinct row.
+    let mut public_key = [0u8; 32];
+    public_key[..16].copy_from_slice(agent_id.as_bytes());
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, $2)")
+        .bind(agent_id)
+        .bind(public_key.as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let evidence_content = "host observation";
+    let evidence_hash = epigraph_crypto::ContentHasher::to_hex(
+        &epigraph_crypto::ContentHasher::hash(evidence_content.as_bytes()),
+    );
+
+    let mut claim = json!({
+        "content": content,
+        "initial_truth": 0.99,
+        "agent_id": agent_id,
+    });
+    if let Some(p) = properties {
+        claim["properties"] = p;
+    }
+
+    let body = json!({
+        "claim": claim,
+        "evidence": [{
+            "content_hash": evidence_hash,
+            "evidence_type": {
+                "type": "observation",
+                "observed_at": chrono::Utc::now(),
+                "method": "test",
+                "location": null
+            },
+            "raw_content": evidence_content,
+            "signature": null
+        }],
+        "reasoning_trace": {
+            "methodology": "deductive",
+            "inputs": [{"type": "evidence", "index": 0}],
+            "confidence": 0.99,
+            "explanation": "test",
+            "signature": null
+        },
+        "signature": "0".repeat(128)
+    });
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/submit/packet")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", test_bearer_token()),
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "submit_packet should succeed; body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    v["claim_id"].as_str().unwrap().parse().unwrap()
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn submit_packet_skips_embedding_for_container_exited(pool: PgPool) {
+    let claim_id = submit_packet_with_properties(
+        pool.clone(),
+        "Container epiclaw-sched-foo exited code 0 after 12345ms",
+        Some(json!({
+            "event": "container_exited",
+            "exit_code": 0,
+            "duration_ms": 12345_i64
+        })),
+    )
+    .await;
+
+    let has_embedding: bool =
+        sqlx::query_scalar("SELECT embedding IS NOT NULL FROM claims WHERE id = $1")
+            .bind(claim_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    assert!(
+        !has_embedding,
+        "claim {claim_id} is host-provenance telemetry (event=container_exited); \
+         embedding should be SKIPPED but column is populated"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn submit_packet_skips_embedding_for_all_known_telemetry_events(pool: PgPool) {
+    for event in [
+        "container_spawned",
+        "container_exited",
+        "agent_output",
+        "task_scheduled",
+        "task_executed",
+        "message_received",
+        "message_sent",
+    ] {
+        let claim_id = submit_packet_with_properties(
+            pool.clone(),
+            &format!("telemetry: {event}"),
+            Some(json!({"event": event})),
+        )
+        .await;
+
+        let has_embedding: bool =
+            sqlx::query_scalar("SELECT embedding IS NOT NULL FROM claims WHERE id = $1")
+                .bind(claim_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        assert!(
+            !has_embedding,
+            "claim with properties.event = {event:?} should not be embedded \
+             (host-telemetry skip)"
+        );
+    }
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn submit_packet_still_embeds_non_telemetry_claims(pool: PgPool) {
+    // No properties.event → embed as normal. This guards against an overly
+    // broad skip rule that would silently drop embeddings for ordinary claims.
+    let claim_id = submit_packet_with_properties(
+        pool.clone(),
+        "An ordinary knowledge claim that should be embedded",
+        None,
+    )
+    .await;
+
+    let has_embedding: bool =
+        sqlx::query_scalar("SELECT embedding IS NOT NULL FROM claims WHERE id = $1")
+            .bind(claim_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    assert!(
+        has_embedding,
+        "ordinary claim {claim_id} (no properties.event) should be embedded"
+    );
+
+    // Unknown event values should NOT trigger the skip — keeps the filter
+    // tight to the known epiclaw-host emitters.
+    let claim_id_unknown = submit_packet_with_properties(
+        pool.clone(),
+        "Claim with unknown event marker",
+        Some(json!({"event": "something_else_entirely"})),
+    )
+    .await;
+
+    let has_embedding_unknown: bool = sqlx::query_scalar(
+        "SELECT embedding IS NOT NULL FROM claims WHERE id = $1",
+    )
+    .bind(claim_id_unknown)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert!(
+        has_embedding_unknown,
+        "claim with unknown properties.event value should still be embedded"
+    );
+}


### PR DESCRIPTION
## Summary
- `epiclaw-host`'s `ProvenanceRecorder` signs every observable orchestrator event as a SubmitPacket for tamper-evidence (container lifecycle, agent output, task scheduling, IPC messages). Each carries sentence-shaped content like `Container epiclaw-X exited code 0 after Yms`.
- Embedding these costs an OpenAI call per event and pollutes the vector space with low-semantic content. Production: 2,116 such claims at deploy time (≈0.5% of live corpus) and growing.
- Adds a single skip-check at the inline-embed callsite in `POST /api/v1/submit/packet`: if `packet.claim.properties.event` matches a known host-emitter event name, log debug and skip the embed.

## What this does NOT change
- No schema change. No `ClaimSubmission` field added.
- Claim insertion is unaffected — host provenance still lands as a signed claim with full `GENERATED_BY` edge graph.
- Only `claims.embedding` is left NULL for telemetry rows.

## Companion change (separate PR, `epiclaw-host` repo)
Three of the seven `record_*` methods in `provenance.rs` currently pass `properties: None` (message_received, message_sent, agent_output). After they're updated to include `properties.event`, 100% of host telemetry hits this skip.

## Test plan
- [x] `tests/integration/skip_embed_host_telemetry.rs`:
  - `container_exited` → `embedding IS NULL`
  - All 7 known event names → `embedding IS NULL`
  - No event marker / unknown event value → `embedding IS NOT NULL` (guards against overly broad filter)
- [ ] CI: full workspace
- [ ] Post-merge: `live_missing` growth rate drops as orchestrator continues operating

🤖 Generated with [Claude Code](https://claude.com/claude-code)