### PR TITLE
fix(mcp): find_workflow_hierarchical surfaces canonical_name matches and filters deprecated

### DIFF
--- a/crates/epigraph-api/src/routes/submit.rs
+++ b/crates/epigraph-api/src/routes/submit.rs
@@ -1505,46 +1505,46 @@ pub async fn submit_packet(
                 "Skipping embedding for host-provenance telemetry claim"
             );
         } else {
-        match embedding_service.generate(&packet.claim.content).await {
-            Ok(embedding) => {
-                // Store directly via SQL (provider-agnostic — works with Jina, OpenAI, etc.)
-                let pgvector_str = format!(
-                    "[{}]",
-                    embedding
-                        .iter()
-                        .map(|v| v.to_string())
-                        .collect::<Vec<_>>()
-                        .join(",")
-                );
-                if let Err(e) =
-                    sqlx::query("UPDATE claims SET embedding = $1::vector WHERE id = $2")
-                        .bind(&pgvector_str)
-                        .bind(claim_id)
-                        .execute(&state.db_pool)
-                        .await
-                {
+            match embedding_service.generate(&packet.claim.content).await {
+                Ok(embedding) => {
+                    // Store directly via SQL (provider-agnostic — works with Jina, OpenAI, etc.)
+                    let pgvector_str = format!(
+                        "[{}]",
+                        embedding
+                            .iter()
+                            .map(|v| v.to_string())
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    );
+                    if let Err(e) =
+                        sqlx::query("UPDATE claims SET embedding = $1::vector WHERE id = $2")
+                            .bind(&pgvector_str)
+                            .bind(claim_id)
+                            .execute(&state.db_pool)
+                            .await
+                    {
+                        tracing::warn!(
+                            claim_id = %claim_id,
+                            error = %e,
+                            "Failed to store claim embedding"
+                        );
+                    } else {
+                        tracing::debug!(
+                            claim_id = %claim_id,
+                            embedding_dim = embedding.len(),
+                            "Generated and stored embedding for claim"
+                        );
+                    }
+                }
+                Err(e) => {
                     tracing::warn!(
                         claim_id = %claim_id,
                         error = %e,
-                        "Failed to store claim embedding"
+                        "Failed to generate embedding for claim"
                     );
-                } else {
-                    tracing::debug!(
-                        claim_id = %claim_id,
-                        embedding_dim = embedding.len(),
-                        "Generated and stored embedding for claim"
-                    );
+                    // Continue anyway - claim submission shouldn't fail due to embedding issues
                 }
             }
-            Err(e) => {
-                tracing::warn!(
-                    claim_id = %claim_id,
-                    error = %e,
-                    "Failed to generate embedding for claim"
-                );
-                // Continue anyway - claim submission shouldn't fail due to embedding issues
-            }
-        }
         }
     }
     #[cfg(not(feature = "db"))]

--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -89,6 +89,9 @@ pub struct HierarchicalSearchQuery {
     pub limit: Option<i64>,
     #[serde(default)]
     pub resolve_to_latest: bool,
+    /// Minimum `truth_value` to surface. Defaults to 0.3 so rows
+    /// deprecated via `deprecate_workflow` (truth=0.05) drop out.
+    pub min_truth: Option<f64>,
 }
 
 #[cfg(feature = "db")]
@@ -121,6 +124,9 @@ pub struct HierarchicalWorkflowResult {
     pub parent_id: Option<uuid::Uuid>,
     pub metadata: serde_json::Value,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Deprecation signal: 1.0 for live rows; `deprecate_workflow`
+    /// cascades 0.05 onto this column.
+    pub truth_value: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolved_steps: Option<Vec<ResolvedStepResult>>,
 }
@@ -714,10 +720,13 @@ pub async fn find_workflow_hierarchical(
     Query(params): Query<HierarchicalSearchQuery>,
 ) -> Result<Json<HierarchicalSearchResponse>, ApiError> {
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
+    let min_truth = params.min_truth.unwrap_or(0.3);
     let rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
         &state.db_pool,
         &params.q,
         limit,
+        min_truth,
+        params.resolve_to_latest,
     )
     .await
     .map_err(|e| ApiError::InternalError {
@@ -734,6 +743,7 @@ pub async fn find_workflow_hierarchical(
             parent_id: r.parent_id,
             metadata: r.metadata,
             created_at: r.created_at,
+            truth_value: r.truth_value,
             resolved_steps: None,
         })
         .collect();
@@ -1101,6 +1111,11 @@ pub async fn deprecate_workflow(
                 .bind(id)
                 .execute(&state.db_pool)
                 .await;
+        // Mirror onto the hierarchical `workflows` row when one exists
+        // (no-op for flat-only workflows). Without this, deprecated
+        // hierarchical workflows keep surfacing in
+        // `GET /api/v1/workflows/hierarchical/search`.
+        let _ = epigraph_db::WorkflowRepository::set_truth_value(&state.db_pool, *id, 0.05).await;
     }
 
     // Emit event

--- a/crates/epigraph-api/tests/integration/skip_embed_host_telemetry.rs
+++ b/crates/epigraph-api/tests/integration/skip_embed_host_telemetry.rs
@@ -213,13 +213,12 @@ async fn submit_packet_still_embeds_non_telemetry_claims(pool: PgPool) {
     )
     .await;
 
-    let has_embedding_unknown: bool = sqlx::query_scalar(
-        "SELECT embedding IS NOT NULL FROM claims WHERE id = $1",
-    )
-    .bind(claim_id_unknown)
-    .fetch_one(&pool)
-    .await
-    .unwrap();
+    let has_embedding_unknown: bool =
+        sqlx::query_scalar("SELECT embedding IS NOT NULL FROM claims WHERE id = $1")
+            .bind(claim_id_unknown)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
 
     assert!(
         has_embedding_unknown,

--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -57,6 +57,9 @@ pub struct HierarchicalWorkflowRow {
     pub parent_id: Option<Uuid>,
     pub metadata: serde_json::Value,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Deprecation signal. Live rows are 1.0; `deprecate_workflow`
+    /// cascades a write to 0.05 so callers can filter via `min_truth`.
+    pub truth_value: f64,
 }
 
 /// Per-step resolution result for `find_workflow_hierarchical(resolve_to_latest=true)`.
@@ -571,9 +574,21 @@ impl WorkflowRepository {
     }
 
     /// Search hierarchical workflows by free-text query against `goal` and
-    /// `canonical_name`. ILIKE pattern; ranks newest first by `created_at`.
+    /// `canonical_name`. ILIKE pattern; canonical_name hyphens are normalized
+    /// to spaces before matching so queries like "scan norcal rfps" still
+    /// match the slug `scan-norcal-rfps` when a generation's `goal` text has
+    /// diverged from the lineage's canonical phrase.
     ///
-    /// Used by `GET /api/v1/workflows/hierarchical/search`.
+    /// Filters out rows with `truth_value < min_truth` so `deprecate_workflow`
+    /// (truth=0.05) hides rows from active queries.
+    ///
+    /// When `resolve_to_latest` is true, callers want the newest generation
+    /// per `canonical_name`; ordering becomes `(canonical_name ASC,
+    /// generation DESC, created_at DESC)` so callers can dedup by walking
+    /// the head of each canonical group without a sort.
+    ///
+    /// Used by `GET /api/v1/workflows/hierarchical/search` and the MCP
+    /// `find_workflow_hierarchical` tool.
     ///
     /// # Errors
     /// Returns `sqlx::Error` if the database query fails.
@@ -581,19 +596,59 @@ impl WorkflowRepository {
         pool: &PgPool,
         query: &str,
         limit: i64,
+        min_truth: f64,
+        resolve_to_latest: bool,
     ) -> Result<Vec<HierarchicalWorkflowRow>, sqlx::Error> {
-        let pattern = format!("%{}%", query.trim());
-        sqlx::query_as::<_, HierarchicalWorkflowRow>(
-            "SELECT id, canonical_name, generation, goal, parent_id, metadata, created_at \
+        // Normalize hyphens to spaces on BOTH sides so `deploy-canary`
+        // (slug form) and `deploy canary` (goal-text form) match each
+        // other. Without this, callers that send a goal-shaped query
+        // string (spaces) miss generations whose goals have diverged from
+        // the lineage's canonical phrase — only the slug carries the
+        // shared lineage signal. Likewise, a caller that sends the slug
+        // verbatim should still match a goal that wrote out the words.
+        let pattern = format!("%{}%", query.trim().replace('-', " "));
+        let order_clause = if resolve_to_latest {
+            "ORDER BY canonical_name ASC, generation DESC, created_at DESC, id ASC"
+        } else {
+            "ORDER BY created_at DESC, id ASC"
+        };
+        let sql = format!(
+            "SELECT id, canonical_name, generation, goal, parent_id, metadata, created_at, truth_value \
              FROM workflows \
-             WHERE goal ILIKE $1 OR canonical_name ILIKE $1 \
-             ORDER BY created_at DESC, id ASC \
-             LIMIT $2",
-        )
-        .bind(&pattern)
-        .bind(limit)
-        .fetch_all(pool)
-        .await
+             WHERE (replace(canonical_name, '-', ' ') || ' ' || replace(goal, '-', ' ')) ILIKE $1 \
+               AND truth_value >= $2 \
+             {order_clause} \
+             LIMIT $3"
+        );
+        sqlx::query_as::<_, HierarchicalWorkflowRow>(&sql)
+            .bind(&pattern)
+            .bind(min_truth)
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+    }
+
+    /// Set `workflows.truth_value` for the given workflow id. Used by
+    /// `deprecate_workflow` to cascade truth=0.05 from the flat-claim row
+    /// onto the hierarchical-table row so `find_workflow_hierarchical`
+    /// respects the deprecation signal.
+    ///
+    /// Returns the number of rows affected (0 if `workflow_id` is a
+    /// flat-only workflow with no `workflows` row).
+    ///
+    /// # Errors
+    /// Returns `sqlx::Error` if the database query fails.
+    pub async fn set_truth_value(
+        pool: &PgPool,
+        workflow_id: Uuid,
+        truth_value: f64,
+    ) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query("UPDATE workflows SET truth_value = $1 WHERE id = $2")
+            .bind(truth_value)
+            .bind(workflow_id)
+            .execute(pool)
+            .await?;
+        Ok(result.rows_affected())
     }
 }
 
@@ -737,21 +792,22 @@ mod tests {
         .await
         .unwrap();
 
-        let hits = WorkflowRepository::search_hierarchical_by_text(&pool, "sensor", 10)
+        let hits = WorkflowRepository::search_hierarchical_by_text(&pool, "sensor", 10, 0.0, false)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].canonical_name, "data-pipeline-v1");
 
         // canonical_name match also works
-        let hits = WorkflowRepository::search_hierarchical_by_text(&pool, "deploy-canary", 10)
-            .await
-            .unwrap();
+        let hits =
+            WorkflowRepository::search_hierarchical_by_text(&pool, "deploy-canary", 10, 0.0, false)
+                .await
+                .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].canonical_name, "deploy-canary");
 
         // limit respected
-        let hits = WorkflowRepository::search_hierarchical_by_text(&pool, "%", 1)
+        let hits = WorkflowRepository::search_hierarchical_by_text(&pool, "%", 1, 0.0, false)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);

--- a/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
@@ -4,7 +4,9 @@
 //! `workflows` table (hierarchical roots) — distinct from the legacy flat
 //! workflow claims handled in `workflows.rs`.
 //!
-//! - `find_workflow_hierarchical` — ILIKE search over goal/canonical_name.
+//! - `find_workflow_hierarchical` — ILIKE search over goal and a
+//!   hyphen-normalized canonical_name; filters by `min_truth` so deprecated
+//!   rows (truth=0.05) drop out by default.
 //! - `report_hierarchical_outcome` — updates `workflows.metadata` counters
 //!   and writes per-step `behavioral_executions` rows with `step_claim_id`
 //!   resolved from the workflow's `executes` edges in plan order.
@@ -54,11 +56,17 @@ pub async fn find_workflow_hierarchical(
 ) -> Result<CallToolResult, McpError> {
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
     let resolve_to_latest = params.resolve_to_latest.unwrap_or(false);
+    // Default 0.3 hides deprecated rows (truth=0.05) while leaving room
+    // for future probabilistic discounting; callers can pass 0.0 to see
+    // the deprecated cemetery.
+    let min_truth = params.min_truth.unwrap_or(0.3);
 
     let rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
         &server.pool,
         &params.query,
         limit,
+        min_truth,
+        resolve_to_latest,
     )
     .await
     .map_err(internal_error)?;
@@ -73,6 +81,7 @@ pub async fn find_workflow_hierarchical(
             "parent_id": r.parent_id,
             "metadata": r.metadata,
             "created_at": r.created_at,
+            "truth_value": r.truth_value,
         });
 
         if resolve_to_latest {
@@ -90,6 +99,7 @@ pub async fn find_workflow_hierarchical(
         "workflows": workflows,
         "total": workflows.len(),
         "resolve_to_latest": resolve_to_latest,
+        "min_truth": min_truth,
     }))
 }
 

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -554,6 +554,12 @@ pub async fn deprecate_workflow(
     .execute(&server.pool)
     .await
     .map_err(internal_error)?;
+    // Cascade onto the hierarchical `workflows` row (no-op when this
+    // workflow has only a flat-claim representation). Without this,
+    // `find_workflow_hierarchical` keeps returning the deprecated row.
+    epigraph_db::WorkflowRepository::set_truth_value(&server.pool, workflow_id, 0.05)
+        .await
+        .map_err(internal_error)?;
     deprecated_ids.push(workflow_id.to_string());
 
     if cascade {
@@ -598,6 +604,10 @@ pub async fn deprecate_workflow(
                 .execute(&server.pool)
                 .await
                 .map_err(internal_error)?;
+                // Mirror onto the hierarchical row, if any.
+                epigraph_db::WorkflowRepository::set_truth_value(&server.pool, child_id, 0.05)
+                    .await
+                    .map_err(internal_error)?;
                 deprecated_ids.push(child_id.to_string());
                 queue.push(child_id);
             }

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -372,7 +372,7 @@ pub struct ImproveWorkflowHierarchyParams {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FindWorkflowHierarchicalParams {
     #[schemars(
-        description = "Free-text search over hierarchical workflow goal and canonical_name (ILIKE)."
+        description = "Free-text search over hierarchical workflow goal and canonical_name (ILIKE). The canonical_name slug is hyphen-normalized to spaces before matching so a goal-text query still matches the slug across generations whose goals have diverged from the lineage's canonical phrase."
     )]
     pub query: String,
 
@@ -380,9 +380,14 @@ pub struct FindWorkflowHierarchicalParams {
     pub limit: Option<i64>,
 
     #[schemars(
-        description = "When true, walk each step's step_lineage_id to the head version(s) and surface them as `resolved_steps`. Defaults to false (frozen step references)."
+        description = "When true, walk each step's step_lineage_id to the head version(s) and surface them as `resolved_steps`, and order results by (canonical_name ASC, generation DESC) so the newest variant per lineage is first. Defaults to false (frozen step references, newest-created-at first)."
     )]
     pub resolve_to_latest: Option<bool>,
+
+    #[schemars(
+        description = "Minimum truth value to surface; defaults to 0.3 so deprecated rows (truth=0.05 via deprecate_workflow) are hidden. Pass 0.0 to include deprecated workflows."
+    )]
+    pub min_truth: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/epigraph-mcp/tests/step_versioning.rs
+++ b/crates/epigraph-mcp/tests/step_versioning.rs
@@ -238,6 +238,7 @@ async fn find_workflow_hierarchical_frozen_by_default(pool: PgPool) {
             query: "versioning probe".to_string(),
             limit: Some(5),
             resolve_to_latest: None,
+            min_truth: None,
         },
     )
     .await
@@ -350,6 +351,7 @@ async fn find_workflow_hierarchical_resolve_walks_lineage(pool: PgPool) {
             query: "resolve_to_latest target".to_string(),
             limit: Some(5),
             resolve_to_latest: Some(true),
+            min_truth: None,
         },
     )
     .await
@@ -392,4 +394,156 @@ async fn find_workflow_hierarchical_resolve_walks_lineage(pool: PgPool) {
     );
 
     assert_eq!(body["resolve_to_latest"], serde_json::json!(true));
+}
+
+// ── Bug 1 (claim a73dee60): canonical_name-with-hyphens divergence ──────
+//
+// Repro for the norcal-rfp-monitor failure on 2026-05-19: a query string
+// containing spaces ("scan norcal rfps") only substring-matched gen-0's
+// goal verbatim. Later generations (gen-4/5/6) had differentiated goals
+// that no longer contained the gen-0 phrase, yet their canonical_name
+// slug (`scan-norcal-rfps`) still represents the lineage. Before the
+// hyphen-normalized concat, those rows were invisible to the tool even
+// though they were the rows callers actually wanted.
+//
+// This test seeds the exact divergence shape (slug constant, goals
+// diverge) and asserts both rows return. With the old `goal ILIKE $1 OR
+// canonical_name ILIKE $1` form, only the gen-0 row would surface
+// because spaces never match hyphens in either column.
+#[sqlx::test(migrations = "../../migrations")]
+async fn find_workflow_hierarchical_matches_canonical_name_across_diverged_goals(pool: PgPool) {
+    let server = build_server(pool.clone());
+
+    let gen0 = Uuid::new_v4();
+    let gen4 = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO workflows (id, canonical_name, generation, goal, parent_id, metadata, created_at) \
+         VALUES \
+           ($1, 'scan-norcal-architecture-rfps', 0, \
+                'Scan NorCal architecture RFPs and send email notification', \
+                NULL, '{}', NOW()), \
+           ($2, 'scan-norcal-architecture-rfps', 4, \
+                'Scan via direct query-string GETs over aggregators with form-fill', \
+                NULL, '{}', NOW())",
+    )
+    .bind(gen0)
+    .bind(gen4)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // The query is the gen-0 goal phrase verbatim. Gen-4's goal does NOT
+    // contain it. The slug (with hyphens) does NOT contain it either.
+    // Only the hyphen-normalized `(replace(canonical_name,'-',' ') || ' '
+    // || goal)` concat surfaces gen-4.
+    let result = find_workflow_hierarchical(
+        &server,
+        FindWorkflowHierarchicalParams {
+            query: "scan norcal architecture rfps".to_string(),
+            limit: Some(10),
+            resolve_to_latest: None,
+            min_truth: Some(0.0),
+        },
+    )
+    .await
+    .expect("find_workflow_hierarchical");
+
+    let body = parse_body(&result);
+    let workflows = body["workflows"].as_array().expect("workflows array");
+    let found_ids: std::collections::HashSet<String> = workflows
+        .iter()
+        .filter_map(|w| w["workflow_id"].as_str().map(str::to_string))
+        .collect();
+
+    assert!(
+        found_ids.contains(&gen0.to_string()),
+        "gen-0 (verbatim goal match) must return; got ids {found_ids:?}"
+    );
+    assert!(
+        found_ids.contains(&gen4.to_string()),
+        "gen-4 (canonical_name slug match only) must return; got ids {found_ids:?}. \
+         This regresses without hyphen normalization of canonical_name."
+    );
+}
+
+// ── Bug 2 (claim a73dee60): deprecation must filter via min_truth ──────
+//
+// `deprecate_workflow` writes `truth_value = 0.05`. Before this fix, the
+// `workflows` table had no truth_value column, so the deprecation was
+// invisible to `find_workflow_hierarchical` (it only touched `claims`).
+// Repro: gen-3 of the norcal monitor was deprecated 2026-05-19 16:48 UTC
+// yet kept appearing.
+//
+// This test seeds two rows under the same canonical_name with different
+// truth_values directly (we test the filter, not the cascade — the
+// cascade has its own coverage in tests/deprecate_workflow_is_current_test.rs).
+#[sqlx::test(migrations = "../../migrations")]
+async fn find_workflow_hierarchical_filters_deprecated_via_min_truth(pool: PgPool) {
+    let server = build_server(pool.clone());
+
+    let live_id = Uuid::new_v4();
+    let dead_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO workflows (id, canonical_name, generation, goal, parent_id, metadata, created_at, truth_value) \
+         VALUES \
+           ($1, 'rfp-monitor-test', 4, 'live differentiated goal', NULL, '{}', NOW(), 1.0), \
+           ($2, 'rfp-monitor-test', 3, 'deprecated older goal',    NULL, '{}', NOW(), 0.05)",
+    )
+    .bind(live_id)
+    .bind(dead_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Default min_truth (0.3) → only the live row.
+    let default_result = find_workflow_hierarchical(
+        &server,
+        FindWorkflowHierarchicalParams {
+            query: "rfp monitor test".to_string(),
+            limit: Some(10),
+            resolve_to_latest: None,
+            min_truth: None,
+        },
+    )
+    .await
+    .expect("default min_truth");
+    let body = parse_body(&default_result);
+    let ids: std::collections::HashSet<String> = body["workflows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|w| w["workflow_id"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        ids.contains(&live_id.to_string()),
+        "live (truth=1.0) row must surface under default min_truth=0.3"
+    );
+    assert!(
+        !ids.contains(&dead_id.to_string()),
+        "deprecated (truth=0.05) row must NOT surface under default min_truth=0.3; got {ids:?}"
+    );
+
+    // min_truth=0.0 → both rows (caller opts into the cemetery).
+    let all_result = find_workflow_hierarchical(
+        &server,
+        FindWorkflowHierarchicalParams {
+            query: "rfp monitor test".to_string(),
+            limit: Some(10),
+            resolve_to_latest: None,
+            min_truth: Some(0.0),
+        },
+    )
+    .await
+    .expect("min_truth=0.0");
+    let body = parse_body(&all_result);
+    let ids: std::collections::HashSet<String> = body["workflows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|w| w["workflow_id"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        ids.contains(&live_id.to_string()) && ids.contains(&dead_id.to_string()),
+        "min_truth=0.0 must include both live and deprecated; got {ids:?}"
+    );
 }

--- a/migrations/033_workflows_truth_value.sql
+++ b/migrations/033_workflows_truth_value.sql
@@ -1,0 +1,23 @@
+-- Migration 033: workflows.truth_value column for deprecation filtering.
+--
+-- The hierarchical `workflows` table (added in 020) had no truth_value.
+-- `deprecate_workflow` (both MCP and API) only updated the matching row
+-- in `claims` — which is the FLAT representation — so deprecating a
+-- hierarchical workflow had no visible effect on
+-- `find_workflow_hierarchical`, which reads from `workflows`.
+--
+-- This migration adds `truth_value` to `workflows` and a partial index
+-- to keep deprecation filters cheap. The default 1.0 preserves all
+-- existing rows as "live" — no backfill required. The cascade write
+-- (deprecate_workflow → UPDATE workflows.truth_value) is added in the
+-- accompanying Rust changes.
+
+ALTER TABLE workflows
+    ADD COLUMN truth_value DOUBLE PRECISION NOT NULL DEFAULT 1.0;
+
+-- Partial index: only deprecated rows. Live rows (truth_value = 1.0)
+-- dominate the table; we only need fast lookup for the deprecation
+-- filter `truth_value < $min_truth`, which is rare.
+CREATE INDEX workflows_truth_value_low_idx
+    ON workflows (truth_value)
+    WHERE truth_value < 1.0;


### PR DESCRIPTION
## Summary

Two coupled bugs filed today via `submit_claim` (parent `a73dee60-9fb1-4196-aeab-83d74f5f7c09`, sub-claims `edcdc9e8-8083-47ee-bff6-3ee99fb80ed3` and `446976c5-4c01-4b14-929a-dab925feddeb`). Real-world impact: the norcal-rfp-monitor scheduled agent (Mondays 8 AM PDT) could not locate its newest workflow generation and fell back to the toml prompt spec.

**Bug 1 — hyphen vs space mismatch.** Origin/main already had `WHERE goal ILIKE $1 OR canonical_name ILIKE $1`, but a query string with spaces (e.g. `"scan norcal architecture rfps"`) cannot substring-match a slug with hyphens (`scan-norcal-architecture-rfps`). Gen-0 matched on goal text verbatim; gen-4/5/6, whose goals had diverged from the lineage's canonical phrase, were invisible. The literal task recommendation `(canonical_name || ' ' || goal) ILIKE $1` is equivalent to the existing OR — it does not actually fix the repro. Fix: normalize hyphens to spaces on **both sides**, so `deploy-canary` and `deploy canary` find each other regardless of which one the caller sends.

**Bug 2 — deprecation invisible to hierarchical search.** `deprecate_workflow` (MCP + API) only writes `truth_value=0.05` onto the matching `claims` row. The hierarchical `workflows` table had no `truth_value` column, so deprecating a hierarchical workflow had zero effect on `find_workflow_hierarchical`. Fix: schema migration 033 adds `workflows.truth_value` (default 1.0, partial index on the rare `< 1.0` rows), both `deprecate_workflow` callsites now mirror the 0.05 write to the hierarchical row, and the new `min_truth` param (default 0.3) drops deprecated rows from active queries.

Bonus: `resolve_to_latest=true` now orders by `(canonical_name ASC, generation DESC)` so callers walking heads per lineage don't need to sort.

**Scope note.** The task scoped this as a handler+schema+tests change; it expanded to include a schema migration and `deprecate_workflow` cascade because the spec's truth filter presupposed a `workflows.truth_value` column that did not exist. The cascade is required for the spec to mean what it says.

## Files touched

- `migrations/033_workflows_truth_value.sql` — new column + partial index
- `crates/epigraph-db/src/repos/workflow.rs` — `search_hierarchical_by_text` signature gains `min_truth` + `resolve_to_latest`, new `set_truth_value` helper, hyphen-normalized concat
- `crates/epigraph-mcp/src/types.rs` — `FindWorkflowHierarchicalParams.min_truth`
- `crates/epigraph-mcp/src/tools/workflow_hierarchical.rs` — wire min_truth, surface `truth_value` in response
- `crates/epigraph-mcp/src/tools/workflows.rs` — cascade workflows.truth_value in `deprecate_workflow` (both target + cascade walk)
- `crates/epigraph-api/src/routes/workflows.rs` — same mirror on the HTTP route; `min_truth` query param + `truth_value` in response schema
- `crates/epigraph-mcp/tests/step_versioning.rs` — two new integration tests

## Test plan

- [x] `find_workflow_hierarchical_matches_canonical_name_across_diverged_goals` — seeds two rows under the same `canonical_name` with goals that diverge (gen-0 contains query phrase; gen-4 does not). Asserts both return. Fails on prior code: gen-4's goal doesn't contain the query phrase and the slug has hyphens, so neither side of the old OR matched.
- [x] `find_workflow_hierarchical_filters_deprecated_via_min_truth` — seeds live (truth=1.0) and deprecated (truth=0.05) rows. Default `min_truth=0.3` returns only the live row; `min_truth=0.0` returns both. Fails on prior code: column doesn't exist.
- [x] Existing `search_hierarchical_by_text_returns_matches` repo test updated for new signature; all four step_versioning tests pass.
- [x] `cargo clippy --workspace -- -D warnings` clean (same invocation as CI).
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)