### PR TITLE
feat(executor): return inserted edges; callers fire epistemic auto-wire

### DIFF
--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -234,6 +234,8 @@ pub async fn store_workflow(
                 message: format!("workflow ingest: {e}"),
             })?;
 
+    auto_wire_inserted_edges(&state.db_pool, &result).await;
+
     // Embed inline, best-effort. Satisfies the is_current=true → has-embedding
     // invariant (CLAUDE.md "Embedding policy"). Failures warn and continue.
     if let Some(embedder) = state.embedding_service() {
@@ -1238,6 +1240,8 @@ pub async fn ingest_workflow(
                 message: format!("workflow ingest: {e}"),
             })?;
 
+    auto_wire_inserted_edges(&state.db_pool, &result).await;
+
     // Embed inline, best-effort. Satisfies the is_current=true → has-embedding
     // invariant (CLAUDE.md "Embedding policy"). Failures warn and continue.
     if let Some(embedder) = state.embedding_service() {
@@ -1309,6 +1313,33 @@ fn format_embedding(embedding: &[f32]) -> String {
             .collect::<Vec<_>>()
             .join(",")
     )
+}
+
+/// Fire `auto_wire_edge_if_epistemic` for each plan edge the executor newly
+/// inserted. Best-effort (the helper logs and swallows individual failures).
+/// Source-claim agent attribution is handled by the engine helper via
+/// `system_agent_id` from the executor result.
+async fn auto_wire_inserted_edges(
+    pool: &sqlx::PgPool,
+    result: &epigraph_ingest_executor::WorkflowIngestExecutionResult,
+) {
+    let Some(agent_id) = result.system_agent_id else {
+        return;
+    };
+    for e in &result.inserted_edges {
+        epigraph_engine::edge_factor::auto_wire_edge_if_epistemic(
+            pool,
+            true, // executor only emits InsertedPlanEdge when was_created=true
+            e.edge_id,
+            e.source_id,
+            &e.source_type,
+            e.target_id,
+            &e.target_type,
+            &e.relationship,
+            agent_id,
+        )
+        .await;
+    }
 }
 
 // ── Internal types ──

--- a/crates/epigraph-ingest-executor/src/lib.rs
+++ b/crates/epigraph-ingest-executor/src/lib.rs
@@ -13,5 +13,5 @@ pub mod workflow_steps;
 
 pub use error::IngestExecutorError;
 pub use system_agent::get_or_create_system_agent;
-pub use workflow::{execute_workflow_ingest_plan, WorkflowIngestExecutionResult};
+pub use workflow::{execute_workflow_ingest_plan, InsertedPlanEdge, WorkflowIngestExecutionResult};
 pub use workflow_steps::{add_step, delete_step, AddStepResult, DeleteStepResult, StepOpError};

--- a/crates/epigraph-ingest-executor/src/workflow.rs
+++ b/crates/epigraph-ingest-executor/src/workflow.rs
@@ -18,6 +18,20 @@ use epigraph_ingest::workflow::WorkflowExtraction;
 use crate::error::IngestExecutorError;
 use crate::system_agent::get_or_create_system_agent;
 
+/// A newly inserted plan edge as returned by the executor. Callers iterate
+/// these post-hoc to fire `auto_wire_edge_if_epistemic` (the executor itself
+/// is pure-DB and doesn't depend on epigraph-engine — mirrors the embedding
+/// pattern documented in CLAUDE.md "Embedding policy").
+#[derive(Debug, Clone)]
+pub struct InsertedPlanEdge {
+    pub edge_id: Uuid,
+    pub source_id: Uuid,
+    pub source_type: String,
+    pub target_id: Uuid,
+    pub target_type: String,
+    pub relationship: String,
+}
+
 /// Summary of what the executor wrote (or skipped) for a single plan.
 #[derive(Debug, Clone)]
 pub struct WorkflowIngestExecutionResult {
@@ -41,6 +55,15 @@ pub struct WorkflowIngestExecutionResult {
     /// is_current=true → has-embedding invariant; see CLAUDE.md
     /// "Embedding policy".
     pub inserted: Vec<(Uuid, String)>,
+    /// Newly inserted plan edges (claim→claim relationships from
+    /// `IngestPlan::edges`). Callers fire `auto_wire_edge_if_epistemic` on
+    /// each so epistemic edges materialize their factor BBA on the target.
+    /// Empty on idempotent re-ingest.
+    pub inserted_edges: Vec<InsertedPlanEdge>,
+    /// Agent the workflow attributes its writes to. Callers pass this to
+    /// `auto_wire_edge_if_epistemic` as the BBA's `source_agent_id`. `None`
+    /// on idempotent re-ingest (no agent created, no edges to wire).
+    pub system_agent_id: Option<Uuid>,
 }
 
 /// Execute a workflow ingest plan against the database.
@@ -85,6 +108,8 @@ pub async fn execute_workflow_ingest_plan(
                 relationship_edges_created: 0,
                 already_ingested: true,
                 inserted: Vec::new(),
+                inserted_edges: Vec::new(),
+                system_agent_id: None,
             });
         }
     }
@@ -252,6 +277,7 @@ pub async fn execute_workflow_ingest_plan(
 
     // ── 7. Intra-claim plan edges (decomposes_to / step_follows / phase_follows / cross-refs) ──
     let mut relationships_created = 0_usize;
+    let mut inserted_edges: Vec<InsertedPlanEdge> = Vec::new();
     for edge in &plan.edges {
         let (src, src_type) = if edge.source_type == "author_placeholder" {
             let idx = edge.properties["author_index"].as_u64().unwrap_or(0) as usize;
@@ -271,7 +297,7 @@ pub async fn execute_workflow_ingest_plan(
             .copied()
             .unwrap_or(edge.target_id);
 
-        let (_row, _was_created) = EdgeRepository::create_if_not_exists(
+        let (row, was_created) = EdgeRepository::create_if_not_exists(
             pool,
             src,
             &src_type,
@@ -284,6 +310,16 @@ pub async fn execute_workflow_ingest_plan(
         )
         .await?;
         relationships_created += 1;
+        if was_created {
+            inserted_edges.push(InsertedPlanEdge {
+                edge_id: row.id,
+                source_id: src,
+                source_type: src_type,
+                target_id: tgt,
+                target_type: edge.target_type.clone(),
+                relationship: edge.relationship.clone(),
+            });
+        }
     }
 
     Ok(WorkflowIngestExecutionResult {
@@ -297,5 +333,7 @@ pub async fn execute_workflow_ingest_plan(
         relationship_edges_created: relationships_created,
         already_ingested: false,
         inserted,
+        inserted_edges,
+        system_agent_id: Some(system_agent_id),
     })
 }

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -14,6 +14,7 @@ use rmcp::model::*;
 
 use crate::errors::{internal_error, invalid_params, McpError};
 use crate::server::EpiGraphMcpFull;
+use crate::tools::ds_auto;
 use crate::types::{ImproveWorkflowHierarchyParams, IngestWorkflowParams};
 
 use epigraph_ingest::workflow::WorkflowExtraction;
@@ -52,6 +53,27 @@ pub(crate) async fn execute_workflow_ingest_with_inserted(
     let result = epigraph_ingest_executor::execute_workflow_ingest_plan(pool, &plan, extraction)
         .await
         .map_err(|e| internal_error(format!("workflow ingest: {e}")))?;
+
+    // Auto-wire DS factors for newly-inserted epistemic edges. The executor
+    // returns the edges so the caller can fire this without pulling
+    // `epigraph-engine` into the executor's dep graph (matches the embedding
+    // pattern documented in CLAUDE.md "Embedding policy").
+    if let Some(agent_id) = result.system_agent_id {
+        for e in &result.inserted_edges {
+            ds_auto::auto_wire_edge_if_epistemic(
+                pool,
+                true, // executor only emits an InsertedPlanEdge when was_created=true
+                e.edge_id,
+                e.source_id,
+                &e.source_type,
+                e.target_id,
+                &e.target_type,
+                &e.relationship,
+                agent_id,
+            )
+            .await;
+        }
+    }
 
     let inserted = result.inserted.clone();
     let response = IngestWorkflowResponse {


### PR DESCRIPTION
## Summary

Closes the third edge-creation call site (after MCP \`ingest_document\` #171 and HTTP \`POST /api/v1/edges\` #172). The \`epigraph-ingest-executor\` is pure-DB by design (no \`epigraph-engine\` dep), so this PR mirrors the embedding-out-of-executor pattern from CLAUDE.md: the executor records what it inserted; callers fire \`auto_wire_edge_if_epistemic\` post-hoc.

## Changes

- \`WorkflowIngestExecutionResult\` gains:
  - \`inserted_edges: Vec<InsertedPlanEdge>\` — one entry per newly-created plan edge (only populated when \`was_created=true\`, so idempotent re-ingest doesn't re-fire).
  - \`system_agent_id: Option<Uuid>\` — the BBA's \`source_agent_id\`. \`None\` on the early-return idempotency-gate path.
- Three callers iterate and fire the engine helper:
  - MCP \`tools::workflow_ingest::execute_workflow_ingest_with_inserted\` — covers \`do_ingest_workflow\`, \`do_ingest_workflow_via_pool\`, and (via re-entry) \`improve_workflow_hierarchy\`.
  - HTTP \`store_workflow\` (\`POST /api/v1/workflows\`) and \`ingest_workflow\` (\`POST /api/v1/workflows/ingest\`), via a new \`auto_wire_inserted_edges\` helper in \`routes/workflows.rs\`.

## Test plan

- [x] \`cargo check --workspace\` — clean
- [x] \`cargo test -p epigraph-engine --lib epistemic_interval\` — 16/16 pass
- [x] Existing executor integration tests still compile against the new struct fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)