### PR TITLE
feat(ds): fire auto_wire_ds_for_edge on epistemic edge creation (ingest)

### DIFF
--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -564,3 +564,38 @@ async fn recompute_combined_belief(
     .map_err(|e| format!("update_claim_belief: {e}"))?;
     Ok(())
 }
+
+/// Fire `auto_wire_ds_for_edge` from an edge-creation call site, gated on
+/// whether the edge was newly created and connects two claim nodes.
+///
+/// Best-effort: failures are logged at `warn` and swallowed. Returns `None`
+/// when the edge wasn't newly created, sources/targets aren't claims, or the
+/// auto-wire call failed. Returns `Some(outcome)` when the trigger fired.
+#[allow(clippy::too_many_arguments)]
+pub async fn auto_wire_edge_if_epistemic(
+    pool: &PgPool,
+    was_created: bool,
+    edge_id: Uuid,
+    source_id: Uuid,
+    source_type: &str,
+    target_id: Uuid,
+    target_type: &str,
+    relationship: &str,
+    agent_id: Uuid,
+) -> Option<EdgeFactorOutcome> {
+    if !was_created || source_type != "claim" || target_type != "claim" {
+        return None;
+    }
+    match auto_wire_ds_for_edge(pool, edge_id, agent_id, source_id, target_id, relationship).await {
+        Ok(outcome) => Some(outcome),
+        Err(e) => {
+            tracing::warn!(
+                edge = %edge_id,
+                target = %target_id,
+                relationship = %relationship,
+                "edge auto-wire failed: {e}",
+            );
+            None
+        }
+    }
+}

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -372,7 +372,7 @@ pub async fn do_ingest_document(
             continue;
         }
 
-        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
+        let (row, was_created) = EdgeRepository::create_if_not_exists(
             pool,
             src,
             &src_type,
@@ -386,6 +386,21 @@ pub async fn do_ingest_document(
         .await
         .map_err(internal_error)?;
         relationships_created += 1;
+
+        // Epistemic-edge factor auto-wire (best-effort; non-epistemic and
+        // non-claim edges are filtered inside the helper).
+        ds_auto::auto_wire_edge_if_epistemic(
+            pool,
+            was_created,
+            row.id,
+            src,
+            &src_type,
+            tgt,
+            &edge.target_type,
+            &edge.relationship,
+            agent_id,
+        )
+        .await;
     }
 
     // ── 6. Auto-CDST batch wire (atoms only) ──


### PR DESCRIPTION
## Summary

- Adds `auto_wire_edge_if_epistemic` in `ds_auto.rs` — thin wrapper that gates on `was_created` + claim→claim source/target before delegating to the new `auto_wire_ds_for_edge` (PR #170).
- Wires it into the `do_ingest_document` edge loop in `tools/ingestion.rs`. New edges with epistemic relationships now produce a per-edge BBA on the target claim, keyed by `edge.id` (perspective_id).

## Why a helper, not inline at the call site

Per the design discussion before PR #170 landed: the canonical advice was wrap-at-tool-layer (don't pollute `EdgeRepository`), don't fan out to every call site by hand. This is the wrapper. Single import, single line at the call site, all the gating logic centralized.

## Followups (intentionally not in this PR)

- **`epigraph-ingest-executor` workflow_ingest path** also creates plan edges but the executor is pure-DB by design (no `epigraph-engine` dep). Needs a returned-edges API so the caller can wire, or a tiny `epigraph-edge-wire` crate. Filing a separate task.
- **HTTP `trigger_edge_ds_recomputation`** in `routes/edges.rs` writes to a legacy `graph-topology` frame (62 BBAs total, last write 2026-05-16) with its own BBA math. The MCP path now writes to canonical `binary_truth`. These should be unified — separate cleanup task.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p epigraph-mcp --lib` — clean
- [x] `cargo test -p epigraph-engine --lib epistemic_interval` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)