### PR TITLE
docs: onboarding tree (README + docs/intro/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# EpiGraph
+
+An epistemic kernel: claims (nouns), edges (verbs), agents that cryptographically sign their assertions, and beliefs propagated via Dempster-Shafer evidence combination. EpiGraph replaces the static-paper model of knowledge with a live loop — hypothesis → experiment → data → analysis → belief update — that downstream applications can interrogate, challenge, and extend.
+
+Where most knowledge bases store *what is currently believed*, EpiGraph stores *what each agent has asserted, with what evidence, signed under what identity, and how those assertions combine into a defensible belief*. It is the substrate the rest of the epigraph-io stack builds on.
+
+## Who is this for?
+
+- **Developers** integrating EpiGraph into an application (build with the Rust crates, talk via the HTTP API, drive via the MCP server)
+- **Researchers and analysts** querying the graph via Claude Code (the MCP tools cover recall, neighborhood traversal, challenge/verify, backlog management)
+- **Contributors** extending the kernel itself (see [`CLAUDE.md`](CLAUDE.md))
+
+## Status
+
+- Version: 0.3.0
+- License: Apache-2.0
+- Maturity: alpha — kernel schema and core primitives are stable; layers built on top (workflows, hierarchical extraction, perspectives) iterate
+
+## 5-minute quickstart
+
+```bash
+# 1. PostgreSQL with pgvector
+createuser epigraph -P && createdb -O epigraph epigraph
+psql -d epigraph -c "CREATE EXTENSION vector;"
+export DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph
+
+# 2. Build
+git clone https://github.com/epigraph-io/epigraph.git && cd epigraph
+cargo build --release -p epigraph-api -p epigraph-mcp
+
+# 3. Migrate + start API
+cargo run --release --bin epigraph-migrate
+cargo run --release -p epigraph-api --bin server &
+
+# 4. Install MCP server
+sudo cp target/release/epigraph-mcp-full /usr/local/bin/epigraph-mcp
+
+# 5. Add this to ~/.mcp.json
+# {
+#   "mcpServers": {
+#     "epigraph": {
+#       "command": "/usr/local/bin/epigraph-mcp",
+#       "args": ["--database-url", "postgres://epigraph:epigraph@localhost:5432/epigraph"],
+#       "env": { "OPENAI_API_KEY": "${OPENAI_API_KEY}", "EPIGRAPH_API_URL": "http://127.0.0.1:8080" }
+#     }
+#   }
+# }
+
+# 6. Open Claude Code and ask it to call mcp__epigraph__recall_with_context with query "test".
+```
+
+If that works, head to the [full quickstart](docs/intro/01-quickstart.md) for explanations and common-error coverage.
+
+## Onboarding tree
+
+- [`docs/intro/01-quickstart.md`](docs/intro/01-quickstart.md) — six-step setup, prereqs, troubleshooting
+- [`docs/intro/02-concepts.md`](docs/intro/02-concepts.md) — noun-claims/verb-edges, agents and signing, DST beliefs, perspectives, hierarchical extraction, backlog discipline
+- [`docs/intro/03-walkthroughs.md`](docs/intro/03-walkthroughs.md) — four end-to-end Claude Code transcripts (coming soon — captured live)
+- [`docs/intro/04-glossary.md`](docs/intro/04-glossary.md) — vocabulary
+- [`docs/intro/05-next-steps.md`](docs/intro/05-next-steps.md) — contributor, deploy, and downstream pointers
+
+## Deeper material
+
+- [`docs/architecture/noun-claims-and-verb-edges.md`](docs/architecture/noun-claims-and-verb-edges.md) — the canonical pattern for what gets stored as a claim vs an edge
+- [`docs/conventions/backlog-retirement.md`](docs/conventions/backlog-retirement.md) — how operational backlog items are resolved
+- [`docs/deploy.md`](docs/deploy.md) — production deploy runbook
+- [`CLAUDE.md`](CLAUDE.md) — agent-session conventions (backlog, schema, tests, workflow)
+- [`scripts/README.md`](scripts/README.md) — operational maintenance scripts

--- a/docs/intro/01-quickstart.md
+++ b/docs/intro/01-quickstart.md
@@ -1,0 +1,141 @@
+# Quickstart
+
+This guide takes you from a clean PostgreSQL + Rust toolchain to a first successful MCP `recall_with_context` call in about ten minutes. Everything below assumes a Unix-like environment (Linux or macOS); Windows users should use WSL2. If you want context on *why* you would run any of this, read [`02-concepts.md`](02-concepts.md) first — this page is purely mechanical setup.
+
+## Prerequisites
+
+- **Rust** ≥ 1.75 (`rustup show` to check)
+- **PostgreSQL** 16+ with the `pgvector` extension installed and available (`SELECT extname FROM pg_extension;` should be runnable as a superuser)
+- **Claude Code** installed and authenticated — this is the MCP client we'll use to drive EpiGraph
+- **OpenAI API key** — exported as `OPENAI_API_KEY`. **Mandatory** for the walkthroughs: `recall_with_context` embeds the query string on every call (see `crates/epigraph-mcp/src/tools/recall.rs`) and fails without a configured embedding provider, even against an empty corpus.
+- **~$5 of OpenAI credit** for the embedding calls in the walkthroughs
+
+Time budget: ~10 minutes to first MCP call if your prereqs are in place; ~30 minutes including a fresh Postgres/pgvector install.
+
+## Step 1 — PostgreSQL
+
+```bash
+# As a Postgres superuser:
+createuser epigraph -P  # set password to 'epigraph' (or any password you wire into DATABASE_URL)
+createdb -O epigraph epigraph
+psql -d epigraph -c "CREATE EXTENSION IF NOT EXISTS vector;"
+```
+
+The runtime role does NOT need `SUPERUSER`. If you also intend to run the test suite (`sqlx::test`), grant `SUPERUSER` temporarily or use a separate test-only role — `sqlx::test` `LOCK`s `pg_namespace` and requires it (see the `feedback_sqlx_test_uses_superuser` memory note).
+
+Set the connection string:
+
+```bash
+export DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph
+```
+
+## Step 2 — Clone and build
+
+```bash
+git clone https://github.com/epigraph-io/epigraph.git
+cd epigraph
+cargo build --release -p epigraph-api -p epigraph-mcp -p epigraph-cli
+```
+
+Note: the `epigraph-mcp` package produces a binary named `epigraph-mcp-full` (see the `[[bin]]` entry in `crates/epigraph-mcp/Cargo.toml`). That's the binary you'll register with Claude Code in Step 5.
+
+## Step 3 — Migrations
+
+```bash
+cargo run --release --bin epigraph-migrate
+```
+
+This runs all 32 kernel migrations from `migrations/` (currently `001_initial_schema.sql` through `032_claim_themes_properties.sql`). For a fresh database this should complete in under a minute. If you're applying migrations to a pre-existing production database that was previously tracked under the internal-repo numbering, see the one-shot reconcile procedure in [`docs/deploy.md`](../deploy.md) before running this step.
+
+## Step 4 — Start the API server
+
+```bash
+cargo run --release -p epigraph-api --bin server
+```
+
+In another shell, verify:
+
+```bash
+curl http://127.0.0.1:8080/health
+```
+
+Expected: an HTTP 200 with a JSON body like
+
+```json
+{"status":"healthy","version":"…","timestamp":"…"}
+```
+
+The server logs its bound address on startup; the default is `0.0.0.0:8080` (override with `EPIGRAPH_PORT=<n>` if 8080 is busy or you want to run two servers side-by-side). `DATABASE_URL` from Step 1 is read from the environment at startup; if you forgot to `export` it, the server will panic immediately with a clear message.
+
+## Step 5 — Install the MCP server and register it with Claude Code
+
+Option A: copy the built binary to a path on your `$PATH` (matching the `~/.mcp.json` pattern used in this repo's deployment):
+
+```bash
+sudo cp target/release/epigraph-mcp-full /usr/local/bin/epigraph-mcp
+```
+
+Option B: `cargo install` it (installed binary is named `epigraph-mcp-full`):
+
+```bash
+cargo install --path crates/epigraph-mcp
+```
+
+Register the server in `~/.mcp.json` (creating the file if it doesn't exist). Use the exact path you installed to:
+
+```json
+{
+  "mcpServers": {
+    "epigraph": {
+      "command": "/usr/local/bin/epigraph-mcp",
+      "args": [
+        "--database-url", "postgres://epigraph:epigraph@localhost:5432/epigraph"
+      ],
+      "env": {
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "EPIGRAPH_API_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}
+```
+
+If you used Option B and didn't rename the binary, change `"command"` to `"/home/youruser/.cargo/bin/epigraph-mcp-full"`.
+
+## Step 6 — Your first MCP call
+
+Open Claude Code (in any working directory). Tell it:
+
+> Use the `recall_with_context` MCP tool to search for "test".
+
+Claude should call `mcp__epigraph__recall_with_context({"query": "test"})` and you should see a JSON response with a `corpus_scope` object showing zero claims, paragraphs, papers, and themes (assuming a fresh database). For background on what `recall_with_context` is actually doing — embedding the query, scoring against paragraph- and claim-level vectors, returning a hybrid result — see [`02-concepts.md#5--hierarchical-extraction`](02-concepts.md#5--hierarchical-extraction).
+
+Next, ask:
+
+> Use `submit_claim` to add this claim: "EpiGraph is installed correctly."
+
+Claude calls `mcp__epigraph__submit_claim(...)` and returns the created claim's UUID. This newly written row is a noun-claim authored by your agent; the conceptual model behind that split is in [`02-concepts.md#1--noun-claims-vs-verb-edges`](02-concepts.md#1--noun-claims-vs-verb-edges). Call `recall_with_context "installed"` again — you should now see the freshly submitted claim in the results.
+
+If you see the claim, your install is working end-to-end.
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| `sqlx checksum mismatch` at startup | See the reconcile procedure in [`docs/deploy.md`](../deploy.md); this only happens against a pre-existing internal-numbered DB. |
+| `Connection refused (os error 111)` on port 5432 | Postgres isn't running. `pg_isready` to check; start it (`brew services start postgresql@16`, `sudo systemctl start postgresql`, etc.). |
+| `extension "vector" is not available` | Install pgvector — see https://github.com/pgvector/pgvector#installation for OS-specific instructions. |
+| `OPENAI_API_KEY not set` from MCP server | Export the env var in the shell that launches Claude Code, or hardcode the value in `~/.mcp.json` (less secure). |
+| Claude Code can't find the MCP tool | `~/.mcp.json` path wrong, or you renamed the binary inconsistently between the file and `cp`. Recheck the exact `"command"` value. |
+| `DATABASE_URL must be set` panic from `epigraph-api` | Step 1's `export` only lasts for the shell that ran it; re-export in the shell that launches the server, or put it in your shell rc file. |
+| Port 8080 already in use | Set `EPIGRAPH_PORT=<n>` and re-run; update the `curl` and the `EPIGRAPH_API_URL` in `~/.mcp.json` accordingly. |
+
+## Tear-down
+
+```bash
+dropdb epigraph
+```
+
+Then drop the role with `dropuser epigraph` if reinstalling.
+
+Once your install is working, the next thing to read is [`02-concepts.md`](02-concepts.md) — it walks through what `claims`, `edges`, agents, perspectives, and DST actually mean in the schema you just migrated. Term-level lookups go to [`04-glossary.md`](04-glossary.md).

--- a/docs/intro/02-concepts.md
+++ b/docs/intro/02-concepts.md
@@ -2,7 +2,7 @@
 
 EpiGraph is an evidence-graph database that records *what is claimed*, *who claimed it*, *when it occurred*, and *how strongly it is believed* — all in a way that survives re-ingest, re-extraction, and disagreement between agents. This page is the orientation layer: each sub-section explains one core idea, points at a worked example, and links to the canonical deeper doc for the specialist details. Read it once front-to-back; later you can jump back via the table of contents below.
 
-If you have not yet read [`01-overview.md`](01-overview.md), do that first — it frames *why* EpiGraph exists. This file answers *what the moving parts are*. The [`04-glossary.md`](04-glossary.md) entries refer back into the sections below by anchor.
+If you have not yet run through [`01-quickstart.md`](01-quickstart.md), do that first — it gets a kernel up so the examples below have somewhere to land. This file answers *what the moving parts are*. The [`04-glossary.md`](04-glossary.md) entries refer back into the sections below by anchor.
 
 ## Table of contents
 

--- a/docs/intro/02-concepts.md
+++ b/docs/intro/02-concepts.md
@@ -1,0 +1,402 @@
+# EpiGraph Concepts
+
+EpiGraph is an evidence-graph database that records *what is claimed*, *who claimed it*, *when it occurred*, and *how strongly it is believed* — all in a way that survives re-ingest, re-extraction, and disagreement between agents. This page is the orientation layer: each sub-section explains one core idea, points at a worked example, and links to the canonical deeper doc for the specialist details. Read it once front-to-back; later you can jump back via the table of contents below.
+
+If you have not yet read [`01-overview.md`](01-overview.md), do that first — it frames *why* EpiGraph exists. This file answers *what the moving parts are*. The [`04-glossary.md`](04-glossary.md) entries refer back into the sections below by anchor.
+
+## Table of contents
+
+1. [Noun-claims vs verb-edges](#1--noun-claims-vs-verb-edges) — what goes in `claims` vs `edges`
+2. [Agents and signing](#2--agents-and-signing) — who authors and how authorship is cryptographically anchored
+3. [Beliefs and DST](#3--beliefs-and-dst) — how the graph carries uncertainty (BetP, mass functions, discounting)
+4. [Perspectives, frames, themes](#4--perspectives-frames-themes) — viewpoints, hypothesis spaces, topical clusters
+5. [Hierarchical extraction](#5--hierarchical-extraction) — papers → paragraphs → atoms and why paragraphs are primary
+6. [Backlog discipline](#6--backlog-discipline) — how operational follow-ups live inside the graph
+
+---
+
+## 1 — Noun-claims vs verb-edges
+
+EpiGraph has two write surfaces — `claims` and `edges` — and the
+rule for which row belongs in which table is the single most
+important architectural fact in the system. The codebase drifted
+into using `claims` for both kinds of write before 2026-04-25; the
+canonical pattern below is the post-S1 state.
+
+A row in `claims` is a **noun**: a stable-identity entity or
+assertion. Its canonical key is `(content_hash, agent_id)`, and
+there is at most one row per key. Examples:
+
+- "Evidence supports H₀ at confidence 0.8" (a textbook fact)
+- "Container `epiclaw-tg-7173612411` exists" (entity)
+- "Task `epistemic-gaps` is scheduled" (operational entity)
+- "The message body 'ok'" (content blob)
+
+Each one names something that has identity independent of any
+particular time it was observed.
+
+A row in `edges` is a **verb event**: a timestamped occurrence or
+relationship involving one or more noun-claims. The edge carries
+`relationship` (the verb), `created_at` (the event time), optional
+`valid_from`/`valid_to`, a `properties` JSONB blob with event
+metadata, and a `signature` / `signer_id` pair. Re-occurrence of the
+same event creates a new edge, never a duplicated noun. Examples:
+
+- `host_agent --[spawned @ T1, props={group:"..."}]--> container_claim`
+- `host_agent --[executed @ T2, props={status:"completed"}]--> task_claim`
+- `paper_artifact --[asserts @ T3, props={extraction_run:"..."}]--> fact_claim`
+
+Worked example — textbook ingest, abbreviated:
+
+```text
+# run 1
+POST /claims  {content="evidence supports H0 at conf 0.8",
+               agent_id=ingest_agent, if_not_exists: true}
+            -> {claim_id=X, was_created: true}
+POST /edges   {source=paper_artifact_run1, target=X,
+               relationship="asserts", created_at="2026-03-30T..."}
+
+# run 2 — same content extracted from a fresh ingest run
+POST /claims  {content="evidence supports H0 at conf 0.8",
+               agent_id=ingest_agent, if_not_exists: true}
+            -> {claim_id=X, was_created: false}   # canonical row already exists
+POST /edges   {source=paper_artifact_run2, target=X,
+               relationship="asserts", created_at="2026-03-31T..."}
+```
+
+The fact-claim is canonical (one row); each run's per-run `paper_artifact` noun gets its own fresh `asserts` verb-edge to the canonical fact.
+
+Three rules fall out of this pattern:
+
+1. **Re-occurrence of a lifecycle event = new edge, not new claim.**
+   Spawning the same container twice produces two `spawned` edges,
+   not two container-claims. The container's existence is the noun;
+   each spawn is a verb event at a different `created_at`.
+
+2. **Re-ingesting the same source = new edge from a per-run
+   source-artifact to the existing fact-claim.** No duplicate fact
+   rows; the audit trail lives in the edges. Per-run paper artifacts
+   are themselves noun-claims (one per run), each with its own
+   `asserts` verb-edge to the canonical fact.
+
+3. **`provenance_log` is unchanged.** Every successful create or
+   patch lands a cryptographic provenance row, whether `was_created`
+   was true or false. The noun/verb split affects what *writers
+   create*, not what the audit log records.
+
+A useful mental check when modelling new data: ask "does this thing
+have stable identity, or is it an event?" Stable identity → noun-claim,
+keyed by `(content_hash, agent_id)`. Event → verb-edge, with `created_at`
+carrying the time and `properties` carrying the metadata.
+
+**See also:** [`docs/architecture/noun-claims-and-verb-edges.md`](../architecture/noun-claims-and-verb-edges.md) for the full migration history, the `if_not_exists: true` semantics, the layered dedup story for LLM-driven writers, and the sub-project map (S1–S4).
+
+---
+
+## 2 — Agents and signing
+
+Every write to EpiGraph is attributed to an **agent** — a signing identity with an Ed25519 keypair and an `agent_id` UUID. Human contributors, ingest scripts, MCP-driven LLMs, host processes, and scheduled tasks all submit work under stable agent IDs, so authorship survives across sessions and across machines. The agent is half of the canonical identity of every claim: `(content_hash, agent_id)` is the dedup key in the noun-claim model from §1.
+
+Agent identity is **deterministic**: rather than minting a fresh keypair
+per process, EpiGraph derives the keypair from a seed string via BLAKE3
+→ Ed25519, so the same logical agent maps to the same `did:key` URI
+everywhere. Three seed strategies are in use today:
+
+- **Human authors** — the seed is an ORCID
+  (e.g., `"orcid:0000-0002-1825-0097"`); for authors without an ORCID,
+  a normalized name string is the fallback. Same author across years
+  of work, one signing identity.
+- **System agents** — fixed strings like `"workflow-ingest-system"`
+  (see [`crates/epigraph-ingest-executor/src/system_agent.rs`](../../crates/epigraph-ingest-executor/src/system_agent.rs)).
+  The same string always produces the same agent across processes,
+  so the get-or-create lookup is idempotent. Container restart, fresh
+  deploy, parallel host — all the same agent UUID.
+- **LLM-driven agents (planned)** — the seed is a hash of
+  `(model identifier, system prompt)` so the same model+prompt pair
+  resolves to the same agent identity across sessions
+  (see user-memory `project_epigraph_agent_identity.md`).
+  User OAuth passthrough sits next on that roadmap, so writes
+  attributed to "Claude with prompt X acting for Jeremy" can be
+  distinguished from "Claude with prompt X acting for Carrie".
+
+A `did:key` URI looks like this:
+
+```text
+did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK
+```
+
+The `z` is base58btc multibase, the leading bytes inside the base58 payload are the multicodec prefix `0xed01` for Ed25519, and the rest is the 32-byte public key. Resolving a DID requires no network call — the public key is in the URI, so signature verification is purely local.
+
+Claim signatures and edge signatures use the same audit guarantee: the schema carries `signature` and `signer_id` columns on both `claims` and `edges` (edge signing was added in migration 073). Today claim signatures are universally populated; edge signing is realised per writer in the S3 plans documented in the noun/verb architecture doc — see "Edge signing" there for the current state of which writers sign. The `provenance_log` table records every create or patch independently of the row-level signature, so even an unsigned edge has a tamper-evident audit trail keyed by the requesting principal.
+
+Two flows mint different tokens, and it is easy to confuse them:
+
+- **Agent identity** (this section) — a long-lived signing keypair
+  derived deterministically from a seed; this is *who* a claim is
+  from, and it stays the same for years.
+- **Bearer tokens for the HTTP API** — short-lived JWTs (or
+  OAuth-issued tokens from `/oauth/token`) that authorise a
+  *request*. For bootstrap scripts, the dev helper is
+  [`scripts/_api_client.py::mint_bearer_token`](../../scripts/_api_client.py)
+  (HS256 JWT with `EPIGRAPH_JWT_SECRET`); for production clients the
+  canonical mint flow is the `/oauth/token` endpoint mounted in
+  `crates/epigraph-api/src/routes/mod.rs`, using an Ed25519 client
+  assertion of `ts(8B BE) || nonce(16B) || sig(64B)`.
+
+The bearer-token's `agent_id` claim — when present — pins the resulting writes to a specific agent; without it, writes are attributed to the OAuth client's default agent. Either way the agent identity is the *durable* identity; the bearer token is just the per-session capability that lets a process act on its behalf.
+
+Practical implication for new code: never generate an Ed25519 keypair at runtime "to identify this process". Pick a seed string that describes the *role* (`"my-extractor-v3"`, an ORCID, or a model+prompt hash), pass it through `did_key_for_author`, and let the get-or-create pattern in `system_agent.rs` find or insert the matching `agents` row. The same role on a different machine then writes against the same agent UUID and the same signing key, so attribution composes cleanly across hosts.
+
+**See also:** [`crates/epigraph-crypto/src/did_key.rs`](../../crates/epigraph-crypto/src/did_key.rs) for `did:key` derivation; [`crates/epigraph-ingest-executor/src/system_agent.rs`](../../crates/epigraph-ingest-executor/src/system_agent.rs) for the get-or-create pattern; user-memory `project_epigraph_agent_identity.md` for the LLM-agent identity roadmap; user-memory `reference_epigraph_oauth_mint.md` for the Ed25519 client-assertion shape against `/oauth/token`.
+
+---
+
+## 3 — Beliefs and DST
+
+EpiGraph does not store a single scalar "truth" for each claim. Instead, every claim that has been judged carries a **Dempster-Shafer mass function** over a frame of discernment, and beliefs are projected from that mass function on demand. This matters because real-world evidence is often partial, conflicting, or missing entirely, and a single scalar cannot distinguish "we think it's 0.5" from "we have no idea, so we are reporting 0.5".
+
+A frame of discernment is the finite set of mutually-exclusive hypotheses the claim ranges over — `{H0, H1}` for a binary fact, or a longer list for multi-class assertions. A mass function assigns probability mass to *subsets* of the frame (focal elements), not just to singletons; mass on the full frame represents ignorance. Mass that does not fit anywhere lands in two diagnostic buckets: `mass_on_conflict` (combination produced contradictory evidence) and `mass_on_missing` (the writer ran out of evidence to attribute). DST handles "we do not know yet" cleanly because ignorance is a first-class quantity, not a synthetic prior.
+
+The canonical scalar belief score in EpiGraph is **BetP** — pignistic probability — which projects a mass function onto a probability over singletons by distributing each focal set's mass uniformly across its members. BetP is a single number in `[0, 1]`; sort by it when you need to rank claims, but read the underlying mass function when you need to know *how confident the rank is*. A `get_belief` response looks like:
+
+```json
+{
+  "claim_id": "8f1de9e2-...-...",
+  "belief": 0.71,
+  "plausibility": 0.86,
+  "ignorance": 0.15,
+  "pignistic_prob": 0.78,
+  "mass_on_conflict": 0.04,
+  "mass_on_missing": 0.00,
+  "source": "combined"
+}
+```
+
+The fields decode like this:
+
+- `belief` (lower bound) and `plausibility` (upper bound) define the
+  DST interval — `belief` is the sum of mass on focal sets fully
+  inside the hypothesis, `plausibility` is the sum of mass on focal
+  sets that *intersect* it.
+- `ignorance` is the gap between them, i.e., mass that supports
+  neither side of the question yet.
+- `pignistic_prob` is BetP and is the field downstream ranking code
+  reads when it needs a single number.
+- `mass_on_conflict` flags conflict from combination; high values
+  mean the sources disagree.
+- `mass_on_missing` tracks mass that the writer could not attribute
+  to any focal set — open-world ignorance, distinct from the
+  "neither side" ignorance counted under `ignorance`.
+- `source` reports how the value was assembled (`"stored"`,
+  `"combined"`, etc.) so callers can tell whether they got a fresh
+  combination or a cached value.
+
+The struct lives at `BeliefResponse` in `crates/epigraph-mcp/src/types.rs`.
+
+When evidence from multiple sources is combined, the writer
+**discounts** each input mass function by a reliability factor in
+`[0, 1]` (1.0 = fully trusted, 0.0 = belief moves entirely to
+ignorance) before applying Dempster combination — this is the
+correct way to fuse evidence under uncertainty per Shenoy-Shafer.
+The `submit_ds_evidence` MCP tool exposes the `reliability`
+parameter directly; multiple combination methods are wired in
+(`Dempster`, `Conjunctive`, `YagerOpen`, `YagerClosed`,
+`DuboisPrade`, `Inagaki`) and `compare_methods` projects all of
+them so you can see how sensitive a claim is to the choice.
+
+Scalar Bayesian belief propagation was tried earlier and removed: multiplying scalar truth values along edges collapses them toward zero independently of how strong the evidence actually is (see user-memory `project_bp_cdst_primary.md` and `feedback_pignistic_not_bayesian.md`). The deprecated `truth_value` column is still present in some rows for back-compat; do not order claims by it. The `bp_messages` table that backed the scalar engine is dead and a candidate for drop (`project_bp_messages_dead.md`).
+
+Math kept at intro level: full DST adds operations like Yager normalisation (re-attributing conflict mass to ignorance), Dubois-Prade combination (used when sources are not independent), and discounting with `mass_on_missing` to model open-world ignorance. Those live in the deeper architecture docs — for the intro, hold onto the three-bucket story: belief, plausibility, ignorance, with BetP as the scalar projection you sort by.
+
+**See also:** the LANL Open World DST paper (LA-UR-25-23655) — user-memory `reference_lanl_open_world_dst.md` — for the practitioner's foundation; [`crates/epigraph-mcp/src/tools/ds.rs`](../../crates/epigraph-mcp/src/tools/ds.rs) for `submit_ds_evidence`, `get_belief`, and `compare_methods`; user-memory `feedback_pignistic_not_bayesian.md` for the BetP-first rule; user-memory `project_bp_cdst_primary.md` for why CDST replaced scalar BP.
+
+---
+
+## 4 — Perspectives, frames, themes
+
+Three vocabulary words sit close enough together that newcomers conflate them. They are different things.
+
+A **frame** is the hypothesis space a single mass function is defined over — `{H0, H1}`, `{accepts, rejects, undecided}`, or any finite mutually-exclusive set. Frames are stored in their own table and re-used across claims that share a hypothesis space; refinements (one frame nested inside another) are first-class via `parent_frame_id`.
+
+A **perspective** is a *viewpoint*: an agent-owned (or community-owned) lens that selects, weights, or filters claims when computing belief. The same atom can carry different BetP values from different perspectives without one overwriting the other — disagreement stays visible instead of being averaged away. Perspectives have a `perspective_type` ("analytical", "narrative", etc.), an optional list of `frame_ids` they operate over, and a `confidence_calibration` factor in `[0, 1]`.
+
+```json
+// mcp__epigraph__list_perspectives  →
+[
+  {
+    "perspective_id": "c5d7...",
+    "name": "biophysics-skeptic",
+    "owner_agent_id": "8f1d...",
+    "perspective_type": "analytical",
+    "confidence_calibration": 0.6
+  },
+  {
+    "perspective_id": "9a02...",
+    "name": "ndi-house-view",
+    "owner_agent_id": "2b46...",
+    "perspective_type": "narrative",
+    "confidence_calibration": 0.8
+  }
+]
+```
+
+A **theme** is a topical cluster derived from semantic clustering
+over claim embeddings. Themes are stored as rows in `claim_themes`
+(`label`, `description`, `centroid` vector, `claim_count`), and
+each clustered claim points to one theme via `claims.theme_id` —
+theme membership is single-valued at the schema level. Themes are
+how you navigate the graph at coarser granularity than individual
+atoms; the `theme_cluster` MCP tool in
+[`crates/epigraph-mcp/src/tools/themes.rs`](../../crates/epigraph-mcp/src/tools/themes.rs)
+(re)builds them from the live corpus by running k-means over
+paragraph embeddings, with elbow-penalised search over
+`k_min..=k_max` when `k` is not pinned. The default `limit` is 500
+(VM OOMs at ~2000 embeddings, per `feedback_memory_limits.md`),
+and `wipe_first=true` is the safe default because `claim_themes`
+has no `UNIQUE(label)` constraint and additive runs silently
+duplicate `auto-00, auto-01, …` rows.
+
+Rule of thumb:
+
+- A **frame** is *what is being judged* — a fixed hypothesis space.
+- A **perspective** is *who is judging* — an agent's or group's lens.
+- A **theme** is *what topic* the claims are about — a cluster label.
+
+They are orthogonal. A single claim can sit in one frame, be
+evaluated under three perspectives, and belong to one theme all
+at the same time, and none of those facts contradict each other.
+
+**See also:** [`crates/epigraph-mcp/src/tools/perspectives.rs`](../../crates/epigraph-mcp/src/tools/perspectives.rs) for `create_perspective`, `list_perspectives`, and `get_perspective`; [`crates/epigraph-mcp/src/tools/themes.rs`](../../crates/epigraph-mcp/src/tools/themes.rs) for theme clustering; the DST tools in `ds.rs` for frame creation.
+
+---
+
+## 5 — Hierarchical extraction
+
+EpiGraph stores documents as a tree, not a flat bag of sentences. Each ingested source becomes a **paper** node; each paper has child **paragraph** nodes; each paragraph has child **atom** nodes. The level lives in `properties->>'level'`: papers are level 1, paragraphs are level 2, atoms are level 3. Edges link each level to its parent so the tree is graph-traversable in either direction, and each child carries its own embedding so searches at any granularity are possible — but only paragraph-level search is *canonical*.
+
+```text
+                paper (level 1)
+                  │
+        ┌─────────┼─────────┐
+   paragraph    paragraph    paragraph   (level 2)
+        │
+   ┌────┼────┐
+  atom atom atom                          (level 3)
+```
+
+**Paragraphs are the primary search target.** The `recall_with_context` MCP tool runs vector kNN over level-2 paragraphs first, then *batches in* the structural context for each hit: the paragraph's atoms (level 3), its sibling paragraphs in the same section (level 2), its corroborating edges, and its neighbor paragraphs. The level-2-only filter is explicit in the SQL (see `(properties->>'level')::int = 2` throughout [`crates/epigraph-mcp/src/tools/recall.rs`](../../crates/epigraph-mcp/src/tools/recall.rs)). Searching at atom level is too noisy — atoms strip away their surrounding context and the kNN catches spurious near-matches. Searching at paper level is too coarse — a 50-page document averages out into a single embedding that does not retrieve well. Paragraphs are the unit of meaning that recall is tuned for.
+
+This shape exists only because ingestion *creates* it that way. The
+single canonical ingest path is **Tier 1 hierarchical extraction**:
+the `extract-claims` LLM extractor consumes a paper, emits
+paragraph- and atom-level claims as a tree, and the
+`ingest_document` writer lands them with the parent edges already
+in place. There is no supported flat-extraction path. Two
+historical failure modes are worth knowing about:
+
+- **Jina embeddings in the primary column.** Earlier attempts at
+  populating the primary embedding column with Jina vectors broke
+  `recall_with_context` because the column held vectors from a
+  model the kNN index was not built against. Never put Jina
+  embeddings in the primary embedding column (user-memory
+  `feedback_tier1_ingestion_only.md`).
+- **Flat extraction without the level-2 paragraph layer.** Without
+  paragraphs, `recall_with_context` has nothing to search at the
+  right granularity — atom-level results lose context and
+  paper-level results lose precision. The tree must exist before
+  search works.
+
+The dimensionality choice is the only thing recall is willing to
+negotiate at query time: it auto-detects 1536 vs 3072 dimensions
+from how the paragraph rows are populated (see
+`paragraph_3072_population` and `detect_centroid_dim` in
+`recall.rs`), defaulting to 3072 when ≥50% of paragraphs carry the
+larger embedding.
+
+Every `recall_with_context` response also carries a `corpus_scope` summary — `claims_total`, `paragraph_total`, `paper_total`, `themes_total` — so callers can tell how big the corpus was at query time. That number changes as ingest runs, and the LLM consuming the result needs to know whether it just searched 200 paragraphs or 200,000 before deciding how much faith to place in "we found nothing relevant".
+
+A single recall hit, abbreviated, looks like this — note the structural batches around each paragraph:
+
+```json
+{
+  "paragraph_id": "8f1d...",
+  "paragraph_content": "DNA-origami actuators driven by ...",
+  "similarity": 0.83,
+  "truth_value": 0.71,
+  "paper": {"doi": "10.1038/s41586-024-...", "title": "..."},
+  "atoms":       [/* level-3 children */],
+  "siblings":    [/* level-2 siblings in same section */],
+  "corroborates":[/* CORROBORATES edges */],
+  "neighbor_paragraphs": [/* nearby level-2 paragraphs */]
+}
+```
+
+Each batched list also carries a `_total` and `_truncated` field (e.g., `atoms_total`, `atoms_truncated`) so the caller can tell when the structural fan-out was clipped. The `truth_value` field on `RecallHit` is a legacy scalar carried for back-compat; treat `pignistic_prob` from `get_belief` (§3) as the authoritative belief signal for ranking.
+
+**See also:** [`crates/epigraph-mcp/src/tools/recall.rs`](../../crates/epigraph-mcp/src/tools/recall.rs) for the paragraph-primary kNN logic and the full `RecallHit` shape; user-memory `feedback_tier1_ingestion_only.md` for the single-canonical-ingest-path rule; the `extract-claims` skill (`.claude/skills/extract-claims/`) for the hierarchical extraction protocol the LLM follows.
+
+---
+
+## 6 — Backlog discipline
+
+EpiGraph eats its own dog food: operational follow-ups are stored *as claims in the graph*, not in an external tracker. A backlog item is a claim filed with `labels=["backlog"]` via `submit_claim` (or `memorize`), with self-contained prose describing what needs to happen.
+
+The retirement rule is rigid and worth memorising — there is exactly one correct tool:
+
+```python
+mcp__epigraph__resolve_backlog_item(
+    original_id=<UUID of backlog claim>,
+    resolution_content="<what was done, why it closes the item>",
+)
+```
+
+`resolve_backlog_item` does two things in a single call: it creates a *resolution claim* labelled `["resolved"]` with content prefixed `"Resolves <id>: "`, and it patches the original backlog claim's labels with `add=["resolved"]`. Skipping either half leaves drift in the graph.
+
+Do **not**:
+
+- File a free-text "Resolves <UUID>" claim alone without patching the original's labels. The original keeps the `[backlog]` label and stays visible in every open-backlog query forever.
+- Use `supersedes` / `is_current` for status. Those are reserved for **epistemic** replacement (one claim refining another's factual content), not operational status.
+- Reach for raw `update_labels` to add `["resolved"]`. That bypasses the canonical resolution-claim trail and breaks downstream queries that join on the resolution prose.
+
+The canonical "query open backlog" snippet from `CLAUDE.md`:
+
+```python
+mcp__epigraph__query_claims_by_label(
+    labels=["backlog"],
+    exclude_labels=["resolved"],
+    current_only=True,
+)
+```
+
+`exclude_labels=["resolved"]` is the half that catches retired items; `current_only=True` drops anything that has been epistemically superseded.
+
+There is a daily safety net:
+[`scripts/reconcile_backlog_labels.py`](../../scripts/reconcile_backlog_labels.py)
+scans for free-text "Resolves <UUID>" claims filed without
+`resolve_backlog_item` and back-fills the missing label patch.
+Ambiguous matches go to
+`docs/superpowers/reports/reconciler-needs-review.log` for human
+triage — do not rely on the reconciler, fix the call site.
+
+Why this matters: open backlog is the *operational* memory of the
+system. If retired items linger as "open", every backlog review
+spends time re-evaluating already-done work, and the open-vs-done
+ratio stops being a usable signal. The `resolve_backlog_item` tool
+exists specifically so that "I closed this" and "the graph knows I
+closed this" are the same act, not two acts where the second one
+gets forgotten.
+
+Related but not the same:
+
+- **Cross-agent backlog retire** is not allowed via
+  `resolve_backlog_item` directly — it enforces owner-equality. The
+  workaround is a free-text "Resolves <UUID>:" prefix on the
+  resolution claim and letting the daily reconciler patch the
+  label (user-memory `feedback_cross_agent_backlog_retire.md`).
+- **EpiClaw dedup-first rule** — EpiClaw's `CLAUDE.md` requires a
+  `recall()` and a restatement test *before* `submit_claim` or
+  `memorize`, including before filing a backlog item. This stops
+  the backlog from accumulating near-duplicates that defeat the
+  open-backlog query.
+
+**See also:** [`docs/conventions/backlog-retirement.md`](../conventions/backlog-retirement.md) for the canonical convention; `CLAUDE.md` for the rule of thumb every session loads; the design spec at `docs/superpowers/specs/2026-05-16-backlog-retirement-design.md` for the full rationale.

--- a/docs/intro/02-concepts.md
+++ b/docs/intro/02-concepts.md
@@ -111,10 +111,9 @@ everywhere. Three seed strategies are in use today:
   The same string always produces the same agent across processes,
   so the get-or-create lookup is idempotent. Container restart, fresh
   deploy, parallel host — all the same agent UUID.
-- **LLM-driven agents (planned)** — the seed is a hash of
-  `(model identifier, system prompt)` so the same model+prompt pair
-  resolves to the same agent identity across sessions
-  (see user-memory `project_epigraph_agent_identity.md`).
+- **LLM-driven agents (planned, tracked in [issue #166](https://github.com/epigraph-io/epigraph/issues/166))** —
+  the seed is a hash of `(model identifier, system prompt)` so the same
+  model+prompt pair resolves to the same agent identity across sessions.
   User OAuth passthrough sits next on that roadmap, so writes
   attributed to "Claude with prompt X acting for Jeremy" can be
   distinguished from "Claude with prompt X acting for Carrie".

--- a/docs/intro/04-glossary.md
+++ b/docs/intro/04-glossary.md
@@ -1,0 +1,113 @@
+# Glossary
+
+Concise definitions for the vocabulary used throughout EpiGraph. Terms are listed alphabetically; each entry links to the file where the concept is treated in depth.
+
+---
+
+## agent
+
+A signing identity that authors claims and edges. Every claim is keyed by `(content_hash, agent_id)` — the agent is half of the canonical identity of every assertion in the graph. Agents are durable: human contributors, ingest scripts, MCP-driven LLMs, and host processes all submit work under stable agent IDs so authorship survives across sessions. [see 02-concepts.md §3 (Agents and authorship)](02-concepts.md)
+
+## atom
+
+The finest-grained extracted unit produced by hierarchical extraction — a single self-contained assertion lifted out of a paragraph. Atoms are the children of paragraphs in the paper → paragraph → atom hierarchy and are the unit at which Dempster-Shafer belief is tracked. [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+
+## backlog
+
+A label applied via `submit_claim` (or `memorize`) with `labels=["backlog"]` to file an issue or follow-up item as a claim. Open backlog is queried with `labels=["backlog"], exclude_labels=["resolved"]`; retirement always goes through `resolve_backlog_item`, which creates a `"Resolves <id>: "` resolution claim and patches the original's labels in one call. See [docs/conventions/backlog-retirement.md](../conventions/backlog-retirement.md) for the canonical convention.
+
+## BetP
+
+The pignistic probability: a scalar in `[0, 1]` derived from a Dempster-Shafer mass function by distributing the mass of each focal set uniformly over its singletons. BetP is the standard projection used to order claims by belief and is the primary belief signal EpiGraph exposes — Bayesian `truth_value` is deprecated. See the LANL Open World DST paper (LA-UR-25-23655) for the standard treatment. [see 02-concepts.md §6 (Belief and DST)](02-concepts.md)
+
+## challenge
+
+A first-class objection or counter-claim posted against an existing claim. Challenges are recorded through the MCP `challenges` tool and feed into the belief layer so that disagreement is visible rather than hidden inside prose. [see 02-concepts.md §7 (Challenges and disagreement)](02-concepts.md)
+
+## claim
+
+A row in the `claims` table representing an entity or assertion with stable identity, canonically keyed by `(content_hash, agent_id)`. In the noun/verb split, claims are the nouns — facts, entities, tasks, container existence — while timestamped occurrences are verb-edges. See [docs/architecture/noun-claims-and-verb-edges.md](../architecture/noun-claims-and-verb-edges.md) for the canonical pattern.
+
+## content_hash
+
+The deterministic hash of a claim's normalized content; together with `agent_id` it forms the canonical key for a noun-claim. POSTing a claim with `if_not_exists: true` and a matching `(content_hash, agent_id)` returns the existing row with `was_created: false` instead of inserting a duplicate. See [docs/architecture/noun-claims-and-verb-edges.md](../architecture/noun-claims-and-verb-edges.md) for the dedup semantics.
+
+## DST
+
+Dempster-Shafer Theory: the mass-function-based belief calculus EpiGraph uses for combining evidence under uncertainty. Each atom carries a mass function over a frame of discernment; evidence is combined via discounted Dempster combination, and BetP projects the result to a scalar for ranking. See the LANL Open World DST paper (LA-UR-25-23655) for the practitioner's treatment. [see 02-concepts.md §6 (Belief and DST)](02-concepts.md)
+
+## edge
+
+A row in the `edges` table representing a timestamped occurrence or relationship between two entities (claims, agents, or papers). Edges carry `relationship` (the verb), `created_at`, optional `valid_from` / `valid_to`, a `properties` JSONB blob, and optional `signature` / `signer_id`. See [docs/architecture/noun-claims-and-verb-edges.md](../architecture/noun-claims-and-verb-edges.md) for verb-edge semantics.
+
+## evidence
+
+A noun-claim attached to a submission that records the supporting material an agent cited for a claim — quoted text, links, observations. Evidence is linked to the target claim with a `HAS_TRACE` verb-edge so the provenance chain is graph-traversable. [see 02-concepts.md §5 (Evidence and trace)](02-concepts.md)
+
+## factor
+
+A node in the factor-graph representation of belief propagation: a local function that constrains the mass on one or more atoms. Factors are how DST combination is structured for incremental, message-passing updates rather than a single all-at-once combination. [see 02-concepts.md §6.3 (Factor graphs)](02-concepts.md)
+
+## frame
+
+The frame of discernment — the finite set of mutually-exclusive hypotheses over which a mass function is defined. For a binary claim the frame is `{true, false}`; for richer claims it can include disjoint alternatives plus the full set representing ignorance. [see 02-concepts.md §6.1 (Frames and mass functions)](02-concepts.md)
+
+## hierarchical extraction
+
+The canonical ingest pipeline that decomposes a source into paper → paragraph (level 2) → atom, with edges linking each level to its parent. Tier 1 hierarchical extraction (`extract-claims` → `ingest_document`) is the only supported ingest path; legacy flat extraction and Jina embeddings break primary-column search and are not used. [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+
+## MCP
+
+Model Context Protocol — the protocol Claude Code and other LLM clients use to call EpiGraph tools. EpiGraph exposes its MCP surface through the `epigraph-mcp-full` binary, whose tool set lives under `crates/epigraph-mcp/src/tools/` (claims, recall, ds, challenges, themes, workflows, and others). [see 02-concepts.md §2 (How clients talk to EpiGraph)](02-concepts.md)
+
+## methodology
+
+A named, structured procedure or playbook ingested into the graph as a hierarchical claim tree (root methodology claim → steps → sub-steps). Methodologies are the unit by which reusable processes — Renaissance Philanthropy playbooks, ingest protocols, governance routines — are represented and applied. [see 02-concepts.md §8 (Methodologies and workflows)](02-concepts.md)
+
+## noun-claim
+
+A `claims` row treated as an entity with stable identity: at most one row per `(content_hash, agent_id)`, keyed for idempotent re-creation. Lifecycle events and relationships about that entity are recorded as verb-edges, not as new claims. Canonical reference: [docs/architecture/noun-claims-and-verb-edges.md](../architecture/noun-claims-and-verb-edges.md).
+
+## paragraph
+
+A level-2 claim in the hierarchical extraction tree: a contiguous span of source text that sits between the paper and its atoms. Paragraphs are the primary target of semantic search (`recall_with_context` searches at level 2, then batches in atoms, siblings, corroborating edges, and neighbor paragraphs). [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+
+## perspective
+
+A named viewpoint — typically an agent's or a group's — under which belief and challenges can be projected separately. Perspectives let the graph carry disagreement explicitly: the same atom can have different BetP values from different perspectives without one overwriting the other. [see 02-concepts.md §7 (Challenges and disagreement)](02-concepts.md)
+
+## pignistic probability
+
+Synonym for BetP: the scalar probability obtained by distributing each focal set's mass uniformly over its singleton elements of the frame. It is the standard decision-theoretic projection from a DST mass function and replaces the deprecated `truth_value` for all belief ordering. See the LANL Open World DST paper (LA-UR-25-23655) for derivation. [see 02-concepts.md §6 (Belief and DST)](02-concepts.md)
+
+## provenance
+
+The cryptographically-audited trail of every write: each create or patch lands a row in `provenance_log` regardless of whether the write produced a new claim or matched an existing one. Provenance is preserved across the noun/verb split — re-ingest produces new edges and new provenance rows, never a duplicate fact-claim. [see 02-concepts.md §5 (Evidence and trace)](02-concepts.md)
+
+## recall
+
+The graph's semantic-search entry point, exposed via the `recall_with_context` MCP tool. It performs paragraph-primary vector search at level 2, batches in structural context (atoms, sibling paragraphs, `CORROBORATES` edges, neighbor paragraphs), and always returns a `corpus_scope` summary so callers can tell how big the searched corpus was. [see 02-concepts.md §2 (How clients talk to EpiGraph)](02-concepts.md)
+
+## signature
+
+An Ed25519 signature attached to a claim or edge by its signer agent, with `signer_id` identifying the key. Signatures give every assertion in the graph an audit guarantee independent of the database; edge signing is schema-supported (migration 073) and writer-realised per S3 plans. [see 02-concepts.md §3 (Agents and authorship)](02-concepts.md)
+
+## supports
+
+A verb-edge `relationship` value indicating that the source claim's content lends evidential weight to the target claim. `supports` is one of the core epistemic relations alongside `CORROBORATES`, `CHALLENGES`, and `DERIVED_FROM`; `supports` is overloaded historically (Episcience separates epistemic and dependency edges into different tables; EpiGraph conflates them via `supports`). [see 02-concepts.md §1 (Noun-claims vs verb-edges)](02-concepts.md)
+
+## synthesis
+
+A claim that integrates or summarises several upstream claims, typically produced by an LLM extraction step that consumes a paragraph and emits both atomic facts and a synthesised summary. Synthesis claims are linked to their inputs via `DERIVED_FROM` verb-edges so the upstream chain is recoverable. [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+
+## theme
+
+A cluster label that groups semantically-related claims into a named higher-level topic. Themes are stored in `claim_themes`, surfaced by the `themes` MCP tool, and used to navigate the graph at a coarser granularity than individual atoms. [see 02-concepts.md §9 (Themes and clusters)](02-concepts.md)
+
+## verb-edge
+
+An `edges` row treated as a timestamped occurrence or relationship between entities, with the `relationship` field carrying the verb and `properties` carrying event metadata. Re-occurrence of the same event creates a new verb-edge, not a duplicated noun-claim. Canonical reference: [docs/architecture/noun-claims-and-verb-edges.md](../architecture/noun-claims-and-verb-edges.md).
+
+## workflow
+
+A stored, re-runnable procedure represented in the graph as a hierarchical claim tree (`store_workflow` / `improve_workflow` MCP tools). Workflows differ from methodologies in operational stance: methodologies are normative playbooks, workflows are executable sequences an agent can step through. [see 02-concepts.md §8 (Methodologies and workflows)](02-concepts.md)

--- a/docs/intro/04-glossary.md
+++ b/docs/intro/04-glossary.md
@@ -6,11 +6,11 @@ Concise definitions for the vocabulary used throughout EpiGraph. Terms are liste
 
 ## agent
 
-A signing identity that authors claims and edges. Every claim is keyed by `(content_hash, agent_id)` — the agent is half of the canonical identity of every assertion in the graph. Agents are durable: human contributors, ingest scripts, MCP-driven LLMs, and host processes all submit work under stable agent IDs so authorship survives across sessions. [see 02-concepts.md §3 (Agents and authorship)](02-concepts.md)
+A signing identity that authors claims and edges. Every claim is keyed by `(content_hash, agent_id)` — the agent is half of the canonical identity of every assertion in the graph. Agents are durable: human contributors, ingest scripts, MCP-driven LLMs, and host processes all submit work under stable agent IDs so authorship survives across sessions. [see 02-concepts.md §2 (Agents and signing)](02-concepts.md#2--agents-and-signing)
 
 ## atom
 
-The finest-grained extracted unit produced by hierarchical extraction — a single self-contained assertion lifted out of a paragraph. Atoms are the children of paragraphs in the paper → paragraph → atom hierarchy and are the unit at which Dempster-Shafer belief is tracked. [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+The finest-grained extracted unit produced by hierarchical extraction — a single self-contained assertion lifted out of a paragraph. Atoms are the children of paragraphs in the paper → paragraph → atom hierarchy and are the unit at which Dempster-Shafer belief is tracked. [see 02-concepts.md §5 (Hierarchical extraction)](02-concepts.md#5--hierarchical-extraction)
 
 ## backlog
 
@@ -18,11 +18,11 @@ A label applied via `submit_claim` (or `memorize`) with `labels=["backlog"]` to 
 
 ## BetP
 
-The pignistic probability: a scalar in `[0, 1]` derived from a Dempster-Shafer mass function by distributing the mass of each focal set uniformly over its singletons. BetP is the standard projection used to order claims by belief and is the primary belief signal EpiGraph exposes — Bayesian `truth_value` is deprecated. See the LANL Open World DST paper (LA-UR-25-23655) for the standard treatment. [see 02-concepts.md §6 (Belief and DST)](02-concepts.md)
+The pignistic probability: a scalar in `[0, 1]` derived from a Dempster-Shafer mass function by distributing the mass of each focal set uniformly over its singletons. BetP is the standard projection used to order claims by belief and is the primary belief signal EpiGraph exposes — Bayesian `truth_value` is deprecated. See the LANL Open World DST paper (LA-UR-25-23655) for the standard treatment. [see 02-concepts.md §3 (Beliefs and DST)](02-concepts.md#3--beliefs-and-dst)
 
 ## challenge
 
-A first-class objection or counter-claim posted against an existing claim. Challenges are recorded through the MCP `challenges` tool and feed into the belief layer so that disagreement is visible rather than hidden inside prose. [see 02-concepts.md §7 (Challenges and disagreement)](02-concepts.md)
+A first-class objection or counter-claim posted against an existing claim. Challenges are recorded through the MCP `challenges` tool and feed into the belief layer so that disagreement is visible rather than hidden inside prose.
 
 ## claim
 
@@ -34,7 +34,7 @@ The deterministic hash of a claim's normalized content; together with `agent_id`
 
 ## DST
 
-Dempster-Shafer Theory: the mass-function-based belief calculus EpiGraph uses for combining evidence under uncertainty. Each atom carries a mass function over a frame of discernment; evidence is combined via discounted Dempster combination, and BetP projects the result to a scalar for ranking. See the LANL Open World DST paper (LA-UR-25-23655) for the practitioner's treatment. [see 02-concepts.md §6 (Belief and DST)](02-concepts.md)
+Dempster-Shafer Theory: the mass-function-based belief calculus EpiGraph uses for combining evidence under uncertainty. Each atom carries a mass function over a frame of discernment; evidence is combined via discounted Dempster combination, and BetP projects the result to a scalar for ranking. See the LANL Open World DST paper (LA-UR-25-23655) for the practitioner's treatment. [see 02-concepts.md §3 (Beliefs and DST)](02-concepts.md#3--beliefs-and-dst)
 
 ## edge
 
@@ -42,27 +42,27 @@ A row in the `edges` table representing a timestamped occurrence or relationship
 
 ## evidence
 
-A noun-claim attached to a submission that records the supporting material an agent cited for a claim — quoted text, links, observations. Evidence is linked to the target claim with a `HAS_TRACE` verb-edge so the provenance chain is graph-traversable. [see 02-concepts.md §5 (Evidence and trace)](02-concepts.md)
+A noun-claim attached to a submission that records the supporting material an agent cited for a claim — quoted text, links, observations. Evidence is linked to the target claim with a `HAS_TRACE` verb-edge so the provenance chain is graph-traversable. See [docs/architecture/noun-claims-and-verb-edges.md](../architecture/noun-claims-and-verb-edges.md) for the noun/verb split that governs evidence and trace.
 
 ## factor
 
-A node in the factor-graph representation of belief propagation: a local function that constrains the mass on one or more atoms. Factors are how DST combination is structured for incremental, message-passing updates rather than a single all-at-once combination. [see 02-concepts.md §6.3 (Factor graphs)](02-concepts.md)
+A node in the factor-graph representation of belief propagation: a local function that constrains the mass on one or more atoms. Factors are how DST combination is structured for incremental, message-passing updates rather than a single all-at-once combination.
 
 ## frame
 
-The frame of discernment — the finite set of mutually-exclusive hypotheses over which a mass function is defined. For a binary claim the frame is `{true, false}`; for richer claims it can include disjoint alternatives plus the full set representing ignorance. [see 02-concepts.md §6.1 (Frames and mass functions)](02-concepts.md)
+The frame of discernment — the finite set of mutually-exclusive hypotheses over which a mass function is defined. For a binary claim the frame is `{true, false}`; for richer claims it can include disjoint alternatives plus the full set representing ignorance. [see 02-concepts.md §4 (Perspectives, frames, themes)](02-concepts.md#4--perspectives-frames-themes)
 
 ## hierarchical extraction
 
-The canonical ingest pipeline that decomposes a source into paper → paragraph (level 2) → atom, with edges linking each level to its parent. Tier 1 hierarchical extraction (`extract-claims` → `ingest_document`) is the only supported ingest path; legacy flat extraction and Jina embeddings break primary-column search and are not used. [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+The canonical ingest pipeline that decomposes a source into paper → paragraph (level 2) → atom, with edges linking each level to its parent. Tier 1 hierarchical extraction (`extract-claims` → `ingest_document`) is the only supported ingest path; legacy flat extraction and Jina embeddings break primary-column search and are not used. [see 02-concepts.md §5 (Hierarchical extraction)](02-concepts.md#5--hierarchical-extraction)
 
 ## MCP
 
-Model Context Protocol — the protocol Claude Code and other LLM clients use to call EpiGraph tools. EpiGraph exposes its MCP surface through the `epigraph-mcp-full` binary, whose tool set lives under `crates/epigraph-mcp/src/tools/` (claims, recall, ds, challenges, themes, workflows, and others). [see 02-concepts.md §2 (How clients talk to EpiGraph)](02-concepts.md)
+Model Context Protocol — the protocol Claude Code and other LLM clients use to call EpiGraph tools. EpiGraph exposes its MCP surface through the `epigraph-mcp-full` binary, whose tool set lives under `crates/epigraph-mcp/src/tools/` (claims, recall, ds, challenges, themes, workflows, and others).
 
 ## methodology
 
-A named, structured procedure or playbook ingested into the graph as a hierarchical claim tree (root methodology claim → steps → sub-steps). Methodologies are the unit by which reusable processes — Renaissance Philanthropy playbooks, ingest protocols, governance routines — are represented and applied. [see 02-concepts.md §8 (Methodologies and workflows)](02-concepts.md)
+A named, structured procedure or playbook ingested into the graph as a hierarchical claim tree (root methodology claim → steps → sub-steps). Methodologies are the unit by which reusable processes — Renaissance Philanthropy playbooks, ingest protocols, governance routines — are represented and applied.
 
 ## noun-claim
 
@@ -70,39 +70,39 @@ A `claims` row treated as an entity with stable identity: at most one row per `(
 
 ## paragraph
 
-A level-2 claim in the hierarchical extraction tree: a contiguous span of source text that sits between the paper and its atoms. Paragraphs are the primary target of semantic search (`recall_with_context` searches at level 2, then batches in atoms, siblings, corroborating edges, and neighbor paragraphs). [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+A level-2 claim in the hierarchical extraction tree: a contiguous span of source text that sits between the paper and its atoms. Paragraphs are the primary target of semantic search (`recall_with_context` searches at level 2, then batches in atoms, siblings, corroborating edges, and neighbor paragraphs). [see 02-concepts.md §5 (Hierarchical extraction)](02-concepts.md#5--hierarchical-extraction)
 
 ## perspective
 
-A named viewpoint — typically an agent's or a group's — under which belief and challenges can be projected separately. Perspectives let the graph carry disagreement explicitly: the same atom can have different BetP values from different perspectives without one overwriting the other. [see 02-concepts.md §7 (Challenges and disagreement)](02-concepts.md)
+A named viewpoint — typically an agent's or a group's — under which belief and challenges can be projected separately. Perspectives let the graph carry disagreement explicitly: the same atom can have different BetP values from different perspectives without one overwriting the other. [see 02-concepts.md §4 (Perspectives, frames, themes)](02-concepts.md#4--perspectives-frames-themes)
 
 ## pignistic probability
 
-Synonym for BetP: the scalar probability obtained by distributing each focal set's mass uniformly over its singleton elements of the frame. It is the standard decision-theoretic projection from a DST mass function and replaces the deprecated `truth_value` for all belief ordering. See the LANL Open World DST paper (LA-UR-25-23655) for derivation. [see 02-concepts.md §6 (Belief and DST)](02-concepts.md)
+Synonym for BetP: the scalar probability obtained by distributing each focal set's mass uniformly over its singleton elements of the frame. It is the standard decision-theoretic projection from a DST mass function and replaces the deprecated `truth_value` for all belief ordering. See the LANL Open World DST paper (LA-UR-25-23655) for derivation. [see 02-concepts.md §3 (Beliefs and DST)](02-concepts.md#3--beliefs-and-dst)
 
 ## provenance
 
-The cryptographically-audited trail of every write: each create or patch lands a row in `provenance_log` regardless of whether the write produced a new claim or matched an existing one. Provenance is preserved across the noun/verb split — re-ingest produces new edges and new provenance rows, never a duplicate fact-claim. [see 02-concepts.md §5 (Evidence and trace)](02-concepts.md)
+The cryptographically-audited trail of every write: each create or patch lands a row in `provenance_log` regardless of whether the write produced a new claim or matched an existing one. Provenance is preserved across the noun/verb split — re-ingest produces new edges and new provenance rows, never a duplicate fact-claim. See [docs/architecture/noun-claims-and-verb-edges.md](../architecture/noun-claims-and-verb-edges.md) for the unchanged-provenance rule.
 
 ## recall
 
-The graph's semantic-search entry point, exposed via the `recall_with_context` MCP tool. It performs paragraph-primary vector search at level 2, batches in structural context (atoms, sibling paragraphs, `CORROBORATES` edges, neighbor paragraphs), and always returns a `corpus_scope` summary so callers can tell how big the searched corpus was. [see 02-concepts.md §2 (How clients talk to EpiGraph)](02-concepts.md)
+The graph's semantic-search entry point, exposed via the `recall_with_context` MCP tool. It performs paragraph-primary vector search at level 2, batches in structural context (atoms, sibling paragraphs, `CORROBORATES` edges, neighbor paragraphs), and always returns a `corpus_scope` summary so callers can tell how big the searched corpus was. [see 02-concepts.md §5 (Hierarchical extraction)](02-concepts.md#5--hierarchical-extraction)
 
 ## signature
 
-An Ed25519 signature attached to a claim or edge by its signer agent, with `signer_id` identifying the key. Signatures give every assertion in the graph an audit guarantee independent of the database; edge signing is schema-supported (migration 073) and writer-realised per S3 plans. [see 02-concepts.md §3 (Agents and authorship)](02-concepts.md)
+An Ed25519 signature attached to a claim or edge by its signer agent, with `signer_id` identifying the key. Signatures give every assertion in the graph an audit guarantee independent of the database; edge signing is schema-supported (migration 073) and writer-realised per S3 plans. [see 02-concepts.md §2 (Agents and signing)](02-concepts.md#2--agents-and-signing)
 
 ## supports
 
-A verb-edge `relationship` value indicating that the source claim's content lends evidential weight to the target claim. `supports` is one of the core epistemic relations alongside `CORROBORATES`, `CHALLENGES`, and `DERIVED_FROM`; `supports` is overloaded historically (Episcience separates epistemic and dependency edges into different tables; EpiGraph conflates them via `supports`). [see 02-concepts.md §1 (Noun-claims vs verb-edges)](02-concepts.md)
+A verb-edge `relationship` value indicating that the source claim's content lends evidential weight to the target claim. `supports` is one of the core epistemic relations alongside `CORROBORATES`, `CHALLENGES`, and `DERIVED_FROM`; `supports` is overloaded historically (Episcience separates epistemic and dependency edges into different tables; EpiGraph conflates them via `supports`). [see 02-concepts.md §1 (Noun-claims vs verb-edges)](02-concepts.md#1--noun-claims-vs-verb-edges)
 
 ## synthesis
 
-A claim that integrates or summarises several upstream claims, typically produced by an LLM extraction step that consumes a paragraph and emits both atomic facts and a synthesised summary. Synthesis claims are linked to their inputs via `DERIVED_FROM` verb-edges so the upstream chain is recoverable. [see 02-concepts.md §4 (Hierarchical extraction)](02-concepts.md)
+A claim that integrates or summarises several upstream claims, typically produced by an LLM extraction step that consumes a paragraph and emits both atomic facts and a synthesised summary. Synthesis claims are linked to their inputs via `DERIVED_FROM` verb-edges so the upstream chain is recoverable. [see 02-concepts.md §5 (Hierarchical extraction)](02-concepts.md#5--hierarchical-extraction)
 
 ## theme
 
-A cluster label that groups semantically-related claims into a named higher-level topic. Themes are stored in `claim_themes`, surfaced by the `themes` MCP tool, and used to navigate the graph at a coarser granularity than individual atoms. [see 02-concepts.md §9 (Themes and clusters)](02-concepts.md)
+A cluster label that groups semantically-related claims into a named higher-level topic. Themes are stored in `claim_themes`, surfaced by the `themes` MCP tool, and used to navigate the graph at a coarser granularity than individual atoms. [see 02-concepts.md §4 (Perspectives, frames, themes)](02-concepts.md#4--perspectives-frames-themes)
 
 ## verb-edge
 
@@ -110,4 +110,4 @@ An `edges` row treated as a timestamped occurrence or relationship between entit
 
 ## workflow
 
-A stored, re-runnable procedure represented in the graph as a hierarchical claim tree (`store_workflow` / `improve_workflow` MCP tools). Workflows differ from methodologies in operational stance: methodologies are normative playbooks, workflows are executable sequences an agent can step through. [see 02-concepts.md §8 (Methodologies and workflows)](02-concepts.md)
+A stored, re-runnable procedure represented in the graph as a hierarchical claim tree (`store_workflow` / `improve_workflow` MCP tools). Workflows differ from methodologies in operational stance: methodologies are normative playbooks, workflows are executable sequences an agent can step through.

--- a/docs/intro/05-next-steps.md
+++ b/docs/intro/05-next-steps.md
@@ -1,0 +1,21 @@
+# Next steps
+
+You've completed the EpiGraph onboarding. Where to from here depends on what you want to do.
+
+## Extending the kernel
+
+If you want to add features to EpiGraph itself, start with [`CLAUDE.md`](../../CLAUDE.md) — it documents the agent conventions (backlog retirement, schema/migrations, claim mechanics, the test database recipe, the `cargo sqlx prepare` workflow). The architecture pattern that governs how new writers should behave is [`docs/architecture/noun-claims-and-verb-edges.md`](../architecture/noun-claims-and-verb-edges.md).
+
+## Adding science-specific tooling
+
+If your use case involves experiments, protocols, samples, blobs, countersignatures, or synthesis claims, you want the **episcience** layer on top of the kernel. See https://github.com/epigraph-io/episcience.
+
+## Deploying in production
+
+See [`docs/deploy.md`](../deploy.md) for the deploy runbook including the 2026-05-05 sqlx-migrations reconcile procedure.
+
+## Building a downstream application
+
+The reference pattern for depending on EpiGraph from another Rust project is the [episcience `Cargo.toml`](https://github.com/epigraph-io/episcience/blob/main/Cargo.toml) — it pins specific epigraph crates to a known-good git rev and documents how to swap in local paths for development via `~/.cargo/config.toml` (not the committed `Cargo.toml`).
+
+If you'll run multiple concurrent Claude Code sessions against the same repo, set up git worktrees per the pattern described in the user-level "use git worktrees" memory note — sessions sharing a single working tree collide on branch state.

--- a/docs/superpowers/plans/2026-05-19-onboarding-docs.md
+++ b/docs/superpowers/plans/2026-05-19-onboarding-docs.md
@@ -1,0 +1,1344 @@
+# Onboarding Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a top-level `README.md` and a `docs/intro/` tree in both `epigraph` and `episcience` so new collaborators can go from `git clone` to a successful MCP `recall_with_context` call in ~10 minutes, and complete the full onboarding (concepts + walkthroughs) in ~1-2 hours.
+
+**Architecture:** Each repo gets a short README landing page (pitch + 5-min quickstart + TOC) plus a numbered `docs/intro/{01-quickstart,02-concepts,03-walkthroughs,04-glossary,05-next-steps}.md` tree. Episcience's tree assumes EpiGraph familiarity and links back to it rather than restating kernel material.
+
+**Tech Stack:** Markdown, the EpiGraph kernel + MCP server, the Episcience extension + MCP server, the `sqlx-cli` for episcience migrations, Claude Code as the MCP client.
+
+**Source spec:** `docs/superpowers/specs/2026-05-19-onboarding-docs-design.md` — every content requirement traces back to that doc; consult it for the full §6 file outlines.
+
+---
+
+## File Structure
+
+### Phase A — EpiGraph (`/home/jeremy/epigraph/`)
+- **Create:** `README.md` — ~150 lines, landing page, written last (after intro tree is real)
+- **Create:** `docs/intro/04-glossary.md` — ~100 lines, written first so other files can link to entries
+- **Create:** `docs/intro/02-concepts.md` — ~400 lines, six sub-sections
+- **Create:** `docs/intro/01-quickstart.md` — ~200 lines, written after concepts so it can link to definitions
+- **Create:** `docs/intro/03-walkthroughs.md` — ~500 lines, populated from captured live MCP transcripts
+- **Create:** `docs/intro/05-next-steps.md` — ~80 lines
+
+### Phase B — Episcience (`/home/jeremy/episcience/`)
+- **Create:** `README.md` — ~80 lines
+- **Create:** `docs/intro/04-glossary.md` — ~60 lines, science-specific terms only
+- **Create:** `docs/intro/02-concepts-science.md` — ~300 lines, six sub-sections
+- **Create:** `docs/intro/01-quickstart-extension.md` — ~150 lines, assumes Phase A complete
+- **Create:** `docs/intro/03-walkthroughs.md` — ~300 lines, three captured transcripts
+- *(No `05-next-steps.md` in episcience — keep it minimal; episcience README links back to EpiGraph's next-steps)*
+
+### Phase C — Cross-cutting
+- Link check both trees
+- Open PRs (one per repo)
+
+---
+
+## Working assumptions
+
+1. The implementer has a working Postgres 16+ with pgvector available locally, and the EpiGraph + Episcience repos cloned at `/home/jeremy/epigraph/` and `/home/jeremy/episcience/`.
+2. The implementer has Claude Code installed and authenticated, with `OPENAI_API_KEY` set in their environment for embedding calls during walkthroughs.
+3. Both repos already have a non-main feature branch checked out (e.g. `spec/cross-source-anchor` carrying the spec commit on EpiGraph). Create a new branch off the current branch for the implementation work — see Task A0 / B0.
+4. If at any point a walkthrough fails because the live system behaves differently from the spec's expected output, **stop and document the discrepancy as a backlog item via `resolve_backlog_item`-friendly free text** ("backlog: docs walkthrough N expected X, got Y") — do not silently massage the docs to match broken behavior. The whole point of writing live transcripts is to catch drift between docs and reality.
+
+---
+
+## Phase A — EpiGraph
+
+### Task A0: Branch and verify build
+
+**Files:**
+- None (environment-only)
+
+- [ ] **Step 1: Create a feature branch**
+
+```bash
+cd /home/jeremy/epigraph
+git checkout -b docs/onboarding-tree
+```
+
+- [ ] **Step 2: Verify the build commands the spec's quickstart will recommend**
+
+```bash
+cargo build --release -p epigraph-api -p epigraph-mcp -p epigraph-cli
+```
+
+Expected: success. If it fails, fix the build before writing docs that tell new users to run this exact command.
+
+- [ ] **Step 3: Verify the binary names**
+
+```bash
+ls target/release/ | grep -E "epigraph-(api|mcp|migrate|server)"
+```
+
+Expected: at minimum `epigraph-mcp-full`, `server`, `epigraph-migrate` appear. Confirms the spec's §6.2 Step 5 corrections are accurate. If any expected binary is missing or renamed, update the spec FIRST, then come back to this plan.
+
+- [ ] **Step 4: Verify the health endpoint**
+
+Start the API:
+```bash
+DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph cargo run --release -p epigraph-api --bin server
+```
+
+In another shell:
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8080/health
+```
+
+Expected: `200`. If non-200 or wrong path, update the spec, then update Task A4 below.
+
+- [ ] **Step 5: Stop the server (Ctrl-C in the first shell)**
+
+No commit yet — this task only validates the environment.
+
+---
+
+### Task A1: Glossary (`docs/intro/04-glossary.md`)
+
+**Files:**
+- Create: `/home/jeremy/epigraph/docs/intro/04-glossary.md`
+
+- [ ] **Step 1: Create the directory and seed the file**
+
+```bash
+mkdir -p /home/jeremy/epigraph/docs/intro
+```
+
+Write the glossary file with alphabetical entries for the following terms (each 2-4 sentences, ending with a cross-reference link to the file where the concept is explained in depth — when those files don't exist yet, leave the link as `[see 02-concepts.md §X.Y](02-concepts.md)` and refine after concepts is written):
+
+```
+agent, atom, BetP, challenge, claim, content_hash, DST, edge, evidence,
+factor, frame, hierarchical extraction, MCP, methodology, noun-claim,
+paragraph, perspective, pignistic probability, provenance, recall,
+signature, supports, synthesis, theme, verb-edge, workflow
+```
+
+For terms that are defined in canonical existing docs, paraphrase the canonical definition and link to it. Specifically:
+- **noun-claim, verb-edge** → link to `docs/architecture/noun-claims-and-verb-edges.md`
+- **backlog (under "label")** → link to `docs/conventions/backlog-retirement.md`
+- **BetP, pignistic probability** → reference the LANL Open World DST paper (see user memory `reference_lanl_open_world_dst.md`)
+
+Use this header at the top:
+
+```markdown
+# Glossary
+
+Concise definitions for the vocabulary used throughout EpiGraph. Terms are listed alphabetically; each entry links to the file where the concept is treated in depth.
+
+---
+```
+
+- [ ] **Step 2: Verify the file renders**
+
+Open the file and confirm each entry is 2-4 sentences and each entry has a working internal link or "(defined in this file)" if standalone.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/intro/04-glossary.md
+git commit -m "docs(intro): glossary of core EpiGraph terms"
+```
+
+---
+
+### Task A2: Concepts (`docs/intro/02-concepts.md`)
+
+**Files:**
+- Create: `/home/jeremy/epigraph/docs/intro/02-concepts.md`
+- Reference (read, do not modify): `/home/jeremy/epigraph/docs/architecture/noun-claims-and-verb-edges.md`, `/home/jeremy/epigraph/docs/conventions/backlog-retirement.md`
+
+- [ ] **Step 1: Outline the six sub-sections**
+
+The file has six numbered sub-sections per spec §6.3, each 50-80 lines:
+
+1. Noun-claims vs verb-edges
+2. Agents and signing
+3. Beliefs and DST
+4. Perspectives, frames, themes
+5. Hierarchical extraction
+6. Backlog discipline
+
+Each sub-section ends with a "See also" line pointing to the canonical deeper doc (architecture, conventions, or a memory reference).
+
+- [ ] **Step 2: Write sub-section 1 (Noun-claims vs verb-edges)**
+
+Source material: `docs/architecture/noun-claims-and-verb-edges.md` (read the full file). For the intro version: state the rule (a `claims` row = noun, an `edges` row = verb event), give the textbook-ingest worked example abbreviated to ~15 lines, list the three rules that fall out of the pattern, and link to the full architecture doc for the migration history. Do NOT include schema details.
+
+- [ ] **Step 3: Write sub-section 2 (Agents and signing)**
+
+Cover: every claim is signed with Ed25519 by an agent; agent identity is deterministic (DID from model+prompt hash — see user memory `project_epigraph_agent_identity.md` for the architectural decision); claim and edge signatures use the same audit guarantee. Show an example agent_id format. Mention that the OAuth mint flow (separate from agent identity) lives at `scripts/mint_epigraph_token.py` — link, do not duplicate.
+
+- [ ] **Step 4: Write sub-section 3 (Beliefs and DST)**
+
+Cover: BetP (pignistic probability) is the canonical belief score; scalar BP is deprecated (multiplicative collapse — see user memory `project_bp_cdst_primary.md` and `feedback_pignistic_not_bayesian.md`); show what a `get_belief` JSON response looks like with BetP and discounting. Reference the LANL Open World DST paper for the formal foundation (LA-UR-25-23655 per user memory). Keep math at the level of "BetP is a single number in [0,1] derived from a mass function" — full DST goes in deeper docs.
+
+- [ ] **Step 5: Write sub-section 4 (Perspectives, frames, themes)**
+
+Cover: a frame is a discernment scope, a perspective is a viewpoint that filters or weights claims, a theme is a topical grouping derived from clustering. Show how an MCP call like `mcp__epigraph__list_perspectives` returns viewpoints, and how a claim can be member of multiple themes via `claim_themes`. Keep it conceptual; reserve API details for walkthroughs.
+
+- [ ] **Step 6: Write sub-section 5 (Hierarchical extraction)**
+
+Cover: documents are extracted as a tree (paper → paragraphs → atoms); paragraphs (`(properties->>'level')::int = 2`) are the primary search target (recall_with_context uses paragraph-primary semantic search per `crates/epigraph-mcp/src/tools/recall.rs`); Tier 1 hierarchical extraction is the only canonical ingest path (user memory `feedback_tier1_ingestion_only.md`); Jina embeddings in the primary column break search and must be avoided.
+
+- [ ] **Step 7: Write sub-section 6 (Backlog discipline)**
+
+Cover: backlog items are claims with `labels=["backlog"]`; resolve via `resolve_backlog_item(original_id, resolution_content)` which creates a resolution claim AND patches the original's labels in one call; do NOT use `supersedes` (reserved for epistemic claim replacement) or raw `update_labels` (bypasses the resolution trail). Show the canonical "query open backlog" snippet from `CLAUDE.md`. Link to `docs/conventions/backlog-retirement.md` for the full spec.
+
+- [ ] **Step 8: Add a top-of-file table-of-contents**
+
+After the title and one-paragraph intro, add an anchored TOC linking to each of the six sub-sections. Use slug-style anchors matching the sub-section headings.
+
+- [ ] **Step 9: Update glossary back-references**
+
+Open `docs/intro/04-glossary.md` and replace any placeholder `[see 02-concepts.md §X.Y]` links with the actual anchors created in Step 8.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add docs/intro/02-concepts.md docs/intro/04-glossary.md
+git commit -m "docs(intro): concepts file covering noun-claims, DST, perspectives, hierarchy, backlog"
+```
+
+---
+
+### Task A3: Quickstart (`docs/intro/01-quickstart.md`)
+
+**Files:**
+- Create: `/home/jeremy/epigraph/docs/intro/01-quickstart.md`
+
+- [ ] **Step 1: Write the prereqs section**
+
+Title the file `# Quickstart` and start with a prereqs list:
+
+```markdown
+## Prerequisites
+
+- **Rust** ≥ 1.75 (`rustup show` to check)
+- **PostgreSQL** 16+ with the `pgvector` extension installed and available (`SELECT extname FROM pg_extension;` should be runnable as a superuser)
+- **Claude Code** installed and authenticated (the MCP client we'll use to drive EpiGraph)
+- **OpenAI API key** — exported as `OPENAI_API_KEY`. **Mandatory** for the walkthroughs: `recall_with_context` embeds the query string on every call (see `crates/epigraph-mcp/src/tools/recall.rs`) and fails without a configured embedding provider, even against an empty corpus.
+- **~$5 of OpenAI credit** for the embedding calls in the walkthroughs
+
+Time budget: ~10 minutes to first MCP call if your prereqs are in place; ~30 minutes including a fresh Postgres/pgvector install.
+```
+
+- [ ] **Step 2: Write Step 1 (Postgres)**
+
+```markdown
+## Step 1 — PostgreSQL
+
+```bash
+# As a Postgres superuser:
+createuser epigraph -P  # set password to 'epigraph' (or any password you wire into DATABASE_URL)
+createdb -O epigraph epigraph
+psql -d epigraph -c "CREATE EXTENSION IF NOT EXISTS vector;"
+```
+
+The runtime role does NOT need `SUPERUSER`. If you also intend to run the test suite (`sqlx::test`), grant `SUPERUSER` temporarily or use a separate test-only role — `sqlx::test` `LOCK`s `pg_namespace` and requires it (see `feedback_sqlx_test_uses_superuser` memory note).
+
+Set the connection string:
+
+```bash
+export DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph
+```
+```
+
+- [ ] **Step 3: Write Step 2 (Clone and build)**
+
+```markdown
+## Step 2 — Clone and build
+
+```bash
+git clone https://github.com/epigraph-io/epigraph.git
+cd epigraph
+cargo build --release -p epigraph-api -p epigraph-mcp -p epigraph-cli
+```
+
+Note: the `epigraph-mcp` package produces a binary named `epigraph-mcp-full` (see `crates/epigraph-mcp/Cargo.toml`'s `[[bin]]` entry). That's the binary you'll register with Claude Code in Step 5.
+```
+
+- [ ] **Step 4: Write Step 3 (Migrations)**
+
+```markdown
+## Step 3 — Migrations
+
+```bash
+cargo run --release --bin epigraph-migrate
+```
+
+This runs all 32 kernel migrations from `migrations/` (currently `001_initial_schema.sql` through `032_claim_themes_properties.sql`). For a fresh database this should complete in under a minute. If you're applying migrations to a pre-existing production database that was previously tracked under the internal-repo numbering, see the one-shot reconcile procedure in `docs/deploy.md` before running this step.
+```
+
+- [ ] **Step 5: Write Step 4 (Start the API)**
+
+```markdown
+## Step 4 — Start the API server
+
+```bash
+cargo run --release -p epigraph-api --bin server
+```
+
+In another shell, verify:
+
+```bash
+curl http://127.0.0.1:8080/health
+```
+
+Expected: `OK` (HTTP 200). The server logs its bound address; default is `127.0.0.1:8080`.
+```
+
+- [ ] **Step 6: Write Step 5 (Install MCP server)**
+
+```markdown
+## Step 5 — Install the MCP server and register it with Claude Code
+
+Option A: copy the built binary to a path on your `$PATH` (matching the `~/.mcp.json` pattern used in this repo's deployment):
+
+```bash
+sudo cp target/release/epigraph-mcp-full /usr/local/bin/epigraph-mcp
+```
+
+Option B: `cargo install` it (installed binary is named `epigraph-mcp-full`):
+
+```bash
+cargo install --path crates/epigraph-mcp
+```
+
+Register the server in `~/.mcp.json` (creating the file if it doesn't exist). Use the exact path you installed to:
+
+```json
+{
+  "mcpServers": {
+    "epigraph": {
+      "command": "/usr/local/bin/epigraph-mcp",
+      "args": [
+        "--database-url", "postgres://epigraph:epigraph@localhost:5432/epigraph"
+      ],
+      "env": {
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "EPIGRAPH_API_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}
+```
+
+If you used Option B and didn't rename the binary, change `"command"` to `"/home/youruser/.cargo/bin/epigraph-mcp-full"`.
+```
+
+- [ ] **Step 7: Write Step 6 (First MCP call)**
+
+```markdown
+## Step 6 — Your first MCP call
+
+Open Claude Code (in any working directory). Tell it:
+
+> Use the `recall_with_context` MCP tool to search for "test".
+
+Claude should call `mcp__epigraph__recall_with_context({"query": "test"})` and you should see a JSON response with a `corpus_scope` object showing zero claims, paragraphs, papers, and themes (assuming a fresh database).
+
+Next, ask:
+
+> Use `submit_claim` to add this claim: "EpiGraph is installed correctly."
+
+Claude calls `mcp__epigraph__submit_claim(...)` and returns the created claim's UUID. Call `recall_with_context "installed"` again — you should now see the freshly submitted claim in the results.
+
+If you see the claim, your install is working end-to-end.
+```
+
+- [ ] **Step 8: Write the Common Errors section**
+
+```markdown
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| `sqlx checksum mismatch` at startup | See the reconcile procedure in `docs/deploy.md`; this only happens against a pre-existing internal-numbered DB. |
+| `Connection refused (os error 111)` on port 5432 | Postgres isn't running. `pg_isready` to check; start it (`brew services start postgresql@16`, `sudo systemctl start postgresql`, etc.). |
+| `extension "vector" is not available` | Install pgvector — see https://github.com/pgvector/pgvector#installation for OS-specific instructions. |
+| `OPENAI_API_KEY not set` from MCP server | Export the env var in the shell that launches Claude Code, or hardcode the value in `~/.mcp.json` (less secure). |
+| Claude Code can't find the MCP tool | `~/.mcp.json` path wrong, or you renamed the binary inconsistently between the file and `cp`. Recheck the exact `"command"` value. |
+
+## Tear-down
+
+```bash
+dropdb epigraph
+```
+
+Then drop the role with `dropuser epigraph` if reinstalling.
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/intro/01-quickstart.md
+git commit -m "docs(intro): six-step quickstart from clone to first MCP call"
+```
+
+---
+
+### Task A4: Run Walkthrough 1 (Ingest a PDF) and capture transcript
+
+**Files:**
+- Create: `/tmp/walkthrough-1-transcript.md` (scratch, not committed)
+- Modify (later in Task A8): `/home/jeremy/epigraph/docs/intro/03-walkthroughs.md`
+
+- [ ] **Step 1: Acquire a small public-domain PDF**
+
+Use a short paper. Suggestion: a 2-page arXiv preprint or a public-domain physics note. Save to `/tmp/walkthrough-1-paper.pdf`.
+
+- [ ] **Step 2: Open Claude Code with the EpiGraph MCP server registered**
+
+Confirm the MCP tools are available:
+
+```
+Ask Claude: "List the EpiGraph MCP tools you have available."
+```
+
+Expected: Claude reports tools including `recall_with_context`, `submit_claim`, `ingest_document`, `query_paper`, `system_stats`.
+
+- [ ] **Step 3: Run the ingest**
+
+```
+Ask Claude: "Call mcp__epigraph__ingest_document with path '/tmp/walkthrough-1-paper.pdf'."
+```
+
+Capture the response: a job ID and a "queued" status.
+
+- [ ] **Step 4: Poll for completion**
+
+```
+Ask Claude: "Call mcp__epigraph__system_stats every 30 seconds until the document is fully ingested."
+```
+
+Capture the progression of stats: claim count goes from N to N+M as paragraphs and atoms are added.
+
+- [ ] **Step 5: Query the resulting claims**
+
+```
+Ask Claude: "Call mcp__epigraph__query_paper with the document path or DOI."
+```
+
+Capture the returned tree of paragraph + atom claims.
+
+- [ ] **Step 6: Save the transcript to `/tmp/walkthrough-1-transcript.md`**
+
+Copy the exact Claude Code session — the prompts, the tool calls, the JSON responses (truncated to ~10 lines per response with a `…` marker if longer). Add a one-paragraph "what just happened" closing that ties back to concepts §5 (hierarchical extraction).
+
+- [ ] **Step 7: Verify the transcript is reproducible**
+
+Re-read it. Could a new user paste each prompt into Claude Code and get something morally equivalent? If not, edit the transcript prompts to be more deterministic (specify exact tool names rather than relying on Claude to guess).
+
+No commit yet — Task A8 commits the combined walkthroughs file.
+
+---
+
+### Task A5: Run Walkthrough 2 (Query and expand) and capture transcript
+
+**Files:**
+- Create: `/tmp/walkthrough-2-transcript.md`
+
+- [ ] **Step 1: Pick a topic from Walkthrough 1's paper**
+
+Choose a substantive phrase from the paper (e.g. "boundary condition", "neutron diffusion", whatever the paper is actually about).
+
+- [ ] **Step 2: Run recall_with_context**
+
+```
+Ask Claude: "Call mcp__epigraph__recall_with_context with query '<your phrase>'."
+```
+
+Capture the response.
+
+- [ ] **Step 3: Pick the top hit and expand its neighborhood**
+
+```
+Ask Claude: "Call mcp__epigraph__get_neighborhood on claim <id of top hit>."
+```
+
+Capture the response showing connected claims, edges, and (if present) the paragraph parent and atom siblings.
+
+- [ ] **Step 4: Traverse two hops out**
+
+```
+Ask Claude: "Call mcp__epigraph__traverse from claim <id> with max_depth 2."
+```
+
+Capture the traversal result.
+
+- [ ] **Step 5: Save the transcript to `/tmp/walkthrough-2-transcript.md`**
+
+Same format as Walkthrough 1; closing paragraph ties back to concepts §4 (perspectives/frames/themes).
+
+---
+
+### Task A6: Run Walkthrough 3 (Challenge a claim) and capture transcript
+
+**Files:**
+- Create: `/tmp/walkthrough-3-transcript.md`
+
+- [ ] **Step 1: Pick a claim from Walkthrough 1**
+
+Any non-trivial claim is fine.
+
+- [ ] **Step 2: Challenge it**
+
+```
+Ask Claude: "Call mcp__epigraph__challenge_claim on claim <id> with reason 'Counter-evidence: <plausible alternative interpretation>'."
+```
+
+Capture the response: a challenge record with its own ID and status.
+
+- [ ] **Step 3: List challenges to confirm**
+
+```
+Ask Claude: "Call mcp__epigraph__list_challenges to see all open challenges."
+```
+
+Capture the list including the just-filed challenge.
+
+- [ ] **Step 4: Verify the original claim despite the challenge**
+
+```
+Ask Claude: "Call mcp__epigraph__verify_claim on claim <id> with verification 'Holds: <reason>'."
+```
+
+Capture the verification record.
+
+- [ ] **Step 5: Save the transcript to `/tmp/walkthrough-3-transcript.md`**
+
+Closing paragraph ties to concepts §3 (DST belief updates under challenge/verification).
+
+---
+
+### Task A7: Run Walkthrough 4 (Backlog roundtrip) and capture transcript
+
+**Files:**
+- Create: `/tmp/walkthrough-4-transcript.md`
+
+- [ ] **Step 1: File a backlog item**
+
+```
+Ask Claude: "Call mcp__epigraph__submit_claim with content 'backlog: example task for the docs walkthrough' and labels ['backlog']."
+```
+
+Capture the created claim's ID — call it `<orig>`.
+
+- [ ] **Step 2: Query open backlog**
+
+```
+Ask Claude: "Call mcp__epigraph__query_claims_by_label with labels ['backlog'], exclude_labels ['resolved'], current_only true."
+```
+
+Capture the response; confirm `<orig>` appears in the list.
+
+- [ ] **Step 3: Resolve it**
+
+```
+Ask Claude: "Call mcp__epigraph__resolve_backlog_item with original_id '<orig>' and resolution_content 'Done as part of the docs intro walkthrough.'"
+```
+
+Capture the response (a new resolution claim, AND the original's labels now include `["resolved"]`).
+
+- [ ] **Step 4: Re-query open backlog**
+
+```
+Ask Claude: "Call mcp__epigraph__query_claims_by_label with labels ['backlog'], exclude_labels ['resolved'], current_only true."
+```
+
+Confirm `<orig>` no longer appears.
+
+- [ ] **Step 5: Save the transcript to `/tmp/walkthrough-4-transcript.md`**
+
+Closing paragraph ties to concepts §6 (backlog discipline) and links to `docs/conventions/backlog-retirement.md`.
+
+---
+
+### Task A8: Assemble walkthroughs file (`docs/intro/03-walkthroughs.md`)
+
+**Files:**
+- Create: `/home/jeremy/epigraph/docs/intro/03-walkthroughs.md`
+- Read: the four `/tmp/walkthrough-N-transcript.md` files from Tasks A4-A7
+
+- [ ] **Step 1: Write the file header and TOC**
+
+```markdown
+# Walkthroughs
+
+Four end-to-end Claude Code sessions showing the EpiGraph MCP tools in action against a freshly initialized database. Each walkthrough is a verbatim transcript — prompts, tool calls, and responses — so you can paste each step into your own Claude Code session and see the same shape of response.
+
+## Table of contents
+
+1. [Ingest a PDF](#walkthrough-1--ingest-a-pdf)
+2. [Query and expand](#walkthrough-2--query-and-expand)
+3. [Challenge a claim](#walkthrough-3--challenge-a-claim)
+4. [Backlog roundtrip](#walkthrough-4--backlog-roundtrip)
+
+Each walkthrough ends with a short "what just happened" paragraph linking back to the relevant section in [02-concepts.md](02-concepts.md).
+
+---
+```
+
+- [ ] **Step 2: Paste in Walkthrough 1**
+
+Take `/tmp/walkthrough-1-transcript.md` and paste under a `## Walkthrough 1 — Ingest a PDF` heading. Format prompts as block quotes and JSON responses as fenced code blocks.
+
+- [ ] **Step 3: Paste in Walkthrough 2**
+
+Same format, under `## Walkthrough 2 — Query and expand`.
+
+- [ ] **Step 4: Paste in Walkthrough 3**
+
+Under `## Walkthrough 3 — Challenge a claim`.
+
+- [ ] **Step 5: Paste in Walkthrough 4**
+
+Under `## Walkthrough 4 — Backlog roundtrip`.
+
+- [ ] **Step 6: Verify the file is under ~600 lines and all links work**
+
+```bash
+wc -l /home/jeremy/epigraph/docs/intro/03-walkthroughs.md
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/intro/03-walkthroughs.md
+git commit -m "docs(intro): four end-to-end walkthroughs captured live"
+```
+
+---
+
+### Task A9: Next-steps (`docs/intro/05-next-steps.md`)
+
+**Files:**
+- Create: `/home/jeremy/epigraph/docs/intro/05-next-steps.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# Next steps
+
+You've completed the EpiGraph onboarding. Where to from here depends on what you want to do.
+
+## Extending the kernel
+
+If you want to add features to EpiGraph itself, start with [`CLAUDE.md`](../../CLAUDE.md) — it documents the agent conventions (backlog retirement, schema/migrations, claim mechanics, the test database recipe, the `cargo sqlx prepare` workflow). The architecture pattern that governs how new writers should behave is [`docs/architecture/noun-claims-and-verb-edges.md`](../architecture/noun-claims-and-verb-edges.md).
+
+## Adding science-specific tooling
+
+If your use case involves experiments, protocols, samples, blobs, countersignatures, or synthesis claims, you want the **episcience** layer on top of the kernel. See https://github.com/epigraph-io/episcience.
+
+## Deploying in production
+
+See [`docs/deploy.md`](../deploy.md) for the deploy runbook including the 2026-05-05 sqlx-migrations reconcile procedure.
+
+## Building a downstream application
+
+The reference pattern for depending on EpiGraph from another Rust project is the [episcience `Cargo.toml`](https://github.com/epigraph-io/episcience/blob/main/Cargo.toml) — it pins specific epigraph crates to a known-good git rev and documents how to swap in local paths for development via `~/.cargo/config.toml` (not the committed `Cargo.toml`).
+
+If you'll run multiple concurrent Claude Code sessions against the same repo, set up git worktrees per the pattern described in the user-level "use git worktrees" memory note — sessions sharing a single working tree collide on branch state.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/intro/05-next-steps.md
+git commit -m "docs(intro): next-steps with contributor, deploy, and downstream pointers"
+```
+
+---
+
+### Task A10: README (`README.md`)
+
+**Files:**
+- Create: `/home/jeremy/epigraph/README.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# EpiGraph
+
+An epistemic kernel: claims (nouns), edges (verbs), agents that cryptographically sign their assertions, and beliefs propagated via Dempster-Shafer evidence combination. EpiGraph replaces the static-paper model of knowledge with a live loop — hypothesis → experiment → data → analysis → belief update — that downstream applications can interrogate, challenge, and extend.
+
+Where most knowledge bases store *what is currently believed*, EpiGraph stores *what each agent has asserted, with what evidence, signed under what identity, and how those assertions combine into a defensible belief*. It is the substrate the rest of the epigraph-io stack builds on.
+
+## Who is this for?
+
+- **Developers** integrating EpiGraph into an application (build with the Rust crates, talk via the HTTP API, drive via the MCP server)
+- **Researchers and analysts** querying the graph via Claude Code (the MCP tools cover recall, neighborhood traversal, challenge/verify, backlog management)
+- **Contributors** extending the kernel itself (see [`CLAUDE.md`](CLAUDE.md))
+
+## Status
+
+- Version: 0.3.0
+- License: Apache-2.0
+- Maturity: alpha — kernel schema and core primitives are stable; layers built on top (workflows, hierarchical extraction, perspectives) iterate
+
+## 5-minute quickstart
+
+```bash
+# 1. PostgreSQL with pgvector
+createuser epigraph -P && createdb -O epigraph epigraph
+psql -d epigraph -c "CREATE EXTENSION vector;"
+export DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph
+
+# 2. Build
+git clone https://github.com/epigraph-io/epigraph.git && cd epigraph
+cargo build --release -p epigraph-api -p epigraph-mcp
+
+# 3. Migrate + start API
+cargo run --release --bin epigraph-migrate
+cargo run --release -p epigraph-api --bin server &
+
+# 4. Install MCP server
+sudo cp target/release/epigraph-mcp-full /usr/local/bin/epigraph-mcp
+
+# 5. Add this to ~/.mcp.json
+# {
+#   "mcpServers": {
+#     "epigraph": {
+#       "command": "/usr/local/bin/epigraph-mcp",
+#       "args": ["--database-url", "postgres://epigraph:epigraph@localhost:5432/epigraph"],
+#       "env": { "OPENAI_API_KEY": "${OPENAI_API_KEY}", "EPIGRAPH_API_URL": "http://127.0.0.1:8080" }
+#     }
+#   }
+# }
+
+# 6. Open Claude Code and ask it to call mcp__epigraph__recall_with_context with query "test".
+```
+
+If that works, head to the [full quickstart](docs/intro/01-quickstart.md) for explanations and common-error coverage.
+
+## Onboarding tree
+
+- [`docs/intro/01-quickstart.md`](docs/intro/01-quickstart.md) — six-step setup, prereqs, troubleshooting
+- [`docs/intro/02-concepts.md`](docs/intro/02-concepts.md) — noun-claims/verb-edges, agents and signing, DST beliefs, perspectives, hierarchical extraction, backlog discipline
+- [`docs/intro/03-walkthroughs.md`](docs/intro/03-walkthroughs.md) — four end-to-end Claude Code transcripts
+- [`docs/intro/04-glossary.md`](docs/intro/04-glossary.md) — vocabulary
+- [`docs/intro/05-next-steps.md`](docs/intro/05-next-steps.md) — contributor, deploy, and downstream pointers
+
+## Deeper material
+
+- [`docs/architecture/noun-claims-and-verb-edges.md`](docs/architecture/noun-claims-and-verb-edges.md) — the canonical pattern for what gets stored as a claim vs an edge
+- [`docs/conventions/backlog-retirement.md`](docs/conventions/backlog-retirement.md) — how operational backlog items are resolved
+- [`docs/deploy.md`](docs/deploy.md) — production deploy runbook
+- [`CLAUDE.md`](CLAUDE.md) — agent-session conventions (backlog, schema, tests, workflow)
+- [`scripts/README.md`](scripts/README.md) — operational maintenance scripts
+```
+
+- [ ] **Step 2: Verify the 5-minute quickstart block matches what you actually ran in Task A0**
+
+If anything in the build/run sequence has changed since Task A0 (binary names, ports, env vars), update the README before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: top-level README with pitch, 5-minute quickstart, and intro tree TOC"
+```
+
+---
+
+### Task A11: Link check Phase A
+
+**Files:**
+- None modified unless broken links found
+
+- [ ] **Step 1: Install a markdown link checker if not already present**
+
+```bash
+cargo install mlc  # markdown-link-check, written in Rust
+# OR: npm install -g markdown-link-check
+```
+
+- [ ] **Step 2: Run on every file in the EpiGraph intro tree and README**
+
+```bash
+cd /home/jeremy/epigraph
+mlc README.md docs/intro/*.md
+```
+
+- [ ] **Step 3: Fix any broken links**
+
+For each reported broken link, either correct the path or remove the link. Commit fixes as `docs: fix broken links found in Phase A link check`.
+
+- [ ] **Step 4: Commit if fixes were made**
+
+If no fixes were needed, skip the commit and proceed to Phase B.
+
+---
+
+## Phase B — Episcience
+
+### Task B0: Branch and verify build
+
+**Files:**
+- None (environment-only)
+
+- [ ] **Step 1: Create a feature branch on episcience**
+
+```bash
+cd /home/jeremy/episcience
+git checkout -b docs/onboarding-tree
+```
+
+- [ ] **Step 2: Verify the build**
+
+```bash
+cargo build --release -p episcience-api
+```
+
+Expected: success. The episcience workspace pins specific epigraph crates by git rev in `Cargo.toml` — if the build fails because the pin is incompatible with the kernel migrations you applied in Task A3, update the pin first (or apply the local `[patch]` override via `~/.cargo/config.toml`).
+
+- [ ] **Step 3: Verify the binaries**
+
+```bash
+ls target/release/ | grep -E "episcience-(server|mcp-server)"
+```
+
+Expected: both binaries present. If a binary name differs, update the spec and this plan before proceeding.
+
+- [ ] **Step 4: Verify sqlx-cli is installed**
+
+```bash
+sqlx --version
+```
+
+If not installed: `cargo install sqlx-cli --no-default-features --features postgres,native-tls`.
+
+- [ ] **Step 5: Apply episcience migrations against the kernel DB from Phase A**
+
+```bash
+cd /home/jeremy/episcience
+sqlx migrate run --source migrations/ --database-url postgres://epigraph:epigraph@localhost/epigraph
+```
+
+Expected: success. If a migration fails with "function does not exist" or "relation does not exist", the kernel migrations weren't applied first — go back to Task A3.
+
+- [ ] **Step 6: Start episcience-server on a separate port**
+
+```bash
+EPISCIENCE_PORT=8090 DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph \
+  cargo run --release -p episcience-api --bin episcience-server
+```
+
+Verify: `curl http://127.0.0.1:8090/health` returns 200.
+
+- [ ] **Step 7: Stop the server**
+
+No commit yet.
+
+---
+
+### Task B1: Glossary (`docs/intro/04-glossary.md`)
+
+**Files:**
+- Create: `/home/jeremy/episcience/docs/intro/04-glossary.md`
+
+- [ ] **Step 1: Create the directory and write the glossary**
+
+```bash
+mkdir -p /home/jeremy/episcience/docs/intro
+```
+
+Write the file with entries for: `blob, countersignature, experiment, experiment-result, PROV-O, protocol, sample, synthesis claim`. Each entry 2-4 sentences. End each entry with a link back to either `02-concepts-science.md` or to the EpiGraph glossary for kernel terms.
+
+Header:
+
+```markdown
+# Glossary (science-specific)
+
+Vocabulary for episcience's experimental loop layer. For kernel terms (claim, edge, agent, BetP, etc.) see the [EpiGraph glossary](https://github.com/epigraph-io/epigraph/blob/main/docs/intro/04-glossary.md).
+
+---
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/intro/04-glossary.md
+git commit -m "docs(intro): science-specific glossary"
+```
+
+---
+
+### Task B2: Concepts (`docs/intro/02-concepts-science.md`)
+
+**Files:**
+- Create: `/home/jeremy/episcience/docs/intro/02-concepts-science.md`
+- Read (do not modify): `/home/jeremy/episcience/migrations/*.sql` — the science layer tables and constraints
+
+- [ ] **Step 1: Outline the six sub-sections per spec §6.9**
+
+1. Experiments and experiment-results
+2. Samples
+3. Protocols
+4. Blobs
+5. Countersignatures
+6. Synthesis claims and PROV-O edges
+
+Each sub-section 40-60 lines. Opens with "This builds on the kernel concept of <noun-claim/edge/etc.> — see the [EpiGraph concepts](https://github.com/epigraph-io/epigraph/blob/main/docs/intro/02-concepts.md) for the kernel pattern."
+
+- [ ] **Step 2: Write sub-section 1 (Experiments and experiment-results)**
+
+Caveat: there's no `experiments` route or table in the current episcience surface (verified in spec review). Cover this honestly: describe the conceptual model (an experiment is a run-time instantiation of a protocol against a sample; an experiment-result is the observed outcome captured as a claim) and note that the current API surfaces this via synthesis claims that reference protocol and sample IDs — a future `experiments` endpoint is planned but not present today.
+
+- [ ] **Step 3: Write sub-section 2 (Samples)**
+
+Cover: a sample is a physical or digital artifact referenced by claims; samples can have parent relationships (one sample derived from another) but parent restriction enforced by migration `5009_samples_parent_restrict.sql` prevents circular lineage. Show a `POST /samples` request shape (read it from `crates/episcience-api/src/routes/samples.rs`).
+
+- [ ] **Step 4: Write sub-section 3 (Protocols)**
+
+Cover: protocols are versioned procedures; `5008_protocol_version_unique.sql` enforces `(name, version)` uniqueness. Show a `POST /protocols` request shape.
+
+- [ ] **Step 5: Write sub-section 4 (Blobs)**
+
+Cover: binary attachments to claims; content type and size are tracked; the `5005_create_blobs.sql` migration defines the schema. Show what's referenced and how (claims reference blob IDs).
+
+- [ ] **Step 6: Write sub-section 5 (Countersignatures)**
+
+Cover: multi-party signing chains via `5010_countersign_chain.sql`. A countersignature is a second (or third, etc.) agent's signature on a claim already signed by another agent. Useful for peer-review style attestation. Show the chain structure.
+
+- [ ] **Step 7: Write sub-section 6 (Synthesis claims and PROV-O edges)**
+
+Cover: a synthesis claim is a higher-level claim derived from one or more lower-level claims via PROV-O `wasDerivedFrom` relationships. Episcience separates 5 epistemic edge types from 4 PROV-O dependency edges in a separate table (user memory `reference_episcience_edge_separation.md`) — explain why this separation matters: epistemic edges describe what supports/refutes/etc.; PROV-O edges describe what derived/was-influenced-by/etc. The two semantics shouldn't be conflated.
+
+- [ ] **Step 8: Add TOC at top, link from glossary entries**
+
+Same pattern as Task A2 Steps 8-9.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/intro/02-concepts-science.md docs/intro/04-glossary.md
+git commit -m "docs(intro): science-layer concepts covering samples, protocols, blobs, countersign, synthesis, PROV-O"
+```
+
+---
+
+### Task B3: Quickstart-extension (`docs/intro/01-quickstart-extension.md`)
+
+**Files:**
+- Create: `/home/jeremy/episcience/docs/intro/01-quickstart-extension.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# Quickstart — episcience extension
+
+This guide assumes you've completed the [EpiGraph quickstart](https://github.com/epigraph-io/epigraph/blob/main/docs/intro/01-quickstart.md) and have a running kernel on `postgres://epigraph:epigraph@localhost/epigraph` with the API listening on `127.0.0.1:8080`.
+
+Time budget: ~5 minutes if the kernel is already running.
+
+## Prerequisites
+
+- A completed EpiGraph quickstart (kernel migrations applied, API server running)
+- The [sqlx CLI](https://github.com/launchbadge/sqlx/tree/main/sqlx-cli) installed: `cargo install sqlx-cli --no-default-features --features postgres,native-tls`
+
+## Step 1 — Clone episcience
+
+```bash
+git clone https://github.com/epigraph-io/episcience.git
+cd episcience
+```
+
+The workspace pins specific epigraph crates by git rev in `Cargo.toml`. If you're hacking on the kernel locally too, override the pin in `~/.cargo/config.toml` (NOT in the committed `Cargo.toml`):
+
+```toml
+[patch."https://github.com/epigraph-io/epigraph"]
+epigraph-core   = { path = "/home/youruser/epigraph/crates/epigraph-core" }
+epigraph-crypto = { path = "/home/youruser/epigraph/crates/epigraph-crypto" }
+epigraph-db     = { path = "/home/youruser/epigraph/crates/epigraph-db" }
+epigraph-engine = { path = "/home/youruser/epigraph/crates/epigraph-engine" }
+epigraph-cli    = { path = "/home/youruser/epigraph/crates/epigraph-cli" }
+epigraph-jobs   = { path = "/home/youruser/epigraph/crates/epigraph-jobs" }
+epigraph-events = { path = "/home/youruser/epigraph/crates/epigraph-events" }
+epigraph-embeddings = { path = "/home/youruser/epigraph/crates/epigraph-embeddings" }
+```
+
+## Step 2 — Apply episcience migrations
+
+```bash
+sqlx migrate run --source migrations/ --database-url postgres://epigraph:epigraph@localhost/epigraph
+```
+
+This applies migrations `001_initial_schema.sql` through `5010_countersign_chain.sql` (and any synthesis/* migrations) onto the existing kernel DB. Ordering matters: the episcience migrations depend on kernel functions like `cascade_delete_edges` and `validate_edge_reference`, which the EpiGraph quickstart's kernel migrations (specifically 024-025) already created.
+
+If you see a "function does not exist" or "relation does not exist" error, the kernel migrations weren't applied first — go back to the [EpiGraph Step 3](https://github.com/epigraph-io/epigraph/blob/main/docs/intro/01-quickstart.md#step-3--migrations).
+
+## Step 3 — Build
+
+```bash
+cargo build --release -p episcience-api
+```
+
+This produces two binaries: `episcience-server` (HTTP API) and `episcience-mcp-server` (MCP for Claude Code).
+
+## Step 4 — Start the API
+
+```bash
+EPISCIENCE_PORT=8090 DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph \
+  cargo run --release -p episcience-api --bin episcience-server
+```
+
+In another shell:
+
+```bash
+curl http://127.0.0.1:8090/health
+```
+
+Expected: 200 OK.
+
+## Step 5 — First synthesis claim
+
+Add the episcience MCP server to `~/.mcp.json` alongside the existing epigraph entry:
+
+```json
+{
+  "mcpServers": {
+    "epigraph": { /* existing */ },
+    "episcience": {
+      "command": "/home/youruser/episcience/target/release/episcience-mcp-server",
+      "env": {
+        "DATABASE_URL": "postgres://epigraph:epigraph@localhost:5432/epigraph",
+        "EPISCIENCE_API_URL": "http://127.0.0.1:8090"
+      }
+    }
+  }
+}
+```
+
+Open Claude Code and ask:
+
+> Use mcp__episcience__synthesize to create a synthesis claim with content "Verification that episcience is installed" and no source claims.
+
+You should see a created synthesis claim ID. Then:
+
+> Use mcp__episcience__recall_synthesis with query "verification".
+
+The synthesis claim should appear.
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| `function "cascade_delete_edges" does not exist` during migration | Kernel migrations not applied. Run EpiGraph Step 3 first. |
+| `Address already in use` on 8090 | Pick a different `EPISCIENCE_PORT`. |
+| MCP tool not found | Path in `~/.mcp.json` wrong, or Claude Code needs a restart to pick up the new server. |
+| sqlx version mismatch error | `sqlx-cli` and the workspace `sqlx` dependency drift; usually `cargo install sqlx-cli --version 0.7` resolves it (match the workspace `Cargo.toml`). |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/intro/01-quickstart-extension.md
+git commit -m "docs(intro): episcience extension quickstart assuming kernel installed"
+```
+
+---
+
+### Task B4: Run Walkthrough 1 (Stage and synthesize) and capture
+
+**Files:**
+- Create: `/tmp/epi-walkthrough-1-transcript.md`
+
+- [ ] **Step 1: Open Claude Code with both MCP servers registered**
+
+Confirm `mcp__episcience__*` tools are available.
+
+- [ ] **Step 2: Create a sample**
+
+```
+Ask Claude: "Make a POST to http://127.0.0.1:8090/samples with body {\"name\": \"docs-walkthrough-sample\", \"description\": \"Synthetic sample for documentation walkthrough\"}."
+```
+
+Capture the response with the new sample ID.
+
+- [ ] **Step 3: Create a protocol**
+
+```
+Ask Claude: "Make a POST to http://127.0.0.1:8090/protocols with body {\"name\": \"docs-walkthrough-protocol\", \"version\": \"1.0.0\", \"description\": \"Read this paragraph and pretend you ran the protocol\"}."
+```
+
+Capture the response.
+
+- [ ] **Step 4: Synthesize with sample and protocol references**
+
+```
+Ask Claude: "Call mcp__episcience__synthesize with content 'Sample <sample-id> processed via protocol <protocol-id> yielded result Y' and source_claim_ids [<sample-id>, <protocol-id>]."
+```
+
+Capture the resulting synthesis claim.
+
+- [ ] **Step 5: Verify the kernel side**
+
+```
+Ask Claude: "Call mcp__epigraph__get_claim on <synthesis-claim-id> and report the entity_type and connected edges."
+```
+
+Confirm the synthesis claim is visible as a kernel noun-claim with the synthesis entity type and PROV-O edges back to the sample and protocol claims.
+
+- [ ] **Step 6: Save to `/tmp/epi-walkthrough-1-transcript.md`**
+
+---
+
+### Task B5: Run Walkthrough 2 (Countersign) and capture
+
+**Files:**
+- Create: `/tmp/epi-walkthrough-2-transcript.md`
+
+- [ ] **Step 1: Countersign Walkthrough 1's synthesis claim**
+
+```
+Ask Claude: "Make a POST to http://127.0.0.1:8090/countersign with body {\"claim_id\": \"<synthesis-claim-id>\", \"agent_id\": \"<a-different-agent-id>\", \"signature\": \"<a valid signature>\"}."
+```
+
+If the second agent identity isn't already provisioned, document the agent-creation step too (consult `episcience-api/src/routes/countersign.rs` for required fields).
+
+Capture the response including the chain position.
+
+- [ ] **Step 2: Verify the chain**
+
+Read back the synthesis claim's countersignatures. First check `crates/episcience-api/src/routes/countersign.rs` to find the exact GET path (likely `GET /countersign/<claim-id>` based on convention). If no GET route exists, query the DB directly:
+
+```bash
+psql -d epigraph -c "SELECT * FROM countersignatures WHERE claim_id = '<synthesis-claim-id>' ORDER BY chain_position;"
+```
+
+Capture either the API response or the SQL result for the transcript.
+
+- [ ] **Step 3: Save to `/tmp/epi-walkthrough-2-transcript.md`**
+
+---
+
+### Task B6: Run Walkthrough 3 (Multi-source synthesis) and capture
+
+**Files:**
+- Create: `/tmp/epi-walkthrough-3-transcript.md`
+
+- [ ] **Step 1: Create three independent samples**
+
+Three POST /samples calls. Capture the three IDs.
+
+- [ ] **Step 2: Synthesize each as a leaf**
+
+Three `mcp__episcience__synthesize` calls, each referencing one sample. Capture the three synthesis claim IDs.
+
+- [ ] **Step 3: Higher-level synthesis from all three**
+
+One `mcp__episcience__synthesize` call referencing all three leaf synthesis claims as `source_claim_ids`. Capture.
+
+- [ ] **Step 4: Observe in the kernel**
+
+```
+Ask Claude: "Call mcp__epigraph__recall_with_context for the higher-level synthesis's content, then mcp__epigraph__get_neighborhood on it to see the PROV-O edges back to the three leaves."
+```
+
+Capture.
+
+- [ ] **Step 5: Also call mcp__episcience__recall_synthesis and mcp__episcience__get_synthesis on the higher-level claim**
+
+Capture how the episcience-side surface presents the same data.
+
+- [ ] **Step 6: Save to `/tmp/epi-walkthrough-3-transcript.md`**
+
+---
+
+### Task B7: Assemble walkthroughs file (`docs/intro/03-walkthroughs.md`)
+
+**Files:**
+- Create: `/home/jeremy/episcience/docs/intro/03-walkthroughs.md`
+
+- [ ] **Step 1: Write header and TOC**
+
+```markdown
+# Walkthroughs
+
+Three Claude Code sessions exercising episcience's exposed surface — samples, protocols, synthesis, and countersignatures. Each walkthrough assumes you've completed the [extension quickstart](01-quickstart-extension.md).
+
+## Table of contents
+
+1. [Stage and synthesize](#walkthrough-1--stage-and-synthesize)
+2. [Countersign](#walkthrough-2--countersign)
+3. [Multi-source synthesis](#walkthrough-3--multi-source-synthesis)
+
+---
+```
+
+- [ ] **Step 2: Paste in the three transcripts**
+
+Under `## Walkthrough 1 — Stage and synthesize`, `## Walkthrough 2 — Countersign`, `## Walkthrough 3 — Multi-source synthesis`. Each ends with a closing paragraph linking back to the relevant section in [`02-concepts-science.md`](02-concepts-science.md).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/intro/03-walkthroughs.md
+git commit -m "docs(intro): three episcience walkthroughs captured live"
+```
+
+---
+
+### Task B8: README (`README.md`)
+
+**Files:**
+- Create: `/home/jeremy/episcience/README.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# episcience
+
+An Apache-2.0 layer over [EpiGraph](https://github.com/epigraph-io/epigraph) that adds the experimental loop: samples, protocols, blobs, countersignatures, and synthesis claims. Where EpiGraph models *what is believed*, episcience models *how beliefs were tested* — the scaffolding needed to do science (or any methodologically rigorous knowledge work) on top of the kernel.
+
+## Status
+
+- Version: 0.1.0
+- License: Apache-2.0
+- Maturity: alpha; the workspace pins specific epigraph crates by git rev in [`Cargo.toml`](Cargo.toml). The pin is currently kept on the head of `feat/phase0-integrated` (PR epigraph-io/epigraph#10); will re-pin to a merged sha once #10 lands.
+
+## Prerequisites
+
+A running EpiGraph kernel — same Postgres instance is fine. Start there: https://github.com/epigraph-io/epigraph#5-minute-quickstart.
+
+## 5-minute extension quickstart
+
+```bash
+# 1. Clone
+git clone https://github.com/epigraph-io/episcience.git && cd episcience
+
+# 2. Apply episcience migrations on the kernel DB
+sqlx migrate run --source migrations/ --database-url postgres://epigraph:epigraph@localhost/epigraph
+
+# 3. Build and start (port 8090 to avoid colliding with epigraph-api on 8080)
+cargo build --release -p episcience-api
+EPISCIENCE_PORT=8090 DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph \
+  cargo run --release -p episcience-api --bin episcience-server &
+
+# 4. Register the MCP server in ~/.mcp.json alongside the epigraph entry
+# (see docs/intro/01-quickstart-extension.md for the JSON block)
+
+# 5. In Claude Code, call mcp__episcience__synthesize and observe the new claim
+```
+
+## Onboarding tree
+
+- [`docs/intro/01-quickstart-extension.md`](docs/intro/01-quickstart-extension.md) — five-step setup assuming kernel installed
+- [`docs/intro/02-concepts-science.md`](docs/intro/02-concepts-science.md) — experiments, samples, protocols, blobs, countersigning, synthesis, PROV-O
+- [`docs/intro/03-walkthroughs.md`](docs/intro/03-walkthroughs.md) — three end-to-end transcripts
+- [`docs/intro/04-glossary.md`](docs/intro/04-glossary.md) — science-specific terms (kernel terms link to the EpiGraph glossary)
+
+## Why a separate repo?
+
+EpiGraph is the public-Apache-2.0 epistemic kernel that other applications (some open, some closed) can depend on. Science-specific scaffolding is its own bounded concern, and lives in its own repo so it can evolve at its own pace and so consumers who don't need the science layer aren't forced to take it.
+
+## Deeper EpiGraph material
+
+- [EpiGraph next-steps](https://github.com/epigraph-io/epigraph/blob/main/docs/intro/05-next-steps.md) — contributor, deploy, downstream pointers
+- [EpiGraph concepts](https://github.com/epigraph-io/epigraph/blob/main/docs/intro/02-concepts.md) — kernel mental model
+```
+
+- [ ] **Step 2: Verify the 5-minute block matches reality**
+
+Same check as Task A10 Step 2 but for episcience.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: episcience README with pitch, extension quickstart, and intro TOC"
+```
+
+---
+
+### Task B9: Link check Phase B
+
+**Files:**
+- None modified unless broken links found
+
+- [ ] **Step 1: Run mlc**
+
+```bash
+cd /home/jeremy/episcience
+mlc README.md docs/intro/*.md
+```
+
+- [ ] **Step 2: Fix broken links and commit**
+
+Same pattern as Task A11.
+
+---
+
+## Phase C — Cross-cutting
+
+### Task C1: Open PRs
+
+**Files:**
+- None
+
+- [ ] **Step 1: Push both branches**
+
+```bash
+cd /home/jeremy/epigraph && git push -u origin docs/onboarding-tree
+cd /home/jeremy/episcience && git push -u origin docs/onboarding-tree
+```
+
+- [ ] **Step 2: Open the EpiGraph PR**
+
+```bash
+cd /home/jeremy/epigraph
+gh pr create --title "docs: onboarding tree (README + docs/intro/)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds top-level `README.md` (pitch, status, 5-min quickstart, intro TOC, deeper-material pointers)
+- Adds `docs/intro/{01-quickstart,02-concepts,03-walkthroughs,04-glossary,05-next-steps}.md`
+- Spec: `docs/superpowers/specs/2026-05-19-onboarding-docs-design.md`
+- Plan: `docs/superpowers/plans/2026-05-19-onboarding-docs.md`
+
+## Test plan
+
+- [ ] All four walkthroughs in `03-walkthroughs.md` reproduce against a fresh kernel install
+- [ ] Every internal link resolves (mlc clean)
+- [ ] A reader new to EpiGraph can complete the quickstart in ≤15 minutes (test with a volunteer if possible)
+- [ ] No leftover transcript stubs (`<id>`, `…`, `TBD`)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Open the episcience PR**
+
+```bash
+cd /home/jeremy/episcience
+gh pr create --title "docs: onboarding tree (README + docs/intro/)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds top-level `README.md` (pitch, status, 5-min extension quickstart, intro TOC, links back to EpiGraph)
+- Adds `docs/intro/{01-quickstart-extension,02-concepts-science,03-walkthroughs,04-glossary}.md`
+- Cross-repo spec lives at: https://github.com/epigraph-io/epigraph/blob/main/docs/superpowers/specs/2026-05-19-onboarding-docs-design.md
+
+## Test plan
+
+- [ ] All three walkthroughs in `03-walkthroughs.md` reproduce against a fresh kernel + episcience install
+- [ ] Every internal link resolves (mlc clean)
+- [ ] A reader who has completed the EpiGraph quickstart can complete the episcience extension in ≤10 minutes
+- [ ] No leftover transcript stubs
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Report the PR URLs to the user**
+
+---
+
+## Notes
+
+- **Merge style:** per user feedback memory `feedback_merge_commit_not_squash.md`, default `gh pr merge --merge --delete-branch` (not `--squash`). Wait for explicit user approval before merging.
+- **Branch hygiene:** if the implementer is running Phase A in an isolated worktree (per user feedback `feedback_use_worktrees.md`), force absolute paths in every Bash block — subagents drift to the main repo otherwise (per user feedback `feedback_subagent_worktree_paths.md`).
+- **Drift:** if any walkthrough fails because the live system behaves differently from the spec's expected output, file a backlog item via `mcp__epigraph__submit_claim` with `labels=["backlog"]` and the discrepancy in the content; resolve it later with `mcp__epigraph__resolve_backlog_item`. Do not silently massage the docs to fit broken behavior.

--- a/docs/superpowers/specs/2026-05-19-onboarding-docs-design.md
+++ b/docs/superpowers/specs/2026-05-19-onboarding-docs-design.md
@@ -1,0 +1,195 @@
+# Onboarding documentation for EpiGraph and Episcience
+
+**Status:** Draft — awaiting user review
+**Owners:** Jeremy Barton
+**Repos affected:** `epigraph-io/epigraph`, `epigraph-io/episcience`
+**Date:** 2026-05-19
+
+---
+
+## 1. Problem
+
+EpiGraph and Episcience have no top-level READMEs and no entry-point documentation for new users. A fresh clone of either repo is opaque: a Rust workspace with 17 (epigraph) or 3 (episcience) crates, 34 (epigraph) or 11 (episcience) migrations, no instructions for getting from "I have the source" to "I successfully called my first MCP tool."
+
+New collaborators — including future contributors, downstream-app builders (WRHQ, Praxis, NDI tooling), and Astera-style residency reviewers — currently rely on synchronous onboarding from Jeremy. The cost grows with each new person and effectively caps how widely the system can be adopted.
+
+## 2. Goals
+
+1. A new person with basic Rust + Postgres familiarity can go from `git clone` to a successful MCP `recall_with_context` call in ~10 minutes by following written instructions only.
+2. After ~1-2 hours of reading the intro tree and running the walkthroughs, that person understands the mental model well enough to design their own claims, edges, and queries.
+3. Episcience layers cleanly on top: an EpiGraph-literate user can spin up episcience in ~5 additional minutes without re-reading kernel docs.
+4. Both READMEs serve as effective GitHub front-doors: a visitor to github.com/epigraph-io/{repo} gets a pitch, a quickstart, and a navigable TOC into deeper material.
+
+## 3. Non-goals
+
+- GUI tour (`epigraph-gui` is a separate concern; we will link to it from `05-next-steps.md` but not document it).
+- Harvester crate documentation (`epigraph-harvester` is excluded from the workspace and currently out of scope).
+- Production deployment runbook (already covered by `docs/deploy.md`; intro tree links to it).
+- OAuth mint flow for downstream services (already covered in user memory `reference_epigraph_oauth_mint.md`; out of scope for the intro tree).
+- Contributor's guide beyond a brief pointer (`CLAUDE.md` already serves agent contributors; the intro tree's `05-next-steps.md` will point human contributors to it).
+- Docker Compose orchestration. Neither repo ships a `docker-compose.yml` today; the quickstart uses hand-started Postgres and `cargo run`. Adding compose is a separate scope expansion if desired later.
+
+## 4. Audience
+
+Mixed, layered per the existing `docs/intro/` convention used by other epigraph-io projects:
+
+- **Technical readers** (Rust devs, agent integrators, contributors): follow the full quickstart, walkthroughs, and concept guide.
+- **Semi-technical readers** (researchers, PMs, founders evaluating the system): skim the README's pitch and concepts file; rely on a peer to run the quickstart, then drive MCP from Claude Code.
+
+The READMEs and `02-concepts.md` are written for both audiences. `01-quickstart.md` and `03-walkthroughs.md` assume a terminal-comfortable reader.
+
+## 5. Architecture
+
+### 5.1 File layout
+
+**`/home/jeremy/epigraph/`** — new files only:
+```
+README.md
+docs/intro/01-quickstart.md
+docs/intro/02-concepts.md
+docs/intro/03-walkthroughs.md
+docs/intro/04-glossary.md
+docs/intro/05-next-steps.md
+```
+
+**`/home/jeremy/episcience/`** — new files only:
+```
+README.md
+docs/intro/01-quickstart-extension.md
+docs/intro/02-concepts-science.md
+docs/intro/03-walkthroughs.md
+docs/intro/04-glossary.md
+```
+
+Existing files (`CLAUDE.md`, `docs/architecture/`, `docs/deploy.md`, `docs/conventions/`, `scripts/README.md`) are untouched. The new intro tree cross-links into them rather than duplicating their content.
+
+### 5.2 Why README + `docs/intro/`
+
+- The top-level `README.md` is what GitHub renders on the repo page. Visitors get a useful first impression: pitch, status, 5-minute quickstart, TOC.
+- The `docs/intro/` tree absorbs the depth (~1-2 hours of full onboarding material) without making the README a 2000-line wall.
+- Numbered filenames (`01-…`, `02-…`) give a stable suggested reading order while letting individual files be referenced independently.
+- The pattern mirrors existing structure in `docs/architecture/` and `docs/conventions/`, so contributors recognize where things live.
+
+### 5.3 Layering: episcience assumes EpiGraph
+
+Episcience's intro tree does not re-explain kernel concepts. `01-quickstart-extension.md` starts from "you have epigraph running"; `02-concepts-science.md` starts from "you understand claims, edges, agents, BetP." Where a science concept extends a kernel concept (e.g., synthesis claims extend noun-claims), episcience docs link back to the EpiGraph file rather than restate it.
+
+## 6. Content specs
+
+### 6.1 EpiGraph `README.md` (~150 lines)
+
+Sections in order:
+1. **What is EpiGraph?** Two paragraphs. EpiGraph is an epistemic kernel: claims (nouns), edges (verbs), agents that sign their assertions, beliefs propagated via Dempster-Shafer. It replaces static papers with a live experimental loop — hypothesis → experiment → data → analysis → belief update.
+2. **Who is this for?** Bulleted: devs building epistemic apps; researchers querying the graph via Claude Code; contributors extending the kernel.
+3. **Status & license.** Apache-2.0, version 0.3.0, "alpha — kernel stable, layers iterate."
+4. **5-minute quickstart** (inline, ~10 commands): clone, start Postgres (`postgres://epigraph:epigraph@localhost`), `cargo build --release -p epigraph-api -p epigraph-mcp`, `cargo run --bin epigraph-migrate`, start the API, register the MCP server in `~/.mcp.json` (show the exact config), open Claude Code, call `recall_with_context "test"`. End-state: a JSON response showing the empty corpus or hitting the user's first claim.
+5. **Where to next.** Linked TOC into `docs/intro/`, plus a "Deeper material" section pointing to `docs/architecture/noun-claims-and-verb-edges.md`, `docs/deploy.md`, `CLAUDE.md` (for agents), and `scripts/README.md`.
+
+### 6.2 EpiGraph `docs/intro/01-quickstart.md` (~200 lines)
+
+A robust expansion of the README's 5-minute version, with:
+
+- **Prereqs** explicit: Rust ≥1.75, PostgreSQL 16+ with the `vector` extension installed, Claude Code installed, ~$5 OpenAI credit for embeddings (set `OPENAI_API_KEY`).
+- **Step 1: PostgreSQL.** Install, create role `epigraph` with password `epigraph` and `SUPERUSER` (required for sqlx-test per memory `feedback_sqlx_test_uses_superuser`), create database `epigraph`, `CREATE EXTENSION vector;`.
+- **Step 2: Clone and build.** `git clone … && cd epigraph && cargo build --release -p epigraph-api -p epigraph-mcp -p epigraph-cli`.
+- **Step 3: Migrations.** `cargo run --release --bin epigraph-migrate`. Document the 2026-05-05 reconcile script as a "first-time-on-pre-existing-prod-data" footnote pointing to `docs/deploy.md`; not required for fresh installs.
+- **Step 4: Start the API.** `cargo run --release -p epigraph-api --bin server`. Verify with `curl http://127.0.0.1:8080/healthz`.
+- **Step 5: Install the MCP server.** Two options: (a) `sudo cp target/release/epigraph-mcp /usr/local/bin/` (matches `/home/jeremy/.mcp.json`); (b) `cargo install --path crates/epigraph-mcp` for users without `/usr/local/bin` write access. Show the exact `~/.mcp.json` block to add.
+- **Step 6: First MCP call.** Open Claude Code in any directory, ask "use the recall tool to search for 'test'", expect a JSON `recall_with_context` response with empty results. Then ask Claude to "submit a claim that 'EpiGraph is installed correctly'" and observe the submitted-claim ID.
+- **Common errors.** Tabular: `sqlx checksum mismatch` → see deploy.md; `connection refused on 5432` → start Postgres; `extension "vector" is not available` → install pgvector; `OPENAI_API_KEY not set` → export it.
+- **Tear-down.** `dropdb epigraph` if reinstalling.
+
+### 6.3 EpiGraph `docs/intro/02-concepts.md` (~400 lines)
+
+Six sub-sections, each 50-80 lines:
+
+1. **Noun-claims vs verb-edges.** Short version of `docs/architecture/noun-claims-and-verb-edges.md` with the textbook-ingest worked example. Link to the full doc for the worked examples and migration history.
+2. **Agents and signing.** Every claim is signed; agent identity is deterministic (DID from model+prompt hash per memory `project_epigraph_agent_identity.md`). Show an example `agent_id` and what its content_hash looks like.
+3. **Beliefs and DST.** What BetP (pignistic probability) means; why scalar BP is deprecated (memory `project_bp_cdst_primary.md`); how to read a belief in `get_belief` output. Brief reference to LANL Open World DST paper for the formal foundation.
+4. **Perspectives, frames, themes.** Multi-viewpoint querying; how claims get scoped to a frame; what a perspective is. Pointer to `mcp__epigraph__list_perspectives`.
+5. **Hierarchical extraction.** Papers → paragraphs → atoms. Why Tier 1 (`extract-claims` → `ingest_document`) is canonical (memory `feedback_tier1_ingestion_only.md`). The level=2 paragraph-primary search pattern.
+6. **Backlog discipline.** `resolve_backlog_item` is the canonical retire-pattern (link to `docs/conventions/backlog-retirement.md`). What "resolved" vs "current" vs "supersedes" mean and when to use each.
+
+### 6.4 EpiGraph `docs/intro/03-walkthroughs.md` (~500 lines)
+
+Four end-to-end transcripts, each ~120 lines, formatted as Claude Code session logs showing exact MCP calls, responses, and brief explanatory prose between steps:
+
+- **Walk 1: Ingest a short PDF.** Use a small public-domain paper. Call `mcp__epigraph__ingest_document` with the path. Observe the job kick off; poll with `mcp__epigraph__system_stats`; query the resulting paragraph + atom claims with `query_paper`.
+- **Walk 2: Query and expand.** Call `recall_with_context` on a topic from Walk 1's paper. Then `get_neighborhood` on the top hit to explore connected claims. Then `traverse` to follow a multi-hop path.
+- **Walk 3: Challenge a claim.** Pick a claim from Walk 1; call `challenge_claim` with a counter-argument; observe the challenge record. Then `verify_claim` to mark it confirmed despite the challenge.
+- **Walk 4: Backlog roundtrip.** Use `submit_claim` with `labels=["backlog"]` to file an item. Query open backlog with `query_claims_by_label(labels=["backlog"], exclude_labels=["resolved"], current_only=True)`. Resolve with `resolve_backlog_item(original_id, resolution_content)`. Verify the original is now labelled `resolved`.
+
+Each walkthrough ends with a "what just happened" paragraph that ties the MCP calls back to concepts from `02-concepts.md`.
+
+### 6.5 EpiGraph `docs/intro/04-glossary.md` (~100 lines)
+
+Alphabetical, two-to-four-sentence definitions, each entry linking to the file where the concept is explained in depth. Entries: agent, atom, BetP, challenge, claim, content_hash, DST, edge, evidence, factor, frame, hierarchical extraction, MCP, methodology, noun-claim, paragraph, perspective, pignistic probability, provenance, recall, signature, supports, synthesis, theme, verb-edge, workflow.
+
+### 6.6 EpiGraph `docs/intro/05-next-steps.md` (~80 lines)
+
+Four short sections, each one paragraph plus links:
+- **Extending the kernel.** Pointers to `CLAUDE.md`, the test DB recipe (`epigraph_db_repo_test`), `cargo sqlx prepare` workflow, the noun-claims-and-verb-edges architecture doc.
+- **Science-specific tooling.** Pointer to episcience's README.
+- **Production deployment.** Pointer to `docs/deploy.md`.
+- **Building a downstream app.** The integration pattern — depending on `epigraph-core` etc. as Cargo git deps, with `Cargo.toml` of episcience as the reference example. Pointer to `feedback_use_worktrees.md` lessons for multi-session work.
+
+### 6.7 Episcience `README.md` (~80 lines)
+
+1. **What is episcience?** One paragraph. Apache-2.0 layer over EpiGraph that adds the experimental loop: samples, protocols, blobs, countersignatures, synthesis claims. Where EpiGraph models *what is believed*, episcience models *how beliefs were tested*.
+2. **Status & license.** Apache-2.0, version 0.1.0, "alpha — Phase 0 prereqs pinned to a specific epigraph rev per `Cargo.toml`."
+3. **Prerequisites.** A running EpiGraph kernel (link to its README quickstart). Same Postgres instance is fine.
+4. **5-minute extension quickstart** (inline, ~5 commands): clone, apply episcience migrations on top of the kernel DB, `cargo build --release -p episcience-api`, start it, verify with a sample synthesis-claim submission.
+5. **TOC** into `docs/intro/` plus a "Why a separate repo?" note (the public Apache-2.0 layer separation, per memory `project_episcience_license.md`).
+
+### 6.8 Episcience `docs/intro/01-quickstart-extension.md` (~150 lines)
+
+- **Prereq.** EpiGraph quickstart completed; `epigraph` DB exists and migrations are applied; API is running.
+- **Step 1.** Clone episcience. Local path overrides for development if also hacking on the kernel (the `[patch."https://github.com/epigraph-io/epigraph"]` block from existing `Cargo.toml` comments).
+- **Step 2.** Apply episcience migrations against the `epigraph` DB: `cd episcience && cargo run --release -p episcience-api --bin episcience-migrate` (or `sqlx migrate run` against `migrations/`). Note ordering: must run after kernel migrations 040-043 are applied (already true if EpiGraph quickstart was followed).
+- **Step 3.** Build and start `episcience-api` on a separate port from `epigraph-api`. Verify `/healthz`.
+- **Step 4.** Submit a sample-bound synthesis claim via curl or MCP; observe it propagate to the EpiGraph kernel as a noun-claim with the synthesis entity type.
+- **Common errors.** Migration order violations; missing kernel functions (`cascade_delete_edges`, `validate_edge_reference`); port collision with `epigraph-api`.
+
+### 6.9 Episcience `docs/intro/02-concepts-science.md` (~300 lines)
+
+Six sub-sections, each 40-60 lines:
+1. **Experiments and experiment-results.** The experimental loop tables and their relationship to claims.
+2. **Samples.** Physical or digital artifacts referenced by claims; the `samples_parent_restrict` semantics from migration 5009.
+3. **Protocols.** Versioned procedures; the `protocol_version_unique` constraint from migration 5008.
+4. **Blobs.** Binary attachments to claims; size/content-type semantics.
+5. **Countersignatures.** Multi-party signing chains; how `countersign_chain` (migration 5010) extends the kernel's single-signer model.
+6. **Synthesis claims and PROV-O edges.** How episcience separates 5 epistemic edge types from 4 PROV-O dependency edges in a separate table (memory `reference_episcience_edge_separation.md`). Why this matters for downstream consumers.
+
+### 6.10 Episcience `docs/intro/03-walkthroughs.md` (~300 lines)
+
+Three transcripts:
+- **Walk 1: Run a single experiment.** Register a protocol, create a sample, run an experiment, file the result as a claim with `samples` and `protocols` references.
+- **Walk 2: Countersign.** Take Walk 1's result; produce a countersignature from a second agent identity; observe the chain.
+- **Walk 3: Synthesize.** Take three experiment-result claims; produce a synthesis claim that PROV-O-derives from them; observe the resulting node and edges in the kernel.
+
+### 6.11 Episcience `docs/intro/04-glossary.md` (~60 lines)
+
+Alphabetical, science-specific terms only: blob, countersignature, experiment, experiment-result, PROV-O, protocol, sample, synthesis claim. Kernel terms link back to EpiGraph's glossary.
+
+## 7. Implementation order
+
+1. Build and verify the EpiGraph quickstart steps locally (some commands may need adjustment from the design above based on what actually works against a clean install).
+2. Write the EpiGraph intro tree files in order: glossary first (so other files can link to it), then concepts, then quickstart, then walkthroughs, then next-steps.
+3. Write the EpiGraph `README.md` last (so its TOC reflects the actually-written files).
+4. Run the four EpiGraph walkthroughs against the local install. Capture real transcripts. Replace the stubbed examples in `03-walkthroughs.md` with the captured output.
+5. Repeat steps 1-4 for episcience: verify the extension quickstart, write glossary → concepts → quickstart → walkthroughs, capture transcripts, write README last.
+6. Cross-link: ensure every "see X" link resolves, both within each repo and across repos (cross-repo links use github.com URLs since both repos are public).
+7. Commit each repo's new files in a single PR per repo; PR descriptions point reviewers to the README first.
+
+## 8. Verification
+
+- A volunteer (not Jeremy) clones each repo cold, follows only the written instructions, and reports time-to-first-`recall_with_context` for EpiGraph and time-to-first-synthesis-claim for episcience. Targets: ≤15 minutes and ≤25 minutes respectively (≤10/≤5 from the design goals plus generous slack for prereq installation).
+- Every link in every new file is checked with a Markdown link-checker.
+- The walkthroughs are re-run against a fresh DB after each non-trivial epigraph or episcience release to catch drift; failures file a backlog item per CLAUDE.md.
+
+## 9. Risks and mitigations
+
+- **Risk: Tooling drifts faster than docs.** Mitigation: the walkthroughs are runnable transcripts, not free prose. A periodic re-run (suggested: a scheduled `loop` agent doing the four EpiGraph walkthroughs nightly) catches drift. Out of scope for this initial doc-writing pass but flagged in `05-next-steps.md` as a future hardening.
+- **Risk: PostgreSQL version / pgvector install friction dominates time-to-first-call.** Mitigation: link to canonical pgvector install instructions per OS; do not duplicate them. If feedback shows this is the actual bottleneck, future work adds a `docker-compose.yml` (out of scope here).
+- **Risk: Episcience migrations break against an arbitrary EpiGraph rev.** Mitigation: the episcience quickstart explicitly pins to the rev recorded in episcience `Cargo.toml`'s `[workspace.dependencies]` block; the quickstart instructs users to clone EpiGraph at that rev. Drift between latest-EpiGraph and pinned-EpiGraph is a known constraint per the existing `Cargo.toml` comment.
+- **Risk: New users don't have an OpenAI key and bounce.** Mitigation: the quickstart's prereq list calls this out *before* any clone/build steps. `recall_with_context` embeds the query string on every call and so requires `OPENAI_API_KEY` even against an empty corpus — no fallback path exists today. If a no-key onboarding mode becomes a recurring ask, it's a feature request against `epigraph-mcp` (out of scope here); the quickstart explicitly notes the key as mandatory rather than papering over the constraint.

--- a/docs/superpowers/specs/2026-05-19-onboarding-docs-design.md
+++ b/docs/superpowers/specs/2026-05-19-onboarding-docs-design.md
@@ -9,7 +9,7 @@
 
 ## 1. Problem
 
-EpiGraph and Episcience have no top-level READMEs and no entry-point documentation for new users. A fresh clone of either repo is opaque: a Rust workspace with 17 (epigraph) or 3 (episcience) crates, 34 (epigraph) or 11 (episcience) migrations, no instructions for getting from "I have the source" to "I successfully called my first MCP tool."
+EpiGraph and Episcience have no top-level READMEs and no entry-point documentation for new users. A fresh clone of either repo is opaque: a Rust workspace with 17 (epigraph) or 3 (episcience) crates, 32 (epigraph) or 11 (episcience) migrations, no instructions for getting from "I have the source" to "I successfully called my first MCP tool."
 
 New collaborators — including future contributors, downstream-app builders (WRHQ, Praxis, NDI tooling), and Astera-style residency reviewers — currently rely on synchronous onboarding from Jeremy. The cost grows with each new person and effectively caps how widely the system can be adopted.
 
@@ -82,7 +82,7 @@ Sections in order:
 1. **What is EpiGraph?** Two paragraphs. EpiGraph is an epistemic kernel: claims (nouns), edges (verbs), agents that sign their assertions, beliefs propagated via Dempster-Shafer. It replaces static papers with a live experimental loop — hypothesis → experiment → data → analysis → belief update.
 2. **Who is this for?** Bulleted: devs building epistemic apps; researchers querying the graph via Claude Code; contributors extending the kernel.
 3. **Status & license.** Apache-2.0, version 0.3.0, "alpha — kernel stable, layers iterate."
-4. **5-minute quickstart** (inline, ~10 commands): clone, start Postgres (`postgres://epigraph:epigraph@localhost`), `cargo build --release -p epigraph-api -p epigraph-mcp`, `cargo run --bin epigraph-migrate`, start the API, register the MCP server in `~/.mcp.json` (show the exact config), open Claude Code, call `recall_with_context "test"`. End-state: a JSON response showing the empty corpus or hitting the user's first claim.
+4. **5-minute quickstart** (inline, ~10 commands): clone, start Postgres (`postgres://epigraph:epigraph@localhost`), `cargo build --release -p epigraph-api -p epigraph-mcp`, `cargo run --bin epigraph-migrate`, start the API, register the MCP server in `~/.mcp.json` (show the exact config, with binary name `epigraph-mcp-full`), open Claude Code, call `recall_with_context "test"`. End-state: a JSON response showing the empty corpus or hitting the user's first claim.
 5. **Where to next.** Linked TOC into `docs/intro/`, plus a "Deeper material" section pointing to `docs/architecture/noun-claims-and-verb-edges.md`, `docs/deploy.md`, `CLAUDE.md` (for agents), and `scripts/README.md`.
 
 ### 6.2 EpiGraph `docs/intro/01-quickstart.md` (~200 lines)
@@ -90,11 +90,11 @@ Sections in order:
 A robust expansion of the README's 5-minute version, with:
 
 - **Prereqs** explicit: Rust ≥1.75, PostgreSQL 16+ with the `vector` extension installed, Claude Code installed, ~$5 OpenAI credit for embeddings (set `OPENAI_API_KEY`).
-- **Step 1: PostgreSQL.** Install, create role `epigraph` with password `epigraph` and `SUPERUSER` (required for sqlx-test per memory `feedback_sqlx_test_uses_superuser`), create database `epigraph`, `CREATE EXTENSION vector;`.
-- **Step 2: Clone and build.** `git clone … && cd epigraph && cargo build --release -p epigraph-api -p epigraph-mcp -p epigraph-cli`.
+- **Step 1: PostgreSQL.** Install, create role `epigraph` with password `epigraph` (no `SUPERUSER` needed for runtime use), create database `epigraph`, `CREATE EXTENSION vector;`. Add a footnote: running the test suite under `sqlx::test` additionally requires `SUPERUSER` because it `LOCK`s `pg_namespace` (memory `feedback_sqlx_test_uses_superuser`); grant it temporarily or use a separate test-only superuser role.
+- **Step 2: Clone and build.** `git clone … && cd epigraph && cargo build --release -p epigraph-api -p epigraph-mcp -p epigraph-cli`. Note that the `epigraph-mcp` package produces a binary named `epigraph-mcp-full` (see `crates/epigraph-mcp/Cargo.toml`).
 - **Step 3: Migrations.** `cargo run --release --bin epigraph-migrate`. Document the 2026-05-05 reconcile script as a "first-time-on-pre-existing-prod-data" footnote pointing to `docs/deploy.md`; not required for fresh installs.
-- **Step 4: Start the API.** `cargo run --release -p epigraph-api --bin server`. Verify with `curl http://127.0.0.1:8080/healthz`.
-- **Step 5: Install the MCP server.** Two options: (a) `sudo cp target/release/epigraph-mcp /usr/local/bin/` (matches `/home/jeremy/.mcp.json`); (b) `cargo install --path crates/epigraph-mcp` for users without `/usr/local/bin` write access. Show the exact `~/.mcp.json` block to add.
+- **Step 4: Start the API.** `cargo run --release -p epigraph-api --bin server`. Verify with `curl http://127.0.0.1:8080/health`.
+- **Step 5: Install the MCP server.** Two options: (a) `sudo cp target/release/epigraph-mcp-full /usr/local/bin/epigraph-mcp` (rename to match `/home/jeremy/.mcp.json`) — or leave the binary name as-is and update the `~/.mcp.json` `command` to `/usr/local/bin/epigraph-mcp-full`; (b) `cargo install --path crates/epigraph-mcp` for users without `/usr/local/bin` write access (installed name will still be `epigraph-mcp-full`). Show the exact `~/.mcp.json` block to add for each option.
 - **Step 6: First MCP call.** Open Claude Code in any directory, ask "use the recall tool to search for 'test'", expect a JSON `recall_with_context` response with empty results. Then ask Claude to "submit a claim that 'EpiGraph is installed correctly'" and observe the submitted-claim ID.
 - **Common errors.** Tabular: `sqlx checksum mismatch` → see deploy.md; `connection refused on 5432` → start Postgres; `extension "vector" is not available` → install pgvector; `OPENAI_API_KEY not set` → export it.
 - **Tear-down.** `dropdb epigraph` if reinstalling.
@@ -138,17 +138,17 @@ Four short sections, each one paragraph plus links:
 1. **What is episcience?** One paragraph. Apache-2.0 layer over EpiGraph that adds the experimental loop: samples, protocols, blobs, countersignatures, synthesis claims. Where EpiGraph models *what is believed*, episcience models *how beliefs were tested*.
 2. **Status & license.** Apache-2.0, version 0.1.0, "alpha — Phase 0 prereqs pinned to a specific epigraph rev per `Cargo.toml`."
 3. **Prerequisites.** A running EpiGraph kernel (link to its README quickstart). Same Postgres instance is fine.
-4. **5-minute extension quickstart** (inline, ~5 commands): clone, apply episcience migrations on top of the kernel DB, `cargo build --release -p episcience-api`, start it, verify with a sample synthesis-claim submission.
+4. **5-minute extension quickstart** (inline, ~5 commands): clone, apply episcience migrations on top of the kernel DB using `sqlx migrate run`, `cargo build --release -p episcience-api`, start `episcience-server`, verify with a sample synthesis-claim submission via the `synthesize` MCP tool.
 5. **TOC** into `docs/intro/` plus a "Why a separate repo?" note (the public Apache-2.0 layer separation, per memory `project_episcience_license.md`).
 
 ### 6.8 Episcience `docs/intro/01-quickstart-extension.md` (~150 lines)
 
 - **Prereq.** EpiGraph quickstart completed; `epigraph` DB exists and migrations are applied; API is running.
-- **Step 1.** Clone episcience. Local path overrides for development if also hacking on the kernel (the `[patch."https://github.com/epigraph-io/epigraph"]` block from existing `Cargo.toml` comments).
-- **Step 2.** Apply episcience migrations against the `epigraph` DB: `cd episcience && cargo run --release -p episcience-api --bin episcience-migrate` (or `sqlx migrate run` against `migrations/`). Note ordering: must run after kernel migrations 040-043 are applied (already true if EpiGraph quickstart was followed).
-- **Step 3.** Build and start `episcience-api` on a separate port from `epigraph-api`. Verify `/healthz`.
-- **Step 4.** Submit a sample-bound synthesis claim via curl or MCP; observe it propagate to the EpiGraph kernel as a noun-claim with the synthesis entity type.
-- **Common errors.** Migration order violations; missing kernel functions (`cascade_delete_edges`, `validate_edge_reference`); port collision with `epigraph-api`.
+- **Step 1.** Clone episcience. Local path overrides for development if also hacking on the kernel: add the `[patch."https://github.com/epigraph-io/epigraph"]` block to `~/.cargo/config.toml` (NOT to the workspace `Cargo.toml`), as documented in the existing `Cargo.toml` comments. The comment explicitly says "Don't commit personal patches."
+- **Step 2.** Apply episcience migrations against the `epigraph` DB using the sqlx CLI: `cd episcience && sqlx migrate run --source migrations/ --database-url postgres://epigraph:epigraph@localhost/epigraph`. There is no `episcience-migrate` binary today; the server explicitly skips embedded migrations (see `crates/episcience-api/src/bin/episcience-server.rs`). Migrations must run after the EpiGraph kernel schema is applied (current kernel migrations through `032_claim_themes_properties.sql`); episcience depends on kernel functions like `cascade_delete_edges` and `validate_edge_reference`, which exist from kernel migrations 024-025 onward.
+- **Step 3.** Build and start `episcience-server` on a separate port from `epigraph-api`. Verify `/health` on that port.
+- **Step 4.** Submit a sample-bound synthesis claim via curl or the `episcience-mcp-server` MCP tool `synthesize`; observe it propagate to the EpiGraph kernel as a noun-claim with the synthesis entity type.
+- **Common errors.** Missing sqlx CLI (`cargo install sqlx-cli --no-default-features --features postgres,native-tls`); migration order violations (running episcience migrations against a DB without the EpiGraph kernel schema); missing kernel functions (`cascade_delete_edges`, `validate_edge_reference`) — symptom is a CREATE TRIGGER or REFERENCES failure mid-migration; port collision with `epigraph-api`.
 
 ### 6.9 Episcience `docs/intro/02-concepts-science.md` (~300 lines)
 
@@ -162,10 +162,11 @@ Six sub-sections, each 40-60 lines:
 
 ### 6.10 Episcience `docs/intro/03-walkthroughs.md` (~300 lines)
 
-Three transcripts:
-- **Walk 1: Run a single experiment.** Register a protocol, create a sample, run an experiment, file the result as a claim with `samples` and `protocols` references.
-- **Walk 2: Countersign.** Take Walk 1's result; produce a countersignature from a second agent identity; observe the chain.
-- **Walk 3: Synthesize.** Take three experiment-result claims; produce a synthesis claim that PROV-O-derives from them; observe the resulting node and edges in the kernel.
+Three transcripts. (Note: there is no `experiments` route or table in episcience today; the surface exposed is samples, protocols, blobs, syntheses, countersignatures, and the `synthesize` / `recall_synthesis` / `get_synthesis` / `list_syntheses` MCP tools. Walkthroughs use only what's actually implemented.)
+
+- **Walk 1: Stage and synthesize.** Create a sample (`POST /samples`), register a protocol (`POST /protocols`), then call the `synthesize` MCP tool to produce a synthesis claim that references the sample and protocol IDs. Observe the resulting EpiGraph noun-claim with the synthesis entity type.
+- **Walk 2: Countersign.** Take Walk 1's synthesis claim; produce a countersignature from a second agent identity via the `countersign` route; observe the chain.
+- **Walk 3: Multi-source synthesis.** Create three independent samples; produce three separate synthesis claims; then call `synthesize` to produce a higher-level synthesis that PROV-O-derives from the three; observe the resulting node and edges in the kernel via `recall_synthesis` and `get_synthesis`.
 
 ### 6.11 Episcience `docs/intro/04-glossary.md` (~60 lines)
 


### PR DESCRIPTION
Replaces #167 (which was contaminated with unrelated commits from `spec/cross-source-anchor`).

## Summary

- Adds top-level `README.md` (pitch, status, 5-min quickstart, intro TOC, deeper-material pointers)
- Adds `docs/intro/{01-quickstart,02-concepts,04-glossary,05-next-steps}.md`
- Adds the design spec and implementation plan that drove this work (under `docs/superpowers/`)

`docs/intro/03-walkthroughs.md` intentionally deferred — captured live in a follow-up PR. README TOC flags it `(coming soon — captured live)`.

## Findings surfaced while writing

- Filed #166 — LLM model+prompt-hash agent identity is referenced in §2 of the concepts doc but not yet implemented; concepts file flags it as "planned" with a link to the issue.
- Server bind / health / port reality differed from spec; quickstart updated to match: `0.0.0.0:8080` (configurable via `EPIGRAPH_PORT`), `/health` returns JSON.
- MCP binary is `epigraph-mcp-full` (the `epigraph-mcp` name in `~/.mcp.json` requires either a rename on copy or pointing at the full name).

## Test plan

- [ ] CI green
- [ ] Every internal link resolves
- [ ] Walkthroughs file added in a follow-up PR (live capture)

Pairs with epigraph-io/episcience#3 (already green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)