### PR TITLE
fix(mcp): plumb claims:admin scope into MCP ownership checks

### DIFF
--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -275,9 +275,16 @@ impl EpiGraphMcpFull {
     async fn resolve_backlog_item(
         &self,
         Parameters(params): Parameters<crate::types::ResolveBacklogItemParams>,
+        extensions: rmcp::model::Extensions,
     ) -> Result<CallToolResult, McpError> {
         self.reject_if_read_only()?;
-        crate::tools::claims::resolve_backlog_item(self, params).await
+        // For HTTP callers `call_tool` copies the AuthContext into
+        // `context.extensions` so admin-scope holders can bypass the
+        // agent-equality ownership check. For stdio (no auth context)
+        // we pass `None` and the handler falls back to agent-equality
+        // against the server's own signer agent.
+        let auth = extensions.get::<epigraph_auth::AuthContext>();
+        crate::tools::claims::resolve_backlog_item(self, params, auth).await
     }
 
     #[tool(
@@ -928,11 +935,21 @@ impl ServerHandler for EpiGraphMcpFull {
         // `http::request::Parts` (see rmcp/src/transport/streamable_http_server/
         // tower.rs:326/384/463). For stdio transport there is no `Parts` attached —
         // the stdio process boundary is the trust gate and no auth check applies.
-        let http_parts = context.extensions.get::<Parts>();
-        let auth = http_parts.and_then(|p| p.extensions.get::<epigraph_auth::AuthContext>());
+        let is_http_call;
+        let auth_owned: Option<epigraph_auth::AuthContext>;
+        {
+            let http_parts = context.extensions.get::<Parts>();
+            is_http_call = http_parts.is_some();
+            // Clone the AuthContext out of the borrow so we can both
+            // (a) run scope enforcement and (b) reassign `context`
+            // below to insert it into rmcp's extensions map.
+            auth_owned = http_parts
+                .and_then(|p| p.extensions.get::<epigraph_auth::AuthContext>())
+                .cloned();
+        }
 
-        if http_parts.is_some() {
-            if let Err(err) = Self::enforce_tool_scope(auth, &request.name) {
+        if is_http_call {
+            if let Err(err) = Self::enforce_tool_scope(auth_owned.as_ref(), &request.name) {
                 // Emit a denial audit event so 403s show up alongside successes.
                 self.emit_tool_invoked(&format!("denied:{}", request.name))
                     .await;
@@ -947,6 +964,21 @@ impl ServerHandler for EpiGraphMcpFull {
         // **DO NOT remove this line without updating
         // `tests/event_log_wiring_tests.rs::tool_dispatch_emits_tool_invoked_event`.**
         self.emit_tool_invoked(&request.name).await;
+
+        // Propagate the HTTP-side `AuthContext` (set by
+        // `auth::bearer_auth_middleware` and forwarded by
+        // `StreamableHttpService` through `http::request::Parts`) into
+        // rmcp's `RequestContext::extensions` so per-tool handlers can
+        // pull it out via the `rmcp::model::Extensions` extractor and
+        // run per-row ownership checks (e.g. `resolve_backlog_item`'s
+        // owner-or-`claims:admin` gate). For stdio transport there is
+        // no `Parts` and no auth to copy; handlers see an empty
+        // extensions map and fall back to coarse, signer-agent-based
+        // checks.
+        let mut context = context;
+        if let Some(auth) = auth_owned {
+            context.extensions.insert(auth);
+        }
 
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         self.tool_router.call(tcc).await

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -411,6 +411,62 @@ pub async fn update_with_evidence(
     })
 }
 
+/// Per-row authorization for MCP tools that mutate an existing claim.
+///
+/// Mirrors `epigraph_api::middleware::scopes::require_owner_or_admin`
+/// (the HTTP layer's check on PATCH `/api/v1/claims/:id/labels`) but
+/// scoped to the MCP entry path. Two callers, two policies:
+///
+/// - **HTTP (`auth = Some(_)`):** allow if the token carries
+///   `claims:admin` OR the caller's principal (`owner_id` falling back
+///   to `client_id`) equals `target_agent_id`. This is the path that
+///   unblocks cross-agent backlog retirement for admin-scope holders
+///   (backlog item `a4cc08a6`).
+/// - **stdio (`auth = None`):** the MCP server has no per-request
+///   identity, so degrade to comparing the claim's author against the
+///   server's own signer agent. Preserves the legacy behavior for
+///   non-HTTP callers without re-opening the cross-agent abuse vector.
+pub(crate) async fn require_owner_or_admin(
+    server: &EpiGraphMcpFull,
+    auth: Option<&epigraph_auth::AuthContext>,
+    target_agent_id: uuid::Uuid,
+) -> Result<(), McpError> {
+    if let Some(auth) = auth {
+        if auth.has_scope("claims:admin") {
+            return Ok(());
+        }
+        let principal = auth.owner_id.unwrap_or(auth.client_id);
+        if principal == target_agent_id {
+            return Ok(());
+        }
+        return Err(McpError {
+            code: rmcp::model::ErrorCode::INVALID_PARAMS,
+            message: format!(
+                "claim is owned by agent {target_agent_id}; \
+                 caller principal {principal} cannot retire it \
+                 (requires claims:admin scope or ownership)"
+            )
+            .into(),
+            data: None,
+        });
+    }
+
+    let caller_agent = server.agent_id().await?;
+    if caller_agent == target_agent_id {
+        return Ok(());
+    }
+    Err(McpError {
+        code: rmcp::model::ErrorCode::INVALID_PARAMS,
+        message: format!(
+            "claim is owned by agent {target_agent_id}; \
+             caller agent {caller_agent} cannot retire it \
+             (no AuthContext on this transport — claims:admin scope only honored over HTTP)"
+        )
+        .into(),
+        data: None,
+    })
+}
+
 /// One-call backlog-item retirement.
 ///
 /// Submits a resolution claim via the canonical `submit_claim` pipeline
@@ -426,6 +482,7 @@ pub async fn update_with_evidence(
 pub async fn resolve_backlog_item(
     server: &EpiGraphMcpFull,
     params: crate::types::ResolveBacklogItemParams,
+    auth: Option<&epigraph_auth::AuthContext>,
 ) -> Result<CallToolResult, McpError> {
     let original_id = parse_uuid(&params.original_id)?;
     let original_claim_id = ClaimId::from_uuid(original_id);
@@ -439,37 +496,15 @@ pub async fn resolve_backlog_item(
         .ok_or_else(|| invalid_params(format!("claim {original_id} not found")))?;
 
     // Authorization: mirror PATCH /api/v1/claims/:id/labels'
-    // `require_owner_or_admin` middleware. The HTTP route's check is
-    // (claims:admin OR auth.owner_id/client_id == claim.agent_id). The
-    // rmcp tool_router macro does NOT forward the request's `AuthContext`
-    // into per-tool handlers — only `Parameters<T>` is passed. So we
-    // cannot read the caller's scopes here (admin override) or their
-    // owner/client UUID. Per Component 2 of the backlog-retirement spec
-    // ("Calls existing HTTP routes…"), HTTP forwarding would be cleaner
-    // but requires a bearer token the MCP server doesn't hold unless the
-    // caller passes one.
-    //
-    // Coarse fallback: compare the claim's author against the server's
-    // own signer agent. This blocks the most common abuse (a token with
-    // claims:write retiring a claim authored by a different signer) but
-    // it does NOT distinguish multiple human/agent callers that share
-    // the same MCP-server signer. Follow-up: plumb AuthContext through
-    // rmcp's Extension<T> pattern at the tool-handler boundary so this
-    // can check has_scope("claims:admin") and auth.owner_id properly.
-    let caller_agent = server.agent_id().await?;
+    // `require_owner_or_admin` middleware. With an HTTP `AuthContext`
+    // available (propagated into rmcp's `RequestContext::extensions` by
+    // `server::call_tool`), allow when the caller has `claims:admin` or
+    // when their principal (`owner_id` falling back to `client_id`)
+    // matches the claim's `agent_id`. With no auth (stdio transport),
+    // fall back to the legacy agent-equality check against the server's
+    // own signer agent — preserves backward compat for non-HTTP callers.
     let target_agent = original.agent_id.as_uuid();
-    if caller_agent != target_agent {
-        return Err(McpError {
-            code: rmcp::model::ErrorCode::INVALID_PARAMS,
-            message: format!(
-                "claim {original_id} is owned by agent {target_agent}; \
-                 caller agent {caller_agent} cannot retire it (claims:admin scope \
-                 override not yet plumbed into MCP tool handlers)"
-            )
-            .into(),
-            data: None,
-        });
-    }
+    require_owner_or_admin(server, auth, target_agent).await?;
 
     // 1. Submit the resolution claim via the canonical pipeline.
     let methodology = params

--- a/crates/epigraph-mcp/tests/resolve_backlog_item.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item.rs
@@ -41,6 +41,7 @@ async fn resolve_backlog_item_creates_resolution_and_patches_original(pool: PgPo
             resolution_content: "Fixed by replacing the index with a GIN BTREE.".to_string(),
             methodology: None,
         },
+        None,
     )
     .await
     .expect("resolve_backlog_item");

--- a/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
@@ -1,6 +1,7 @@
 //! Integration test for the owner-or-admin check in
 //! [`resolve_backlog_item`] (deferred-review item #2 of the
-//! backlog-retirement work).
+//! backlog-retirement work; cross-agent unblock for backlog item
+//! `a4cc08a6`).
 //!
 //! Background: previously `resolve_backlog_item` called
 //! `ClaimRepository::update_labels` directly on the repo layer, bypassing
@@ -9,24 +10,28 @@
 //! could retire ANY agent's claim. The fix mirrors the HTTP check inside
 //! the MCP handler.
 //!
-//! Caveat: rmcp's `tool_router` macro does NOT forward `AuthContext` into
-//! per-tool handlers (only `Parameters<T>`), so the MCP handler cannot
-//! read the caller's scopes (`claims:admin` override) or owner UUID. The
-//! check therefore degrades to agent-equality against the server's own
-//! signer agent. This test exercises that check:
+//! `AuthContext` is now propagated from the HTTP `Bearer` middleware
+//! into rmcp's `RequestContext::extensions` by `server::call_tool`, and
+//! `resolve_backlog_item` takes an `Option<&AuthContext>`. Two paths:
 //!
-//! - **Foreign-agent claim → FORBIDDEN.** Seeds a claim authored by a
-//!   freshly-inserted foreign agent UUID. `resolve_backlog_item` must
-//!   refuse with INVALID_PARAMS (the agent-equality fallback maps onto
-//!   that rmcp ErrorCode; see the `claims.rs` impl).
-//! - **Own-signer claim → OK.** Submits a claim through the same MCP
-//!   server (auto-registers the signer agent), then retires it. Must
-//!   succeed.
+//! - **With `auth = Some(_)`:** `claims:admin` OR principal-equality
+//!   against the claim's `agent_id` (mirrors HTTP layer).
+//! - **With `auth = None`:** legacy fallback — agent-equality vs the
+//!   server's own signer agent. This preserves stdio transport's
+//!   behavior (no per-request identity available there).
 //!
-//! The admin-scope override path is intentionally NOT tested here — it
-//! is unreachable without plumbing AuthContext into the tool layer
-//! (tracked as the follow-up in the handler's authz comment).
+//! This file tests both. The HTTP-path admin/principal combinations are
+//! exercised by `cross_agent_admin_scope_*` tests; the stdio-path
+//! foreign/own-signer tests use `auth = None`.
+//!
+//! - **stdio + foreign-agent claim → FORBIDDEN.** Seeds a claim authored
+//!   by a freshly-inserted foreign agent UUID. `resolve_backlog_item`
+//!   must refuse with INVALID_PARAMS.
+//! - **stdio + own-signer claim → OK.** Submits a claim through the
+//!   same MCP server (auto-registers the signer agent), then retires
+//!   it. Must succeed.
 
+use epigraph_auth::{AuthContext, ClientType};
 use epigraph_core::ClaimId;
 use epigraph_db::ClaimRepository;
 use epigraph_mcp::tools::claims::resolve_backlog_item;
@@ -59,6 +64,7 @@ async fn resolve_backlog_item_refuses_foreign_agent_claim(pool: PgPool) {
             resolution_content: "should be rejected".to_string(),
             methodology: None,
         },
+        None,
     )
     .await
     .expect_err("resolve_backlog_item must refuse a foreign-agent claim");
@@ -116,6 +122,7 @@ async fn resolve_backlog_item_permits_own_signer_claim(pool: PgPool) {
             resolution_content: "retired by own signer".to_string(),
             methodology: None,
         },
+        None,
     )
     .await
     .expect("resolve_backlog_item must permit retirement of own claim");
@@ -131,6 +138,139 @@ async fn resolve_backlog_item_permits_own_signer_claim(pool: PgPool) {
         labels.contains(&"resolved".to_string()),
         "own claim's label patch must succeed: {labels:?}"
     );
+}
+
+// ── HTTP-path tests: AuthContext present ────────────────────────────────────
+//
+// These exercise the path that was previously unreachable. With an
+// `AuthContext` propagated from the HTTP bearer middleware, an admin
+// token can retire a foreign-agent claim and a non-admin matching
+// principal can retire its own.
+
+/// `auth.has_scope("claims:admin")` should allow retirement of a
+/// foreign-agent claim — the cross-agent unblock for backlog
+/// `a4cc08a6`.
+#[sqlx::test(migrations = "../../migrations")]
+async fn resolve_backlog_item_admin_scope_overrides_foreign_agent(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+
+    let foreign_agent = seed_random_agent(&pool).await;
+    let foreign_claim = seed_claim_with_agent(&pool, foreign_agent, &["backlog"]).await;
+
+    let admin_auth = make_auth(&["claims:admin"], Uuid::new_v4(), None);
+
+    let result = resolve_backlog_item(
+        &server,
+        ResolveBacklogItemParams {
+            original_id: foreign_claim.as_uuid().to_string(),
+            resolution_content: "retired by admin token".to_string(),
+            methodology: None,
+        },
+        Some(&admin_auth),
+    )
+    .await
+    .expect("admin scope must override foreign-agent ownership check");
+
+    let body = parse_json(&result);
+    let labels: Vec<String> = body["original_labels"]
+        .as_array()
+        .expect("original_labels is array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        labels.contains(&"resolved".to_string()),
+        "admin retirement must patch the foreign claim's labels: {labels:?}"
+    );
+}
+
+/// Non-admin token whose principal (`owner_id` falling back to
+/// `client_id`) equals the claim's `agent_id` should pass — mirrors
+/// HTTP `require_owner_or_admin` semantics.
+#[sqlx::test(migrations = "../../migrations")]
+async fn resolve_backlog_item_matching_principal_passes_without_admin(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+
+    let agent = seed_random_agent(&pool).await;
+    let claim = seed_claim_with_agent(&pool, agent, &["backlog"]).await;
+
+    // Caller is `claims:write`-only but their owner_id == claim.agent_id.
+    let auth = make_auth(&["claims:write"], Uuid::new_v4(), Some(agent));
+
+    let result = resolve_backlog_item(
+        &server,
+        ResolveBacklogItemParams {
+            original_id: claim.as_uuid().to_string(),
+            resolution_content: "retired by owning principal".to_string(),
+            methodology: None,
+        },
+        Some(&auth),
+    )
+    .await
+    .expect("owning principal must succeed without admin scope");
+
+    let body = parse_json(&result);
+    let labels: Vec<String> = body["original_labels"]
+        .as_array()
+        .expect("original_labels is array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        labels.contains(&"resolved".to_string()),
+        "matching-principal retirement must patch labels: {labels:?}"
+    );
+}
+
+/// Foreign-agent claim + non-matching principal + no admin scope must
+/// be denied even when an `AuthContext` is present. This is the
+/// negative test for the admin/principal gate.
+#[sqlx::test(migrations = "../../migrations")]
+async fn resolve_backlog_item_foreign_principal_without_admin_denied(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+
+    let foreign_agent = seed_random_agent(&pool).await;
+    let foreign_claim = seed_claim_with_agent(&pool, foreign_agent, &["backlog"]).await;
+
+    // Caller's principal is some other UUID — neither admin nor owner.
+    let auth = make_auth(&["claims:write"], Uuid::new_v4(), Some(Uuid::new_v4()));
+
+    let err = resolve_backlog_item(
+        &server,
+        ResolveBacklogItemParams {
+            original_id: foreign_claim.as_uuid().to_string(),
+            resolution_content: "should be rejected".to_string(),
+            methodology: None,
+        },
+        Some(&auth),
+    )
+    .await
+    .expect_err("non-admin foreign principal must be denied");
+
+    let msg = err.message.to_string();
+    assert!(
+        msg.contains("claims:admin") || msg.contains("ownership"),
+        "denial must cite the required permission, got: {msg:?}"
+    );
+
+    let labels = ClaimRepository::get_labels(&pool, foreign_claim)
+        .await
+        .expect("get_labels foreign");
+    assert!(
+        !labels.contains(&"resolved".to_string()),
+        "foreign claim must NOT have been labeled 'resolved' after deny: {labels:?}"
+    );
+}
+
+fn make_auth(scopes: &[&str], client_id: Uuid, owner_id: Option<Uuid>) -> AuthContext {
+    AuthContext {
+        client_id,
+        agent_id: None,
+        owner_id,
+        client_type: ClientType::Service,
+        scopes: scopes.iter().map(|s| (*s).to_string()).collect(),
+        jti: Uuid::new_v4(),
+    }
 }
 
 fn parse_json(result: &CallToolResult) -> Value {


### PR DESCRIPTION
## Summary
- Plumbs `AuthContext` from rmcp dispatch through to tool handlers (via `RequestContext.extensions` + the built-in `rmcp::model::Extensions` extractor) so `claims:admin` scope holders can bypass the agent-equality ownership check (matches HTTP layer's `require_owner_or_admin` pattern)
- Replaces `resolve_backlog_item`'s hardcoded "scope override not plumbed" error with a proper owner-or-admin gate
- Preserves stdio-transport behavior: when no `AuthContext` is attached, the handler falls back to the legacy signer-equality check (no abuse vector re-opened)

## Why
Backlog `a4cc08a6`. Today's conflict-cluster cleanup hit this 12 times -- we worked around with admin SQL. Every cron run that wants to retire its OWN prior backlog items hits the same wall because ephemeral `mcp-agent` UUIDs aren't shared across runs. Admin-scope holders (the natural caller for cross-agent retirement) had no way through.

## Implementation
- `server::call_tool` clones the `AuthContext` out of `http::request::Parts.extensions` (where `bearer_auth_middleware` puts it) and inserts it into rmcp's `RequestContext.extensions` so per-tool handlers can extract it.
- `server::resolve_backlog_item` tool handler now accepts a `rmcp::model::Extensions` parameter (built-in extractor — no new wrapper type) and forwards `extensions.get::<AuthContext>()` to the impl.
- `tools/claims::resolve_backlog_item` now takes `auth: Option<&AuthContext>` and delegates the per-row decision to a new `require_owner_or_admin` helper that mirrors `epigraph_api::middleware::scopes::require_owner_or_admin`.

## Test plan
- [x] Unit/integration tests in `resolve_backlog_item_ownership.rs`:
  - `admin_scope_overrides_foreign_agent` -- admin token retires foreign-agent claim, labels patched
  - `matching_principal_passes_without_admin` -- non-admin caller whose principal (owner_id || client_id) equals claim.agent_id succeeds
  - `foreign_principal_without_admin_denied` -- non-admin, non-matching principal is denied; no side-effect leak
- [x] Existing `resolve_backlog_item_ownership.rs` tests (stdio-path, `auth = None`) still pass: `refuses_foreign_agent_claim`, `permits_own_signer_claim`
- [x] Existing `resolve_backlog_item.rs` happy-path test still passes
- [x] `cargo fmt --all` clean
- [x] `SQLX_OFFLINE=true cargo check --workspace` clean
- [x] `cargo test -p epigraph-mcp --lib` -- 22 passed
- [x] `cargo test -p epigraph-mcp --test resolve_backlog_item_ownership` -- 5 passed
- [x] `cargo test -p epigraph-mcp --test resolve_backlog_item` -- 1 passed

No `sqlx::query!` macros touched -- no `.sqlx/` regen needed.

Generated with Claude Code