### PR TITLE
fix(mcp,db): embedding-based find_workflow_hierarchical with ILIKE fallback

### DIFF
--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -723,17 +723,42 @@ pub async fn find_workflow_hierarchical(
 ) -> Result<Json<HierarchicalSearchResponse>, ApiError> {
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
     let min_truth = params.min_truth.unwrap_or(0.3);
-    let rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
-        &state.db_pool,
-        &params.q,
-        limit,
-        min_truth,
-        params.resolve_to_latest,
-    )
-    .await
-    .map_err(|e| ApiError::InternalError {
-        message: format!("hierarchical search failed: {e}"),
-    })?;
+    let similarity_threshold = 0.5_f64;
+
+    // Embedding-first to tolerate paraphrasing; ILIKE fallback for short
+    // queries, when embedder is unavailable, or when no embedded rows clear
+    // the similarity floor.
+    let mut rows = if let Some(embedder) = state.embedding_service() {
+        match embedder.generate(&params.q).await {
+            Ok(qvec) => epigraph_db::WorkflowRepository::find_hierarchical_by_embedding(
+                &state.db_pool,
+                &qvec,
+                similarity_threshold,
+                min_truth,
+                limit,
+                params.resolve_to_latest,
+            )
+            .await
+            .unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
+    } else {
+        Vec::new()
+    };
+
+    if rows.is_empty() {
+        rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
+            &state.db_pool,
+            &params.q,
+            limit,
+            min_truth,
+            params.resolve_to_latest,
+        )
+        .await
+        .map_err(|e| ApiError::InternalError {
+            message: format!("hierarchical search failed: {e}"),
+        })?;
+    }
 
     let mut workflows: Vec<HierarchicalWorkflowResult> = rows
         .into_iter()

--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -628,6 +628,101 @@ impl WorkflowRepository {
             .await
     }
 
+    /// Cosine-similarity search over `workflows.goal_embedding`.
+    ///
+    /// Mirrors `find_by_embedding` (flat) but reads the hierarchical
+    /// `workflows` table. Rows without an embedding are skipped — caller
+    /// should fall back to `search_hierarchical_by_text` for those.
+    ///
+    /// `similarity_threshold` filters by `(1 - cosine_distance) >=
+    /// threshold`. `min_truth` filters out deprecated rows
+    /// (`deprecate_workflow` writes 0.05). When `resolve_to_latest` is
+    /// true, ordering is `(canonical_name ASC, generation DESC,
+    /// distance ASC)` so heads-of-lineage surface first; otherwise
+    /// `distance ASC, created_at DESC`.
+    ///
+    /// # Errors
+    /// Returns `sqlx::Error` if the database query fails.
+    pub async fn find_hierarchical_by_embedding(
+        pool: &PgPool,
+        query_embedding: &[f32],
+        similarity_threshold: f64,
+        min_truth: f64,
+        limit: i64,
+        resolve_to_latest: bool,
+    ) -> Result<Vec<HierarchicalWorkflowRow>, sqlx::Error> {
+        let vec_str = format!(
+            "[{}]",
+            query_embedding
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        // For embedding-based search, semantic distance is the primary signal —
+        // sorting by canonical_name first (as the ILIKE path does for heads-walk
+        // dedup) would defeat that. Always sort by distance first; when
+        // resolve_to_latest is requested, prefer higher generation as a
+        // tiebreaker so newer variants of an equally-close lineage surface
+        // first.
+        let order_clause = if resolve_to_latest {
+            "ORDER BY distance ASC, generation DESC, created_at DESC"
+        } else {
+            "ORDER BY distance ASC, created_at DESC, id ASC"
+        };
+        let sql = format!(
+            "WITH q AS (SELECT $1::vector AS v) \
+             SELECT id, canonical_name, generation, goal, parent_id, metadata, created_at, truth_value, \
+                    (w.goal_embedding <=> q.v) AS distance \
+             FROM workflows w, q \
+             WHERE w.goal_embedding IS NOT NULL \
+               AND w.truth_value >= $3 \
+               AND (1 - (w.goal_embedding <=> q.v)) >= $2 \
+             {order_clause} \
+             LIMIT $4"
+        );
+        // The SELECT adds a `distance` column for ordering but it's not part of
+        // HierarchicalWorkflowRow — wrap in an outer SELECT that drops it.
+        let outer_sql = format!(
+            "SELECT id, canonical_name, generation, goal, parent_id, metadata, created_at, truth_value \
+             FROM ({sql}) inner_q"
+        );
+        sqlx::query_as::<_, HierarchicalWorkflowRow>(&outer_sql)
+            .bind(&vec_str)
+            .bind(similarity_threshold)
+            .bind(min_truth)
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+    }
+
+    /// Write the embedding vector for a hierarchical workflow's goal text.
+    /// Idempotent: caller is expected to skip rows where `goal_embedding`
+    /// is already set unless explicitly re-embedding.
+    ///
+    /// # Errors
+    /// Returns `sqlx::Error` if the database query fails.
+    pub async fn set_goal_embedding(
+        pool: &PgPool,
+        workflow_id: Uuid,
+        embedding: &[f32],
+    ) -> Result<u64, sqlx::Error> {
+        let vec_str = format!(
+            "[{}]",
+            embedding
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let r = sqlx::query("UPDATE workflows SET goal_embedding = $1::vector WHERE id = $2")
+            .bind(&vec_str)
+            .bind(workflow_id)
+            .execute(pool)
+            .await?;
+        Ok(r.rows_affected())
+    }
+
     /// Set `workflows.truth_value` for the given workflow id. Used by
     /// `deprecate_workflow` to cascade truth=0.05 from the flat-claim row
     /// onto the hierarchical-table row so `find_workflow_hierarchical`

--- a/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_hierarchical.rs
@@ -60,16 +60,66 @@ pub async fn find_workflow_hierarchical(
     // for future probabilistic discounting; callers can pass 0.0 to see
     // the deprecated cemetery.
     let min_truth = params.min_truth.unwrap_or(0.3);
+    // Cosine-similarity floor for embedding hits. 0.5 mirrors the
+    // behavioral_affinity_lineage default used by flat find_workflow.
+    let similarity_threshold = 0.5_f64;
 
-    let rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
-        &server.pool,
-        &params.query,
-        limit,
-        min_truth,
-        resolve_to_latest,
-    )
-    .await
-    .map_err(internal_error)?;
+    // Try embedding-first to tolerate paraphrasing, punctuation drift, and
+    // word-order differences. Falls through to ILIKE substring match (the
+    // legacy search_hierarchical_by_text path) when the embedder is
+    // unavailable, the API call fails, or zero workflows have an embedding
+    // similar enough to clear the threshold.
+    let mut search_path = "ilike";
+    let mut rows = if server.embedder.is_mock() {
+        Vec::new()
+    } else {
+        match server.embedder.generate(&params.query).await {
+            Ok(qvec) => {
+                match epigraph_db::WorkflowRepository::find_hierarchical_by_embedding(
+                    &server.pool,
+                    &qvec,
+                    similarity_threshold,
+                    min_truth,
+                    limit,
+                    resolve_to_latest,
+                )
+                .await
+                {
+                    Ok(rs) if !rs.is_empty() => {
+                        search_path = "embedding";
+                        rs
+                    }
+                    Ok(_) => Vec::new(), // embedding ran but no rows cleared threshold
+                    Err(e) => {
+                        tracing::warn!(
+                            error = ?e,
+                            "find_hierarchical_by_embedding failed; falling back to ILIKE"
+                        );
+                        Vec::new()
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = ?e,
+                    "embedder.generate failed; falling back to ILIKE"
+                );
+                Vec::new()
+            }
+        }
+    };
+
+    if rows.is_empty() {
+        rows = epigraph_db::WorkflowRepository::search_hierarchical_by_text(
+            &server.pool,
+            &params.query,
+            limit,
+            min_truth,
+            resolve_to_latest,
+        )
+        .await
+        .map_err(internal_error)?;
+    }
 
     let mut workflows: Vec<serde_json::Value> = Vec::with_capacity(rows.len());
     for r in rows {
@@ -100,6 +150,7 @@ pub async fn find_workflow_hierarchical(
         "total": workflows.len(),
         "resolve_to_latest": resolve_to_latest,
         "min_truth": min_truth,
+        "search_path": search_path,
     }))
 }
 

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -123,6 +123,27 @@ pub async fn do_ingest_workflow(
         let _ = server.embedder.embed_and_store(*claim_id, content).await;
     }
 
+    // Also embed the workflows-table goal for semantic find_workflow_hierarchical.
+    // Best-effort: workflow is still findable via ILIKE fallback if this errors.
+    if let Ok(wf_id) = uuid::Uuid::parse_str(&response.workflow_id) {
+        match server.embedder.generate(&extraction.source.goal).await {
+            Ok(qvec) => {
+                if let Err(e) = epigraph_db::WorkflowRepository::set_goal_embedding(
+                    &server.pool,
+                    wf_id,
+                    &qvec,
+                )
+                .await
+                {
+                    tracing::warn!(workflow_id=%wf_id, error=?e, "set_goal_embedding failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(workflow_id=%wf_id, error=?e, "goal embedding generation failed");
+            }
+        }
+    }
+
     success_json(&response)
 }
 

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -128,12 +128,9 @@ pub async fn do_ingest_workflow(
     if let Ok(wf_id) = uuid::Uuid::parse_str(&response.workflow_id) {
         match server.embedder.generate(&extraction.source.goal).await {
             Ok(qvec) => {
-                if let Err(e) = epigraph_db::WorkflowRepository::set_goal_embedding(
-                    &server.pool,
-                    wf_id,
-                    &qvec,
-                )
-                .await
+                if let Err(e) =
+                    epigraph_db::WorkflowRepository::set_goal_embedding(&server.pool, wf_id, &qvec)
+                        .await
                 {
                     tracing::warn!(workflow_id=%wf_id, error=?e, "set_goal_embedding failed");
                 }

--- a/migrations/040_workflows_goal_embedding.sql
+++ b/migrations/040_workflows_goal_embedding.sql
@@ -1,0 +1,21 @@
+-- Add goal_embedding to workflows table for semantic-similarity search.
+--
+-- find_workflow_hierarchical previously matched goal text via single ILIKE
+-- substring match. Any punctuation, word-order, or paraphrase difference
+-- between the caller's query string and the stored goal returned zero hits,
+-- defeating cron tasks that called the tool with the exact bootstrap goal
+-- text. Adding goal_embedding lets the MCP tool route through the existing
+-- OpenAI embedding service (text-embedding-3-small, 1536-dim) for cosine
+-- similarity search — same pattern flat find_workflow already uses on
+-- claims.embedding. ILIKE remains as fallback when no embedder is available
+-- or when goal_embedding has not been backfilled.
+
+ALTER TABLE workflows ADD COLUMN IF NOT EXISTS goal_embedding vector(1536);
+
+-- ivfflat index for cosine distance lookups. lists=10 chosen for the
+-- current ~200-row workflows table (rule of thumb: lists = rows^0.5 / 2).
+-- Re-tune via REINDEX with WITH (lists = N) when the table crosses ~5k rows.
+CREATE INDEX IF NOT EXISTS idx_workflows_goal_embedding
+    ON workflows
+    USING ivfflat (goal_embedding vector_cosine_ops)
+    WITH (lists = 10);


### PR DESCRIPTION
## Summary
- Adds `workflows.goal_embedding vector(1536)` + ivfflat index (migration 040) so hierarchical workflow lookup can use semantic similarity instead of `%query%` substring match.
- MCP `find_workflow_hierarchical` and HTTP `GET /api/v1/workflows/hierarchical/search` now try embedding-first via the existing `EmbeddingService`, fall through to the legacy `search_hierarchical_by_text` ILIKE path when the embedder is unavailable, errors, or returns zero rows clearing the 0.5 cosine threshold.
- `do_ingest_workflow` embeds `extraction.source.goal` into the new column post-commit, best-effort (warns on failure, ingest still succeeds). Mirrors the embedding policy in CLAUDE.md.
- MCP response now carries a `search_path` field (`"embedding"` or `"ilike"`) for observability.

## Why
Backlog `506ca4e8`: full goal text queries returned 0 results because the bag-of-text was wrapped as a single ILIKE pattern. Any punctuation, word-order, or paraphrase difference between the caller and the stored goal defeated the substring match. This neutralized the 2026-05-27 migration that switched 15 cron prompts from `find_workflow(goal:)` to `find_workflow_hierarchical(query:)` — the new hierarchical path was silently falling back to flat lookup for every long-text query.

## Verified
180 existing workflows backfilled via OpenAI `text-embedding-3-small` (matches `behavioral_executions.goal_embedding` dim).

Post-deploy:
```
q = "Scan for epistemic conflicts compare CDST methods check DS vs Bayesian divergence auto-resolve escalate"
```
returns `c66ce78a` (exact match) ranked **#1** with `resolve_to_latest=true`. Previously: 0 results.

## Test plan
- [ ] `cargo check --workspace` passes (verified locally before commit)
- [ ] Migration 040 applies cleanly to staging DB
- [ ] After deploy + backfill, `find_workflow_hierarchical` returns non-empty for at least 5 cron-style full-goal queries that previously returned 0
- [ ] `search_path` field reads `"embedding"` for normal queries and `"ilike"` when `OPENAI_API_KEY` is unset
- [ ] `do_ingest_workflow` writes `goal_embedding` for a freshly-ingested workflow (spot-check `SELECT goal_embedding IS NOT NULL FROM workflows WHERE id = $1`)
- [ ] Existing `search_hierarchical_by_text_returns_matches` test still passes (ILIKE fallback path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)