### PR TITLE
fix(scripts): port run_assessment_worker.py with psycopg2 (drop psql shell-out)

### DIFF
--- a/scripts/lib/claude_cli.py
+++ b/scripts/lib/claude_cli.py
@@ -1,0 +1,59 @@
+"""Shared Claude CLI helper for all EpiGraph Python scripts.
+
+Uses the claude CLI with OAuth (Max subscription). Never use the Anthropic SDK
+directly -- OAuth was painful to set up and is prepaid.
+
+Pattern: remove CLAUDECODE + ANTHROPIC_API_KEY from env, use --output-format json,
+parse the {"type":"result","result":"..."} envelope.
+"""
+
+import asyncio
+import json
+import os
+import re
+import shutil
+
+
+async def claude_cli_call(prompt: str, timeout_secs: int = 90, model: str | None = None) -> str:
+    """Call claude CLI and return the result text.
+
+    Raises RuntimeError if claude is not found or the call fails/times out.
+    """
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        raise RuntimeError("claude CLI not found on PATH")
+
+    cmd = [claude_bin, "-p", "--output-format", "json", "--max-turns", "1"]
+    if model:
+        cmd.extend(["--model", model])
+
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("CLAUDECODE", "ANTHROPIC_API_KEY")}
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    stdout, stderr = await asyncio.wait_for(
+        proc.communicate(input=prompt.encode()),
+        timeout=timeout_secs,
+    )
+
+    output = stdout.decode().strip() or stderr.decode().strip()
+    if not output:
+        raise RuntimeError(f"claude CLI produced no output (exit {proc.returncode})")
+
+    envelope = json.loads(output)
+    if envelope.get("is_error"):
+        raise RuntimeError(f"claude CLI error: {envelope.get('result', 'unknown')}")
+
+    result_text = envelope.get("result", "")
+    # Strip markdown fences if present
+    if result_text.startswith("```"):
+        result_text = re.sub(r"^```(?:json)?\n?", "", result_text)
+        result_text = re.sub(r"\n?```$", "", result_text)
+
+    return result_text.strip()

--- a/scripts/lib/tiered_enrichment.py
+++ b/scripts/lib/tiered_enrichment.py
@@ -1,0 +1,367 @@
+"""Tiered enrichment utility for EpiGraph claim evidence.
+
+Provides enrich_tier1/2/3() and auto_tier() router. Uses claude CLI for LLM calls.
+Constrains methodology output to canonical Rust vocabulary (cdst.rs methodology_profile keys).
+
+Can be imported as a library or invoked as a CLI:
+    python3 scripts/lib/tiered_enrichment.py --tier 1 --claim-text "..." --evidence-text "..."
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass, asdict
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lib.claude_cli import claude_cli_call
+
+log = logging.getLogger(__name__)
+
+# ── Canonical vocabulary (must match Rust cdst.rs methodology_profile keys) ──
+
+CANONICAL_METHODOLOGIES = {
+    "deductive_logic",
+    "meta_analysis",
+    "statistical_analysis",
+    "bayesian_inference",
+    "inductive_generalization",
+    "expert_elicitation",
+    "extraction",
+}
+
+METHODOLOGY_ALIASES = {
+    "deductive": "deductive_logic",
+    "deductive_reasoning": "deductive_logic",
+    "meta-analysis": "meta_analysis",
+    "statistical": "statistical_analysis",
+    "statistical_inference": "statistical_analysis",
+    "bayesian": "bayesian_inference",
+    "inductive": "inductive_generalization",
+    "expert": "expert_elicitation",
+    "testimonial": "expert_elicitation",
+    "llm_extraction": "extraction",
+    "instrumental": "inductive_generalization",
+    "experimental_observation": "inductive_generalization",
+    "instrumental_measurement": "inductive_generalization",
+    "computational": "statistical_analysis",
+    "computational_simulation": "statistical_analysis",
+    "visual_inspection": "extraction",
+    "negative_result": "inductive_generalization",
+    "theoretical_derivation": "deductive_logic",
+    "literature_synthesis": "meta_analysis",
+}
+
+DEFAULT_METHODOLOGY = "extraction"
+
+
+def normalize_methodology(raw: str) -> str:
+    """Normalize a methodology string to canonical vocabulary."""
+    low = raw.strip().lower()
+    if low in CANONICAL_METHODOLOGIES:
+        return low
+    if low in METHODOLOGY_ALIASES:
+        return METHODOLOGY_ALIASES[low]
+    log.warning("Unknown methodology '%s', falling back to '%s'", raw, DEFAULT_METHODOLOGY)
+    return DEFAULT_METHODOLOGY
+
+
+# ── Result type ──
+
+@dataclass
+class EnrichmentResult:
+    methodology: str
+    confidence: float
+    supports_claim: bool
+    instruments_used: list[str]
+    reagents_involved: list[str]
+    conditions: list[str]
+    evidence_type: str
+    tier: int
+    reasoning: str | None = None
+
+
+# ── Prompt templates ──
+
+_METHODOLOGY_LIST = ", ".join(sorted(CANONICAL_METHODOLOGIES))
+
+TIER1_PROMPT = """\
+Analyze this scientific evidence and classify its methodology.
+
+Claim: {claim_text}
+Evidence: {evidence_text}
+
+Return a JSON object with these fields:
+- "methodology": one of [{methodologies}]
+- "confidence": float 0.0-1.0, how confident the evidence supports/refutes the claim
+- "supports_claim": boolean, does the evidence support (true) or refute (false) the claim
+- "instruments_used": list of instruments/tools mentioned
+- "reagents_involved": list of chemicals/reagents mentioned
+- "conditions": list of experimental conditions
+- "evidence_type": one of ["empirical", "statistical", "logical", "testimonial", "circumstantial"]
+
+Respond with ONLY a JSON object. No markdown, no explanation.""".format(
+    methodologies=_METHODOLOGY_LIST,
+    claim_text="{claim_text}",
+    evidence_text="{evidence_text}",
+)
+
+TIER2_PROMPT = """\
+Analyze this scientific evidence with full paper context and classify its methodology.
+
+Claim: {claim_text}
+Evidence: {evidence_text}
+
+Paper abstract: {abstract}
+Surrounding sentences: {surrounding_sentences}
+
+Given the broader paper context, reconsider the methodology classification carefully.
+Double-negatives and indirect evidence relationships are common — assess direction precisely.
+
+Return a JSON object with these fields:
+- "methodology": one of [{methodologies}]
+- "confidence": float 0.0-1.0
+- "supports_claim": boolean
+- "instruments_used": list of instruments/tools
+- "reagents_involved": list of chemicals/reagents
+- "conditions": list of experimental conditions
+- "evidence_type": one of ["empirical", "statistical", "logical", "testimonial", "circumstantial"]
+- "reasoning": string explaining why you chose this methodology given the paper context
+
+Respond with ONLY a JSON object. No markdown, no explanation.""".format(
+    methodologies=_METHODOLOGY_LIST,
+    claim_text="{claim_text}",
+    evidence_text="{evidence_text}",
+    abstract="{abstract}",
+    surrounding_sentences="{surrounding_sentences}",
+)
+
+TIER3_PROMPT = """\
+Analyze this scientific evidence in the context of cross-source corroboration and conflict.
+
+Claim: {claim_text}
+Evidence: {evidence_text}
+Paper abstract: {abstract}
+
+Cross-source history (other sources that reference this claim):
+{cross_source_history}
+
+Current Dempster-Shafer belief state:
+{ds_belief_state}
+
+Assess whether conflicting evidence reflects genuine scientific disagreement or
+methodological artifacts (e.g., different measurement conditions, scope differences).
+
+Return a JSON object with these fields:
+- "methodology": one of [{methodologies}]
+- "confidence": float 0.0-1.0
+- "supports_claim": boolean
+- "instruments_used": list of instruments/tools
+- "reagents_involved": list of chemicals/reagents
+- "conditions": list of experimental conditions
+- "evidence_type": one of ["empirical", "statistical", "logical", "testimonial", "circumstantial"]
+- "reasoning": string explaining your assessment in light of the cross-source evidence
+
+Respond with ONLY a JSON object. No markdown, no explanation.""".format(
+    methodologies=_METHODOLOGY_LIST,
+    claim_text="{claim_text}",
+    evidence_text="{evidence_text}",
+    abstract="{abstract}",
+    cross_source_history="{cross_source_history}",
+    ds_belief_state="{ds_belief_state}",
+)
+
+
+def _parse_enrichment(raw_json: str, tier: int) -> EnrichmentResult:
+    """Parse LLM JSON response into EnrichmentResult with normalization."""
+    start = raw_json.find("{")
+    end = raw_json.rfind("}") + 1
+    if start < 0 or end <= start:
+        raise ValueError(f"No JSON object found in response: {raw_json[:200]}")
+
+    data = json.loads(raw_json[start:end])
+    return EnrichmentResult(
+        methodology=normalize_methodology(data.get("methodology", DEFAULT_METHODOLOGY)),
+        confidence=float(data.get("confidence", 0.5)),
+        supports_claim=bool(data.get("supports_claim", True)),
+        instruments_used=data.get("instruments_used", []),
+        reagents_involved=data.get("reagents_involved", []),
+        conditions=data.get("conditions", []),
+        evidence_type=data.get("evidence_type", "empirical"),
+        tier=tier,
+        reasoning=data.get("reasoning") if tier >= 2 else None,
+    )
+
+
+# ── Tier functions ──
+
+async def enrich_tier1(claim_text: str, evidence_text: str) -> EnrichmentResult:
+    """Tier 1: claim + evidence text only. Cost: ~$0.001/claim."""
+    prompt = TIER1_PROMPT.format(claim_text=claim_text, evidence_text=evidence_text)
+    raw = await claude_cli_call(prompt, timeout_secs=60)
+    return _parse_enrichment(raw, tier=1)
+
+
+async def enrich_tier2(
+    claim_text: str,
+    evidence_text: str,
+    abstract: str,
+    surrounding_sentences: list[str],
+) -> EnrichmentResult:
+    """Tier 2: + abstract context + surrounding sentences. Cost: ~$0.003/claim."""
+    prompt = TIER2_PROMPT.format(
+        claim_text=claim_text,
+        evidence_text=evidence_text,
+        abstract=abstract,
+        surrounding_sentences="\n".join(surrounding_sentences),
+    )
+    raw = await claude_cli_call(prompt, timeout_secs=90)
+    return _parse_enrichment(raw, tier=2)
+
+
+async def enrich_tier3(
+    claim_text: str,
+    evidence_text: str,
+    abstract: str,
+    cross_source_history: list[dict],
+    ds_belief_state: dict,
+) -> EnrichmentResult:
+    """Tier 3: + cross-source history + DS belief state. Cost: ~$0.005/claim."""
+    prompt = TIER3_PROMPT.format(
+        claim_text=claim_text,
+        evidence_text=evidence_text,
+        abstract=abstract,
+        cross_source_history=json.dumps(cross_source_history, indent=2),
+        ds_belief_state=json.dumps(ds_belief_state, indent=2),
+    )
+    raw = await claude_cli_call(prompt, timeout_secs=120)
+    return _parse_enrichment(raw, tier=3)
+
+
+async def auto_tier(
+    claim_text: str,
+    evidence_text: str,
+    tier1_confidence: float | None = None,
+    has_conflict: bool = False,
+    **context,
+) -> EnrichmentResult:
+    """Router: picks appropriate tier based on confidence/conflict.
+
+    Context kwargs for higher tiers:
+      - abstract: str (Tier 2/3)
+      - surrounding_sentences: list[str] (Tier 2)
+      - cross_source_history: list[dict] (Tier 3)
+      - ds_belief_state: dict (Tier 3)
+    """
+    # Step 1: Run Tier 1 if no confidence provided
+    tier1_result = None
+    if tier1_confidence is None:
+        tier1_result = await enrich_tier1(claim_text, evidence_text)
+        tier1_confidence = tier1_result.confidence
+
+    # Step 2: High confidence + no conflict → return Tier 1 result
+    if tier1_confidence >= 0.3 and not has_conflict:
+        if tier1_result is not None:
+            return tier1_result
+        return await enrich_tier1(claim_text, evidence_text)
+
+    # Step 3: Low confidence → Tier 2
+    if tier1_confidence < 0.3:
+        if "abstract" not in context:
+            raise ValueError("Tier 2 enrichment requires 'abstract' in context kwargs")
+        return await enrich_tier2(
+            claim_text, evidence_text,
+            context["abstract"],
+            context.get("surrounding_sentences", []),
+        )
+
+    # Step 4: has_conflict AND Tier 3 context available → Tier 3
+    if has_conflict:
+        if "cross_source_history" in context and "ds_belief_state" in context:
+            return await enrich_tier3(
+                claim_text, evidence_text,
+                context.get("abstract", ""),
+                context["cross_source_history"],
+                context["ds_belief_state"],
+            )
+        # Step 5: has_conflict but no Tier 3 context → fallback to Tier 2
+        if "abstract" not in context:
+            raise ValueError("Tier 2 enrichment requires 'abstract' in context kwargs")
+        return await enrich_tier2(
+            claim_text, evidence_text,
+            context["abstract"],
+            context.get("surrounding_sentences", []),
+        )
+
+    # Fallback: return Tier 1
+    if tier1_result is not None:
+        return tier1_result
+    return await enrich_tier1(claim_text, evidence_text)
+
+
+# ── CLI interface ──
+
+def main():
+    parser = argparse.ArgumentParser(description="Tiered enrichment utility")
+    parser.add_argument("--tier", type=int, choices=[1, 2, 3], required=True)
+    parser.add_argument("--claim-text", default=None)
+    parser.add_argument("--evidence-text", default=None)
+    parser.add_argument("--abstract", default="")
+    parser.add_argument("--output", choices=["json", "text"], default="json")
+    parser.add_argument("--claim-id", type=str, help="Load claim from database by UUID")
+    parser.add_argument("--database-url", type=str,
+        default="postgres://epigraph_ro:epigraph_ro@localhost:5432/epigraph")
+    args = parser.parse_args()
+
+    claim_text = args.claim_text
+    evidence_text = args.evidence_text
+
+    if args.claim_id:
+        import psycopg2
+        import uuid as uuid_mod
+        try:
+            uuid_mod.UUID(args.claim_id)
+        except ValueError:
+            print(f"Invalid UUID: {args.claim_id}", file=sys.stderr)
+            sys.exit(1)
+        conn = psycopg2.connect(args.database_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT content FROM claims WHERE id = %s::uuid", (args.claim_id,))
+            row = cur.fetchone()
+        conn.close()
+        if not row:
+            print(f"Claim {args.claim_id} not found", file=sys.stderr)
+            sys.exit(1)
+        claim_text = row[0]
+
+    if not claim_text:
+        parser.error("--claim-text or --claim-id is required")
+    if not evidence_text:
+        evidence_text = claim_text  # Fallback: use claim text as evidence
+
+    async def run():
+        if args.tier == 1:
+            result = await enrich_tier1(claim_text, evidence_text)
+        elif args.tier == 2:
+            result = await enrich_tier2(
+                claim_text, evidence_text,
+                args.abstract, [],
+            )
+        else:
+            result = await enrich_tier3(
+                claim_text, evidence_text,
+                args.abstract, [], {},
+            )
+        if args.output == "json":
+            print(json.dumps(asdict(result), indent=2))
+        else:
+            print(f"Tier {result.tier}: {result.methodology} (conf={result.confidence:.2f})")
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_assessment_worker.py
+++ b/scripts/run_assessment_worker.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Assessment queue worker -- drains pending assessment_queue entries with tiered enrichment.
+
+Queries assessment_queue for pending (or failed) entries ordered by conflict_k DESC,
+runs auto_tier() enrichment on each claim, and marks entries completed.
+
+Usage:
+    # Process up to 10 pending assessments (default)
+    python3 scripts/run_assessment_worker.py
+
+    # Process more
+    python3 scripts/run_assessment_worker.py --limit 25
+
+    # Dry run (show what would be processed, don't write)
+    python3 scripts/run_assessment_worker.py --dry-run
+
+    # Also retry previously failed assessments
+    python3 scripts/run_assessment_worker.py --retry-failed
+
+    # Combine flags
+    python3 scripts/run_assessment_worker.py --dry-run --limit 5 --retry-failed
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+
+import psycopg2
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+
+from lib.tiered_enrichment import auto_tier, EnrichmentResult
+
+log = logging.getLogger(__name__)
+
+# Read-only DB for all SELECT queries
+DATABASE_RO_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgres://epigraph_ro:epigraph_ro@localhost:5432/epigraph",
+)
+# Admin DB for UPDATE assessment_queue (status transitions only)
+DATABASE_ADMIN_URL = os.environ.get(
+    "DATABASE_ADMIN_URL",
+    "postgres://epigraph_admin:epigraph_admin@localhost:5432/epigraph",
+)
+API_URL = os.environ.get("EPIGRAPH_API_URL", "http://127.0.0.1:8080")
+
+# Threshold at which has_conflict=True is set for auto_tier()
+CONFLICT_THRESHOLD = 0.3
+MAX_SURROUNDING = 5
+MAX_CROSS_SOURCE = 10
+
+
+# -- Database helpers ----------------------------------------------------------
+
+def psql_query(sql: str, params: tuple = (), database_url: str = DATABASE_RO_URL) -> list:
+    """Run a parameterized SELECT, return rows as tuples of strings (psql-compatible shape).
+
+    Values are coerced to str (or None) to preserve the legacy psql `-t -A` text output
+    contract the rest of this script was written against.
+    """
+    try:
+        conn = psycopg2.connect(database_url)
+    except psycopg2.Error as e:
+        log.error("psycopg2 connect error: %s", e)
+        return []
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            raw_rows = cur.fetchall()
+    except psycopg2.Error as e:
+        log.error("psycopg2 query error: %s", e)
+        return []
+    finally:
+        conn.close()
+
+    rows = []
+    for raw in raw_rows:
+        rows.append(tuple(None if v is None else str(v) for v in raw))
+    return rows
+
+
+def psql_exec(sql: str, params: tuple = ()) -> bool:
+    """Execute a parameterized write via epigraph_admin. Returns True on success."""
+    try:
+        conn = psycopg2.connect(DATABASE_ADMIN_URL)
+    except psycopg2.Error as e:
+        log.error("psycopg2 admin connect error: %s", e)
+        return False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+        conn.commit()
+        return True
+    except psycopg2.Error as e:
+        log.error("psycopg2 exec error: %s", e)
+        conn.rollback()
+        return False
+    finally:
+        conn.close()
+
+
+# -- Queue queries -------------------------------------------------------------
+
+def get_pending_assessments(limit: int, include_failed: bool) -> list:
+    """Fetch pending (and optionally failed) assessment_queue entries."""
+    if include_failed:
+        statuses = ("pending", "failed")
+    else:
+        statuses = ("pending",)
+
+    sql = """
+    SELECT id::text, claim_id::text, trigger, conflict_k::text, k_band
+    FROM assessment_queue
+    WHERE status = ANY(%s)
+    ORDER BY conflict_k DESC
+    LIMIT %s
+    """
+    rows = psql_query(sql, (list(statuses), limit))
+    entries = []
+    for parts in rows:
+        if len(parts) >= 5:
+            entries.append({
+                "id": parts[0],
+                "claim_id": parts[1],
+                "trigger": parts[2],
+                "conflict_k": float(parts[3]) if parts[3] else 0.0,
+                "k_band": parts[4],
+            })
+    return entries
+
+
+# -- Claim context fetchers ----------------------------------------------------
+
+def get_claim_content(claim_id: str) -> str:
+    """Fetch the text content of a claim."""
+    sql = "SELECT content FROM claims WHERE id = %s::uuid LIMIT 1"
+    rows = psql_query(sql, (claim_id,))
+    if rows and rows[0][0]:
+        return rows[0][0]
+    return None
+
+
+def get_claim_doi(claim_id: str) -> str:
+    """Fetch the source_doi property for a claim."""
+    sql = """
+    SELECT properties->>'source_doi'
+    FROM claims
+    WHERE id = %s::uuid
+    LIMIT 1
+    """
+    rows = psql_query(sql, (claim_id,))
+    if rows and rows[0][0]:
+        return rows[0][0]
+    return None
+
+
+def get_paper_abstract(doi: str) -> str:
+    """Fetch paper abstract from the papers table."""
+    if not doi:
+        return ""
+    sql = "SELECT abstract_text FROM papers WHERE doi = %s LIMIT 1"
+    rows = psql_query(sql, (doi,))
+    return rows[0][0] if rows and rows[0][0] else ""
+
+
+def get_surrounding_claims(claim_id: str) -> list:
+    """Fetch content of claims connected via structural edges for context."""
+    sql = """
+    SELECT LEFT(c2.content, 200)
+    FROM edges e
+    JOIN claims c2 ON c2.id = CASE
+        WHEN e.source_id = %s THEN e.target_id::uuid
+        ELSE e.source_id::uuid END
+    WHERE (e.source_id = %s OR e.target_id = %s)
+      AND e.source_type = 'claim' AND e.target_type = 'claim'
+      AND e.relationship IN ('supports', 'contradicts', 'refines', 'decomposes_to', 'continues_argument')
+    LIMIT %s
+    """
+    rows = psql_query(sql, (claim_id, claim_id, claim_id, MAX_SURROUNDING))
+    return [r[0] for r in rows if r[0]]
+
+
+def get_cross_source_history(claim_id: str) -> list:
+    """Fetch cross-source corroboration/contradiction edges for Tier 3."""
+    sql = """
+    SELECT e.relationship, LEFT(c2.content, 200) AS other_content,
+           c2.truth_value::text
+    FROM edges e
+    JOIN claims c2 ON c2.id = CASE
+        WHEN e.source_id = %s THEN e.target_id::uuid
+        ELSE e.source_id::uuid END
+    WHERE (e.source_id = %s OR e.target_id = %s)
+      AND e.source_type = 'claim' AND e.target_type = 'claim'
+      AND e.relationship IN ('CORROBORATES', 'contradicts', 'CONTRADICTS')
+    LIMIT %s
+    """
+    rows = psql_query(sql, (claim_id, claim_id, claim_id, MAX_CROSS_SOURCE))
+    return [
+        {"relationship": r[0], "content": r[1], "truth": float(r[2]) if r[2] else 0.5}
+        for r in rows if len(r) >= 3
+    ]
+
+
+def get_ds_belief_state(claim_id: str) -> dict:
+    """Fetch the latest Dempster-Shafer mass function for a claim."""
+    sql = """
+    SELECT masses::text, conflict_k::text, combination_method
+    FROM mass_functions
+    WHERE claim_id = %s::uuid
+    ORDER BY created_at DESC
+    LIMIT 1
+    """
+    rows = psql_query(sql, (claim_id,))
+    if not rows or len(rows[0]) < 3:
+        return {}
+    try:
+        return {
+            "masses": json.loads(rows[0][0]),
+            "conflict_k": float(rows[0][1]) if rows[0][1] else 0.0,
+            "method": rows[0][2] or "dempster",
+        }
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+# -- Queue status transitions --------------------------------------------------
+
+def set_assessment_status(queue_id: str, status: str) -> bool:
+    """Update assessment_queue status. Uses epigraph_admin role."""
+    sql = """
+    UPDATE assessment_queue
+    SET status = %s
+    WHERE id = %s::uuid
+    """
+    return psql_exec(sql, (status, queue_id))
+
+
+# -- API interaction -----------------------------------------------------------
+
+def _acquire_token() -> str:
+    """Get a bearer token via client_credentials grant."""
+    import urllib.request
+
+    token_req = urllib.request.Request(
+        "{api}/oauth/token".format(api=API_URL),
+        data=json.dumps({
+            "grant_type": "client_credentials",
+            "client_id": os.environ.get("EPIGRAPH_SERVICE_CLIENT_ID", "epiclaw-agent-service"),
+            "client_secret": os.environ.get("EPIGRAPH_SERVICE_SECRET", ""),
+        }).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(token_req, timeout=10) as resp:
+            return json.loads(resp.read())["access_token"]
+    except Exception as e:
+        log.error("Token acquisition failed: %s", e)
+        return None
+
+
+def add_claim_label(claim_id: str, tier: int, token: str) -> bool:
+    """Add enrichment:tierN_complete label to a claim via the API."""
+    import urllib.request
+
+    tier_label = "enrichment:tier{t}_complete".format(t=tier)
+    label_req = urllib.request.Request(
+        "{api}/api/v1/claims/{cid}/labels".format(api=API_URL, cid=claim_id),
+        data=json.dumps({
+            "add": [tier_label],
+        }).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer {tok}".format(tok=token),
+        },
+        method="PATCH",
+    )
+    try:
+        with urllib.request.urlopen(label_req, timeout=10):
+            return True
+    except Exception as e:
+        log.error("Label update failed for %s: %s", claim_id[:8], e)
+        return False
+
+
+# -- Core processing -----------------------------------------------------------
+
+async def process_entry(entry: dict, dry_run: bool, token) -> bool:
+    """Process a single assessment_queue entry. Returns True on success."""
+    claim_id = entry["claim_id"]
+    queue_id = entry["id"]
+    conflict_k = entry["conflict_k"]
+
+    log.info(
+        "Processing queue entry %s -> claim %s (conflict_k=%.3f, band=%s, trigger=%s)",
+        queue_id[:8], claim_id[:8], conflict_k, entry["k_band"], entry["trigger"],
+    )
+
+    # Fetch claim content
+    content = get_claim_content(claim_id)
+    if not content:
+        log.warning("Claim %s not found or has no content -- skipping", claim_id[:8])
+        if not dry_run:
+            set_assessment_status(queue_id, "skipped")
+        return False
+
+    # Fetch paper abstract via source_doi
+    doi = get_claim_doi(claim_id)
+    abstract = get_paper_abstract(doi) if doi else ""
+
+    # Fetch surrounding claims (structural edges, limit 5)
+    surrounding = get_surrounding_claims(claim_id)
+
+    # Fetch cross-source history (CORROBORATES/contradicts, limit 10)
+    cross_source = get_cross_source_history(claim_id)
+
+    # Fetch DS belief state (latest mass_function)
+    ds_state = get_ds_belief_state(claim_id)
+
+    if dry_run:
+        log.info(
+            "[DRY RUN] Would enrich claim %s: abstract=%s, %d surrounding, "
+            "%d cross-source, ds_state=%s",
+            claim_id[:8],
+            "yes" if abstract else "no",
+            len(surrounding),
+            len(cross_source),
+            "present" if ds_state else "absent",
+        )
+        return True
+
+    # Mark as 'assessing' before LLM call
+    if not set_assessment_status(queue_id, "assessing"):
+        log.error("Failed to set status=assessing for queue entry %s", queue_id[:8])
+        return False
+
+    # Run auto_tier with full context
+    has_conflict = conflict_k >= CONFLICT_THRESHOLD
+    try:
+        result = await auto_tier(
+            claim_text=content,
+            evidence_text=content,   # Claim is its own primary evidence unit
+            has_conflict=has_conflict,
+            abstract=abstract or content[:500],
+            surrounding_sentences=surrounding,
+            cross_source_history=cross_source,
+            ds_belief_state=ds_state,
+        )
+    except Exception as e:
+        log.error("auto_tier failed for claim %s: %s", claim_id[:8], e)
+        set_assessment_status(queue_id, "failed")
+        return False
+
+    log.info(
+        "Enrichment result for %s: tier=%d methodology=%s confidence=%.2f supports=%s",
+        claim_id[:8], result.tier, result.methodology, result.confidence, result.supports_claim,
+    )
+
+    # Add enrichment label via API
+    if token and not add_claim_label(claim_id, result.tier, token):
+        log.warning("Label add failed for %s -- still marking completed", claim_id[:8])
+
+    # Mark queue entry as 'completed'
+    if not set_assessment_status(queue_id, "completed"):
+        log.error("Failed to set status=completed for queue entry %s", queue_id[:8])
+        return False
+
+    return True
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Assessment queue worker with tiered enrichment")
+    parser.add_argument("--limit", type=int, default=10, help="Max assessments to process per run")
+    parser.add_argument("--dry-run", action="store_true", help="Show pending entries without processing")
+    parser.add_argument("--retry-failed", action="store_true", help="Also retry previously failed entries")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    entries = get_pending_assessments(args.limit, include_failed=args.retry_failed)
+
+    if not entries:
+        print("TASK_SILENT")
+        return
+
+    log.info(
+        "Found %d assessment queue entries to process (retry_failed=%s)",
+        len(entries), args.retry_failed,
+    )
+
+    # Acquire bearer token once for all label updates (skip in dry-run)
+    token = None
+    if not args.dry_run:
+        token = _acquire_token()
+        if not token:
+            log.warning("Could not acquire API token -- label updates will be skipped")
+
+    processed = 0
+    failed = 0
+    for entry in entries:
+        success = await process_entry(entry, args.dry_run, token)
+        if success:
+            processed += 1
+        else:
+            failed += 1
+
+    if args.dry_run:
+        log.info("Dry run complete: %d entries would be processed", processed)
+    else:
+        log.info("Assessment worker complete: %d succeeded, %d failed", processed, failed)
+
+    if processed == 0 and failed == 0:
+        print("TASK_SILENT")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Ports run_assessment_worker.py (and its lib deps tiered_enrichment.py + claude_cli.py) from deprecated EpigraphV2 monorepo to canonical epigraph/scripts/
- Replaces psql subprocess helpers with psycopg2.connect (matches existing pattern in scripts/backfill_source_strength.py)
- Drops unused cdst_bba import that would have required porting 431 LOC of dead code

## Why
Backlog 5bfd44a1. The scheduled assessment-worker cron relies on a /workspace/group/psql wrapper as a workaround inside epiclaw containers that lack psql. With this port, the script runs natively wherever python3 + psycopg2 are available.

## Test plan
- [x] python3 -m py_compile passes on all three files
- [x] Top-level import succeeds (no ImportError on lib deps)
- [ ] Smoke test against epigraph_db_repo_test once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)