### PR TITLE
refactor: centralize claim belief/plausibility write-contract clamp (closes #139)

### DIFF
--- a/crates/epigraph-api/tests/bp_apply_plausibility_bounds.rs
+++ b/crates/epigraph-api/tests/bp_apply_plausibility_bounds.rs
@@ -46,8 +46,7 @@ mod common;
 /// FK is satisfied. Idempotent across test runs.
 async fn ensure_binary_frame(pool: &PgPool) -> Uuid {
     // Deterministic UUID so repeated test runs reuse the same row.
-    let frame_id =
-        Uuid::parse_str("00000000-0000-0000-0000-00000000bf01").expect("constant uuid");
+    let frame_id = Uuid::parse_str("00000000-0000-0000-0000-00000000bf01").expect("constant uuid");
     sqlx::query(
         "INSERT INTO frames (id, name, hypotheses) \
          VALUES ($1, 'bp_apply_test_binary', ARRAY['supported','unsupported']::text[]) \
@@ -220,9 +219,15 @@ async fn cdst_bp_apply_clamps_drifted_plausibility() {
     // Confirm the CDST branch was actually taken — otherwise the test is
     // not exercising the surface we're auditing.
     let mode = body.get("mode").and_then(|v| v.as_str()).unwrap_or("");
-    assert_eq!(mode, "cdst", "expected CDST branch, got mode={mode}; body={body_text}");
+    assert_eq!(
+        mode, "cdst",
+        "expected CDST branch, got mode={mode}; body={body_text}"
+    );
 
-    let applied = body.get("applied").and_then(|v| v.as_bool()).unwrap_or(false);
+    let applied = body
+        .get("applied")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     assert!(applied, "expected applied=true; body={body_text}");
 
     let factors_count = body
@@ -245,13 +250,12 @@ async fn cdst_bp_apply_clamps_drifted_plausibility() {
     // is what we are auditing; if the apply path ever wrote >1.0, the UPDATE
     // would have failed (silently incrementing apply_failures). This is a
     // belt-and-braces post-condition.
-    let row: (f64, f64, Option<f64>) = sqlx::query_as(
-        "SELECT belief, plausibility, pignistic_prob FROM claims WHERE id = $1",
-    )
-    .bind(claim_drift)
-    .fetch_one(&pool)
-    .await
-    .expect("read back drift claim");
+    let row: (f64, f64, Option<f64>) =
+        sqlx::query_as("SELECT belief, plausibility, pignistic_prob FROM claims WHERE id = $1")
+            .bind(claim_drift)
+            .fetch_one(&pool)
+            .await
+            .expect("read back drift claim");
     assert!(
         (0.0..=1.0).contains(&row.0),
         "belief escaped [0,1] after apply: {}",

--- a/crates/epigraph-api/tests/bp_apply_plausibility_bounds.rs
+++ b/crates/epigraph-api/tests/bp_apply_plausibility_bounds.rs
@@ -1,0 +1,271 @@
+#![cfg(feature = "db")]
+
+//! Regression for issue #139 covering the CDST BP apply path.
+//!
+//! `routes/computation.rs:621-630` writes `bel`, `pl` from
+//! `result.updated_intervals` and `betp` from `result.updated_betps` directly
+//! into `claims` without going through the centralized clamp helper.
+//!
+//! ## Outcome: PASSED (no red repro achievable)
+//!
+//! Per Task 3 of the plan, this test was intended to reproduce
+//! `claims_plausibility_bounds` constraint violations via a 20-BBA drift seed
+//! (`[0.05; 20].sum() == 1.0000000000000002`). It does not — and cannot —
+//! because PR #149 pushed `.clamp(0.0, 1.0)` upstream into every value the BP
+//! apply path receives:
+//!
+//! - `result.updated_intervals` is built by
+//!   `epigraph_engine::cdst_bp::mass_to_interval`, which calls
+//!   `epigraph_ds::measures::belief` and `plausibility`, both of which
+//!   `.clamp(0.0, 1.0)` their results (measures.rs:39, :63).
+//! - The clamped (bel, pl) pair is then passed to
+//!   `EpistemicInterval::from_mass_components -> EpistemicInterval::new`, which
+//!   re-clamps (epistemic_interval.rs:36-37).
+//! - `result.updated_betps` is `pignistic_probability(m, H_SUPPORTED)`, which
+//!   clamps internally before returning (measures.rs:129-134).
+//!
+//! Triple-clamped values reach the UPDATE statement at computation.rs:622, so
+//! the CHECK constraint is satisfied. The test still exercises the path end to
+//! end to assert this invariant going forward — if any future refactor moves
+//! clamping out of the engine layer, this regression will surface.
+//!
+//! Task 4's helper migration of computation.rs:621/655 is therefore a
+//! defense-in-depth refactor (centralizing the contract), not a bug fix; the
+//! bug was already fixed at the engine layer in PR #149.
+
+use serde_json::{json, Value};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+mod common;
+
+/// Frame fixture: binary frame matching `epigraph_engine::cdst_bp::BINARY_FRAME`
+/// (`{"supported", "unsupported"}`). Stored in `frames` so `mass_functions.frame_id`
+/// FK is satisfied. Idempotent across test runs.
+async fn ensure_binary_frame(pool: &PgPool) -> Uuid {
+    // Deterministic UUID so repeated test runs reuse the same row.
+    let frame_id =
+        Uuid::parse_str("00000000-0000-0000-0000-00000000bf01").expect("constant uuid");
+    sqlx::query(
+        "INSERT INTO frames (id, name, hypotheses) \
+         VALUES ($1, 'bp_apply_test_binary', ARRAY['supported','unsupported']::text[]) \
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(frame_id)
+    .execute(pool)
+    .await
+    .expect("seed binary frame");
+    frame_id
+}
+
+/// Seed a claim with explicit belief/plausibility/BetP. Mirrors the helper in
+/// `crates/epigraph-mcp/tests/common/mod.rs::seed_claim_with_belief`.
+async fn seed_claim_with_belief(
+    pool: &PgPool,
+    belief: f64,
+    plausibility: f64,
+    pignistic_prob: Option<f64>,
+) -> Uuid {
+    let agent_id = common::seed_system_agent(pool).await;
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id.as_bytes().iter().copied().cycle().take(32).collect();
+    sqlx::query(
+        "INSERT INTO claims \
+            (id, content, content_hash, agent_id, truth_value, \
+             belief, plausibility, pignistic_prob, is_current, labels) \
+         VALUES ($1, $2, $3, $4, 0.5, $5, $6, $7, true, ARRAY[]::text[])",
+    )
+    .bind(id)
+    .bind(format!("bp_apply drift seed {id}"))
+    .bind(&hash)
+    .bind(agent_id)
+    .bind(belief)
+    .bind(plausibility)
+    .bind(pignistic_prob)
+    .execute(pool)
+    .await
+    .expect("seed claim with belief");
+    id
+}
+
+/// Seed `n` independent mass-function rows for `claim_id`, each carrying mass
+/// `per_bba_mass` on `{supported}` and `1 - per_bba_mass` on `{unsupported}`.
+///
+/// The route at `computation.rs:567-581` combines all rows for a claim via
+/// `adaptive_combine`. With `n=20` and `per_bba_mass=0.05`, the engine sees
+/// 20 simple BBAs whose serial combination produces a drifted plausibility
+/// that — pre-clamp — would land at `1.0 + 1 ULP`.
+///
+/// `source_strength` is set high (0.95) per-row so adaptive_combine treats each
+/// fold as confident evidence; this maximizes the chance of accumulated
+/// floating-point drift in the combined plausibility before the engine's
+/// belief()/plausibility() functions clamp.
+async fn seed_drifting_bbas(
+    pool: &PgPool,
+    claim_id: Uuid,
+    frame_id: Uuid,
+    n: usize,
+    per_bba_mass: f64,
+) {
+    // 0 = supported, 1 = unsupported (matches engine's BINARY_FRAME constants).
+    let mut masses: BTreeMap<String, f64> = BTreeMap::new();
+    masses.insert("0".to_string(), per_bba_mass);
+    masses.insert("1".to_string(), 1.0 - per_bba_mass);
+    let masses_json = serde_json::to_value(&masses).expect("serialize masses");
+
+    for _ in 0..n {
+        let mf_id = Uuid::new_v4();
+        // Each row needs a distinct source_agent_id to bypass
+        // mass_functions_unique_per_perspective (claim_id, frame_id, source_agent_id, perspective_id).
+        let source_agent = common::seed_system_agent(pool).await;
+        sqlx::query(
+            "INSERT INTO mass_functions \
+               (id, claim_id, frame_id, source_agent_id, masses, source_strength, evidence_type) \
+             VALUES ($1, $2, $3, $4, $5, 0.95, 'empirical')",
+        )
+        .bind(mf_id)
+        .bind(claim_id)
+        .bind(frame_id)
+        .bind(source_agent)
+        .bind(&masses_json)
+        .execute(pool)
+        .await
+        .expect("insert mass_function row");
+    }
+}
+
+/// Seed an `evidential_support` factor connecting two claims. The CDST BP path
+/// is only entered when `factors` is non-empty and >50% of variables have a
+/// stored mass_function (see `computation.rs:541-555`).
+async fn seed_evidential_support_factor(
+    pool: &PgPool,
+    frame_id: Uuid,
+    claim_a: Uuid,
+    claim_b: Uuid,
+) {
+    let factor_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO factors \
+           (id, factor_type, variable_ids, potential, frame_id) \
+         VALUES ($1, 'evidential_support', $2, $3, $4)",
+    )
+    .bind(factor_id)
+    .bind(vec![claim_a, claim_b])
+    .bind(json!({"strength": 0.8}))
+    .bind(frame_id)
+    .execute(pool)
+    .await
+    .expect("seed factor");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cdst_bp_apply_clamps_drifted_plausibility() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&url)
+        .await
+        .expect("db pool");
+
+    let frame_id = ensure_binary_frame(&pool).await;
+
+    // The "drifting" claim — seeded at Pl=1.0 so any post-recompute write above
+    // 1.0 trips claims_plausibility_bounds CHECK.
+    let claim_drift = seed_claim_with_belief(&pool, 0.4, 1.0, Some(0.4)).await;
+
+    // Companion claim so the factor has the 2 variables it requires
+    // (factors_min_variables CHECK in migrations/001_initial_schema.sql:975).
+    let claim_companion = seed_claim_with_belief(&pool, 0.5, 0.6, Some(0.55)).await;
+
+    // 20 BBA rows on the drifting claim — combine path produces 1.0+1ULP raw Pl.
+    seed_drifting_bbas(&pool, claim_drift, frame_id, 20, 0.05).await;
+
+    // 1 BBA on companion so >50% coverage triggers the CDST branch in auto mode.
+    seed_drifting_bbas(&pool, claim_companion, frame_id, 1, 0.6).await;
+
+    seed_evidential_support_factor(&pool, frame_id, claim_drift, claim_companion).await;
+
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let token = common::test_bearer_token_with_scopes(&["claims:write", "graph:read"]);
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/bp/propagate"))
+        .bearer_auth(&token)
+        .json(&json!({
+            "frame_id": frame_id,
+            "apply_updates": true,
+            "mode": "cdst",
+            "max_iterations": 5,
+        }))
+        .send()
+        .await
+        .expect("POST /api/v1/bp/propagate");
+
+    let status = resp.status();
+    let body_text = resp.text().await.unwrap_or_default();
+
+    assert!(
+        status.is_success(),
+        "bp/propagate returned {status}: {body_text}"
+    );
+
+    // Even if HTTP 200, the apply path swallows sqlx errors into apply_failures.
+    // A non-zero apply_failures with the drift seed in play would indicate
+    // claims_plausibility_bounds (or another CHECK) tripped silently.
+    let body: Value = serde_json::from_str(&body_text)
+        .unwrap_or_else(|_| panic!("response not JSON: {body_text}"));
+
+    // Confirm the CDST branch was actually taken — otherwise the test is
+    // not exercising the surface we're auditing.
+    let mode = body.get("mode").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(mode, "cdst", "expected CDST branch, got mode={mode}; body={body_text}");
+
+    let applied = body.get("applied").and_then(|v| v.as_bool()).unwrap_or(false);
+    assert!(applied, "expected applied=true; body={body_text}");
+
+    let factors_count = body
+        .get("factors_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_default();
+    assert!(factors_count > 0, "no factors loaded; body={body_text}");
+
+    let apply_failures = body
+        .get("apply_failures")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_default();
+    assert_eq!(
+        apply_failures, 0,
+        "bp/propagate apply_failures={apply_failures} body={body_text}"
+    );
+
+    // Drift assertion at the DB level: after apply, plausibility on the drifting
+    // claim must be in [0, 1]. The claims_plausibility_bounds CHECK constraint
+    // is what we are auditing; if the apply path ever wrote >1.0, the UPDATE
+    // would have failed (silently incrementing apply_failures). This is a
+    // belt-and-braces post-condition.
+    let row: (f64, f64, Option<f64>) = sqlx::query_as(
+        "SELECT belief, plausibility, pignistic_prob FROM claims WHERE id = $1",
+    )
+    .bind(claim_drift)
+    .fetch_one(&pool)
+    .await
+    .expect("read back drift claim");
+    assert!(
+        (0.0..=1.0).contains(&row.0),
+        "belief escaped [0,1] after apply: {}",
+        row.0
+    );
+    assert!(
+        (0.0..=1.0).contains(&row.1),
+        "plausibility escaped [0,1] after apply: {}",
+        row.1
+    );
+    if let Some(betp) = row.2 {
+        assert!(
+            (0.0..=1.0).contains(&betp),
+            "pignistic_prob escaped [0,1] after apply: {betp}"
+        );
+    }
+}

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -526,6 +526,116 @@ mod tests {
         assert_eq!(rows[0].combination_method.as_deref(), Some("second"));
     }
 
+    /// Anti-foot-gun ratchet: pins `update_claim_belief`'s parameter ordering
+    /// to its SQL `UPDATE` column ordering.
+    ///
+    /// The function calls `epigraph_ds::measures::clamp_claim_belief_measures`,
+    /// whose parameter order differs (`pignistic_prob` is 3rd in the helper
+    /// but 4th in `update_claim_belief`). A future swap that routes
+    /// `mass_on_empty` into the `pignistic_prob` column (or any similar
+    /// reshuffle) would ship silently without this test.
+    ///
+    /// Five distinct in-range values + one ULP-drifted `belief` lock both
+    /// the column-to-arg mapping and the clamp behaviour through the helper.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn update_claim_belief_persists_each_field_to_its_own_column(pool: sqlx::PgPool) {
+        let agent_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels)
+             VALUES (sha256(gen_random_uuid()::text::bytea), 'update-claim-belief-cols', 'system', ARRAY['test'])
+             RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Seed in-range starting state. The seed itself doesn't matter — what
+        // we're testing is the column→arg mapping for update_claim_belief's
+        // inputs.
+        let claim_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (
+                 content, content_hash, truth_value, agent_id,
+                 belief, plausibility, mass_on_empty, pignistic_prob, mass_on_missing
+             )
+             VALUES ($1, sha256($1::bytea), 0.5, $2, 0.5, 0.5, 0.0, 0.5, 0.0)
+             RETURNING id",
+        )
+        .bind(format!("update-claim-belief-cols-{}", Uuid::new_v4()))
+        .bind(agent_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Canonical summation drift: 0.05 * 20 sums to ~1.0000000000000002
+        // (one ULP above 1.0). Confirms the helper's f64::clamp actually
+        // applies on the write path.
+        //
+        // Drift is applied to `plausibility` (not `belief`) because the
+        // `claims_bel_pl_order` CHECK requires `belief <= plausibility`;
+        // a drifted-belief of 1.0 with plausibility=0.7 would trip the
+        // constraint before reaching the column-mapping assertions. The
+        // anti-swap and drift-clamp invariants are unchanged.
+        let drifted_plausibility: f64 = [0.05_f64; 20].iter().sum();
+        assert!(
+            drifted_plausibility > 1.0,
+            "test precondition: 0.05 summed 20× must drift above 1.0 (got {drifted_plausibility})"
+        );
+
+        // Five field-identifying values. A parameter swap that lands
+        // `mass_on_empty=0.1` in the `pignistic_prob` column would fail
+        // the `pignistic_prob == Some(0.6)` assertion with "got 0.1".
+        // A `belief ↔ plausibility` swap would land 1.0 in belief and 0.7
+        // in plausibility, tripping `claims_bel_pl_order` (bonus catch).
+        MassFunctionRepository::update_claim_belief(
+            &pool,
+            claim_id,
+            0.7,                  // belief
+            drifted_plausibility, // plausibility (drift; expect clamp to 1.0)
+            0.1,                  // mass_on_empty
+            Some(0.6),            // pignistic_prob
+            0.05,                 // mass_on_missing
+        )
+        .await
+        .expect("update_claim_belief must succeed for in-range / drifted inputs");
+
+        let (belief, plausibility, mass_on_empty, pignistic_prob, mass_on_missing): (
+            f64,
+            f64,
+            f64,
+            Option<f64>,
+            f64,
+        ) = sqlx::query_as(
+            "SELECT belief, plausibility, mass_on_empty, pignistic_prob, mass_on_missing
+             FROM claims WHERE id = $1",
+        )
+        .bind(claim_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Exact-equality passthrough — helper is a no-op for in-range f64.
+        assert_eq!(belief, 0.7, "belief column must receive arg 1");
+        // Drift case — helper's clamp must collapse 1.0000000000000002 → 1.0
+        // before the bind. A regression that bypassed the helper would
+        // persist the drifted value and trip claims_plausibility_bounds.
+        assert_eq!(
+            plausibility, 1.0,
+            "plausibility drift must be clamped to 1.0 by the helper (got {plausibility})"
+        );
+        assert_eq!(
+            mass_on_empty, 0.1,
+            "mass_on_empty column must receive arg 3"
+        );
+        assert_eq!(
+            pignistic_prob,
+            Some(0.6),
+            "pignistic_prob column must receive arg 4 (anti-swap ratchet)"
+        );
+        assert_eq!(
+            mass_on_missing, 0.05,
+            "mass_on_missing column must receive arg 5"
+        );
+    }
+
     #[test]
     fn mass_function_row_has_expected_fields() {
         let _row = MassFunctionRow {

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -262,8 +262,9 @@ impl MassFunctionRepository {
     /// Update a claim's belief, plausibility, and pignistic probability columns
     ///
     /// Called after combining mass functions to persist the computed interval.
-    /// All numeric values are clamped to [0, 1] at the write boundary so
-    /// floating-point drift accumulated upstream cannot trip the
+    /// Values are clamped to `[0, 1]` at the write boundary via
+    /// `epigraph_ds::measures::clamp_claim_belief_measures` so floating-point
+    /// drift accumulated upstream cannot trip the
     /// `claims_{belief,plausibility,mass_on_empty,mass_on_missing,pignistic_prob}_bounds`
     /// CHECK constraints.
     ///
@@ -279,11 +280,18 @@ impl MassFunctionRepository {
         pignistic_prob: Option<f64>,
         mass_on_missing: f64,
     ) -> Result<(), DbError> {
-        let belief = belief.clamp(0.0, 1.0);
-        let plausibility = plausibility.clamp(0.0, 1.0);
-        let mass_on_empty = mass_on_empty.clamp(0.0, 1.0);
-        let mass_on_missing = mass_on_missing.clamp(0.0, 1.0);
-        let pignistic_prob = pignistic_prob.map(|p| p.clamp(0.0, 1.0));
+        // claims_{belief,plausibility,mass_empty}_bounds — see helper at
+        // epigraph_ds::measures::clamp_claim_belief_measures.
+        // Note: helper threads pignistic_prob between plausibility and mass_on_empty;
+        // this function's parameter order differs, so arguments are threaded explicitly.
+        let (belief, plausibility, pignistic_prob, mass_on_empty, mass_on_missing) =
+            epigraph_ds::measures::clamp_claim_belief_measures(
+                belief,
+                plausibility,
+                pignistic_prob,
+                mass_on_empty,
+                mass_on_missing,
+            );
 
         sqlx::query(
             r#"

--- a/crates/epigraph-ds/src/measures.rs
+++ b/crates/epigraph-ds/src/measures.rs
@@ -240,6 +240,36 @@ pub fn beta_to_cbpa(
     Ok(MassFunction::from_raw(frame.clone(), masses))
 }
 
+/// Clamp the five belief-measure fields written to `claims` to `[0.0, 1.0]`.
+///
+/// Three of the five — `belief`, `plausibility`, `mass_on_empty` — are enforced
+/// at the DB level by `claims_belief_bounds`, `claims_plausibility_bounds`, and
+/// `claims_mass_empty_bounds` respectively (see
+/// `migrations/001_initial_schema.sql:627-631`). `pignistic_prob` and
+/// `mass_on_missing` have no CHECK constraint today but are clamped defensively
+/// so a future `ALTER TABLE ... ADD CONSTRAINT ...` lands without surfacing a
+/// new bug.
+///
+/// All callers that issue
+/// `UPDATE claims SET belief|plausibility|pignistic_prob|mass_on_empty|mass_on_missing ...`
+/// MUST route their values through this helper.
+#[must_use]
+pub fn clamp_claim_belief_measures(
+    belief: f64,
+    plausibility: f64,
+    pignistic_prob: Option<f64>,
+    mass_on_empty: f64,
+    mass_on_missing: f64,
+) -> (f64, f64, Option<f64>, f64, f64) {
+    (
+        belief.clamp(0.0, 1.0),
+        plausibility.clamp(0.0, 1.0),
+        pignistic_prob.map(|p| p.clamp(0.0, 1.0)),
+        mass_on_empty.clamp(0.0, 1.0),
+        mass_on_missing.clamp(0.0, 1.0),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -685,6 +715,55 @@ mod tests {
         // ~{1} on binary = {0}, so Bel({0}) should be 0.6 after evaluation
         let bel = belief_classical(&m, &fe0);
         assert!((bel - 0.6).abs() < 1e-10);
+    }
+}
+
+#[cfg(test)]
+mod clamp_tests {
+    use super::clamp_claim_belief_measures;
+
+    #[test]
+    fn clamps_one_ulp_drift_to_one() {
+        // Summing 0.05 twenty times yields 1.0 + 1 ULP in f64 — the drift
+        // case from tests/order_independence_smoke.rs that tripped
+        // claims_{belief,plausibility}_bounds pre-#149. (The product form
+        // 0.05 * 20.0 rounds to exactly 1.0 and does NOT drift, despite what
+        // the original plan suggested; only the summation drifts.)
+        let drifted: f64 = [0.05_f64; 20].iter().sum();
+        assert!(drifted > 1.0, "test setup: expected drift > 1.0");
+        let (bel, pl, betp, me, mm) =
+            clamp_claim_belief_measures(drifted, drifted, Some(drifted), drifted, drifted);
+        assert_eq!(bel, 1.0);
+        assert_eq!(pl, 1.0);
+        assert_eq!(betp, Some(1.0));
+        assert_eq!(me, 1.0);
+        assert_eq!(mm, 1.0);
+    }
+
+    #[test]
+    fn clamps_overshoot_and_undershoot() {
+        let (bel, pl, betp, me, mm) = clamp_claim_belief_measures(1.5, -0.1, Some(2.0), -0.5, 1.7);
+        assert_eq!(bel, 1.0);
+        assert_eq!(pl, 0.0);
+        assert_eq!(betp, Some(1.0));
+        assert_eq!(me, 0.0);
+        assert_eq!(mm, 1.0);
+    }
+
+    #[test]
+    fn passes_through_in_range_values() {
+        let (bel, pl, betp, me, mm) = clamp_claim_belief_measures(0.4, 0.9, Some(0.5), 0.1, 0.05);
+        assert_eq!(bel, 0.4);
+        assert_eq!(pl, 0.9);
+        assert_eq!(betp, Some(0.5));
+        assert_eq!(me, 0.1);
+        assert_eq!(mm, 0.05);
+    }
+
+    #[test]
+    fn preserves_none_pignistic() {
+        let (_, _, betp, _, _) = clamp_claim_belief_measures(0.4, 0.9, None, 0.1, 0.05);
+        assert_eq!(betp, None);
     }
 }
 

--- a/crates/epigraph-mcp/tests/common/mod.rs
+++ b/crates/epigraph-mcp/tests/common/mod.rs
@@ -137,6 +137,42 @@ pub async fn seed_claim(pool: &PgPool, content: &str, truth: f64) -> Uuid {
     id
 }
 
+/// Seed a claim with explicit DST belief-measure fields.
+///
+/// Used by `update_with_evidence_plausibility_one.rs` (issue #139 regression):
+/// the test needs to plant a claim at `plausibility = 1.0` so that any
+/// post-evidence drift above 1.0 trips `claims_plausibility_bounds`. The
+/// standard `seed_claim` helper leaves these columns at their defaults.
+///
+/// Returns the new claim's UUID. Reuses `seed_agent`'s test-signer pattern.
+pub async fn seed_claim_with_belief(
+    pool: &PgPool,
+    belief: f64,
+    plausibility: f64,
+    pignistic_prob: Option<f64>,
+) -> Uuid {
+    let agent_id = seed_agent(pool).await;
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id.as_bytes().iter().copied().cycle().take(32).collect();
+    sqlx::query(
+        "INSERT INTO claims \
+            (id, content, content_hash, agent_id, truth_value, \
+             belief, plausibility, pignistic_prob, is_current, labels) \
+         VALUES ($1, $2, $3, $4, 0.5, $5, $6, $7, true, ARRAY[]::text[])",
+    )
+    .bind(id)
+    .bind(format!("seed_claim_with_belief regression {id}"))
+    .bind(&hash)
+    .bind(agent_id)
+    .bind(belief)
+    .bind(plausibility)
+    .bind(pignistic_prob)
+    .execute(pool)
+    .await
+    .expect("seed claim with belief");
+    id
+}
+
 pub async fn seed_claim_with_labels(pool: &PgPool, content: &str, labels: &[&str]) -> Uuid {
     let id = seed_claim(pool, content, 0.5).await;
     let labels_owned: Vec<String> = labels.iter().map(|s| (*s).to_string()).collect();

--- a/crates/epigraph-mcp/tests/update_with_evidence_plausibility_one.rs
+++ b/crates/epigraph-mcp/tests/update_with_evidence_plausibility_one.rs
@@ -1,0 +1,48 @@
+//! Regression for issue #139.
+//!
+//! Seeds a claim at (plausibility=1.0, belief=0.4) and calls
+//! update_with_evidence with supporting evidence. The issue body asserts
+//! Postgres returns claims_plausibility_bounds. Post-PR #149 the
+//! auto_wire_ds_update path clamps, so this test may pass on main;
+//! if so, Task 3 captures the still-unclamped surface.
+//!
+//! Outcome: PASSED — auto_wire_ds_update path already clamps post-#149.
+//! Task 3 covers the still-unclamped BP apply path.
+
+mod common;
+use common::*;
+
+use epigraph_mcp::types::UpdateWithEvidenceParams;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn update_with_evidence_does_not_violate_plausibility_bounds_at_one(pool: sqlx::PgPool) {
+    let claim_id = seed_claim_with_belief(
+        &pool,
+        /* belief */ 0.4,
+        /* plausibility */ 1.0,
+        /* pignistic_prob */ Some(0.4),
+    )
+    .await;
+
+    let server = build_test_server(pool.clone());
+
+    let result = epigraph_mcp::tools::claims::update_with_evidence(
+        &server,
+        UpdateWithEvidenceParams {
+            claim_id: claim_id.to_string(),
+            evidence_type: "empirical".into(),
+            evidence_data: "Supporting observation that narrows belief but \
+                            does not require lowering plausibility."
+                .into(),
+            source_url: None,
+            supports: true,
+            strength: 0.8,
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "update_with_evidence on Pl=1.0 claim returned err: {result:?}"
+    );
+}

--- a/docs/superpowers/plans/2026-05-27-claims-belief-bounds-clamp.md
+++ b/docs/superpowers/plans/2026-05-27-claims-belief-bounds-clamp.md
@@ -1,0 +1,730 @@
+# `claims_*_bounds` Write-Contract Clamp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize the `[0.0, 1.0]` clamp for the five belief-measure columns (`belief`, `plausibility`, `pignistic_prob`, `mass_on_empty`, `mass_on_missing`) into one helper, then route every `UPDATE claims SET ...` write site through it. Closes issue #139.
+
+**Architecture:** New helper `clamp_claim_belief_measures` in `crates/epigraph-ds/src/measures.rs`. Three confirmed write sites are migrated onto it: `MassFunctionRepository::update_claim_belief` (already clamps inline — drops the inline clamps in favor of the helper), `routes/computation.rs:621` (CDST BP apply — currently unclamped), `routes/computation.rs:655` (scalar BP fallback — currently unclamped, single-field). Per-site drift tests assert in-bounds persistence. An end-to-end test reproduces #139's repro and asserts no constraint violation.
+
+**Tech Stack:** Rust, sqlx, Postgres (`epigraph_db_repo_test`), `epigraph-ds` crate, `epigraph-db` repo layer, `epigraph-mcp` MCP tools, `epigraph-api` HTTP routes.
+
+---
+
+## Setup
+
+**Test database.** Every test in this plan runs against `epigraph_db_repo_test`, per `CLAUDE.md`:
+
+```bash
+export DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test'
+```
+
+**Branch.** Already on `spec/claims-belief-bounds-clamp` (the spec lives here). Continue on this branch.
+
+**Background.** PR #149 / commit `a5b908e` (2026-05-16, *after* #139 was filed on 2026-05-14) added inline clamps to `epigraph_ds::measures::{belief, plausibility}` and to `MassFunctionRepository::update_claim_belief`. The `auto_wire_ds_update → update_claim_belief` path the issue body traces is therefore likely already protected. The remaining unclamped sites are in `crates/epigraph-api/src/routes/computation.rs`. The reproduction test in Task 1 establishes which path actually fails today.
+
+---
+
+### Task 1: Reproduce via `update_with_evidence` (the path the issue traces)
+
+**Files:**
+- Create: `crates/epigraph-mcp/tests/update_with_evidence_plausibility_one.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+//! Regression for issue #139.
+//!
+//! Seeds a claim at (plausibility=1.0, belief=0.4) and calls
+//! update_with_evidence with supporting evidence. The issue body asserts
+//! Postgres returns claims_plausibility_bounds. Post-PR #149 the
+//! auto_wire_ds_update path clamps, so this test may pass on main;
+//! if so, Task 3 captures the still-unclamped surface.
+
+use epigraph_mcp::tests::common::{TestServer, seed_claim_with_belief};
+
+#[tokio::test]
+async fn update_with_evidence_does_not_violate_plausibility_bounds_at_one() {
+    let server = TestServer::start().await;
+    let claim_id = seed_claim_with_belief(
+        &server.pool,
+        /* belief */ 0.4,
+        /* plausibility */ 1.0,
+        /* pignistic_prob */ Some(0.4),
+    )
+    .await;
+
+    let result = server
+        .update_with_evidence(epigraph_mcp::types::UpdateWithEvidenceParams {
+            claim_id: claim_id.to_string(),
+            evidence_type: "experimental_data".into(),
+            evidence_data: "Supporting observation that narrows belief but \
+                            does not require lowering plausibility.".into(),
+            source_url: None,
+            supports: true,
+            strength: 0.8,
+        })
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "update_with_evidence on Pl=1.0 claim returned err: {result:?}"
+    );
+}
+```
+
+If `seed_claim_with_belief` does not exist in `tests/common`, create it (Step 2). If `TestServer` does not exist, model on existing test fixtures (e.g., `crates/epigraph-mcp/tests/source_strength_tests.rs`).
+
+- [ ] **Step 2: Add the seed helper if missing**
+
+```rust
+// crates/epigraph-mcp/tests/common/mod.rs (add to the existing mod)
+pub async fn seed_claim_with_belief(
+    pool: &sqlx::PgPool,
+    belief: f64,
+    plausibility: f64,
+    pignistic_prob: Option<f64>,
+) -> uuid::Uuid {
+    let id = uuid::Uuid::new_v4();
+    let agent_id = ensure_test_agent(pool).await;
+    let content_hash: [u8; 32] = rand::random();
+    sqlx::query(
+        r#"
+        INSERT INTO claims
+            (id, content, content_hash, agent_id, truth_value,
+             belief, plausibility, pignistic_prob, is_current)
+        VALUES ($1, $2, $3, $4, 0.5, $5, $6, $7, true)
+        "#,
+    )
+    .bind(id)
+    .bind("test claim — pre-evidence Pl=1.0")
+    .bind(content_hash.to_vec())
+    .bind(agent_id)
+    .bind(belief)
+    .bind(plausibility)
+    .bind(pignistic_prob)
+    .execute(pool)
+    .await
+    .expect("seed claim");
+    id
+}
+```
+
+Re-use `ensure_test_agent` if it already exists; otherwise inline a minimal `INSERT INTO agents` for a test signer.
+
+- [ ] **Step 3: Run the test and record the outcome**
+
+```bash
+cd /home/jeremy/epigraph
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test -p epigraph-mcp \
+  --test update_with_evidence_plausibility_one -- --nocapture
+```
+
+Expected: one of two outcomes.
+- **(a)** Test fails with `claims_plausibility_bounds` violation. Record the stack — that is the still-unclamped path.
+- **(b)** Test passes. Path is already protected by PR #149's inline clamps. The BP apply path in Task 3 is still unclamped and that is where the next reproduction is built.
+
+Write the outcome into a one-paragraph note at the top of the test file as a `//!` comment so future reviewers know which case fired.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-mcp/tests/update_with_evidence_plausibility_one.rs \
+        crates/epigraph-mcp/tests/common/mod.rs
+git commit -m "test(mcp): regression repro for #139 (update_with_evidence at Pl=1.0)"
+```
+
+---
+
+### Task 2: Add the centralized helper with unit tests
+
+**Files:**
+- Modify: `crates/epigraph-ds/src/measures.rs`
+- Modify: `crates/epigraph-ds/src/lib.rs` (re-export if needed)
+
+- [ ] **Step 1: Write helper unit tests first**
+
+Append to `crates/epigraph-ds/src/measures.rs`:
+
+```rust
+#[cfg(test)]
+mod clamp_tests {
+    use super::clamp_claim_belief_measures;
+
+    #[test]
+    fn clamps_one_ulp_drift_to_one() {
+        // 0.05 * 20 = 1.0000000000000002 in f64 — the exact drift case
+        // measured in the order_independence_smoke test.
+        let drifted = 0.05_f64 * 20.0;
+        assert!(drifted > 1.0, "test setup: expected drift > 1.0");
+        let (bel, pl, betp, me, mm) =
+            clamp_claim_belief_measures(drifted, drifted, Some(drifted), drifted, drifted);
+        assert_eq!(bel, 1.0);
+        assert_eq!(pl, 1.0);
+        assert_eq!(betp, Some(1.0));
+        assert_eq!(me, 1.0);
+        assert_eq!(mm, 1.0);
+    }
+
+    #[test]
+    fn clamps_overshoot_and_undershoot() {
+        let (bel, pl, betp, me, mm) =
+            clamp_claim_belief_measures(1.5, -0.1, Some(2.0), -0.5, 1.7);
+        assert_eq!(bel, 1.0);
+        assert_eq!(pl, 0.0);
+        assert_eq!(betp, Some(1.0));
+        assert_eq!(me, 0.0);
+        assert_eq!(mm, 1.0);
+    }
+
+    #[test]
+    fn passes_through_in_range_values() {
+        let (bel, pl, betp, me, mm) =
+            clamp_claim_belief_measures(0.4, 0.9, Some(0.5), 0.1, 0.05);
+        assert_eq!(bel, 0.4);
+        assert_eq!(pl, 0.9);
+        assert_eq!(betp, Some(0.5));
+        assert_eq!(me, 0.1);
+        assert_eq!(mm, 0.05);
+    }
+
+    #[test]
+    fn preserves_none_pignistic() {
+        let (_, _, betp, _, _) =
+            clamp_claim_belief_measures(0.4, 0.9, None, 0.1, 0.05);
+        assert_eq!(betp, None);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they fail with "function not defined"**
+
+```bash
+cd /home/jeremy/epigraph
+cargo test -p epigraph-ds clamp_tests -- --nocapture
+```
+
+Expected: `error[E0425]: cannot find function clamp_claim_belief_measures`.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `crates/epigraph-ds/src/measures.rs` (above the `#[cfg(test)]` block):
+
+```rust
+/// Clamp the five belief-measure fields written to `claims` to `[0.0, 1.0]`.
+///
+/// Three of the five — `belief`, `plausibility`, `mass_on_empty` — are enforced
+/// at the DB level by `claims_belief_bounds`, `claims_plausibility_bounds`, and
+/// `claims_mass_empty_bounds` respectively (see
+/// `migrations/001_initial_schema.sql:627-631`). `pignistic_prob` and
+/// `mass_on_missing` have no CHECK constraint today but are clamped defensively
+/// so a future `ALTER TABLE ... ADD CONSTRAINT ...` lands without surfacing a
+/// new bug.
+///
+/// All callers that issue
+/// `UPDATE claims SET belief|plausibility|pignistic_prob|mass_on_empty|mass_on_missing ...`
+/// MUST route their values through this helper.
+#[must_use]
+pub fn clamp_claim_belief_measures(
+    belief: f64,
+    plausibility: f64,
+    pignistic_prob: Option<f64>,
+    mass_on_empty: f64,
+    mass_on_missing: f64,
+) -> (f64, f64, Option<f64>, f64, f64) {
+    (
+        belief.clamp(0.0, 1.0),
+        plausibility.clamp(0.0, 1.0),
+        pignistic_prob.map(|p| p.clamp(0.0, 1.0)),
+        mass_on_empty.clamp(0.0, 1.0),
+        mass_on_missing.clamp(0.0, 1.0),
+    )
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+```bash
+cargo test -p epigraph-ds clamp_tests -- --nocapture
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/epigraph-ds/src/measures.rs
+git commit -m "feat(ds): centralized clamp_claim_belief_measures helper"
+```
+
+---
+
+### Task 3: Reproduce via the CDST BP apply path (the still-unclamped surface)
+
+**Files:**
+- Create: `crates/epigraph-api/tests/bp_apply_plausibility_bounds.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+//! Regression for issue #139 covering the BP apply path.
+//!
+//! routes/computation.rs:621 writes raw bel/pl from result.updated_intervals
+//! without clamping. A combine sequence whose raw plausibility drifts above
+//! 1.0 by one ULP trips claims_plausibility_bounds on apply.
+
+use epigraph_api::tests::common::TestApi;
+use serde_json::json;
+
+#[tokio::test]
+async fn cdst_bp_apply_clamps_drifted_plausibility() {
+    let api = TestApi::start().await;
+    let claim = api.seed_claim_with_belief(0.4, 1.0, Some(0.4)).await;
+
+    // Seed enough BBAs (each w/ source_strength forcing the combined Pl above 1.0
+    // by ULP drift) to trip the apply path. The 0.05 * 20 trick from
+    // order_independence_smoke is reused.
+    api.seed_drifting_bbas(claim, 20, 0.05).await;
+
+    let resp = api
+        .post(
+            "/api/v1/graph/recompute_beliefs",
+            json!({ "apply": true, "engine": "cdst" }),
+        )
+        .await;
+
+    assert!(
+        resp.status().is_success(),
+        "recompute_beliefs apply returned {}: {}",
+        resp.status(),
+        resp.text().await
+    );
+}
+```
+
+If `TestApi::seed_drifting_bbas` is not present in test common helpers, add it: inserts 20 single-focal-element BBAs each carrying mass 0.05 against the binary frame for `claim_id`. Model on the seed helper in `crates/epigraph-ds/tests/order_independence_smoke.rs`.
+
+- [ ] **Step 2: Run the test, observe failure**
+
+```bash
+cargo test -p epigraph-api --test bp_apply_plausibility_bounds -- --nocapture
+```
+
+Expected: HTTP 500 or err string containing `claims_plausibility_bounds`. If the test passes without the fix, the drift seed is not aggressive enough — increase the number of focal elements or the per-BBA mass until reproduction is achieved, and note in the test docstring.
+
+- [ ] **Step 3: Do NOT commit yet — task 4 makes it pass**
+
+The test is intentionally red; commit happens after Task 4.
+
+---
+
+### Task 4: Migrate `routes/computation.rs` BP apply paths to the helper
+
+**Files:**
+- Modify: `crates/epigraph-api/src/routes/computation.rs:611-660`
+
+- [ ] **Step 1: Replace the CDST BP apply UPDATE with a helper call**
+
+Current (`computation.rs:611-630`):
+
+```rust
+        // Apply updates: write pignistic_prob, belief, plausibility to claims
+        let mut apply_failures = 0_usize;
+        if apply {
+            for (claim_id, betp) in &result.updated_betps {
+                let iv = result
+                    .updated_intervals
+                    .iter()
+                    .find(|(id, _)| id == claim_id)
+                    .map(|(_, iv)| iv);
+                let (bel, pl) = iv.map(|i| (i.bel, i.pl)).unwrap_or((0.0, 1.0));
+                if sqlx::query(
+                    "UPDATE claims SET pignistic_prob = $1, belief = $2, plausibility = $3, updated_at = NOW() WHERE id = $4",
+                )
+                .bind(betp).bind(bel).bind(pl).bind(claim_id)
+                .execute(&state.db_pool)
+                .await
+                .is_err() {
+                    apply_failures += 1;
+                }
+            }
+        }
+```
+
+Replace with:
+
+```rust
+        // Apply updates: write pignistic_prob, belief, plausibility to claims.
+        // claims_{belief,plausibility}_bounds CHECK constraint is satisfied via
+        // epigraph_ds::measures::clamp_claim_belief_measures — see
+        // docs/superpowers/specs/2026-05-27-claims-belief-bounds-clamp-design.md.
+        let mut apply_failures = 0_usize;
+        if apply {
+            for (claim_id, betp) in &result.updated_betps {
+                let iv = result
+                    .updated_intervals
+                    .iter()
+                    .find(|(id, _)| id == claim_id)
+                    .map(|(_, iv)| iv);
+                let (raw_bel, raw_pl) = iv.map(|i| (i.bel, i.pl)).unwrap_or((0.0, 1.0));
+                let (bel, pl, betp_clamped, _me, _mm) =
+                    epigraph_ds::measures::clamp_claim_belief_measures(
+                        raw_bel,
+                        raw_pl,
+                        Some(*betp),
+                        0.0,
+                        0.0,
+                    );
+                let betp_clamped = betp_clamped.unwrap_or(*betp);
+                if sqlx::query(
+                    "UPDATE claims SET pignistic_prob = $1, belief = $2, plausibility = $3, updated_at = NOW() WHERE id = $4",
+                )
+                .bind(betp_clamped).bind(bel).bind(pl).bind(claim_id)
+                .execute(&state.db_pool)
+                .await
+                .is_err() {
+                    apply_failures += 1;
+                }
+            }
+        }
+```
+
+- [ ] **Step 2: Replace the scalar BP fallback UPDATE**
+
+Current (`computation.rs:653-660`):
+
+```rust
+        for (claim_id, new_betp) in &result.updated_beliefs {
+            let _ = sqlx::query("UPDATE claims SET pignistic_prob = $1 WHERE id = $2")
+                .bind(new_betp)
+                .bind(claim_id)
+                .execute(&state.db_pool)
+                .await;
+        }
+```
+
+Replace with:
+
+```rust
+        for (claim_id, new_betp) in &result.updated_beliefs {
+            let (_, _, betp_clamped, _, _) =
+                epigraph_ds::measures::clamp_claim_belief_measures(
+                    0.0,
+                    0.0,
+                    Some(*new_betp),
+                    0.0,
+                    0.0,
+                );
+            let betp_clamped = betp_clamped.unwrap_or(*new_betp);
+            let _ = sqlx::query("UPDATE claims SET pignistic_prob = $1 WHERE id = $2")
+                .bind(betp_clamped)
+                .bind(claim_id)
+                .execute(&state.db_pool)
+                .await;
+        }
+```
+
+- [ ] **Step 3: Run the Task 3 test, verify it now passes**
+
+```bash
+cargo test -p epigraph-api --test bp_apply_plausibility_bounds -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Tasks 3 and 4 together**
+
+```bash
+git add crates/epigraph-api/tests/bp_apply_plausibility_bounds.rs \
+        crates/epigraph-api/src/routes/computation.rs
+# include any test-common helper additions in the same commit
+git commit -m "fix(api): clamp BP apply writes to claims_*_bounds via helper
+
+routes/computation.rs:621 wrote raw bel/pl from updated_intervals without
+clamping, tripping claims_plausibility_bounds when combine drift pushed
+Pl one ULP above 1.0. Now routes through
+epigraph_ds::measures::clamp_claim_belief_measures, same contract as
+MassFunctionRepository::update_claim_belief. Scalar BP fallback at
+:655 migrated for consistency."
+```
+
+---
+
+### Task 5: Migrate `MassFunctionRepository::update_claim_belief` to the helper
+
+**Files:**
+- Modify: `crates/epigraph-db/src/repos/mass_function.rs:275-307`
+
+- [ ] **Step 1: Replace inline clamps with helper call**
+
+Current (`mass_function.rs:275-307`):
+
+```rust
+        claim_id: Uuid,
+        belief: f64,
+        plausibility: f64,
+        mass_on_empty: f64,
+        pignistic_prob: Option<f64>,
+        mass_on_missing: f64,
+    ) -> Result<(), DbError> {
+        let belief = belief.clamp(0.0, 1.0);
+        let plausibility = plausibility.clamp(0.0, 1.0);
+        let mass_on_empty = mass_on_empty.clamp(0.0, 1.0);
+        let mass_on_missing = mass_on_missing.clamp(0.0, 1.0);
+        let pignistic_prob = pignistic_prob.map(|p| p.clamp(0.0, 1.0));
+```
+
+Replace with:
+
+```rust
+        claim_id: Uuid,
+        belief: f64,
+        plausibility: f64,
+        mass_on_empty: f64,
+        pignistic_prob: Option<f64>,
+        mass_on_missing: f64,
+    ) -> Result<(), DbError> {
+        // claims_{belief,plausibility,mass_empty}_bounds — see helper docs.
+        let (belief, plausibility, pignistic_prob, mass_on_empty, mass_on_missing) =
+            epigraph_ds::measures::clamp_claim_belief_measures(
+                belief,
+                plausibility,
+                pignistic_prob,
+                mass_on_empty,
+                mass_on_missing,
+            );
+```
+
+(Confirm `epigraph_ds` is already a dependency of `epigraph-db` via `cargo metadata -p epigraph-db | grep epigraph-ds`. If not, add to `crates/epigraph-db/Cargo.toml`.)
+
+- [ ] **Step 2: Run the existing order_independence_smoke regression**
+
+```bash
+cargo test -p epigraph-ds order_independence_smoke -- --nocapture
+```
+
+Expected: PASS — confirms semantic behavior of the helper matches the prior inline clamps.
+
+- [ ] **Step 3: Run the repo's own tests**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test -p epigraph-db mass_function -- --nocapture
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-db/src/repos/mass_function.rs \
+        crates/epigraph-db/Cargo.toml
+git commit -m "refactor(db): mass_function update_claim_belief uses central clamp helper"
+```
+
+---
+
+### Task 6: Per-site drift regression tests
+
+**Files:**
+- Modify: `crates/epigraph-db/tests/` (or create `mass_function_update_belief_drift.rs`)
+- Modify: existing `bp_apply_plausibility_bounds.rs` from Task 3 (already covers the BP-apply site)
+
+- [ ] **Step 1: Add the repo-level drift test**
+
+Create `crates/epigraph-db/tests/mass_function_update_belief_drift.rs`:
+
+```rust
+//! Drift regression for MassFunctionRepository::update_claim_belief — proves
+//! that one-ULP overshoot persists as 1.0 exactly, not 1.0000000000000002 and
+//! not 0.97 (i.e., the clamp is applied where the inline code used to apply
+//! it pre-helper).
+
+use epigraph_db::repos::{ClaimRepository, MassFunctionRepository};
+
+mod common;
+
+#[tokio::test]
+async fn update_claim_belief_clamps_one_ulp_drift() {
+    let pool = common::test_pool().await;
+    let (claim_id, _agent) = common::seed_minimal_claim(&pool).await;
+    let frame_id = common::ensure_binary_frame(&pool).await;
+
+    let drifted = 0.05_f64 * 20.0; // > 1.0 by one ULP
+    assert!(drifted > 1.0);
+
+    MassFunctionRepository::update_claim_belief(
+        &pool,
+        claim_id,
+        /* belief */ drifted,
+        /* plausibility */ drifted,
+        /* mass_on_empty */ drifted,
+        /* pignistic_prob */ Some(drifted),
+        /* mass_on_missing */ drifted,
+    )
+    .await
+    .expect("update_claim_belief tolerates drifted input");
+
+    let row: (f64, f64, Option<f64>) = sqlx::query_as(
+        "SELECT belief, plausibility, pignistic_prob FROM claims WHERE id = $1",
+    )
+    .bind(claim_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(row.0, 1.0, "belief persisted unclamped");
+    assert_eq!(row.1, 1.0, "plausibility persisted unclamped");
+    assert_eq!(row.2, Some(1.0), "pignistic_prob persisted unclamped");
+}
+```
+
+If `common::seed_minimal_claim` / `common::ensure_binary_frame` do not exist in `crates/epigraph-db/tests/common`, add minimal versions modeled on existing repo test fixtures.
+
+- [ ] **Step 2: Run all three regression tests together**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' cargo test \
+  -p epigraph-db mass_function_update_belief_drift \
+  -p epigraph-api bp_apply_plausibility_bounds \
+  -p epigraph-mcp update_with_evidence_plausibility_one \
+  -- --nocapture
+```
+
+Expected: all 3 pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/epigraph-db/tests/mass_function_update_belief_drift.rs \
+        crates/epigraph-db/tests/common/
+git commit -m "test(db): drift regression for MassFunctionRepository::update_claim_belief"
+```
+
+---
+
+### Task 7: Final sweep — verify no other write sites slipped through
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Re-grep the workspace**
+
+```bash
+cd /home/jeremy/epigraph
+# Using the Grep tool / ripgrep equivalent:
+rg -n 'UPDATE claims SET[^"]*(belief|plausibility|pignistic_prob|mass_on_empty|mass_on_missing)' \
+   crates/ migrations/
+```
+
+Expected output (no others):
+- `crates/epigraph-api/src/routes/computation.rs:62?` — both BP apply sites (using helper)
+- `crates/epigraph-db/src/repos/mass_function.rs:29?` — `update_claim_belief` (using helper)
+- migration files (schema only, not application code)
+
+If any additional UPDATE site appears (e.g., a new ingest path, a future migration script), migrate it via the helper now and add a drift test for it.
+
+- [ ] **Step 2: Workspace build / lint / test**
+
+```bash
+SQLX_OFFLINE=true cargo check --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test --workspace
+```
+
+Expected: clean across all four.
+
+- [ ] **Step 3: Re-prepare sqlx if any `query!` macros changed**
+
+If `cargo check` reports `query!` macro mismatches:
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo sqlx prepare --workspace -- --tests
+git add .sqlx
+```
+
+(No `query!` macros are expected to change since we only touch dynamic `sqlx::query(...)` strings, but verify.)
+
+- [ ] **Step 4: Commit any sqlx or formatting fallout**
+
+```bash
+git status -sb
+# If anything is staged from steps 2–3:
+git commit -m "chore: cargo fmt + sqlx prepare after clamp-helper migration"
+```
+
+---
+
+### Task 8: Push branch and open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin spec/claims-belief-bounds-clamp
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --repo epigraph-io/epigraph \
+  --title "fix: clamp claim belief/plausibility writes through central helper (#139)" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `epigraph_ds::measures::clamp_claim_belief_measures` helper; every `UPDATE claims SET ... (belief|plausibility|pignistic_prob|mass_on_empty|mass_on_missing)` site routes through it.
+- `routes/computation.rs:621` (CDST BP apply) and `:655` (scalar BP fallback) previously wrote raw values; now clamped.
+- `MassFunctionRepository::update_claim_belief` keeps the same clamp semantics, sourced from the helper instead of inline.
+- Three regression tests prove drifted input persists at exactly 1.0 (not 1.0 + 1ULP).
+
+## Why
+Issue #139 traced `update_with_evidence` to a `claims_plausibility_bounds` violation. PR #149 fixed the inline `auto_wire_ds_update` path, but the BP apply path was never audited. Centralizing the contract prevents this class of bug from re-appearing at the next new write site.
+
+## Test plan
+- [x] `cargo test -p epigraph-ds clamp_tests` — 4 unit tests
+- [x] `cargo test -p epigraph-mcp update_with_evidence_plausibility_one`
+- [x] `cargo test -p epigraph-api bp_apply_plausibility_bounds`
+- [x] `cargo test -p epigraph-db mass_function_update_belief_drift`
+- [x] `cargo test --workspace` against epigraph_db_repo_test
+- [x] `cargo fmt --check` / `cargo clippy --all-targets -D warnings`
+
+Closes #139.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify PR exists**
+
+```bash
+gh pr view --repo epigraph-io/epigraph --json url,number,title
+```
+
+- [ ] **Step 4: Retire backlog claim**
+
+Per `CLAUDE.md`, retire the backlog item via `mcp__epigraph__resolve_backlog_item`:
+
+```python
+mcp__epigraph__resolve_backlog_item(
+    original_id="8c921f32-e99a-4045-981a-031f14d784ba",
+    resolution_content=(
+        "Resolves 8c921f32: clamp_claim_belief_measures helper now gates "
+        "every UPDATE claims SET belief|plausibility|pignistic_prob|mass_on_empty|"
+        "mass_on_missing site. CDST BP apply path (routes/computation.rs:621) "
+        "was the live unclamped surface; sweeping all sites via the helper "
+        "prevents the next instance. See PR #<NN>."
+    ),
+)
+```
+
+Substitute `<NN>` with the PR number from Step 3.
+
+---
+
+## Done
+
+- Helper exists, every write site routes through it.
+- Three regression tests pin the contract.
+- #139 closed by PR merge.
+- Backlog claim `8c921f32` retired via `resolve_backlog_item`.

--- a/docs/superpowers/plans/2026-05-27-claims-belief-bounds-clamp.md
+++ b/docs/superpowers/plans/2026-05-27-claims-belief-bounds-clamp.md
@@ -153,10 +153,11 @@ mod clamp_tests {
 
     #[test]
     fn clamps_one_ulp_drift_to_one() {
-        // 0.05 * 20 = 1.0000000000000002 in f64 — the exact drift case
-        // measured in the order_independence_smoke test.
-        let drifted = 0.05_f64 * 20.0;
-        assert!(drifted > 1.0, "test setup: expected drift > 1.0");
+        // 0.05 * 20.0 ROUNDS to exactly 1.0 in f64; the canonical drift case
+        // is the *summation* form (see order_independence_smoke.rs:60-61):
+        // [0.05; 20].iter().sum() = 1.0000000000000002.
+        let drifted: f64 = [0.05_f64; 20].iter().sum();
+        assert!(drifted > 1.0, "test setup: summation must drift one ULP above 1.0");
         let (bel, pl, betp, me, mm) =
             clamp_claim_belief_measures(drifted, drifted, Some(drifted), drifted, drifted);
         assert_eq!(bel, 1.0);
@@ -550,8 +551,10 @@ async fn update_claim_belief_clamps_one_ulp_drift() {
     let (claim_id, _agent) = common::seed_minimal_claim(&pool).await;
     let frame_id = common::ensure_binary_frame(&pool).await;
 
-    let drifted = 0.05_f64 * 20.0; // > 1.0 by one ULP
-    assert!(drifted > 1.0);
+    // 0.05 * 20.0 rounds to exactly 1.0 in f64; the canonical drift case
+    // is the *summation* form (see crates/epigraph-ds/tests/order_independence_smoke.rs:60-61).
+    let drifted: f64 = [0.05_f64; 20].iter().sum(); // = 1.0000000000000002
+    assert!(drifted > 1.0, "summation form drifts above 1.0");
 
     MassFunctionRepository::update_claim_belief(
         &pool,

--- a/docs/superpowers/specs/2026-05-27-claims-belief-bounds-clamp-design.md
+++ b/docs/superpowers/specs/2026-05-27-claims-belief-bounds-clamp-design.md
@@ -1,0 +1,125 @@
+# `claims_*_bounds` write-contract clamp (Spec 1)
+
+**Date:** 2026-05-27
+**Status:** Design — awaiting review
+**Author:** Jeremy Barton (with Claude)
+**Closes:** [#139](https://github.com/epigraph-io/epigraph/issues/139)
+
+## Problem
+
+The Postgres CHECK constraint `claims_plausibility_bounds` (`migrations/001_initial_schema.sql:631`) requires `plausibility` to lie in `[0.0, 1.0]`. There is a matching `claims_belief_bounds` constraint on `belief`. Both can be tripped by post-combine values that drift one ULP above 1.0 (or, in pathological combine sequences, by raw values that exceed 1.0 outright).
+
+PR #149 (2026-04-?) added defensive `.clamp(0.0, 1.0)` calls to `epigraph_ds::measures::{belief, plausibility}` to absorb the most common drift. `MassFunctionRepository::update_claim_belief` (`crates/epigraph-db/src/repos/mass_function.rs:282`) clamps again on the write side.
+
+But the write contract is enforced inconsistently. At least one BP write path — `crates/epigraph-api/src/routes/computation.rs:621` — writes raw `bel`, `pl` straight from `result.updated_intervals` without clamping. Any future write site added without this discipline reintroduces the bug.
+
+Issue #139 reports that `update_with_evidence` violates `claims_plausibility_bounds` when a claim is at `plausibility=1.0` and additional evidence is submitted. The issue body guesses at the cause; the audit so far suggests the failure may surface through a write path other than the `auto_wire_ds_update → update_claim_belief` route the issue traces. Reproducing first will pin down the actual culprit; sweeping every write site will prevent the next instance.
+
+## Goals
+
+1. Deterministic reproduction of the #139 failure mode against `epigraph_db_repo_test`.
+2. Single source of truth for the `claims_*_bounds` write contract — one helper, used by every write site that touches `belief`, `plausibility`, `pignistic_prob`, `mass_on_empty`, or `mass_on_missing`.
+3. Every existing `UPDATE claims SET ...` site that writes those columns is routed through the helper.
+4. Per-site unit tests assert that drifted inputs produce in-bounds outputs.
+5. An end-to-end regression test that reproduces the original `update_with_evidence` failure and now passes.
+
+**Non-goals.** Changing how belief / plausibility / pignistic probability are *computed*. The combine logic, discounting, and BP message-passing are out of scope — this spec is purely about the write contract.
+
+## Approach
+
+### Step 1 — Reproduce
+
+Add a failing integration test in `crates/epigraph-mcp/tests/` (or `crates/epigraph-api/tests/` if the actual culprit is HTTP-side). The test:
+
+1. Seeds a claim in `epigraph_db_repo_test` with `plausibility = 1.0, belief = 0.4, pignistic_prob = 0.4`.
+2. Calls `update_with_evidence` (via the MCP tool entry point) with supporting evidence and a non-trivial strength.
+3. Asserts `Ok(_)` from the call.
+
+If the test fails on the current main branch with `claims_plausibility_bounds`, the bug is reproduced. If it passes, drive the input toward known drift cases (multi-evidence sequences where the BBA sum drifts above 1.0) until reproduction is achieved, and note the actual surfacing code path in this spec before continuing.
+
+### Step 2 — Centralized helper
+
+Add to `crates/epigraph-ds/src/measures.rs`:
+
+```rust
+/// Clamp the five belief-measure fields written to `claims` to `[0.0, 1.0]`.
+///
+/// Three of the five — `belief`, `plausibility`, `mass_on_empty` — are enforced
+/// at the DB level by `claims_belief_bounds`, `claims_plausibility_bounds`, and
+/// `claims_mass_empty_bounds` respectively (see `migrations/001_initial_schema.sql`).
+/// `pignistic_prob` and `mass_on_missing` have no CHECK constraint today but are
+/// clamped defensively so future constraints can be added without code changes.
+///
+/// All callers that issue
+/// `UPDATE claims SET belief|plausibility|pignistic_prob|mass_on_empty|mass_on_missing ...`
+/// MUST route their values through this helper.
+#[must_use]
+pub fn clamp_claim_belief_measures(
+    belief: f64,
+    plausibility: f64,
+    pignistic_prob: Option<f64>,
+    mass_on_empty: f64,
+    mass_on_missing: f64,
+) -> (f64, f64, Option<f64>, f64, f64) {
+    (
+        belief.clamp(0.0, 1.0),
+        plausibility.clamp(0.0, 1.0),
+        pignistic_prob.map(|p| p.clamp(0.0, 1.0)),
+        mass_on_empty.clamp(0.0, 1.0),
+        mass_on_missing.clamp(0.0, 1.0),
+    )
+}
+```
+
+Constraint names confirmed against `migrations/001_initial_schema.sql`:
+`claims_belief_bounds` (line 627), `claims_mass_empty_bounds` (630),
+`claims_plausibility_bounds` (631), `claims_truth_value_bounds` (634). No CHECK
+exists for `pignistic_prob` or `mass_on_missing` as of 2026-05-27. The helper
+clamps all five regardless so a future `ALTER TABLE ... ADD CONSTRAINT ...
+pignistic_bounds` lands without surfacing a new bug.
+
+### Step 3 — Audit and sweep
+
+Grep `UPDATE claims SET` across the workspace. Every site that writes any of the five measures is migrated to call the helper before binding. After the sweep:
+
+- `crates/epigraph-db/src/repos/mass_function.rs:282` (inline-clamping today) routes through the helper, dropping the per-field `.clamp` calls.
+- `crates/epigraph-api/src/routes/computation.rs:621` routes through the helper.
+- Any third site grep turns up routes through the helper.
+
+Plan-stage step: produce the full audit list inline in the plan; this spec does not enumerate beyond the two confirmed.
+
+### Step 4 — Tests
+
+Three tiers, each adversarial enough to satisfy the council-of-critics rule:
+
+1. **Helper unit tests** in `crates/epigraph-ds/src/measures.rs` — drifted-input cases (`1.0 + 1ULP`, `-0.0`, `Option::None`, `1.5`, `-0.5`) → asserts clamped outputs.
+2. **Per-site write-path tests.** For each repo / route that writes the five fields, a test that constructs a `MassFunction` whose combine produces drift above 1.0, calls the write path, and asserts the persisted row's `plausibility = 1.0` exactly (not 1.0000000000000002, not 0.97).
+3. **End-to-end reproduction test** — the Step 1 test, now passing. This is the "this is the bug from the issue" guardrail.
+
+### Step 5 — Constraint-name doc comment
+
+The helper's doc comment names every constraint it satisfies, with a `// see migration NNN` pointer. Future engineers adding a sixth belief-measure column or a sixth write site can grep for the helper name and find both the contract and the constraint list in one place.
+
+## Out of scope
+
+- Changes to `epigraph-ds` combine logic, discounting, or BP message-passing.
+- New belief-measure columns or new CHECK constraints.
+- Refactoring the `claim_from_row` read path or widening its signature (forbidden by `CLAUDE.md`).
+- Migration to drop or modify the existing `claims_*_bounds` constraints.
+
+## Acceptance
+
+- [ ] Reproduction test exists and fails on current `main`.
+- [ ] `clamp_claim_belief_measures` exists in `epigraph-ds` with unit tests covering drift, negative, out-of-range, and `None` cases.
+- [ ] Every `UPDATE claims SET ... {belief|plausibility|pignistic_prob|mass_on_empty|mass_on_missing}` site in the workspace calls the helper.
+- [ ] Per-site write-path tests assert in-bounds persistence under drifted input.
+- [ ] Reproduction test passes after the fix.
+- [ ] `cargo sqlx prepare --workspace -- --tests` is re-run if any `query!` macros are touched (per `CLAUDE.md`).
+- [ ] `cargo fmt`, `cargo clippy --workspace`, `cargo test --workspace` clean against `epigraph_db_repo_test`.
+
+## Related
+
+- PR #149 — `belief` / `plausibility` clamp in `measures.rs`
+- `crates/epigraph-ds/tests/order_independence_smoke.rs` — drift regression for the *compute* side
+- `feedback_pignistic_not_bayesian.md` — `pignistic_prob` (BetP) is the canonical decision measure; clamping it matters for downstream ordering
+- `feedback_council_of_critics.md` — adversarial-test rule justifies the per-site drift test rather than a "no error thrown" smoke


### PR DESCRIPTION
## Summary
- New `epigraph_ds::measures::clamp_claim_belief_measures(belief, plausibility, pignistic_prob, mass_on_empty, mass_on_missing) -> (f64, f64, Option<f64>, f64, f64)` helper — single source of truth for the `claims_{belief,plausibility,mass_empty}_bounds` CHECK contract.
- `MassFunctionRepository::update_claim_belief` (`crates/epigraph-db/src/repos/mass_function.rs:273`) replaced its 5 inline `.clamp(0.0, 1.0)` calls with one call to the helper.
- Invariant-lock test at `crates/epigraph-api/tests/bp_apply_plausibility_bounds.rs` guards the BP apply path's upstream clamping (it does not currently violate, and we want a fast-failure if a future refactor moves clamping downstream).
- Integration drift test at `crates/epigraph-db/src/repos/mass_function.rs::tests::update_claim_belief_persists_each_field_to_its_own_column` pins both the helper wiring AND the SQL bind column-to-arg mapping (catches a parameter-order swap that would silently corrupt rows — see the inline foot-gun comment in `update_claim_belief`).
- Helper has 4 adversarial unit tests in `crates/epigraph-ds/src/measures.rs::clamp_tests` covering one-ULP summation drift, overshoot, undershoot, in-range passthrough, and `None`-pignistic preservation.
- Reproduction test at `crates/epigraph-mcp/tests/update_with_evidence_plausibility_one.rs` is GREEN against the current code, with a `//!` note documenting that this is intentional (issue #139's underlying constraint violation is already absorbed by PR #149's upstream clamps).

## Why
[Issue #139](https://github.com/epigraph-io/epigraph/issues/139) reported `update_with_evidence` violating `claims_plausibility_bounds` at `plausibility=1.0`. Investigation found that **PR #149 already fixed the underlying bug** by adding `.clamp(0.0, 1.0)` to `epigraph_ds::measures::{belief, plausibility}` (`crates/epigraph-ds/src/measures.rs:39, :63`) and to `MassFunctionRepository::update_claim_belief`'s inline clamps.

But the inline-clamp pattern was duplicated across sites with no central contract. A future write site added without re-implementing the clamp would reintroduce the bug class. This PR turns "every author of a new write site has to remember to clamp" into "every author calls one helper" — a structural fix to the contract, not a fix to a live violation.

**What is intentionally NOT changed:** `routes/computation.rs:621-630` and `:655` (CDST BP apply + scalar BP fallback) write `bel`, `pl`, `betp` values that are already clamped upstream by `cdst_bp::mass_to_interval` → `epigraph_ds::measures::{belief, plausibility}`, then re-clamped by `EpistemicInterval::new`, with `pignistic_probability` clamping internally. Migrating those route handlers through the helper would add a redundant fourth clamp layer for zero correctness gain. The BP-apply invariant-lock test in this PR guards against any future refactor that moves the clamp layer.

## Test plan
- [x] `cargo test -p epigraph-ds clamp_tests` — 4 helper unit tests
- [x] `cargo test -p epigraph-ds order_independence_smoke` — engine-level drift regression (pre-existing, still green)
- [x] `cargo test -p epigraph-mcp --test update_with_evidence_plausibility_one` — #139 reproduction (green by design — PR #149 fixed the underlying)
- [x] `cargo test -p epigraph-api --test bp_apply_plausibility_bounds` — invariant lock on BP apply path
- [x] `cargo test -p epigraph-db mass_function` — 4 repo-level tests including the new `update_claim_belief_persists_each_field_to_its_own_column` drift integration test
- [x] `SQLX_OFFLINE=true cargo check --workspace` clean
- [x] `cargo fmt --all -- --check` clean

`cargo test --workspace` (the global suite) was not run cleanly due to known cross-worktree cargo-target rmeta drift in the shared `/home/jeremy/.cargo-target` (see local feedback `feedback_cargo_target_shared.md`). Per-crate runs against the four branch-touched surfaces all pass in isolation. CI will run the full workspace test on a clean target dir; if anything new fails there, it's a CI signal rather than a branch regression.

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)