### PR TITLE
feat: locality-aware source_strength on evidential edges (closes #142)

### DIFF
--- a/calibration.toml
+++ b/calibration.toml
@@ -141,3 +141,15 @@ include_agent_id = false
 
 [matcher.fan_out]
 max_per_claim = 32
+
+# ── Evidence Locality Discounting ───────────────────────────────────────────
+# Shafer reliability discount applied to evidential BBAs based on whether the
+# edge crosses paper boundaries. Intra-source supporters are not independent
+# observations of a target, so their per-BBA reliability is lower.
+#
+# Defaults tuned against the synthetic 19-supporter NEMS regression: target
+# BetP lands in [0.7, 0.85] (replacing the un-discounted 0.997 inflation).
+
+[evidence_locality]
+intra_source_support_strength = 0.3
+cross_source_support_strength = 1.0

--- a/calibration.toml
+++ b/calibration.toml
@@ -151,5 +151,5 @@ max_per_claim = 32
 # BetP lands in [0.7, 0.85] (replacing the un-discounted 0.997 inflation).
 
 [evidence_locality]
-intra_source_support_strength = 0.3
+intra_source_support_strength = 0.25
 cross_source_support_strength = 1.0

--- a/crates/epigraph-db/tests/same_source_papers_truth_table.rs
+++ b/crates/epigraph-db/tests/same_source_papers_truth_table.rs
@@ -125,10 +125,7 @@ async fn same_source_papers_truth_table(pool: PgPool) {
     insert_edge(&pool, a1, a2, "claim", "claim", "decomposes_to").await;
 
     // ── Truth table ────────────────────────────────────────────────────
-    assert!(
-        same_source(&pool, a1, a1).await,
-        "self-pair must be true"
-    );
+    assert!(same_source(&pool, a1, a1).await, "self-pair must be true");
     assert!(
         same_source(&pool, a1, a2).await,
         "intra-paper via asserts+asserts (sibling) must be true"

--- a/crates/epigraph-db/tests/same_source_papers_truth_table.rs
+++ b/crates/epigraph-db/tests/same_source_papers_truth_table.rs
@@ -1,0 +1,152 @@
+//! Truth-table coverage for migration 041's `same_source_papers` function.
+//!
+//! Setup: two papers, each asserting two claims. Intra-paper pairs return
+//! true (regardless of which traversal path), cross-paper pairs return
+//! false, self-pair returns true (short-circuit).
+//!
+//! Schema notes (mirrors `claim_search_by_embedding.rs`):
+//!   * `claims.agent_id` is NOT NULL, so we seed an `agents` row first.
+//!   * `(content_hash, agent_id)` is UNIQUE, so we hand-build distinct
+//!     32-byte hashes for each claim.
+//!   * `edges.source_type` / `target_type` are NOT NULL and validated
+//!     against the entity-type allowlist; we use `'paper'`/`'claim'` for
+//!     `asserts`, `'claim'`/`'claim'` for `decomposes_to`.
+//!   * `relationship` is a free-form `varchar(100)` — `'asserts'` and
+//!     `'decomposes_to'` insert without enum constraints.
+//!
+//! Fixtures are kept inline (no `tests/common/` module) to match the
+//! pattern in `claim_search_by_embedding.rs` and `paper_repo_tests.rs`.
+
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+/// Insert an `agents` row whose UUID we control so that downstream claims
+/// can reference it. `public_key` is a deterministic 32-byte tag.
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(agent_id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    agent_id
+}
+
+/// Build a 32-byte hash with the high byte set to `tag` so each claim gets
+/// a distinct `content_hash` without depending on pgcrypto.
+fn distinct_hash(tag: u8) -> Vec<u8> {
+    let mut h = vec![0u8; 32];
+    h[0] = tag;
+    h
+}
+
+async fn seed_paper(pool: &PgPool, doi: &str, title: &str) -> Uuid {
+    let paper_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO papers (id, doi, title) VALUES ($1, $2, $3)")
+        .bind(paper_id)
+        .bind(doi)
+        .bind(title)
+        .execute(pool)
+        .await
+        .expect("seed paper");
+    paper_id
+}
+
+async fn seed_claim(pool: &PgPool, agent_id: Uuid, content: &str, tag: u8) -> Uuid {
+    let claim_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value) \
+         VALUES ($1, $2, $3, $4, 0.5)",
+    )
+    .bind(claim_id)
+    .bind(content)
+    .bind(distinct_hash(tag))
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("seed claim");
+    claim_id
+}
+
+async fn insert_edge(
+    pool: &PgPool,
+    source: Uuid,
+    target: Uuid,
+    source_type: &str,
+    target_type: &str,
+    relationship: &str,
+) {
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)",
+    )
+    .bind(source)
+    .bind(source_type)
+    .bind(target)
+    .bind(target_type)
+    .bind(relationship)
+    .execute(pool)
+    .await
+    .expect("insert edge");
+}
+
+async fn same_source(pool: &PgPool, a: Uuid, b: Uuid) -> bool {
+    sqlx::query("SELECT same_source_papers($1, $2) AS r")
+        .bind(a)
+        .bind(b)
+        .fetch_one(pool)
+        .await
+        .expect("call same_source_papers")
+        .get::<bool, _>("r")
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn same_source_papers_truth_table(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+
+    let p1 = seed_paper(&pool, "10.1/paper-one", "Paper One").await;
+    let p2 = seed_paper(&pool, "10.2/paper-two", "Paper Two").await;
+
+    let a1 = seed_claim(&pool, agent, "p1::claim1", 1).await;
+    let a2 = seed_claim(&pool, agent, "p1::claim2", 2).await;
+    let b1 = seed_claim(&pool, agent, "p2::claim1", 3).await;
+    let b2 = seed_claim(&pool, agent, "p2::claim2", 4).await;
+
+    // p1 asserts a1, a2
+    insert_edge(&pool, p1, a1, "paper", "claim", "asserts").await;
+    insert_edge(&pool, p1, a2, "paper", "claim", "asserts").await;
+
+    // p2 asserts b1, b2
+    insert_edge(&pool, p2, b1, "paper", "claim", "asserts").await;
+    insert_edge(&pool, p2, b2, "paper", "claim", "asserts").await;
+
+    // a1 decomposes_to a2 (intra-paper sibling-via-decomposes)
+    insert_edge(&pool, a1, a2, "claim", "claim", "decomposes_to").await;
+
+    // ── Truth table ────────────────────────────────────────────────────
+    assert!(
+        same_source(&pool, a1, a1).await,
+        "self-pair must be true"
+    );
+    assert!(
+        same_source(&pool, a1, a2).await,
+        "intra-paper via asserts+asserts (sibling) must be true"
+    );
+    assert!(
+        same_source(&pool, a2, a1).await,
+        "intra-paper symmetric (a2,a1) must be true"
+    );
+    assert!(
+        !same_source(&pool, a1, b1).await,
+        "cross-paper must be false"
+    );
+    assert!(
+        !same_source(&pool, b1, a2).await,
+        "cross-paper must be false (reversed)"
+    );
+    assert!(
+        same_source(&pool, b1, b2).await,
+        "intra-paper for paper 2 must be true"
+    );
+}

--- a/crates/epigraph-engine/src/calibration.rs
+++ b/crates/epigraph-engine/src/calibration.rs
@@ -74,7 +74,7 @@ pub struct EvidenceLocality {
 
 fn default_evidence_locality() -> EvidenceLocality {
     EvidenceLocality {
-        intra_source_support_strength: 0.3,
+        intra_source_support_strength: 0.25,
         cross_source_support_strength: 1.0,
     }
 }
@@ -99,6 +99,32 @@ impl CalibrationConfig {
         let contents = std::fs::read_to_string(path)?;
         let config: Self = toml::from_str(&contents)?;
         Ok(config)
+    }
+
+    /// Loads `calibration.toml` from the `CALIBRATION_PATH` env var if set,
+    /// otherwise from the workspace root via `CARGO_MANIFEST_DIR` (best effort).
+    ///
+    /// Falls back to the literal path `"calibration.toml"` (cwd-relative) when
+    /// neither env var is present at runtime. Returns the same
+    /// [`CalibrationError`] variants as [`Self::load`].
+    ///
+    /// Production hot-path callers should treat I/O failure as recoverable
+    /// (e.g. `.ok().map(...).unwrap_or((defaults))`) rather than propagating —
+    /// the engine has reasonable defaults for every locality / weight key.
+    pub fn from_workspace_root() -> Result<Self, CalibrationError> {
+        let path = if let Ok(explicit) = std::env::var("CALIBRATION_PATH") {
+            std::path::PathBuf::from(explicit)
+        } else if let Some(manifest_dir) = option_env!("CARGO_MANIFEST_DIR") {
+            // crates/epigraph-engine/ → workspace root is two levels up.
+            std::path::PathBuf::from(manifest_dir)
+                .parent()
+                .and_then(|p| p.parent())
+                .map(|root| root.join("calibration.toml"))
+                .unwrap_or_else(|| std::path::PathBuf::from("calibration.toml"))
+        } else {
+            std::path::PathBuf::from("calibration.toml")
+        };
+        Self::load(&path)
     }
 
     /// Resolve a methodology string to its `(base_support, base_against, base_ignorance)` profile.
@@ -217,7 +243,7 @@ mod tests {
     fn test_evidence_locality_loads() {
         let config = load_config();
         assert!(
-            (config.evidence_locality.intra_source_support_strength - 0.3).abs() < 1e-9,
+            (config.evidence_locality.intra_source_support_strength - 0.25).abs() < 1e-9,
             "intra_source_support_strength = {}",
             config.evidence_locality.intra_source_support_strength
         );

--- a/crates/epigraph-engine/src/calibration.rs
+++ b/crates/epigraph-engine/src/calibration.rs
@@ -49,8 +49,34 @@ pub struct CalibrationConfig {
     /// Journal name → reliability score.
     pub journal_reliability: HashMap<String, f64>,
 
+    /// Evidence-locality discounts applied to per-BBA source_strength.
+    ///
+    /// Drives Shafer reliability discounting in
+    /// `routes/edges.rs::trigger_edge_ds_recomputation` based on whether the
+    /// supporting and supported claims share a source paper.
+    #[serde(default = "default_evidence_locality")]
+    pub evidence_locality: EvidenceLocality,
+
     /// Classifier decision thresholds (NEI, support, conflict).
     pub classifier_thresholds: ClassifierThresholds,
+}
+
+/// Discount factors keyed on whether evidence crosses paper boundaries.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvidenceLocality {
+    /// `source_strength` for intra-paper evidential BBAs (low — supporters
+    /// from one paper are not independent observations).
+    pub intra_source_support_strength: f64,
+
+    /// `source_strength` for cross-paper evidential BBAs (full reliability).
+    pub cross_source_support_strength: f64,
+}
+
+fn default_evidence_locality() -> EvidenceLocality {
+    EvidenceLocality {
+        intra_source_support_strength: 0.3,
+        cross_source_support_strength: 1.0,
+    }
 }
 
 /// Thresholds used by the BetP-based classifier.
@@ -184,6 +210,21 @@ mod tests {
         assert!(
             (cfg.default_journal_reliability - 0.78).abs() < f64::EPSILON,
             "default_journal_reliability should be 0.78"
+        );
+    }
+
+    #[test]
+    fn test_evidence_locality_loads() {
+        let config = load_config();
+        assert!(
+            (config.evidence_locality.intra_source_support_strength - 0.3).abs() < 1e-9,
+            "intra_source_support_strength = {}",
+            config.evidence_locality.intra_source_support_strength
+        );
+        assert!(
+            (config.evidence_locality.cross_source_support_strength - 1.0).abs() < 1e-9,
+            "cross_source_support_strength = {}",
+            config.evidence_locality.cross_source_support_strength
         );
     }
 

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -74,19 +74,49 @@ pub async fn auto_wire_ds_for_edge(
     let source_interval =
         EpistemicInterval::new(bel, pl, ow_opt.unwrap_or((pl - bel).max(0.0) * 0.5));
 
-    let (restricted, source_strength) = match restriction {
-        RestrictionKind::Positive(f) => (restrict_epistemic_positive(&source_interval, f), f),
-        RestrictionKind::Negative(f) => (restrict_epistemic_negative(&source_interval, f), f),
-        RestrictionKind::FrameEvidence(f) => (
-            restrict_epistemic_frame_evidence(&source_interval, source_interval.betp(), f),
-            f,
-        ),
+    // The restriction transmission factor (`f`) is already folded into the
+    // BBA mass shape via `restrict_epistemic_*`; only the locality factor
+    // lands on the stored `source_strength` column below.
+    let restricted = match restriction {
+        RestrictionKind::Positive(f) => restrict_epistemic_positive(&source_interval, f),
+        RestrictionKind::Negative(f) => restrict_epistemic_negative(&source_interval, f),
+        RestrictionKind::FrameEvidence(f) => {
+            restrict_epistemic_frame_evidence(&source_interval, source_interval.betp(), f)
+        }
         RestrictionKind::Neutral => unreachable!(),
     };
 
     if restricted.width() >= 0.999 && restricted.bel < 0.01 {
         return Ok(EdgeFactorOutcome::Vacuous);
     }
+
+    // Locality-aware reliability discount. Same-paper supporters are not
+    // independent observations of the target — apply a smaller source_strength
+    // so the existing Shafer discount in CDST combine deflates the per-BBA
+    // contribution. Defaults: intra=0.3, cross=1.0 (see calibration.toml).
+    //
+    // We REPLACE the restriction transmission factor with the locality factor
+    // (rather than multiplying) per the spec at
+    // docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md §2:
+    // the calibrated [0.7, 0.85] band for 19 intra-source supporters assumes
+    // the locality value IS the stored source_strength, not a composition.
+    let same_source: bool = sqlx::query_scalar::<_, bool>("SELECT same_source_papers($1, $2)")
+        .bind(source_id)
+        .bind(target_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| format!("same_source_papers: {e}"))?;
+    let calibration = crate::calibration::CalibrationConfig::from_workspace_root().ok();
+    let (intra, cross) = calibration
+        .as_ref()
+        .map(|c| {
+            (
+                c.evidence_locality.intra_source_support_strength,
+                c.evidence_locality.cross_source_support_strength,
+            )
+        })
+        .unwrap_or((0.3, 1.0));
+    let source_strength = if same_source { intra } else { cross };
 
     let frame_id = ensure_binary_frame(pool).await?;
     let frame = binary_frame()?;

--- a/crates/epigraph-engine/tests/intra_source_discount_calibration.rs
+++ b/crates/epigraph-engine/tests/intra_source_discount_calibration.rs
@@ -1,0 +1,29 @@
+//! Calibration canary — trips if the locality-discount defaults are moved
+//! without re-tuning the 19-supporter regression. This is intentionally
+//! adversarial: a future PR that adjusts the calibration must update the
+//! regression test together, and this canary fails fast if only one side
+//! changes.
+
+use epigraph_engine::calibration::CalibrationConfig;
+
+#[test]
+fn intra_source_strength_in_documented_band() {
+    let config = CalibrationConfig::from_workspace_root().expect("calibration.toml should load");
+    let intra = config.evidence_locality.intra_source_support_strength;
+    assert!(
+        (0.15..=0.45).contains(&intra),
+        "intra_source_support_strength out of documented band [0.15, 0.45]: got {intra}. \
+         If you intend to retune, update intra_source_19_supporters_betp_in_band as well."
+    );
+}
+
+#[test]
+fn cross_source_strength_is_one() {
+    let config = CalibrationConfig::from_workspace_root().expect("calibration.toml should load");
+    let cross = config.evidence_locality.cross_source_support_strength;
+    assert!(
+        (cross - 1.0).abs() < 1e-9,
+        "cross_source_support_strength must remain 1.0 (got {cross}); \
+         lowering it changes baseline BetP across the entire graph."
+    );
+}

--- a/crates/epigraph-engine/tests/intra_source_discount_regression.rs
+++ b/crates/epigraph-engine/tests/intra_source_discount_regression.rs
@@ -1,0 +1,312 @@
+//! 19-supporter synthetic regression for locality-aware discounting.
+//!
+//! Mirrors the NEMS shape from issue #142: one target T, 19 supporting claims
+//! S1..S19. With cross-source `source_strength = 1.0` the combined BetP
+//! approaches 1.0 (the un-discounted Dempster product). With intra-source
+//! `source_strength = 0.3` from calibration.toml, BetP drops into the
+//! [0.70, 0.85] band the issue requires.
+//!
+//! The test exercises the centralized BBA write path
+//! `epigraph_engine::edge_factor::auto_wire_ds_for_edge` directly. No HTTP /
+//! MCP server is required.
+//!
+//! Schema notes (mirrors `crates/epigraph-db/tests/same_source_papers_truth_table.rs`):
+//!   * `claims.agent_id` is NOT NULL — seed an `agents` row first.
+//!   * `(content_hash, agent_id)` is UNIQUE — hand-build distinct 32-byte hashes.
+//!   * `edges.source_type` / `target_type` are NOT NULL and validated against
+//!     the entity-type allowlist; we use `'paper'` / `'claim'` for `asserts`,
+//!     `'claim'` / `'claim'` for `supports`.
+//!
+//! IMPORTANT: `auto_wire_ds_for_edge` short-circuits to `SourceFactorless`
+//! when the source claim has NULL belief or plausibility. Each supporter
+//! must be seeded with `belief = plausibility = 0.68` (a certain interval
+//! at the NEMS mean from the issue body), not just `truth_value = 0.68`.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use epigraph_engine::edge_factor::{auto_wire_ds_for_edge, EdgeFactorOutcome};
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+/// Build a 32-byte hash with the first three bytes set from `tag` so each
+/// claim/agent/paper gets a distinct `content_hash` without depending on
+/// pgcrypto. Caller passes a `u32` tag to avoid collisions across the 19
+/// supporters + 19 papers + 1 target seeded by `cross_source_19_supporters`.
+fn distinct_hash(tag: u32) -> Vec<u8> {
+    let mut h = vec![0u8; 32];
+    h[0] = (tag & 0xff) as u8;
+    h[1] = ((tag >> 8) & 0xff) as u8;
+    h[2] = ((tag >> 16) & 0xff) as u8;
+    h
+}
+
+async fn seed_agent(pool: &PgPool, tag: u32) -> Uuid {
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, $2)")
+        .bind(agent_id)
+        .bind(distinct_hash(tag))
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    agent_id
+}
+
+async fn seed_paper(pool: &PgPool, doi: &str, title: &str) -> Uuid {
+    let paper_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO papers (id, doi, title) VALUES ($1, $2, $3)")
+        .bind(paper_id)
+        .bind(doi)
+        .bind(title)
+        .execute(pool)
+        .await
+        .expect("seed paper");
+    paper_id
+}
+
+/// Seed a claim with a populated belief / plausibility interval so that
+/// `auto_wire_ds_for_edge` can read it as the source of a `supports` edge.
+/// Without `belief` and `plausibility`, the auto-wire path returns
+/// `SourceFactorless` and writes no BBA.
+async fn seed_claim_with_belief(
+    pool: &PgPool,
+    agent_id: Uuid,
+    content: &str,
+    tag: u32,
+    truth_value: f64,
+    belief: f64,
+    plausibility: f64,
+) -> Uuid {
+    let claim_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims \
+         (id, content, content_hash, agent_id, truth_value, belief, plausibility, open_world_mass, is_current) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 0.0, true)",
+    )
+    .bind(claim_id)
+    .bind(content)
+    .bind(distinct_hash(tag))
+    .bind(agent_id)
+    .bind(truth_value)
+    .bind(belief)
+    .bind(plausibility)
+    .execute(pool)
+    .await
+    .expect("seed claim");
+    claim_id
+}
+
+async fn insert_edge(
+    pool: &PgPool,
+    source: Uuid,
+    target: Uuid,
+    source_type: &str,
+    target_type: &str,
+    relationship: &str,
+) -> Uuid {
+    let edge_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(edge_id)
+    .bind(source)
+    .bind(source_type)
+    .bind(target)
+    .bind(target_type)
+    .bind(relationship)
+    .execute(pool)
+    .await
+    .expect("insert edge");
+    edge_id
+}
+
+async fn read_betp(pool: &PgPool, claim_id: Uuid) -> Option<f64> {
+    sqlx::query_scalar::<_, Option<f64>>("SELECT pignistic_prob FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
+        .await
+        .expect("read pignistic_prob")
+}
+
+async fn count_target_bbas(pool: &PgPool, claim_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM mass_functions WHERE claim_id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
+        .await
+        .expect("count BBAs")
+}
+
+const NEMS_BELIEF: f64 = 0.68;
+
+// ── Intra-source: 19 supporters, all from one paper ────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn intra_source_19_supporters_betp_in_band(pool: PgPool) {
+    let agent = seed_agent(&pool, 0xA0_0001).await;
+    let paper = seed_paper(&pool, "10.intra/p1", "Synthesis paper").await;
+
+    // Target — start with NULL belief/plausibility so the only BBAs on the
+    // target's row come from the 19 supporter edges (no self-evidence).
+    let target_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current) \
+         VALUES ($1, $2, $3, $4, 0.5, true)",
+    )
+    .bind(target_id)
+    .bind("GEN-2 NEMS target")
+    .bind(distinct_hash(0x10_0000))
+    .bind(agent)
+    .execute(&pool)
+    .await
+    .expect("seed target");
+
+    // The same paper asserts the target and all 19 supporters → same_source_papers
+    // must return true for every (supporter, target) pair.
+    insert_edge(&pool, paper, target_id, "paper", "claim", "asserts").await;
+
+    for i in 0..19u32 {
+        let supporter = seed_claim_with_belief(
+            &pool,
+            agent,
+            &format!("intra supporter {i}"),
+            0x20_0000 + i,
+            NEMS_BELIEF,
+            NEMS_BELIEF,
+            NEMS_BELIEF,
+        )
+        .await;
+
+        insert_edge(&pool, paper, supporter, "paper", "claim", "asserts").await;
+
+        // Fire the centralized BBA write path — same code path 5 entry
+        // points use (HTTP edges, HTTP workflows, MCP ingestion,
+        // MCP workflow_ingest, CLI backfill_factors).
+        let edge_id = insert_edge(&pool, supporter, target_id, "claim", "claim", "supports").await;
+        let outcome =
+            auto_wire_ds_for_edge(&pool, edge_id, agent, supporter, target_id, "supports")
+                .await
+                .expect("auto_wire_ds_for_edge");
+        assert_eq!(
+            outcome,
+            EdgeFactorOutcome::Wired,
+            "supporter {i}: expected Wired, got {outcome:?} (missing belief/plausibility on the source?)"
+        );
+    }
+
+    // Sanity: exactly 19 BBAs landed on the target.
+    let bba_count = count_target_bbas(&pool, target_id).await;
+    assert_eq!(
+        bba_count, 19,
+        "expected 19 BBAs on the target, got {bba_count} — auto-wire short-circuited somewhere"
+    );
+
+    // Spot-check: every BBA carries the intra-source discount.
+    let intra_row_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mass_functions \
+         WHERE claim_id = $1 AND source_strength = 0.25",
+    )
+    .bind(target_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count intra rows");
+    assert_eq!(
+        intra_row_count, 19,
+        "expected all 19 BBAs to be discounted to 0.25, got {intra_row_count}"
+    );
+
+    let betp = read_betp(&pool, target_id)
+        .await
+        .expect("target should have computed BetP after 19 supporter wires");
+    eprintln!("[intra_source_19_supporters_betp_in_band] BetP = {betp}");
+    assert!(
+        (0.70..=0.85).contains(&betp),
+        "expected intra-source-discounted BetP in [0.70, 0.85], got {betp}"
+    );
+}
+
+// ── Cross-source: 19 supporters, each from its own paper ───────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn cross_source_19_supporters_keeps_high_betp(pool: PgPool) {
+    let agent = seed_agent(&pool, 0xB0_0001).await;
+
+    // Target paper is distinct from all 19 supporter papers — none of the
+    // 19 supporters share a source paper with the target, so
+    // `same_source_papers` returns false for every pair and the cross-source
+    // strength (1.0) is applied.
+    let target_paper = seed_paper(&pool, "10.cross/target", "Target paper").await;
+    let target_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current) \
+         VALUES ($1, $2, $3, $4, 0.5, true)",
+    )
+    .bind(target_id)
+    .bind("cross-source target")
+    .bind(distinct_hash(0x30_0000))
+    .bind(agent)
+    .execute(&pool)
+    .await
+    .expect("seed target");
+    insert_edge(&pool, target_paper, target_id, "paper", "claim", "asserts").await;
+
+    for i in 0..19u32 {
+        let paper = seed_paper(
+            &pool,
+            &format!("10.cross/p{i}"),
+            &format!("supporter paper {i}"),
+        )
+        .await;
+        let supporter = seed_claim_with_belief(
+            &pool,
+            agent,
+            &format!("cross supporter {i}"),
+            0x40_0000 + i,
+            NEMS_BELIEF,
+            NEMS_BELIEF,
+            NEMS_BELIEF,
+        )
+        .await;
+        insert_edge(&pool, paper, supporter, "paper", "claim", "asserts").await;
+
+        let edge_id = insert_edge(&pool, supporter, target_id, "claim", "claim", "supports").await;
+        let outcome =
+            auto_wire_ds_for_edge(&pool, edge_id, agent, supporter, target_id, "supports")
+                .await
+                .expect("auto_wire_ds_for_edge");
+        assert_eq!(
+            outcome,
+            EdgeFactorOutcome::Wired,
+            "supporter {i}: expected Wired, got {outcome:?}"
+        );
+    }
+
+    let bba_count = count_target_bbas(&pool, target_id).await;
+    assert_eq!(
+        bba_count, 19,
+        "expected 19 BBAs on the target, got {bba_count}"
+    );
+
+    // Spot-check: every BBA carries the cross-source (no-discount) strength.
+    let cross_row_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mass_functions \
+         WHERE claim_id = $1 AND source_strength = 1.0",
+    )
+    .bind(target_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count cross rows");
+    assert_eq!(
+        cross_row_count, 19,
+        "expected all 19 BBAs to use source_strength=1.0, got {cross_row_count}"
+    );
+
+    let betp = read_betp(&pool, target_id)
+        .await
+        .expect("target should have computed BetP after 19 supporter wires");
+    eprintln!("[cross_source_19_supporters_keeps_high_betp] BetP = {betp}");
+    assert!(
+        betp > 0.9,
+        "cross-source 19-supporter BetP should stay > 0.9, got {betp}"
+    );
+}

--- a/docs/superpowers/plans/2026-05-27-locality-aware-discounting.md
+++ b/docs/superpowers/plans/2026-05-27-locality-aware-discounting.md
@@ -1,0 +1,868 @@
+# Locality-Aware Source-Strength Discounting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a `supports`/`refutes`/`corroborates`/`contradicts` edge is created, detect whether endpoints share a source paper. If so, write the BBA with a smaller `source_strength` so the existing Shafer discount in CDST combine deflates the intra-source contribution instead of treating it as a fully independent observation. Closes issue #142 (in spirit — the original retype mechanism is replaced; see spec).
+
+**Architecture:** New Postgres function `same_source_papers(a, b)` traversing the `{asserts, same_source, section_follows, continues_argument, decomposes_to}` closure. `trigger_edge_ds_recomputation` (in `crates/epigraph-api/src/routes/edges.rs`) consults this function and picks a `source_strength` from new calibration keys `evidence_locality.{intra_source,cross_source}_support_strength`. The combine path itself does not change — only the per-BBA reliability does. Existing data is cleaned up by a one-shot operator script.
+
+**Tech Stack:** Postgres (recursive CTE function), Rust, sqlx, `epigraph-engine::calibration`, `epigraph-api`, `epigraph-mcp` MCP tools, Python operator script (for backfill).
+
+---
+
+## Setup
+
+**Branch.** Branch from `origin/main` (not from the spec branches). The latest migration on `main` is `040_workflows_goal_embedding.sql`, so this plan uses `041`.
+
+```bash
+cd /home/jeremy/epigraph
+git fetch origin main
+git checkout -b feat/locality-aware-discounting origin/main
+```
+
+**Test database.** `epigraph_db_repo_test`, per `CLAUDE.md`:
+
+```bash
+export DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test'
+```
+
+**Spec reference.** `docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md` § 2 (Locality-aware discounting). This plan implements that section only; the alt-set companion plan covers § 1, 3, 4, 5.
+
+---
+
+### Task 1: `same_source_papers` Postgres function
+
+**Files:**
+- Create: `migrations/041_same_source_papers_function.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 041_same_source_papers_function.sql
+--
+-- Predicate: do claims a and b share a source paper, traversing the
+-- transitive closure of {asserts, same_source, section_follows,
+-- continues_argument, decomposes_to}?
+--
+-- Used by edges.rs::trigger_edge_ds_recomputation to set a smaller
+-- source_strength on intra-source evidential BBAs (Shafer reliability
+-- discount). See docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md.
+
+CREATE OR REPLACE FUNCTION same_source_papers(a UUID, b UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    result BOOLEAN;
+BEGIN
+    IF a = b THEN
+        RETURN TRUE;
+    END IF;
+
+    WITH RECURSIVE seeds AS (
+        -- Papers that assert `a` are seed nodes.
+        SELECT e.source_id AS paper_id
+        FROM edges e
+        WHERE e.target_id = a
+          AND e.relationship = 'asserts'
+    ),
+    paper_a_closure AS (
+        -- Claims reachable from any of a's papers through intra-source edges.
+        SELECT e.target_id AS claim_id
+        FROM seeds s
+        JOIN edges e
+          ON e.source_id = s.paper_id
+         AND e.relationship = 'asserts'
+        UNION
+        SELECT e2.target_id
+        FROM paper_a_closure pac
+        JOIN edges e2
+          ON e2.source_id = pac.claim_id
+         AND e2.relationship IN (
+             'same_source', 'section_follows',
+             'continues_argument', 'decomposes_to'
+         )
+        UNION
+        SELECT e3.source_id
+        FROM paper_a_closure pac
+        JOIN edges e3
+          ON e3.target_id = pac.claim_id
+         AND e3.relationship IN (
+             'same_source', 'section_follows',
+             'continues_argument', 'decomposes_to'
+         )
+    )
+    SELECT EXISTS (
+        SELECT 1 FROM paper_a_closure WHERE claim_id = b
+    ) INTO result;
+
+    RETURN COALESCE(result, FALSE);
+END;
+$$;
+
+COMMENT ON FUNCTION same_source_papers(UUID, UUID) IS
+'True iff claim a and claim b share a source paper via the transitive closure of '
+'{asserts, same_source, section_follows, continues_argument, decomposes_to}. '
+'Drives intra-source source_strength discounting in trigger_edge_ds_recomputation.';
+```
+
+- [ ] **Step 2: Apply and confirm the migration**
+
+```bash
+cd /home/jeremy/epigraph
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  sqlx migrate run
+psql "$DATABASE_URL" -c "\\df same_source_papers"
+```
+
+Expected: function appears in `\df` output with signature `(uuid, uuid) -> boolean`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add migrations/041_same_source_papers_function.sql
+git commit -m "feat(db): same_source_papers function for locality-aware discounting"
+```
+
+---
+
+### Task 2: Truth-table integration test for the predicate
+
+**Files:**
+- Create: `crates/epigraph-db/tests/same_source_papers_truth_table.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+//! Truth-table coverage for migration 041's same_source_papers function.
+//!
+//! Setup: two papers, each asserting two claims. Intra-paper pairs return true
+//! (regardless of which traversal path), cross-paper pairs return false,
+//! self-pair returns true (short-circuit).
+
+mod common;
+
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+async fn seed(pool: &PgPool) -> (Uuid, Uuid, Uuid, Uuid) {
+    let p1 = common::seed_paper(pool, "Paper One").await;
+    let p2 = common::seed_paper(pool, "Paper Two").await;
+
+    let a1 = common::seed_claim(pool, "p1::claim1").await;
+    let a2 = common::seed_claim(pool, "p1::claim2").await;
+    let b1 = common::seed_claim(pool, "p2::claim1").await;
+    let b2 = common::seed_claim(pool, "p2::claim2").await;
+
+    // p1 asserts a1, a2
+    common::insert_edge(pool, p1, a1, "paper", "claim", "asserts").await;
+    common::insert_edge(pool, p1, a2, "paper", "claim", "asserts").await;
+
+    // p2 asserts b1, b2
+    common::insert_edge(pool, p2, b1, "paper", "claim", "asserts").await;
+    common::insert_edge(pool, p2, b2, "paper", "claim", "asserts").await;
+
+    // a1 decomposes_to a2 (intra-paper sibling-via-decomposes)
+    common::insert_edge(pool, a1, a2, "claim", "claim", "decomposes_to").await;
+
+    (a1, a2, b1, b2)
+}
+
+#[tokio::test]
+async fn same_source_papers_truth_table() {
+    let pool = common::test_pool().await;
+    let (a1, a2, b1, b2) = seed(&pool).await;
+
+    let q = |x: Uuid, y: Uuid| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query("SELECT same_source_papers($1, $2) AS r")
+                .bind(x)
+                .bind(y)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .get::<bool, _>("r")
+        }
+    };
+
+    assert!(q(a1, a1).await, "self-pair must be true");
+    assert!(q(a1, a2).await, "intra-paper via asserts+asserts (sibling)");
+    assert!(q(a2, a1).await, "intra-paper symmetric (a2,a1)");
+    assert!(!q(a1, b1).await, "cross-paper must be false");
+    assert!(!q(b1, a2).await, "cross-paper must be false (reversed)");
+    assert!(q(b1, b2).await, "intra-paper for paper 2");
+}
+```
+
+If `crates/epigraph-db/tests/common/` is missing helpers `seed_paper`, `seed_claim`, `insert_edge`, `test_pool`, add minimal versions modeled on `crates/epigraph-db/tests/paper_repo_tests.rs` (which already seeds papers).
+
+- [ ] **Step 2: Run and verify the test passes against the function from Task 1**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test -p epigraph-db --test same_source_papers_truth_table -- --nocapture
+```
+
+Expected: PASS (6 assertions).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/epigraph-db/tests/same_source_papers_truth_table.rs \
+        crates/epigraph-db/tests/common/
+git commit -m "test(db): truth-table for same_source_papers predicate"
+```
+
+---
+
+### Task 3: Calibration keys for locality discounts
+
+**Files:**
+- Modify: `calibration.toml` (workspace root)
+- Modify: `crates/epigraph-engine/src/calibration.rs`
+
+- [ ] **Step 1: Add the calibration block**
+
+Append to `/home/jeremy/epigraph/calibration.toml`:
+
+```toml
+# ── Evidence Locality Discounting ───────────────────────────────────────────
+# Shafer reliability discount applied to evidential BBAs based on whether the
+# edge crosses paper boundaries. Intra-source supporters are not independent
+# observations of a target, so their per-BBA reliability is lower.
+#
+# Defaults tuned against the synthetic 19-supporter NEMS regression: target
+# BetP lands in [0.7, 0.85] (replacing the un-discounted 0.997 inflation).
+
+[evidence_locality]
+intra_source_support_strength = 0.3
+cross_source_support_strength = 1.0
+```
+
+- [ ] **Step 2: Extend `CalibrationConfig`**
+
+In `crates/epigraph-engine/src/calibration.rs`, add to `CalibrationConfig` (after the `journal_reliability` field, before `classifier_thresholds`):
+
+```rust
+    /// Evidence-locality discounts applied to per-BBA source_strength.
+    ///
+    /// Drives Shafer reliability discounting in
+    /// `routes/edges.rs::trigger_edge_ds_recomputation` based on whether the
+    /// supporting and supported claims share a source paper.
+    #[serde(default = "default_evidence_locality")]
+    pub evidence_locality: EvidenceLocality,
+```
+
+And below the existing struct, add:
+
+```rust
+/// Discount factors keyed on whether evidence crosses paper boundaries.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvidenceLocality {
+    /// `source_strength` for intra-paper evidential BBAs (low — supporters
+    /// from one paper are not independent observations).
+    pub intra_source_support_strength: f64,
+
+    /// `source_strength` for cross-paper evidential BBAs (full reliability).
+    pub cross_source_support_strength: f64,
+}
+
+fn default_evidence_locality() -> EvidenceLocality {
+    EvidenceLocality {
+        intra_source_support_strength: 0.3,
+        cross_source_support_strength: 1.0,
+    }
+}
+```
+
+The `serde(default)` lets older / partial calibration files keep loading.
+
+- [ ] **Step 3: Add a unit test confirming the keys round-trip**
+
+In `crates/epigraph-engine/src/calibration.rs`, add to the existing test module:
+
+```rust
+    #[test]
+    fn test_evidence_locality_loads() {
+        let config = CalibrationConfig::from_workspace_root()
+            .expect("calibration.toml should load successfully");
+        assert!(
+            (config.evidence_locality.intra_source_support_strength - 0.3).abs() < 1e-9,
+            "intra_source_support_strength = {}",
+            config.evidence_locality.intra_source_support_strength
+        );
+        assert!(
+            (config.evidence_locality.cross_source_support_strength - 1.0).abs() < 1e-9,
+            "cross_source_support_strength = {}",
+            config.evidence_locality.cross_source_support_strength
+        );
+    }
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cargo test -p epigraph-engine test_evidence_locality_loads -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calibration.toml crates/epigraph-engine/src/calibration.rs
+git commit -m "feat(engine): evidence_locality calibration keys for intra/cross-source discount"
+```
+
+---
+
+### Task 4: Wire locality-aware `source_strength` into `trigger_edge_ds_recomputation`
+
+**Files:**
+- Modify: `crates/epigraph-api/src/routes/edges.rs:155-300` (the function body of `trigger_edge_ds_recomputation`)
+
+- [ ] **Step 1: Look up the current function**
+
+```bash
+grep -n "fn trigger_edge_ds_recomputation\|MassFunctionRepository::store" \
+     crates/epigraph-api/src/routes/edges.rs
+```
+
+Expected: function starts at `:156`; the existing `MassFunctionRepository::store` call (around `:224`) passes `None` (or a literal `0.7 * 0.5` inside `mass_value`) — it does *not* currently set `source_strength`. The change below replaces that call with one that binds `source_strength` from the locality predicate.
+
+- [ ] **Step 2: Modify the function to consult `same_source_papers` and pass `source_strength`**
+
+In `crates/epigraph-api/src/routes/edges.rs`, inside `trigger_edge_ds_recomputation`, just before the `MassFunctionRepository::store(...)` call (currently around `:224`), insert:
+
+```rust
+    // Locality-aware reliability discount. Same-paper supporters are not
+    // independent observations of the target — apply a smaller source_strength
+    // so the existing Shafer discount in CDST combine deflates the per-BBA
+    // contribution. Defaults: intra=0.3, cross=1.0 (see calibration.toml).
+    let same_source: bool = sqlx::query_scalar::<_, bool>(
+        "SELECT same_source_papers($1, $2)",
+    )
+    .bind(source_claim_id)
+    .bind(target_claim_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| crate::errors::ApiError::DatabaseError {
+        message: format!("same_source_papers: {e}"),
+    })?;
+
+    let calibration = epigraph_engine::calibration::CalibrationConfig::from_workspace_root()
+        .ok();
+    let (intra, cross) = calibration
+        .as_ref()
+        .map(|c| {
+            (
+                c.evidence_locality.intra_source_support_strength,
+                c.evidence_locality.cross_source_support_strength,
+            )
+        })
+        .unwrap_or((0.3, 1.0));
+    let source_strength = if same_source { intra } else { cross };
+```
+
+Then replace the existing `MassFunctionRepository::store(...)` call with `store_with_perspective(...)`, which already accepts `source_strength` (see `crates/epigraph-mcp/src/tools/ds_auto.rs:269-280` for the canonical caller). The store call becomes:
+
+```rust
+    MassFunctionRepository::store_with_perspective(
+        pool,
+        target_claim_id,
+        frame_id,
+        Some(source_agent_id),
+        None,                              // perspective_id — keep current behavior
+        &masses_json,
+        None,                              // conflict_k
+        Some("discount"),                  // combination_method
+        Some(source_strength),             // source_strength — locality-aware
+        None,                              // evidence_type — N/A for edge-derived BBAs
+    )
+    .await
+    .map_err(|e| crate::errors::ApiError::DatabaseError {
+        message: format!("Failed to store edge mass function: {e}"),
+    })?;
+```
+
+`store_with_perspective` is already public (per its use in `ds_auto.rs:269-280` from an external crate).
+
+- [ ] **Step 3: Confirm the change compiles**
+
+```bash
+SQLX_OFFLINE=true cargo check -p epigraph-api
+```
+
+Expected: clean. If `sqlx::query_scalar` flags an offline-mode mismatch, run:
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo sqlx prepare --workspace -- --tests
+git add .sqlx/
+```
+
+- [ ] **Step 4: Do NOT commit yet — Task 5 covers it together with the regression**
+
+---
+
+### Task 5: 19-supporter synthetic regression test
+
+**Files:**
+- Create: `crates/epigraph-engine/tests/intra_source_discount_regression.rs`
+
+- [ ] **Step 1: Write the regression test**
+
+```rust
+//! 19-supporter synthetic regression for locality-aware discounting.
+//!
+//! Mirrors the NEMS shape from issue #142: one target T, 19 supporting claims
+//! S1..S19 each asserting (paper p1) the same target. With cross-source
+//! source_strength=1.0 the combined BetP approaches 0.997 (current behavior).
+//! With intra-source source_strength=0.3 from calibration.toml, BetP drops
+//! into [0.7, 0.85] — the band the issue requires.
+
+mod common;
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_19_intra_source_supporters(pool: &PgPool) -> Uuid {
+    let paper = common::seed_paper(pool, "Synthesis paper").await;
+    let target = common::seed_claim(pool, "GEN-2 NEMS").await;
+    common::insert_edge(pool, paper, target, "paper", "claim", "asserts").await;
+
+    for i in 0..19 {
+        let supporter = common::seed_claim(pool, &format!("supporter {i}")).await;
+        common::insert_edge(pool, paper, supporter, "paper", "claim", "asserts").await;
+        // Each supporter has truth_value 0.68 (mean from issue body)
+        sqlx::query("UPDATE claims SET truth_value = 0.68 WHERE id = $1")
+            .bind(supporter)
+            .execute(pool)
+            .await
+            .unwrap();
+        // Edge create fires trigger_edge_ds_recomputation, which writes the
+        // locality-discounted BBA.
+        common::insert_edge(pool, supporter, target, "claim", "claim", "supports").await;
+    }
+
+    target
+}
+
+#[tokio::test]
+async fn intra_source_19_supporters_betp_in_band() {
+    let pool = common::test_pool().await;
+    let target = seed_19_intra_source_supporters(&pool).await;
+
+    let betp: Option<f64> = sqlx::query_scalar(
+        "SELECT pignistic_prob FROM claims WHERE id = $1",
+    )
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let betp = betp.expect("target should have computed BetP after edge creates");
+    assert!(
+        (0.70..=0.85).contains(&betp),
+        "expected intra-source-discounted BetP in [0.70, 0.85], got {betp}"
+    );
+}
+
+#[tokio::test]
+async fn cross_source_19_supporters_keeps_high_betp() {
+    let pool = common::test_pool().await;
+    let target = common::seed_claim(&pool, "cross-source target").await;
+    // 19 supporters, each from its own paper — cross_source path
+    for i in 0..19 {
+        let paper = common::seed_paper(&pool, &format!("p{i}")).await;
+        let supporter = common::seed_claim(&pool, &format!("cs-supporter {i}")).await;
+        common::insert_edge(&pool, paper, supporter, "paper", "claim", "asserts").await;
+        sqlx::query("UPDATE claims SET truth_value = 0.68 WHERE id = $1")
+            .bind(supporter)
+            .execute(&pool)
+            .await
+            .unwrap();
+        common::insert_edge(&pool, supporter, target, "claim", "claim", "supports").await;
+    }
+
+    let betp: Option<f64> = sqlx::query_scalar(
+        "SELECT pignistic_prob FROM claims WHERE id = $1",
+    )
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let betp = betp.expect("BetP");
+    assert!(
+        betp > 0.9,
+        "cross-source 19-supporter BetP should remain near 1.0 (got {betp})"
+    );
+}
+```
+
+If `common::seed_paper` / `common::seed_claim` / `common::insert_edge` / `common::test_pool` are not present in `crates/epigraph-engine/tests/common/`, port them from the Task 2 test helpers (or share a `tests/common/` module — at minimum, copy with attribution comments pointing at the source).
+
+- [ ] **Step 2: Run the test, observe both pass**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test -p epigraph-engine --test intra_source_discount_regression -- --nocapture
+```
+
+Expected: BOTH pass.
+
+- If `intra_source_19_supporters_betp_in_band` fails with `betp = 0.99...`, the Task 4 wiring did not take effect — verify the `same_source_papers` SQL returned `true` (add a `dbg!` in the test or check the `mass_functions` row's `source_strength` column).
+- If `cross_source_19_supporters_keeps_high_betp` fails with a too-low BetP, locality detection over-fires (the predicate is reporting same-source for genuinely cross-source pairs); debug the recursive CTE.
+
+- [ ] **Step 3: Commit Tasks 4 + 5 together**
+
+```bash
+git add crates/epigraph-api/src/routes/edges.rs \
+        crates/epigraph-engine/tests/intra_source_discount_regression.rs \
+        crates/epigraph-engine/tests/common/ \
+        .sqlx/
+git commit -m "feat(api,engine): locality-aware source_strength on evidential edges
+
+trigger_edge_ds_recomputation now consults same_source_papers(a,b) and
+writes the BBA with intra_source_support_strength (default 0.3) when
+endpoints share a paper, cross_source_support_strength (1.0) otherwise.
+19-supporter NEMS regression: BetP drops from 0.997 to ~0.78."
+```
+
+---
+
+### Task 6: Calibration canary test
+
+**Files:**
+- Create: `crates/epigraph-engine/tests/intra_source_discount_calibration.rs`
+
+- [ ] **Step 1: Write the canary**
+
+```rust
+//! Calibration canary — trips if the locality-discount defaults are moved
+//! without re-tuning the 19-supporter regression. This is intentionally
+//! adversarial: a future PR that adjusts the calibration must update the
+//! regression test together, and this canary fails fast if only one side
+//! changes.
+
+use epigraph_engine::calibration::CalibrationConfig;
+
+#[test]
+fn intra_source_strength_in_documented_band() {
+    let config = CalibrationConfig::from_workspace_root()
+        .expect("calibration.toml should load");
+    let intra = config.evidence_locality.intra_source_support_strength;
+    assert!(
+        (0.15..=0.45).contains(&intra),
+        "intra_source_support_strength out of documented band [0.15, 0.45]: got {intra}. \
+         If you intend to retune, update intra_source_19_supporters_betp_in_band as well."
+    );
+}
+
+#[test]
+fn cross_source_strength_is_one() {
+    let config = CalibrationConfig::from_workspace_root()
+        .expect("calibration.toml should load");
+    let cross = config.evidence_locality.cross_source_support_strength;
+    assert!(
+        (cross - 1.0).abs() < 1e-9,
+        "cross_source_support_strength must remain 1.0 (got {cross}); \
+         lowering it changes baseline BetP across the entire graph."
+    );
+}
+```
+
+- [ ] **Step 2: Run the canary**
+
+```bash
+cargo test -p epigraph-engine --test intra_source_discount_calibration -- --nocapture
+```
+
+Expected: both pass against the values from Task 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/epigraph-engine/tests/intra_source_discount_calibration.rs
+git commit -m "test(engine): calibration canary for evidence_locality defaults"
+```
+
+---
+
+### Task 7: Operator backfill script
+
+**Files:**
+- Create: `scripts/backfill_intra_source_discount.py`
+
+- [ ] **Step 1: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Backfill source_strength on existing intra-source evidential BBAs.
+
+Pre-2026-05-27, every evidential edge wrote source_strength=1.0 regardless
+of whether the source and target shared a paper. After the locality-aware
+discount lands, new edges get the right value automatically, but the
+historical mass_functions rows are still over-strong.
+
+This script:
+  1. Loads intra_source_support_strength from calibration.toml.
+  2. UPDATEs mass_functions rows whose underlying edge is intra-source.
+  3. Collects affected claim_ids and POSTs each to
+     /api/v1/graph/reconcile_sheaf to recompute belief.
+
+Usage:
+    DATABASE_URL=postgres://... EPIGRAPH_API=http://localhost:8080 \\
+        python3 scripts/backfill_intra_source_discount.py [--dry-run]
+
+The --dry-run mode reports the count of rows that would be updated and the
+distinct affected claims without writing.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+import psycopg2
+import requests
+
+
+def load_intra_strength() -> float:
+    repo_root = Path(__file__).resolve().parent.parent
+    with (repo_root / "calibration.toml").open("rb") as f:
+        cfg = tomllib.load(f)
+    return float(cfg["evidence_locality"]["intra_source_support_strength"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="report only, no writes")
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    api_url = os.environ.get("EPIGRAPH_API", "http://localhost:8080")
+    if not db_url:
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    intra = load_intra_strength()
+    print(f"intra_source_support_strength = {intra}")
+
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        SELECT mf.id, mf.claim_id, mf.source_strength, e.id AS edge_id
+          FROM mass_functions mf
+          JOIN edges e
+            ON mf.source_agent_id = e.source_id
+           AND mf.claim_id        = e.target_id
+         WHERE e.relationship IN ('supports','refutes','corroborates','contradicts')
+           AND same_source_papers(e.source_id, e.target_id);
+        """
+    )
+    rows = cur.fetchall()
+    affected_claims = sorted({r[1] for r in rows})
+    print(f"matched {len(rows)} BBAs across {len(affected_claims)} target claims")
+    if not rows:
+        print("nothing to do")
+        return 0
+
+    if args.dry_run:
+        print("dry-run: would update; exiting without write")
+        return 0
+
+    cur.execute(
+        """
+        UPDATE mass_functions mf
+           SET source_strength = %s
+          FROM edges e
+         WHERE mf.source_agent_id = e.source_id
+           AND mf.claim_id        = e.target_id
+           AND e.relationship IN ('supports','refutes','corroborates','contradicts')
+           AND same_source_papers(e.source_id, e.target_id);
+        """,
+        (intra,),
+    )
+    conn.commit()
+    print(f"updated {cur.rowcount} BBAs")
+
+    print(f"reconciling {len(affected_claims)} target claims via {api_url}")
+    failures = 0
+    for claim_id in affected_claims:
+        r = requests.post(
+            f"{api_url}/api/v1/graph/reconcile_sheaf",
+            json={"claim_id": str(claim_id)},
+            timeout=60,
+        )
+        if not r.ok:
+            failures += 1
+            print(f"  reconcile failed for {claim_id}: {r.status_code} {r.text[:200]}")
+    print(f"done — {failures} reconcile failures")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Smoke-test against the test DB seeded by Task 5**
+
+```bash
+# First re-seed via the Task 5 test (or seed manually); then:
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  python3 scripts/backfill_intra_source_discount.py --dry-run
+```
+
+Expected: "matched N BBAs across M target claims" with N=19 (after seed_19), M=1.
+
+- [ ] **Step 3: Confirm the script is idempotent**
+
+Running with no `--dry-run`, then again, should produce zero matched rows on the second pass (the BBAs already have the intra value), or stay stable if same_source_papers is deterministic and source_strength is already 0.3.
+
+```bash
+python3 scripts/backfill_intra_source_discount.py
+python3 scripts/backfill_intra_source_discount.py
+```
+
+Expected: second pass shows "matched N BBAs" but the UPDATE is a no-op (no row changes). If the script must be exactly idempotent (zero rows reported on the second pass), add `AND mf.source_strength IS DISTINCT FROM %s` to the WHERE clause. (Choose one; document the choice in the script docstring.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/backfill_intra_source_discount.py
+git commit -m "scripts: backfill_intra_source_discount.py (one-shot operator pass)"
+```
+
+---
+
+### Task 8: Workspace verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run full workspace lint and tests**
+
+```bash
+cd /home/jeremy/epigraph
+SQLX_OFFLINE=true cargo check --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test --workspace
+```
+
+Expected: all clean.
+
+- [ ] **Step 2: Re-prepare sqlx if needed**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo sqlx prepare --workspace -- --tests
+git status -sb
+```
+
+- [ ] **Step 3: Commit any cleanup**
+
+```bash
+# If anything is uncommitted:
+git add .sqlx/
+git commit -m "chore: cargo sqlx prepare after locality discount wiring"
+```
+
+---
+
+### Task 9: Push and open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/locality-aware-discounting
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --repo epigraph-io/epigraph \
+  --title "feat: locality-aware source_strength on evidential edges (#142)" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `same_source_papers(a, b)` Postgres function (migration 041) traversing `{asserts, same_source, section_follows, continues_argument, decomposes_to}` closure.
+- `trigger_edge_ds_recomputation` now writes BBAs with `source_strength = intra_source_support_strength` (default 0.3) when endpoints share a paper, `cross_source_support_strength` (1.0) otherwise.
+- New `[evidence_locality]` calibration block with tunable defaults.
+- 19-supporter synthetic regression: BetP drops from 0.997 (current main) to ~0.78.
+- Operator backfill script for historical BBAs.
+
+## Why
+The original #142 fix proposed retyping every intra-source `supports` to `decomposes_to`. That conflates two cases: decomposition (which is dependency, not evidence) and intra-source evidence (paper claims X, paper also reports experiment supporting X — cherry-picked perhaps, but still evidence). Blanket retyping zeroes out case 2 along with case 1. Locality discounting preserves the signal while deflating the spurious Dempster product inflation on decomposition clusters.
+
+See `docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md` § 2.
+
+## Test plan
+- [x] `cargo test -p epigraph-db same_source_papers_truth_table` — predicate
+- [x] `cargo test -p epigraph-engine test_evidence_locality_loads` — calibration
+- [x] `cargo test -p epigraph-engine intra_source_discount_regression` — 19-supporter BetP in [0.70, 0.85]; cross-source 19-supporter BetP > 0.9
+- [x] `cargo test -p epigraph-engine intra_source_discount_calibration` — defaults in documented band
+- [x] `cargo test --workspace` against `epigraph_db_repo_test`
+- [x] `cargo fmt --check` / `cargo clippy --all-targets -D warnings`
+- [ ] Operator: run `scripts/backfill_intra_source_discount.py --dry-run` against production read-replica, review counts before applying
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+gh pr view --repo epigraph-io/epigraph --json url,number,title
+```
+
+- [ ] **Step 4: Retire the backlog claim**
+
+Per `CLAUDE.md`:
+
+```python
+mcp__epigraph__resolve_backlog_item(
+    original_id="98d5a2d5-0c92-4712-8db7-c850614ce97d",
+    resolution_content=(
+        "Resolves 98d5a2d5: replaced the retyping migration with locality-aware "
+        "source_strength discounting. trigger_edge_ds_recomputation reads "
+        "same_source_papers(a,b) and writes intra_source_support_strength=0.3 "
+        "(or cross=1.0) into mass_functions. Decomposition-cluster inflation "
+        "deflated; intra-source evidence preserved with discounted mass. "
+        "See PR #<NN>."
+    ),
+)
+```
+
+Substitute `<NN>` with the PR number from Step 3.
+
+Also retire the companion backlog `351cae08-bb06-4f10-89ad-58526780b00c` (the SQL screen) — the predicate `same_source_papers` *is* the screen:
+
+```python
+mcp__epigraph__resolve_backlog_item(
+    original_id="351cae08-bb06-4f10-89ad-58526780b00c",
+    resolution_content=(
+        "Resolves 351cae08: same_source_papers(a,b) is the screen — any "
+        "evidential edge where it returns true is intra-source. See PR #<NN>."
+    ),
+)
+```
+
+---
+
+## Done
+
+- Locality detection lives in one place (the function).
+- Engine reads it at edge-create time and adjusts per-BBA reliability.
+- Existing data cleaned up by a one-shot operator pass.
+- NEMS-style inflation deflated.

--- a/docs/superpowers/plans/2026-05-27-locality-aware-discounting.md
+++ b/docs/superpowers/plans/2026-05-27-locality-aware-discounting.md
@@ -61,35 +61,36 @@ BEGIN
         RETURN TRUE;
     END IF;
 
-    WITH RECURSIVE seeds AS (
-        -- Papers that assert `a` are seed nodes.
+    -- Postgres parses `WITH RECURSIVE x AS (anchor UNION recursive)` as a
+    -- two-branch UNION: the anchor MUST be the left side and must not
+    -- self-reference. Use ONE recursive branch that walks intra-source
+    -- edges in either direction via a CASE expression, rather than two
+    -- separate recursive branches.
+    WITH RECURSIVE
+    seeds AS (
         SELECT e.source_id AS paper_id
         FROM edges e
         WHERE e.target_id = a
           AND e.relationship = 'asserts'
     ),
     paper_a_closure AS (
-        -- Claims reachable from any of a's papers through intra-source edges.
+        -- Anchor: claims directly asserted by any of a's source papers.
         SELECT e.target_id AS claim_id
         FROM seeds s
         JOIN edges e
           ON e.source_id = s.paper_id
          AND e.relationship = 'asserts'
         UNION
-        SELECT e2.target_id
+        -- Recursive: follow intra-source edges in either direction.
+        SELECT
+            CASE
+                WHEN e2.source_id = pac.claim_id THEN e2.target_id
+                ELSE e2.source_id
+            END AS claim_id
         FROM paper_a_closure pac
         JOIN edges e2
-          ON e2.source_id = pac.claim_id
+          ON (e2.source_id = pac.claim_id OR e2.target_id = pac.claim_id)
          AND e2.relationship IN (
-             'same_source', 'section_follows',
-             'continues_argument', 'decomposes_to'
-         )
-        UNION
-        SELECT e3.source_id
-        FROM paper_a_closure pac
-        JOIN edges e3
-          ON e3.target_id = pac.claim_id
-         AND e3.relationship IN (
              'same_source', 'section_follows',
              'continues_argument', 'decomposes_to'
          )

--- a/docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md
+++ b/docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md
@@ -1,0 +1,210 @@
+# Alternative & Dependency Edges (Spec 2)
+
+**Date:** 2026-05-27
+**Status:** Design — awaiting review
+**Author:** Jeremy Barton (with Claude)
+**Closes:** [#140](https://github.com/epigraph-io/epigraph/issues/140), [#141](https://github.com/epigraph-io/epigraph/issues/141), [#142](https://github.com/epigraph-io/epigraph/issues/142)
+
+## Problem
+
+Three separate issues describe symptoms of the same underlying defect: the Dempster product-rule combine treats every supporter as an independent observation. Three failure modes:
+
+1. **Intra-source supporter inflation (#142).** A paper that decomposes one synthesis claim into 19 atomic sub-claims, all `supports`-linked to the synthesis, produces 19 BBAs that combine as if from 19 independent sources. NEMS claim BetPs land at 0.997 / 0.970 — well above any individual supporter (mean ~0.68).
+2. **Competing-hypothesis over-combination (#141).** Two mutually-exclusive supporters {A1, A2} of a shared target T (e.g., competing mechanistic hypotheses) get product-combined as if their evidence stacked. Real semantics: T's belief should be bounded by the most permissive single alternative, not the conjunctive product.
+3. **No vocabulary for the alternative-set relation (#140).** No edge type exists to mark two claims as alt-set members, so the engine cannot distinguish "independent supporters" from "competing alternatives".
+
+The original #142 proposal — retype every intra-source `supports` to `decomposes_to` — was rejected during brainstorming because it conflates two genuinely different cases inside one paper:
+
+- **Decomposition.** Paper claims X. Extractor emits X₁..Xₙ as sub-claims with `supports` edges to X. These aren't N observations; they're one assertion with N parts. (This is the inflation source.)
+- **Intra-source evidence.** Paper claims Y. Paper *also* reports experiment Z (within the same paper) supporting Y. Z genuinely supports Y — cherry-picked maybe, but still evidence. Negative versions ("paper notes contradicting result W") are exactly what we want surfaced and weighted, not zeroed out.
+
+Blanket retyping collapses case 2 onto zero. The correct treatment is **discounted** evidence: intra-source is non-zero but the independence assumption is suspect, so the Shafer reliability factor lands somewhere below cross-source. Same paper ≠ no evidence.
+
+## Goals
+
+1. Intra-source supporters contribute discounted (not zero) mass to their targets; NEMS-style inflation drops into the 0.7–0.85 BetP range matching the supporter mean.
+2. New `alternative_of` edge type expresses mutually-exclusive supporters of a shared target. Symmetric. SQL view exposes the equivalence class under transitive closure.
+3. CDST BP detects alternative sets among the supporters of a target and reduces them via max-Bel / max-Pl ("least restrictive alternative") before Dempster-combining with non-alt supporters.
+4. Candidate-finder tool surfaces likely-alternative pairs from the existing graph as operator suggestions, no auto-promotion.
+5. Operator-runnable backfill recomputes `source_strength` on existing intra-source BBAs to the new discount and re-runs `reconcile_sheaf`. No edge data is rewritten.
+
+**Non-goals.**
+
+- Retroactive `supports → decomposes_to` retyping. Replaced by locality-aware discounting.
+- Auto-promoting suggested alt pairs into explicit edges. Operator-mediated.
+- Alt-set semantics on `refutes`/`contradicts` edges. Symmetric case is a follow-up if it surfaces.
+- Replacing CDST as the primary BP engine.
+- Scope expansion to the four evidential relationships beyond what locality-discount already does (which is all four).
+
+## Architecture
+
+### 1. Edge vocabulary
+
+`crates/epigraph-api/src/routes/edges.rs:65` — `VALID_RELATIONSHIPS` gains:
+
+- `"alternative_of"` — claim ↔ claim, symmetric, mutually-exclusive supporters of a shared target.
+
+Symmetric uniqueness via a partial unique index on the canonicalized endpoint pair:
+
+```sql
+CREATE UNIQUE INDEX edges_alternative_of_symmetric_uniq
+  ON edges (LEAST(source_id, target_id), GREATEST(source_id, target_id))
+  WHERE relationship = 'alternative_of';
+```
+
+A view exposes the equivalence class under transitive closure:
+
+```sql
+CREATE VIEW alternative_set AS
+WITH RECURSIVE pairs AS (
+  SELECT source_id AS a, target_id AS b
+    FROM edges WHERE relationship = 'alternative_of'
+  UNION
+  SELECT target_id, source_id
+    FROM edges WHERE relationship = 'alternative_of'
+), closure AS (
+  SELECT a, b FROM pairs
+  UNION
+  SELECT c.a, p.b FROM closure c JOIN pairs p ON c.b = p.a
+)
+SELECT a AS claim_id, array_agg(DISTINCT b ORDER BY b) AS alt_members
+  FROM closure GROUP BY a;
+```
+
+A new migration (next-numbered slot in `migrations/`) lands the index and view. No alteration of existing edge-CHECK constraints — `alternative_of` is added to the application-level allow-list, and the DB enforces nothing about the relationship string today (per current schema, the column is free-form `text`).
+
+### 2. Locality-aware discounting
+
+**Predicate.** `same_source_papers(a UUID, b UUID) RETURNS BOOLEAN` — Postgres function that returns true iff `a` and `b` share a transitive closure under edges of relationship `{asserts, same_source, section_follows, continues_argument, decomposes_to}`. Implementation: recursive CTE rooted at the smaller of `(a, b)`, expanded across the five relationship types, returning true if the larger appears in the closure. Materialized as a function so callers (engine + backfill) share one definition.
+
+**Engine integration.** `trigger_edge_ds_recomputation` (`crates/epigraph-api/src/routes/edges.rs:156`) consults the predicate at edge-create time and writes the BBA with:
+
+- `source_strength = config.cross_source_support_strength` (default `1.0`) when endpoints are cross-source.
+- `source_strength = config.intra_source_support_strength` (default `0.3`, tunable) when same-source.
+
+The existing CDST combine already discounts each BBA by its stored `source_strength` (`crates/epigraph-mcp/src/tools/ds_auto.rs:295-307`). Locality only adjusts the per-BBA reliability — no combine-rule change.
+
+**Calibration.** Two new keys in `config/calibration.toml`:
+
+```toml
+[evidence_locality]
+intra_source_support_strength = 0.3
+cross_source_support_strength = 1.0
+```
+
+Defaults are starting points, tuned against the NEMS regression and a synthetic 19-supporter test until the BetP lands in 0.7–0.85.
+
+**Backfill.** Operator-run script `scripts/backfill_intra_source_discount.py`. Single SQL pass:
+
+```sql
+UPDATE mass_functions mf
+SET source_strength = $1   -- bound from config.evidence_locality.intra_source_support_strength
+FROM edges e
+WHERE mf.source_agent_id = e.source_id
+  AND mf.claim_id        = e.target_id
+  AND e.relationship IN ('supports','refutes','corroborates','contradicts')
+  AND same_source_papers(e.source_id, e.target_id)
+RETURNING mf.claim_id;
+```
+
+The script loads `intra_source_support_strength` from `config/calibration.toml`, binds it as `$1`, and POSTs the distinct returned `claim_id` set to `/api/v1/graph/reconcile_sheaf`. A `--dry-run` mode reports the row count without writing. Not application code; one-time hygiene pass run by an operator after the engine-side change ships.
+
+### 3. `alternative_of` combine rule
+
+`crates/epigraph-ds/src/combination.rs` gains:
+
+```rust
+/// Reduce a set of mutually-exclusive supporter BBAs to a single representative
+/// BBA via max-Bel/max-Pl on the projected belief interval toward `target`.
+///
+/// Used by CDST BP for alternative-set members: independence has failed, so
+/// product-rule (Dempster) over-combines. Max-Pl is the "least restrictive
+/// alternative" rule from regulatory/legal reasoning. Members are passed
+/// post-discount (the caller applies source_strength discount first).
+pub fn combine_alternative_set(
+    bbas: &[MassFunction],
+    target: &FocalElement,
+) -> Result<MassFunction, DsError>;
+```
+
+Semantics: for each member i, compute `Bel_i = belief(m_i, target)`, `Pl_i = plausibility(m_i, target)`. Take `max_Bel = max_i Bel_i`, `max_Pl = max_i Pl_i`. Construct a fresh BBA on the same frame with:
+
+- `m({target}) = max_Bel`
+- `m(target ∪ complement(target)) = max_Pl − max_Bel`  (ignorance band)
+- `m(complement(target)) = 1.0 − max_Pl`
+
+Singletons (one-element groups) return the single member unchanged.
+
+### 4. Engine integration
+
+In `crates/epigraph-engine/src/cdst_bp.rs`, before combining the supporters of a target T:
+
+1. Group T's incoming `supports` BBAs by `alternative_set` membership. The view's `alt_members` array drives membership. Unaffiliated supporters form singleton groups.
+2. For each multi-member group, call `combine_alternative_set(group, target=T)` to reduce it to one BBA.
+3. Dempster-combine the resulting per-group BBAs as today.
+
+Overlapping alt sets resolve through the equivalence-class view's transitive closure — they collapse into one group. No special handling required.
+
+### 5. Candidate-finder tool
+
+MCP tool `mcp__epigraph__suggest_alternative_sets` and HTTP route `GET /api/v1/alternative_sets/suggest`:
+
+- **Input:** optional `target_claim_id` filter, optional `min_pair_strength` (default 0.5).
+- **Output:** ordered list of `(claim_a, claim_b, score, reason)` candidate pairs.
+- **Heuristic v1:** A and B both `supports`-link to the same T, and `contradicts(A, B)` exists. `score = min(BetP_A, BetP_B)`. `reason = "contradicts edge between supporters of <T_id>"`.
+- **No auto-creation.** Operator reviews and promotes by submitting an explicit `alternative_of` edge.
+
+Tool exists in `crates/epigraph-mcp/src/tools/` and is wired into the scope map (`scope_map`) under `claims:read`.
+
+## Testing
+
+### Locality-discount
+
+- **Unit.** `same_source_papers` on a synthetic two-paper four-claim graph. Truth table: same-paper pairs → true (regardless of which traversal path), cross-paper pairs → false, self-pairs → true.
+- **Integration.** 19-supporter synthetic claim mirroring the NEMS shape. Each supporter has a BBA with `betp ≈ 0.68`. After locality-aware combine, target BetP lands in `[0.7, 0.85]`. Mirror setup with cross-source supporters keeps BetP near current (un-discounted) behavior. Both assertions adversarial — fails if defaults are tuned wrong, not just if the code is wrong.
+- **Calibration canary.** `cargo test -p epigraph-engine intra_source_discount_calibration` reads the calibration values and asserts they're within the documented band. Trips if a future change moves the defaults without re-tuning the synthetic NEMS regression.
+
+### `alternative_of` and max-Pl
+
+- **`combine_alternative_set` unit tests** covering the three #141 regression cases:
+  - Single-member set → returns input unchanged.
+  - Two disjoint sets, two members each → each set combined separately, then product-aggregated with the others.
+  - Mixed alt + independent supporters → `dempster(maxPl({A1,A2}), A3)` ≠ `dempster(A1,A2,A3)` (asserts the rule is actually being applied, not silently dropped to Dempster).
+- **DB symmetric uniqueness.** Insert `alternative_of(A, B)` succeeds; inserting `alternative_of(B, A)` afterward returns a dedup hit (existing edge_id, `created=false`), not a duplicate row.
+- **View transitive closure.** 3-cycle `(A↔B, B↔C)` produces `{A, B, C}` in each member's `alt_members`.
+- **Engine.** Factor graph with alt set `{A1, A2}` both supporting T, plus independent A3 supporting T. Combined T BetP equals `dempster(maxPl({A1,A2}), A3)`, *not* `dempster(A1,A2,A3)`. Numeric tolerance via `(actual − expected).abs() < 1e-9`.
+
+### Candidate-finder
+
+- **Integration.** Three supporters of T; two linked by `contradicts`. Tool returns exactly one pair, with `score = min(BetP_A, BetP_B)`. No false positives for the third supporter.
+
+## Out of scope
+
+- Retroactive `supports → decomposes_to` retyping (the original #142 mechanism).
+- Auto-promotion of suggested pairs to explicit edges.
+- Alt-set semantics on `refutes`/`contradicts` (symmetric case follow-up).
+- New BP engine.
+- Locality discount on non-evidential edges (`derived_from`, `cites`, etc.) — those don't write BBAs today.
+
+## Acceptance
+
+- [ ] `alternative_of` accepted by `is_valid_relationship` and `POST /api/v1/edges`.
+- [ ] Symmetric uniqueness index lands; duplicate-direction insert dedupes.
+- [ ] `alternative_set` view returns transitive-closure equivalence classes.
+- [ ] `same_source_papers(a, b)` Postgres function exists and passes its truth-table tests.
+- [ ] `trigger_edge_ds_recomputation` writes locality-aware `source_strength` per the calibration values.
+- [ ] `combine_alternative_set` lives in `epigraph-ds` with the three regression-case unit tests passing.
+- [ ] CDST BP routes alt-set members through `combine_alternative_set` before Dempster, per integration test.
+- [ ] `mcp__epigraph__suggest_alternative_sets` returns scored candidate pairs.
+- [ ] Operator backfill script exists at `scripts/backfill_intra_source_discount.py`, dry-run mode reports the count of BBAs that would be updated.
+- [ ] 19-supporter synthetic regression: locality-aware BetP lands in `[0.7, 0.85]`.
+- [ ] `cargo sqlx prepare --workspace -- --tests` re-run if any `query!` macros change.
+- [ ] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` clean against `epigraph_db_repo_test`.
+
+## Related
+
+- `feedback_pignistic_not_bayesian.md` — `pignistic_prob` is the canonical decision measure
+- `project_bp_cdst_primary.md` — CDST is the primary BP engine
+- Spec 1 (`docs/superpowers/specs/2026-05-27-claims-belief-bounds-clamp-design.md`) — write-contract clamp, ships independently; this spec assumes that contract is honored
+- Episcience `EdgeType` design — separates `Supports` (cross-source corroboration) from dependency edges; the locality-discount approach generalizes that distinction to a continuous reliability dial rather than a binary type swap
+- `feedback_council_of_critics.md` — adversarial-test rule justifies the calibration-canary and the engine integration test asserting the rule is actually applied

--- a/migrations/041_same_source_papers_function.sql
+++ b/migrations/041_same_source_papers_function.sql
@@ -1,0 +1,70 @@
+-- 041_same_source_papers_function.sql
+--
+-- Predicate: do claims a and b share a source paper, traversing the
+-- transitive closure of {asserts, same_source, section_follows,
+-- continues_argument, decomposes_to}?
+--
+-- Used by edges.rs::trigger_edge_ds_recomputation to set a smaller
+-- source_strength on intra-source evidential BBAs (Shafer reliability
+-- discount). See docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md.
+
+CREATE OR REPLACE FUNCTION same_source_papers(a UUID, b UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    result BOOLEAN;
+BEGIN
+    IF a = b THEN
+        RETURN TRUE;
+    END IF;
+
+    -- Postgres parses `WITH RECURSIVE x AS (anchor UNION recursive)` as a
+    -- two-branch UNION: the anchor MUST be the left side and must not
+    -- self-reference. We therefore use ONE recursive branch that walks
+    -- intra-source edges in either direction via a CASE expression, rather
+    -- than two separate recursive branches that would put a recursive
+    -- reference inside the anchor.
+    WITH RECURSIVE
+    seeds AS (
+        SELECT e.source_id AS paper_id
+        FROM edges e
+        WHERE e.target_id = a
+          AND e.relationship = 'asserts'
+    ),
+    paper_a_closure AS (
+        -- Anchor: claims directly asserted by any of a's source papers.
+        SELECT e.target_id AS claim_id
+        FROM seeds s
+        JOIN edges e
+          ON e.source_id = s.paper_id
+         AND e.relationship = 'asserts'
+        UNION
+        -- Recursive: follow intra-source edges in either direction.
+        SELECT
+            CASE
+                WHEN e2.source_id = pac.claim_id THEN e2.target_id
+                ELSE e2.source_id
+            END AS claim_id
+        FROM paper_a_closure pac
+        JOIN edges e2
+          ON (e2.source_id = pac.claim_id OR e2.target_id = pac.claim_id)
+         AND e2.relationship IN (
+             'same_source', 'section_follows',
+             'continues_argument', 'decomposes_to'
+         )
+    )
+    SELECT EXISTS (
+        SELECT 1 FROM paper_a_closure WHERE claim_id = b
+    ) INTO result;
+
+    RETURN COALESCE(result, FALSE);
+END;
+$$;
+
+COMMENT ON FUNCTION same_source_papers(UUID, UUID) IS
+'True iff claim a and claim b share a source paper via the transitive closure of '
+'{asserts, same_source, section_follows, continues_argument, decomposes_to}. '
+'Drives intra-source source_strength discounting in trigger_edge_ds_recomputation.';

--- a/scripts/backfill_intra_source_discount.py
+++ b/scripts/backfill_intra_source_discount.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Backfill source_strength on existing intra-source evidential BBAs.
+
+Pre-2026-05-27, every evidential edge wrote source_strength=1.0 regardless
+of whether the source and target shared a paper. After the locality-aware
+discount lands, new edges get the right value automatically, but the
+historical mass_functions rows are still over-strong.
+
+This script:
+  1. Loads intra_source_support_strength from calibration.toml.
+  2. UPDATEs mass_functions rows whose underlying edge is intra-source.
+  3. Collects affected claim_ids and POSTs each to
+     /api/v1/graph/reconcile_sheaf to recompute belief.
+
+Usage:
+    DATABASE_URL=postgres://... EPIGRAPH_API=http://localhost:8080 \
+        python3 scripts/backfill_intra_source_discount.py [--dry-run]
+
+The --dry-run mode reports the count of rows that would be updated and the
+distinct affected claims without writing.
+
+Idempotency: the SELECT and UPDATE both include
+``mf.source_strength IS DISTINCT FROM <intra>`` so a second run against an
+already-backfilled DB matches zero rows. This is the strict-idempotent
+variant flagged in the plan (Task 7 Step 3).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreters
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+import psycopg2
+import requests
+
+
+def load_intra_strength() -> float:
+    repo_root = Path(__file__).resolve().parent.parent
+    with (repo_root / "calibration.toml").open("rb") as f:
+        cfg = tomllib.load(f)
+    return float(cfg["evidence_locality"]["intra_source_support_strength"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="report only, no writes")
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    api_url = os.environ.get("EPIGRAPH_API", "http://localhost:8080")
+    if not db_url:
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    intra = load_intra_strength()
+    print(f"intra_source_support_strength = {intra}")
+
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        SELECT mf.id, mf.claim_id, mf.source_strength, e.id AS edge_id
+          FROM mass_functions mf
+          JOIN edges e
+            ON mf.source_agent_id = e.source_id
+           AND mf.claim_id        = e.target_id
+         WHERE e.relationship IN ('supports','refutes','corroborates','contradicts')
+           AND mf.source_strength IS DISTINCT FROM %s
+           AND same_source_papers(e.source_id, e.target_id);
+        """,
+        (intra,),
+    )
+    rows = cur.fetchall()
+    affected_claims = sorted({r[1] for r in rows})
+    print(f"matched {len(rows)} BBAs across {len(affected_claims)} target claims")
+    if not rows:
+        print("nothing to do")
+        return 0
+
+    if args.dry_run:
+        print("dry-run: would update; exiting without write")
+        return 0
+
+    cur.execute(
+        """
+        UPDATE mass_functions mf
+           SET source_strength = %s
+          FROM edges e
+         WHERE mf.source_agent_id = e.source_id
+           AND mf.claim_id        = e.target_id
+           AND e.relationship IN ('supports','refutes','corroborates','contradicts')
+           AND mf.source_strength IS DISTINCT FROM %s
+           AND same_source_papers(e.source_id, e.target_id);
+        """,
+        (intra, intra),
+    )
+    conn.commit()
+    print(f"updated {cur.rowcount} BBAs")
+
+    print(f"reconciling {len(affected_claims)} target claims via {api_url}")
+    failures = 0
+    for claim_id in affected_claims:
+        r = requests.post(
+            f"{api_url}/api/v1/graph/reconcile_sheaf",
+            json={"claim_id": str(claim_id)},
+            timeout=60,
+        )
+        if not r.ok:
+            failures += 1
+            print(f"  reconcile failed for {claim_id}: {r.status_code} {r.text[:200]}")
+    print(f"done - {failures} reconcile failures")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New `same_source_papers(a, b) -> BOOLEAN` Postgres function (migration 041) traversing the `{asserts, same_source, section_follows, continues_argument, decomposes_to}` transitive closure.
- `epigraph_engine::edge_factor::auto_wire_ds_for_edge` (the centralized BBA-write path called by 5 entry points — HTTP edges, HTTP workflows, MCP ingestion, MCP workflow_ingest, CLI backfill_factors) consults the predicate and writes the BBA with `source_strength = intra_source_support_strength` (default `0.25`) when endpoints share a paper, `cross_source_support_strength` (`1.0`) otherwise.
- New `[evidence_locality]` calibration block with tunable defaults, plus a calibration-canary test that locks the range `[0.15, 0.45]` for intra and `== 1.0` for cross.
- 19-supporter synthetic regression: intra-source BetP lands at `0.835` (in the documented `[0.70, 0.85]` band); cross-source BetP stays at `0.9999`.
- Operator backfill script `scripts/backfill_intra_source_discount.py` with `--dry-run` and `IS DISTINCT FROM`-based strict idempotency for historical BBAs.
- Truth-table integration test for `same_source_papers` covering self-pair, intra-paper, symmetric, cross-paper.

## Why
[Issue #142](https://github.com/epigraph-io/epigraph/issues/142) originally proposed retyping every intra-source `supports` edge to `decomposes_to` to deflate synthesis-cluster BetP inflation (NEMS-style 0.997 from 19 supporters of one synthesis claim). That plan was rejected during brainstorming because it conflates two cases within one paper:

1. **Decomposition.** Paper claims X. Extractor emits X₁..Xₙ as sub-claims with `supports` edges to X. These aren't N observations; they're one assertion with N parts. This *is* the inflation source.
2. **Intra-source evidence.** Paper claims Y. Paper *also* reports experiment Z (within the same paper) supporting Y. Z genuinely supports Y, even if cherry-picked. Negative versions (paper notes contradicting result W) are exactly what we want surfaced.

Blanket retyping collapses case 2 to zero. The correct treatment is **discounted** evidence: same-paper independence is suspect (Shafer reliability < 1.0), but it's not zero.

Locality-aware `source_strength` is the natural lever. The existing CDST combine already applies the Shafer reliability discount per BBA — locality just adjusts what value gets stored. Cross-source supports stay at full strength; intra-source drop to 0.25. The 19-supporter NEMS-shaped regression test lands BetP at 0.835, in the issue's target band.

See `docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md` § 2.

## Test plan
- [x] `cargo test -p epigraph-db --test same_source_papers_truth_table` — predicate truth table (1 test, 6 assertions)
- [x] `cargo test -p epigraph-engine --lib test_evidence_locality_loads` — calibration TOML roundtrip
- [x] `cargo test -p epigraph-engine --test intra_source_discount_regression` — 19-supporter band: intra BetP in `[0.70, 0.85]`, cross BetP > 0.9
- [x] `cargo test -p epigraph-engine --test intra_source_discount_calibration` — defaults in documented band
- [x] `SQLX_OFFLINE=true cargo check --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Per-crate `cargo clippy --lib -- -D warnings` clean for epigraph-engine, -api, -db (pre-existing `--all-targets` failures in `epigraph-engine` benches/tests on `origin/main` — deprecated `BayesianUpdater` usage — unrelated to this branch).
- [ ] **Operator:** run `python3 scripts/backfill_intra_source_discount.py --dry-run` against the production DB read-replica, review the matched-BBA count, then re-run without `--dry-run` and re-run `reconcile_sheaf` on the affected target claims. The PR merge does NOT trigger backfill — new edges get correct locality automatically, but historical BBAs retain `source_strength=1.0` until the script runs.

## Out of scope
Retroactive `supports → decomposes_to` retyping (the original #142 mechanism — see commit `ad72975` rationale and the spec § "Problem"). `alternative_of` edge type (#140) and max-Pl combine (#141) ship in a separate PR.

Closes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)