### PR TITLE
fix(db): collapse NULL-perspective BBA duplicates via NULLS NOT DISTINCT

### DIFF
--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -477,19 +477,43 @@ mod tests {
         let second = serde_json::json!({"0": 0.8, "0,1": 0.2});
 
         MassFunctionRepository::store_with_perspective(
-            &pool, claim_id, frame_id, Some(agent_id), None,
-            &first, None, Some("first"), Some(0.7), Some("auto_wire"),
-        ).await.unwrap();
+            &pool,
+            claim_id,
+            frame_id,
+            Some(agent_id),
+            None,
+            &first,
+            None,
+            Some("first"),
+            Some(0.7),
+            Some("auto_wire"),
+        )
+        .await
+        .unwrap();
 
         MassFunctionRepository::store_with_perspective(
-            &pool, claim_id, frame_id, Some(agent_id), None,
-            &second, None, Some("second"), Some(0.9), Some("auto_wire"),
-        ).await.unwrap();
+            &pool,
+            claim_id,
+            frame_id,
+            Some(agent_id),
+            None,
+            &second,
+            None,
+            Some("second"),
+            Some(0.9),
+            Some("auto_wire"),
+        )
+        .await
+        .unwrap();
 
         let rows = MassFunctionRepository::get_for_claim_frame(&pool, claim_id, frame_id)
             .await
             .unwrap();
-        assert_eq!(rows.len(), 1, "NULL-perspective upsert must collapse to one row");
+        assert_eq!(
+            rows.len(),
+            1,
+            "NULL-perspective upsert must collapse to one row"
+        );
         assert_eq!(rows[0].masses, second, "Latest write must win on conflict");
         assert_eq!(rows[0].combination_method.as_deref(), Some("second"));
     }

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -440,6 +440,60 @@ mod tests {
         assert!(all.iter().any(|r| r.claim_id == claim2_id));
     }
 
+    /// Regression test for the NULL-perspective upsert bug fixed by
+    /// migration 034. Before the migration, the unique constraint was
+    /// NULL-distinct, so two `store_with_perspective(.., None, ..)` calls
+    /// for the same (claim, frame, agent) inserted two rows instead of
+    /// upserting. This silently amplified structural belief on hub claims.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn null_perspective_upsert_collapses_to_single_row(pool: sqlx::PgPool) {
+        let agent_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels)
+             VALUES (sha256(gen_random_uuid()::text::bytea), 'null-persp-upsert', 'system', ARRAY['test'])
+             RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let frame_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO frames (name, hypotheses) VALUES ($1, '{\"supported\",\"contradicted\"}') RETURNING id",
+        )
+        .bind(format!("null-persp-upsert-{}", Uuid::new_v4()))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let claim_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, truth_value, agent_id) VALUES ($1, sha256($1::bytea), 0.5, $2) RETURNING id",
+        )
+        .bind(format!("null-persp-upsert-{}", Uuid::new_v4()))
+        .bind(agent_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let first = serde_json::json!({"0": 0.5, "0,1": 0.5});
+        let second = serde_json::json!({"0": 0.8, "0,1": 0.2});
+
+        MassFunctionRepository::store_with_perspective(
+            &pool, claim_id, frame_id, Some(agent_id), None,
+            &first, None, Some("first"), Some(0.7), Some("auto_wire"),
+        ).await.unwrap();
+
+        MassFunctionRepository::store_with_perspective(
+            &pool, claim_id, frame_id, Some(agent_id), None,
+            &second, None, Some("second"), Some(0.9), Some("auto_wire"),
+        ).await.unwrap();
+
+        let rows = MassFunctionRepository::get_for_claim_frame(&pool, claim_id, frame_id)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "NULL-perspective upsert must collapse to one row");
+        assert_eq!(rows[0].masses, second, "Latest write must win on conflict");
+        assert_eq!(rows[0].combination_method.as_deref(), Some("second"));
+    }
+
     #[test]
     fn mass_function_row_has_expected_fields() {
         let _row = MassFunctionRow {

--- a/migrations/034_mass_functions_null_perspective_unique.sql
+++ b/migrations/034_mass_functions_null_perspective_unique.sql
@@ -1,0 +1,84 @@
+-- 034_mass_functions_null_perspective_unique.sql
+--
+-- Fix BBA duplication caused by PostgreSQL's default NULL-distinct unique
+-- semantics on mass_functions_unique_per_perspective.
+--
+-- Background:
+--   `store_with_perspective` performs an upsert with
+--   `ON CONFLICT (claim_id, frame_id, source_agent_id, perspective_id)`.
+--   Because the unique constraint was created with default NULL-distinct
+--   semantics, two rows with `perspective_id IS NULL` and otherwise
+--   identical key columns never conflicted. Every `auto_wire_ds_for_claim`
+--   call (and any auto_cdst / discount BBA write with perspective_id = NULL)
+--   inserted a *new* row instead of updating the existing one. This
+--   structurally amplified belief for hub claims (e.g. NEMS hubs, Hero's
+--   Journey hub) and inflated sheaf-cohomology h1.
+--
+-- Fix:
+--   1. Collapse each (claim_id, frame_id, source_agent_id, perspective_id)
+--      group to a single row, keeping the most recent write (latest
+--      `created_at`, tie-broken by `id`). Latest-wins matches the existing
+--      ON CONFLICT DO UPDATE semantics — the constraint's original design
+--      intent was one BBA per (claim, frame, agent, perspective); the NULL
+--      bug just suppressed the conflict.
+--   2. Rebuild `mass_functions_unique_per_perspective` with
+--      `NULLS NOT DISTINCT` (PostgreSQL >= 15) so NULL perspective_id and
+--      NULL source_agent_id participate in conflict detection. The existing
+--      ON CONFLICT target then resolves against this constraint without
+--      any code change.
+--
+-- Post-migration verification lives in the PR description; cached BetP
+-- columns on `claims` are not recomputed here — the
+-- `report_workflow_outcome` / sheaf_cohomology paths re-derive them.
+
+BEGIN;
+
+-- Step 1: dedup. Use a CTE-based DELETE so the row_number window is
+-- evaluated once over the full table. PARTITION BY treats NULL as equal,
+-- which is exactly the grouping the new constraint enforces.
+--
+-- Note: cached BetP columns on `claims` (belief, plausibility, pignistic_prob,
+-- truth_value, mass_on_empty, mass_on_missing, open_world_mass) are NOT
+-- recomputed here. For claims whose surviving BBA differs from the previous
+-- Dempster-combination of all duplicates, cached values will be stale until
+-- the next sheaf_cohomology / report_workflow_outcome pass. The follow-up
+-- recompute script is tracked separately (see backlog).
+DO $$
+DECLARE
+    affected_claims integer;
+BEGIN
+    SELECT COUNT(DISTINCT claim_id) INTO affected_claims
+    FROM (
+        SELECT claim_id,
+               row_number() OVER (
+                   PARTITION BY claim_id, frame_id, source_agent_id, perspective_id
+                   ORDER BY created_at DESC, id DESC
+               ) AS rn
+        FROM mass_functions
+    ) sub
+    WHERE rn > 1;
+    RAISE NOTICE 'mass_functions dedup: % distinct claims have BBAs deleted; cached BetP on those claims is now stale until next recompute', affected_claims;
+END $$;
+
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY claim_id, frame_id, source_agent_id, perspective_id
+               ORDER BY created_at DESC, id DESC
+           ) AS rn
+    FROM mass_functions
+)
+DELETE FROM mass_functions mf
+USING ranked
+WHERE mf.id = ranked.id
+  AND ranked.rn > 1;
+
+-- Step 2: replace the unique constraint with a NULLS NOT DISTINCT variant.
+ALTER TABLE mass_functions
+    DROP CONSTRAINT mass_functions_unique_per_perspective;
+
+ALTER TABLE mass_functions
+    ADD CONSTRAINT mass_functions_unique_per_perspective
+    UNIQUE NULLS NOT DISTINCT (claim_id, frame_id, source_agent_id, perspective_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Migration `034_mass_functions_null_perspective_unique.sql` rebuilds the `mass_functions_unique_per_perspective` constraint with PG16 `UNIQUE NULLS NOT DISTINCT`, fixing the long-standing BBA duplication on every `store_with_perspective(.., perspective_id=None, ..)` write path.
- Latest-wins dedup pass collapses existing duplicates (36,247 excess rows across 25,475 (claim, frame, agent, NULL-perspective) groups on prod).
- Regression test `null_perspective_upsert_collapses_to_single_row` locks in the upsert behavior end-to-end.

## Why

`store_with_perspective` already encodes the intended latest-wins semantics via `ON CONFLICT (claim_id, frame_id, source_agent_id, perspective_id) DO UPDATE`. The constraint, however, was created with default NULL-distinct semantics, so every `auto_wire_ds_for_claim` / `auto_cdst` / discount BBA write with `perspective_id IS NULL` inserted a fresh row instead of upserting. Hub claims (e.g. NEMS hubs `720a6fce` / `a29c2b65`, Hero's Journey hub `1aa53200`) accumulated multiple copies of effectively-identical BBAs, and Dempster combination over those copies concentrated mass on the supported singleton — structurally amplifying BetP and inflating sheaf cohomology h1.

The fix is purely schema-level. No caller change required.

## Design notes

- **Latest-wins**, not oldest-wins. Diverges from the original plan in backlog claim `1c5a3132` but matches the existing `DO UPDATE SET masses = EXCLUDED.masses` semantics and preserves the user's manually-corrected Hero's Journey cached BetP (0.822 from the surviving `auto_wire` row).
- **`NULLS NOT DISTINCT` over partial unique index.** Cleaner one-constraint solution on PG15+; the existing ON CONFLICT target resolves against it without code change. Prod runs PG16.
- **Cached BetP on `claims` is NOT recomputed here.** The migration deletes BBAs but does not rewrite `claims.{belief, plausibility, pignistic_prob, truth_value, mass_on_empty, mass_on_missing, open_world_mass}`. For affected claims, cached values reflect the prior all-duplicates Dempster combination and will be stale (inflated) until a follow-up recompute pass. Follow-up filed as backlog `dc3fe5fe`. The migration `RAISE NOTICE`s the affected-claim count at apply time for traceability.

## Test plan

- [x] Apply to fresh `epigraph_db_repo_test` via `cargo sqlx migrate run --source migrations` — all 34 migrations apply cleanly.
- [x] Constraint definition reads `UNIQUE NULLS NOT DISTINCT (claim_id, frame_id, source_agent_id, perspective_id)`.
- [x] Two consecutive `INSERT ... ON CONFLICT DO UPDATE` calls with `perspective_id = NULL` produce one row with the latest masses (manual DO block + new regression test).
- [x] `DATABASE_URL=... cargo sqlx prepare --workspace -- --tests` — no `.sqlx/` diff (no macro-checked query depended on the constraint shape).
- [x] `SQLX_OFFLINE=true cargo check --workspace` passes.
- [x] `cargo test -p epigraph-db --lib repos::mass_function` — 3 passed, including the new regression test.
- [ ] Post-merge: apply to prod and re-run `sheaf_cohomology`; verify `h1_normalized` drops materially (predicted in `1c5a3132`).

## Related

- Resolves backlog claim `1c5a3132-3a61-4356-9533-0e2b2590a9e9` (resolution claim `f5470c1c`).
- Follow-up filed: `dc3fe5fe-8774-4d6d-b50c-0a2fe901311b` — recompute cached BetP for the ~25,475 affected claims.
- Prod application is gated on merge per the spec-branch-migrations restart-safety rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)