### PR TITLE
chore(db): drop orphan graph-topology BBAs after edge-factor unification

### DIFF
--- a/migrations/035_drop_graph_topology_orphans.sql
+++ b/migrations/035_drop_graph_topology_orphans.sql
@@ -1,0 +1,26 @@
+-- Drop orphan BBAs + claim assignments on the legacy `graph-topology` frame.
+--
+-- PR #172 unified the HTTP edge-triggered DS recomputation path onto the
+-- canonical `binary_truth` frame, replacing the parallel `graph-topology`
+-- implementation (hypotheses {supported, contradicted}, hardcoded math
+-- `mass = source_truth * 0.7 * 0.5`). After the merge, no code path reads
+-- or writes the graph-topology mass_function rows; they are dead data.
+--
+-- This migration removes the orphans but **keeps the `frames` row itself**
+-- so historical references (older migrations, archived audit logs) stay
+-- coherent.
+--
+-- Pre-migration audit (run on prod 2026-05-26):
+--   orphan_bbas        = 62 (last write 2026-05-16)
+--   orphan_assignments = 4
+-- Post-migration: both should be 0.
+
+BEGIN;
+
+DELETE FROM mass_functions
+WHERE frame_id IN (SELECT id FROM frames WHERE name = 'graph-topology');
+
+DELETE FROM claim_frames
+WHERE frame_id IN (SELECT id FROM frames WHERE name = 'graph-topology');
+
+COMMIT;


### PR DESCRIPTION
## Summary

PR #172 unified the HTTP edge-triggered DS recomputation onto the canonical \`binary_truth\` frame, replacing the legacy parallel \`graph-topology\` implementation. After that merge the \`graph-topology\` mass_function rows have no readers or writers.

Pre-migration audit (prod, 2026-05-26):

| | |
|---|---|
| orphan BBAs | 62 (last write 2026-05-16) |
| orphan claim_frames assignments | 4 |

This migration deletes them. The \`frames\` row itself is kept so historical references stay coherent.

## Test plan

- [x] Applied to \`epigraph_db_repo_test\` cleanly (18ms): \`Applied 35/migrate drop graph topology orphans\`
- [x] Post-migration audit on test DB confirms 0 orphans

## Deploy plan

\`cargo sqlx migrate run\` against prod after merge. No code restart required — the migration only deletes orphan rows that no live code path touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)