### PR TITLE
feat: alternative_of edge + max-Pl combine + suggest_alternative_sets (closes #140, #141)

### DIFF
--- a/crates/epigraph-api/src/routes/computation.rs
+++ b/crates/epigraph-api/src/routes/computation.rs
@@ -594,10 +594,26 @@ pub async fn propagate_beliefs(
             })
             .collect();
 
+        // Load the alternative-set equivalence class for every claim from the
+        // `alternative_set` view (migration 042). Empty on a fresh graph —
+        // BP must not fail in that case, so we tolerate query failures and
+        // proceed with an empty map (== legacy pure-Dempster behavior).
+        let alt_set_rows: Vec<(Uuid, Vec<Uuid>)> =
+            sqlx::query_as("SELECT claim_id, alt_members FROM alternative_set")
+                .fetch_all(&state.db_pool)
+                .await
+                .unwrap_or_default();
+
+        let mut alt_set_membership: epigraph_engine::cdst_bp::AltSetMembership = HashMap::new();
+        for (claim_id, members) in alt_set_rows {
+            alt_set_membership.insert(claim_id, members);
+        }
+
         let cdst_config = epigraph_engine::cdst_bp::CdstBpConfig {
             max_iterations: config.max_iterations,
             convergence_threshold: config.convergence_threshold,
             damping: config.damping,
+            alt_set_membership,
             ..epigraph_engine::cdst_bp::CdstBpConfig::default()
         };
 

--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -82,26 +82,27 @@ const VALID_RELATIONSHIPS: &[&str] = &[
     "OPERATED_BY",     // software_agent/instrument → person (prov:actedOnBehalfOf)
     "MANUFACTURED_BY", // instrument → organization
     // Ingestion and cross-source edge types (used by Python migration scripts)
-    "asserts",               // paper → claim (paper asserts a claim)
-    "same_source",           // claim → claim (same source document)
-    "decomposes_to",         // claim → claim (atomic decomposition)
-    "section_follows",       // claim → claim (sibling section ordering within a document)
-    "continues_argument",    // claim → claim (sibling paragraph ordering within a section)
-    "same_as",               // claim → claim (deduplication identity)
-    "CORROBORATES",          // claim → claim (cross-source corroboration)
-    "AUTHORED",              // agent → claim (materialized authorship)
-    "ATTRIBUTED_TO",         // claim → agent (prov:wasAttributedTo)
-    "refines",               // claim → claim (refinement)
-    "cites",                 // claim → claim (citation link)
-    "EQUIVALENT_TO",         // claim → claim (semantic equivalence)
-    "CONTRADICTS",           // claim → claim (contradiction)
-    "supersedes",            // claim → claim (version chain)
-    "revises",               // claim → claim (concurrent branch from common ancestor)
-    "enables",               // claim → claim (enablement)
+    "alternative_of",     // claim → claim (alternative formulation; spec 2026-05-27)
+    "asserts",            // paper → claim (paper asserts a claim)
+    "same_source",        // claim → claim (same source document)
+    "decomposes_to",      // claim → claim (atomic decomposition)
+    "section_follows",    // claim → claim (sibling section ordering within a document)
+    "continues_argument", // claim → claim (sibling paragraph ordering within a section)
+    "same_as",            // claim → claim (deduplication identity)
+    "CORROBORATES",       // claim → claim (cross-source corroboration)
+    "AUTHORED",           // agent → claim (materialized authorship)
+    "ATTRIBUTED_TO",      // claim → agent (prov:wasAttributedTo)
+    "refines",            // claim → claim (refinement)
+    "cites",              // claim → claim (citation link)
+    "EQUIVALENT_TO",      // claim → claim (semantic equivalence)
+    "CONTRADICTS",        // claim → claim (contradiction)
+    "supersedes",         // claim → claim (version chain)
+    "revises",            // claim → claim (concurrent branch from common ancestor)
+    "enables",            // claim → claim (enablement)
     "has_method_capability", // method → capability (method graph)
-    "interpreted_by",        // claim → agent (interpretation provenance)
-    "concludes",             // trace → claim (reasoning conclusion)
-    "HAS_TRACE",             // claim → trace (reasoning trace link)
+    "interpreted_by",     // claim → agent (interpretation provenance)
+    "concludes",          // trace → claim (reasoning conclusion)
+    "HAS_TRACE",          // claim → trace (reasoning trace link)
     // AI development patterns — context persistence, issue generation, observability
     "OBSERVED_DURING", // claim → claim (design decision observed during feature work)
     "INFORMS",         // claim → claim (decision informs future work)
@@ -2355,6 +2356,7 @@ mod tests {
         assert!(is_valid_relationship("section_follows"));
         assert!(is_valid_relationship("continues_argument"));
         assert!(is_valid_relationship("INSTANTIATES"));
+        assert!(is_valid_relationship("alternative_of"));
         assert!(!is_valid_relationship("invalid"));
         assert!(!is_valid_relationship(""));
     }

--- a/crates/epigraph-api/tests/alternative_of_symmetric_dedup.rs
+++ b/crates/epigraph-api/tests/alternative_of_symmetric_dedup.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "db")]
+//! Inserting alternative_of(A,B) and alternative_of(B,A) must produce
+//! exactly one edge row (the second insertion is a dedup hit on the
+//! symmetric uniqueness index from migration 042).
+
+mod common;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alternative_of_dedupes_under_endpoint_swap() {
+    let pool = common::test_pool().await;
+    let a = common::seed_claim(&pool, "alt-dedup-A").await;
+    let b = common::seed_claim(&pool, "alt-dedup-B").await;
+
+    let id1 = common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
+
+    // Reversed direction — should be rejected by the unique index, not
+    // silently double-recorded.
+    let res = sqlx::query(
+        "INSERT INTO edges (source_id, target_id, source_type, target_type, relationship) \
+         VALUES ($1, $2, 'claim', 'claim', 'alternative_of')",
+    )
+    .bind(b)
+    .bind(a)
+    .execute(&pool)
+    .await;
+    assert!(
+        res.is_err(),
+        "reversed alternative_of insert must hit unique index, got: {res:?}"
+    );
+
+    let cnt: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE relationship = 'alternative_of' \
+         AND ((source_id = $1 AND target_id = $2) OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(a)
+    .bind(b)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(cnt.0, 1, "exactly one row, got {}", cnt.0);
+
+    // Cleanup so reruns don't accumulate fixture rows.
+    sqlx::query("DELETE FROM edges WHERE id = $1")
+        .bind(id1)
+        .execute(&pool)
+        .await
+        .unwrap();
+}

--- a/crates/epigraph-api/tests/alternative_of_symmetric_dedup.rs
+++ b/crates/epigraph-api/tests/alternative_of_symmetric_dedup.rs
@@ -2,16 +2,21 @@
 //! Inserting alternative_of(A,B) and alternative_of(B,A) must produce
 //! exactly one edge row (the second insertion is a dedup hit on the
 //! symmetric uniqueness index from migration 042).
+//!
+//! Uses `#[sqlx::test]` so each run gets a fresh ephemeral DB with all
+//! migrations applied — sidesteps shared-DB pollution and the
+//! migration-038 checksum skew on `epigraph_db_repo_test`.
 
 mod common;
 
-#[tokio::test(flavor = "multi_thread")]
-async fn alternative_of_dedupes_under_endpoint_swap() {
-    let pool = common::test_pool().await;
+use sqlx::PgPool;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn alternative_of_dedupes_under_endpoint_swap(pool: PgPool) {
     let a = common::seed_claim(&pool, "alt-dedup-A").await;
     let b = common::seed_claim(&pool, "alt-dedup-B").await;
 
-    let id1 = common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
+    let _id1 = common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
 
     // Reversed direction — should be rejected by the unique index, not
     // silently double-recorded.
@@ -38,11 +43,4 @@ async fn alternative_of_dedupes_under_endpoint_swap() {
     .await
     .unwrap();
     assert_eq!(cnt.0, 1, "exactly one row, got {}", cnt.0);
-
-    // Cleanup so reruns don't accumulate fixture rows.
-    sqlx::query("DELETE FROM edges WHERE id = $1")
-        .bind(id1)
-        .execute(&pool)
-        .await
-        .unwrap();
 }

--- a/crates/epigraph-api/tests/alternative_set_view_closure.rs
+++ b/crates/epigraph-api/tests/alternative_set_view_closure.rs
@@ -1,0 +1,75 @@
+#![cfg(feature = "db")]
+//! 3-cycle (A↔B, B↔C) under alternative_of must collapse into one
+//! equivalence class — every member's alt_members lists the other two.
+
+mod common;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alternative_set_view_transitive_closure() {
+    let pool = common::test_pool().await;
+    let a = common::seed_claim(&pool, "alt-closure-A").await;
+    let b = common::seed_claim(&pool, "alt-closure-B").await;
+    let c = common::seed_claim(&pool, "alt-closure-C").await;
+
+    let e_ab = common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
+    let e_bc = common::insert_edge(&pool, b, c, "claim", "claim", "alternative_of").await;
+
+    let row_a: (Vec<uuid::Uuid>,) =
+        sqlx::query_as("SELECT alt_members FROM alternative_set WHERE claim_id = $1")
+            .bind(a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        row_a.0.contains(&b),
+        "A's alt_members must include B, got {:?}",
+        row_a.0
+    );
+    assert!(
+        row_a.0.contains(&c),
+        "A's alt_members must include C (transitive), got {:?}",
+        row_a.0
+    );
+
+    let row_c: (Vec<uuid::Uuid>,) =
+        sqlx::query_as("SELECT alt_members FROM alternative_set WHERE claim_id = $1")
+            .bind(c)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        row_c.0.contains(&a),
+        "C's alt_members must include A (transitive), got {:?}",
+        row_c.0
+    );
+    assert!(
+        row_c.0.contains(&b),
+        "C's alt_members must include B, got {:?}",
+        row_c.0
+    );
+
+    let row_b: (Vec<uuid::Uuid>,) =
+        sqlx::query_as("SELECT alt_members FROM alternative_set WHERE claim_id = $1")
+            .bind(b)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        row_b.0.contains(&a),
+        "B's alt_members must include A, got {:?}",
+        row_b.0
+    );
+    assert!(
+        row_b.0.contains(&c),
+        "B's alt_members must include C, got {:?}",
+        row_b.0
+    );
+
+    // Cleanup so reruns don't accumulate fixture rows; FK on edges to
+    // claims doesn't cascade so we drop edges before the fixture claims age out.
+    sqlx::query("DELETE FROM edges WHERE id = ANY($1)")
+        .bind(&[e_ab, e_bc][..])
+        .execute(&pool)
+        .await
+        .unwrap();
+}

--- a/crates/epigraph-api/tests/alternative_set_view_closure.rs
+++ b/crates/epigraph-api/tests/alternative_set_view_closure.rs
@@ -1,18 +1,23 @@
 #![cfg(feature = "db")]
 //! 3-cycle (A↔B, B↔C) under alternative_of must collapse into one
 //! equivalence class — every member's alt_members lists the other two.
+//!
+//! Uses `#[sqlx::test]` so each run gets a fresh ephemeral DB with all
+//! migrations applied — sidesteps shared-DB pollution and the
+//! migration-038 checksum skew on `epigraph_db_repo_test`.
 
 mod common;
 
-#[tokio::test(flavor = "multi_thread")]
-async fn alternative_set_view_transitive_closure() {
-    let pool = common::test_pool().await;
+use sqlx::PgPool;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn alternative_set_view_transitive_closure(pool: PgPool) {
     let a = common::seed_claim(&pool, "alt-closure-A").await;
     let b = common::seed_claim(&pool, "alt-closure-B").await;
     let c = common::seed_claim(&pool, "alt-closure-C").await;
 
-    let e_ab = common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
-    let e_bc = common::insert_edge(&pool, b, c, "claim", "claim", "alternative_of").await;
+    let _e_ab = common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
+    let _e_bc = common::insert_edge(&pool, b, c, "claim", "claim", "alternative_of").await;
 
     let row_a: (Vec<uuid::Uuid>,) =
         sqlx::query_as("SELECT alt_members FROM alternative_set WHERE claim_id = $1")
@@ -64,12 +69,4 @@ async fn alternative_set_view_transitive_closure() {
         "B's alt_members must include C, got {:?}",
         row_b.0
     );
-
-    // Cleanup so reruns don't accumulate fixture rows; FK on edges to
-    // claims doesn't cascade so we drop edges before the fixture claims age out.
-    sqlx::query("DELETE FROM edges WHERE id = ANY($1)")
-        .bind(&[e_ab, e_bc][..])
-        .execute(&pool)
-        .await
-        .unwrap();
 }

--- a/crates/epigraph-api/tests/common/mod.rs
+++ b/crates/epigraph-api/tests/common/mod.rs
@@ -185,6 +185,44 @@ pub async fn seed_system_agent(pool: &PgPool) -> Uuid {
     id
 }
 
+/// Connect to the configured test database. Tests that need just a pool
+/// (no spawned HTTP app) use this helper to centralize the connection.
+pub async fn test_pool() -> PgPool {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("connect to test db")
+}
+
+/// Insert an edge directly via SQL. Returns the generated edge id.
+/// Used by tests that need to seed edge fixtures without going through
+/// the HTTP edges route (e.g., tests of unique indexes, view closures,
+/// or relationships not yet exposed by the public API).
+pub async fn insert_edge(
+    pool: &PgPool,
+    source_id: Uuid,
+    target_id: Uuid,
+    source_type: &str,
+    target_type: &str,
+    relationship: &str,
+) -> Uuid {
+    let id: Uuid = sqlx::query_scalar(
+        "INSERT INTO edges (source_id, target_id, source_type, target_type, relationship) \
+         VALUES ($1, $2, $3, $4, $5) RETURNING id",
+    )
+    .bind(source_id)
+    .bind(target_id)
+    .bind(source_type)
+    .bind(target_type)
+    .bind(relationship)
+    .fetch_one(pool)
+    .await
+    .expect("insert edge");
+    id
+}
+
 /// Insert a minimal claim with per-call unique content_hash.
 pub async fn seed_claim(pool: &PgPool, content: &str) -> Uuid {
     let agent = seed_system_agent(pool).await;

--- a/crates/epigraph-ds/src/combination.rs
+++ b/crates/epigraph-ds/src/combination.rs
@@ -767,6 +767,97 @@ fn check_frame_compat(m1: &MassFunction, m2: &MassFunction) -> Result<(), DsErro
     Ok(())
 }
 
+/// Reduce a set of mutually-exclusive supporter BBAs to a single representative
+/// BBA via max-Bel / max-Pl on the projected belief interval toward `target`.
+///
+/// Used by CDST BP for alternative-set members: independence has failed (these
+/// claims compete to support the same target), so the product rule
+/// ([`combine_multiple`]) over-combines. Max-Pl is the "least restrictive
+/// alternative" rule from regulatory/legal reasoning: the combined belief is
+/// bounded by the most permissive single alternative.
+///
+/// Members are passed *post-discount* — the caller applies any per-BBA
+/// `source_strength` reliability discount via [`discount`] before invoking
+/// this function.
+///
+/// The result is a three-focal classical BBA:
+/// - `m({target}) = max_Bel`
+/// - `m(Θ)        = max_Pl - max_Bel`  (ignorance band)
+/// - `m(¬target)  = 1 - max_Pl`        (refutation mass)
+///
+/// Returns the singleton input unchanged.
+///
+/// # Errors
+/// - [`DsError::InsufficientSources`] if `bbas` is empty.
+/// - [`DsError::IncompatibleFrames`] if BBAs span different frames.
+/// - [`DsError::InvalidMassSum`] if the resulting masses fail validation
+///   (should not happen — internal invariant check).
+pub fn combine_alternative_set(
+    bbas: &[MassFunction],
+    target: &FocalElement,
+) -> Result<MassFunction, DsError> {
+    if bbas.is_empty() {
+        return Err(DsError::InsufficientSources);
+    }
+    if bbas.len() == 1 {
+        return Ok(bbas[0].clone());
+    }
+    let frame = bbas[0].frame().clone();
+    for m in &bbas[1..] {
+        if m.frame().id != frame.id {
+            return Err(DsError::IncompatibleFrames {
+                left: frame.id.clone(),
+                right: m.frame().id.clone(),
+            });
+        }
+    }
+
+    let max_bel = bbas
+        .iter()
+        .map(|m| crate::measures::belief(m, target))
+        .fold(0.0_f64, f64::max);
+    let max_pl = bbas
+        .iter()
+        .map(|m| crate::measures::plausibility(m, target))
+        .fold(0.0_f64, f64::max);
+    let max_bel = max_bel.clamp(0.0, 1.0);
+    let max_pl = max_pl.clamp(max_bel, 1.0); // Pl >= Bel by definition
+
+    // Construct: m({target}) = max_bel, m(Θ) = max_pl - max_bel,
+    //            m(complement(target)) = 1 - max_pl
+    let mut masses: BTreeMap<FocalElement, f64> = BTreeMap::new();
+    if max_bel > 0.0 {
+        masses.insert(target.clone(), max_bel);
+    }
+    let ignorance = max_pl - max_bel;
+    if ignorance > 1e-12 {
+        // Θ = full frame
+        masses.insert(FocalElement::positive(frame.full_set()), ignorance);
+    }
+    let neg_mass = 1.0 - max_pl;
+    if neg_mass > 1e-12 {
+        // complement of target within the frame
+        let comp: BTreeSet<usize> = frame
+            .full_set()
+            .difference(&target.subset)
+            .copied()
+            .collect();
+        if !comp.is_empty() {
+            masses.insert(FocalElement::positive(comp), neg_mass);
+        }
+    }
+
+    // Renormalize to compensate for tiny floating-point drift before validation.
+    let sum: f64 = masses.values().sum();
+    if sum > 0.0 && (sum - 1.0).abs() > 0.0 {
+        for v in masses.values_mut() {
+            *v /= sum;
+        }
+    }
+
+    MassFunction::new(frame, masses)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1801,5 +1892,83 @@ mod tests {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod combine_alternative_set_tests {
+    use super::combine_alternative_set;
+    use crate::{
+        measures::{belief, plausibility},
+        FocalElement, FrameOfDiscernment, MassFunction,
+    };
+    use std::collections::BTreeSet;
+
+    fn binary() -> FrameOfDiscernment {
+        FrameOfDiscernment::new(
+            "alt-set-test",
+            vec!["supported".into(), "unsupported".into()],
+        )
+        .unwrap()
+    }
+
+    fn target() -> FocalElement {
+        FocalElement::positive(BTreeSet::from([0])) // {supported}
+    }
+
+    #[test]
+    fn singleton_returns_input_unchanged() {
+        let frame = binary();
+        let m = MassFunction::simple(frame, BTreeSet::from([0]), 0.6).unwrap();
+        let combined = combine_alternative_set(std::slice::from_ref(&m), &target()).unwrap();
+        assert!((belief(&combined, &target()) - 0.6).abs() < 1e-9);
+        assert!((plausibility(&combined, &target()) - 1.0).abs() < 1e-9); // simple gives m(Θ) = 0.4
+    }
+
+    #[test]
+    fn two_member_set_picks_max_bel_and_max_pl() {
+        let frame = binary();
+        // Member A: BBA pushing strongly toward {supported}: Bel=0.7, Pl=1.0 (ignorance 0.3 on Θ)
+        let a = MassFunction::simple(frame.clone(), BTreeSet::from([0]), 0.7).unwrap();
+        // Member B: BBA pushing weakly toward {supported}: Bel=0.3, Pl=1.0
+        let b = MassFunction::simple(frame, BTreeSet::from([0]), 0.3).unwrap();
+        let combined = combine_alternative_set(&[a, b], &target()).unwrap();
+        let bel = belief(&combined, &target());
+        let pl = plausibility(&combined, &target());
+        assert!(
+            (bel - 0.7).abs() < 1e-9,
+            "max_Bel should equal max(0.7, 0.3) = 0.7, got {bel}"
+        );
+        assert!(
+            (pl - 1.0).abs() < 1e-9,
+            "max_Pl should equal max(1.0, 1.0) = 1.0, got {pl}"
+        );
+    }
+
+    #[test]
+    fn mixed_alt_vs_independent_differs_from_dempster() {
+        use crate::combination::combine_multiple;
+        let frame = binary();
+        // Alt members A1, A2 — same shape as previous test
+        let a1 = MassFunction::simple(frame.clone(), BTreeSet::from([0]), 0.7).unwrap();
+        let a2 = MassFunction::simple(frame.clone(), BTreeSet::from([0]), 0.3).unwrap();
+        // Independent A3
+        let a3 = MassFunction::simple(frame, BTreeSet::from([0]), 0.5).unwrap();
+
+        let alt_combined = combine_alternative_set(&[a1.clone(), a2.clone()], &target()).unwrap();
+        let (mixed, _) = combine_multiple(&[alt_combined, a3.clone()], 0.1).unwrap();
+        let (pure_dempster, _) = combine_multiple(&[a1, a2, a3], 0.1).unwrap();
+
+        let mixed_bel = belief(&mixed, &target());
+        let pure_bel = belief(&pure_dempster, &target());
+        assert!(
+            (mixed_bel - pure_bel).abs() > 1e-3,
+            "max-Pl ⊕ Dempster must differ from pure-Dempster: mixed={mixed_bel}, pure={pure_bel}"
+        );
+        // Sanity: max-Pl path should not over-combine, so mixed_bel < pure_bel
+        assert!(
+            mixed_bel < pure_bel,
+            "max-Pl reduction should yield lower combined Bel than pure Dempster"
+        );
     }
 }

--- a/crates/epigraph-engine/Cargo.toml
+++ b/crates/epigraph-engine/Cargo.toml
@@ -98,5 +98,9 @@ path = "tests/diverse_retrieval_integration.rs"
 name = "diverse_retrieval_layering"
 path = "tests/diverse_retrieval_layering.rs"
 
+[[test]]
+name = "alt_set_cdst_integration"
+path = "tests/alt_set_cdst_integration.rs"
+
 [lints]
 workspace = true

--- a/crates/epigraph-engine/src/cdst_bp.rs
+++ b/crates/epigraph-engine/src/cdst_bp.rs
@@ -11,13 +11,23 @@ use std::sync::LazyLock;
 use uuid::Uuid;
 
 use epigraph_ds::{
-    combination::{adaptive_combine, discount},
+    combination::{adaptive_combine, combine_alternative_set, discount},
     measures::pignistic_probability,
     FocalElement, FrameOfDiscernment, MassFunction,
 };
 
 use crate::bp::FactorPotential;
 use crate::epistemic_interval::EpistemicInterval;
+
+/// Per-claim alternative-set membership loaded from the `alternative_set` view.
+///
+/// Map keys are claim IDs; values are the sorted equivalence-class members
+/// (excluding the key itself). The engine routes a target T's incoming
+/// supporters through [`combine_alternative_set`] when two or more
+/// supporters share an equivalence class, before Dempster-combining the
+/// per-group BBAs against unaffiliated supporters. An empty map preserves
+/// the legacy "pure Dempster" semantics.
+pub type AltSetMembership = HashMap<Uuid, Vec<Uuid>>;
 
 // -- Canonical binary frame ------------------------------------------------
 
@@ -157,6 +167,11 @@ pub struct CdstBpConfig {
     pub convergence_threshold: f64,
     pub damping: f64,
     pub conflict_threshold: f64,
+    /// Map of claim_id -> equivalence-class members (sorted, excluding self).
+    /// When two or more supporters of the same target share a class, their
+    /// BBAs are reduced via [`combine_alternative_set`] before the rest of
+    /// the per-target combine. Empty map => legacy pure-Dempster semantics.
+    pub alt_set_membership: AltSetMembership,
 }
 
 impl Default for CdstBpConfig {
@@ -166,6 +181,7 @@ impl Default for CdstBpConfig {
             convergence_threshold: 0.01,
             damping: 0.5,
             conflict_threshold: 0.3,
+            alt_set_membership: AltSetMembership::new(),
         }
     }
 }
@@ -243,6 +259,30 @@ pub fn cdst_bp_iteration(
     let mut msg_count = 0_usize;
     let mut max_conflict = 0.0_f64;
 
+    // Build a lookup from (factor_id, target_var) -> Some(source_claim_id) for
+    // 2-variable "supporter" factors (EvidentialSupport, SharedEvidence,
+    // DirectionalSupport). MutualExclusion / multi-variable / 1-variable
+    // factors map to `None` and bypass alt-set grouping (they are not
+    // supporters in the alt-set sense). Built fresh each iteration; cost is
+    // O(#factors).
+    let mut message_source: HashMap<(Uuid, Uuid), Option<Uuid>> = HashMap::new();
+    for (factor_id, potential, vars) in factors {
+        let is_supporter_potential = matches!(
+            potential,
+            FactorPotential::EvidentialSupport { .. }
+                | FactorPotential::SharedEvidence { .. }
+                | FactorPotential::DirectionalSupport { .. }
+        );
+        for &var in vars {
+            let source = if is_supporter_potential && vars.len() == 2 {
+                Some(if var == vars[0] { vars[1] } else { vars[0] })
+            } else {
+                None
+            };
+            message_source.insert((*factor_id, var), source);
+        }
+    }
+
     // Phase 1: factor->variable messages
     for (factor_id, potential, vars) in factors {
         for &var in vars {
@@ -252,25 +292,86 @@ pub fn cdst_bp_iteration(
         }
     }
 
-    // Phase 2: variable updates with evidence anchoring
-    let mut var_incoming: HashMap<Uuid, Vec<MassFunction>> = HashMap::new();
-    for ((_, var), msg) in messages.iter() {
-        var_incoming.entry(*var).or_default().push(msg.clone());
+    // Phase 2: variable updates with evidence anchoring.
+    //
+    // Incoming messages are tagged with the source claim_id (when known), so
+    // we can group "supporter" messages by alternative-set equivalence class
+    // *before* the existing pairwise adaptive_combine sweep. Multi-member
+    // groups reduce via combine_alternative_set (max-Bel/max-Pl, the
+    // least-restrictive-alternative rule). Singleton groups and untagged
+    // messages (e.g., MutualExclusion's anti-support) pass through unchanged.
+    let mut var_incoming: HashMap<Uuid, Vec<(Option<Uuid>, MassFunction)>> = HashMap::new();
+    for ((factor_id, var), msg) in messages.iter() {
+        let source = message_source.get(&(*factor_id, *var)).copied().flatten();
+        var_incoming
+            .entry(*var)
+            .or_default()
+            .push((source, msg.clone()));
     }
+
+    // Canonical-class id per claim: the minimum claim_id in the equivalence
+    // class, used as a deterministic group key. Singletons (claims not
+    // appearing in alt_set_membership) map to themselves.
+    let canonical_class = |claim_id: Uuid| -> Uuid {
+        match config.alt_set_membership.get(&claim_id) {
+            Some(members) => std::iter::once(claim_id)
+                .chain(members.iter().copied())
+                .min()
+                .unwrap_or(claim_id),
+            None => claim_id,
+        }
+    };
+
+    let target_focal = FocalElement::positive(BTreeSet::from([H_SUPPORTED]));
 
     let mut max_change = 0.0_f64;
 
-    for (var, msgs) in &var_incoming {
-        if msgs.is_empty() {
+    for (var, tagged_msgs) in &var_incoming {
+        if tagged_msgs.is_empty() {
             continue;
         }
 
         let old_m = beliefs.get(var).cloned().unwrap_or_else(vacuous);
         let old_iv = mass_to_interval(&old_m);
 
-        // Combine all incoming factor messages
-        let mut m_graph = msgs[0].clone();
-        for next in &msgs[1..] {
+        // Group supporter messages by canonical alt-set class; untagged
+        // messages (source=None) form an "anonymous" bucket that bypasses
+        // grouping and feeds the combine loop as singletons.
+        let mut supporter_groups: HashMap<Uuid, Vec<MassFunction>> = HashMap::new();
+        let mut anonymous: Vec<MassFunction> = Vec::new();
+        for (source, msg) in tagged_msgs {
+            match source {
+                Some(src) => supporter_groups
+                    .entry(canonical_class(*src))
+                    .or_default()
+                    .push(msg.clone()),
+                None => anonymous.push(msg.clone()),
+            }
+        }
+
+        // Reduce each multi-member group via combine_alternative_set;
+        // singletons pass through.
+        let mut reduced: Vec<MassFunction> = Vec::new();
+        for (_class_id, group) in supporter_groups {
+            if group.len() == 1 {
+                reduced.extend(group);
+            } else {
+                match combine_alternative_set(&group, &target_focal) {
+                    Ok(m) => reduced.push(m),
+                    Err(_) => reduced.push(vacuous()),
+                }
+            }
+        }
+        reduced.extend(anonymous);
+
+        if reduced.is_empty() {
+            continue;
+        }
+
+        // Combine all (post-grouping) incoming factor messages via the
+        // existing pairwise adaptive_combine loop.
+        let mut m_graph = reduced[0].clone();
+        for next in &reduced[1..] {
             match adaptive_combine(&m_graph, next, config.conflict_threshold) {
                 Ok((combined, report)) => {
                     max_conflict = max_conflict.max(report.conflict_k);

--- a/crates/epigraph-engine/tests/alt_set_cdst_integration.rs
+++ b/crates/epigraph-engine/tests/alt_set_cdst_integration.rs
@@ -1,0 +1,163 @@
+//! Regression: CDST BP groups a target's incoming supporter messages by
+//! alternative-set equivalence class before Dempster-combining.
+//!
+//! Setup: three supporters A1, A2, A3 each evidentially-support a single
+//! target T. A1 and A2 are marked `alternative_of` (mutually-exclusive
+//! supporters); A3 is independent.
+//!
+//! - **Control run** (`AltSetMembership` empty): the engine treats the three
+//!   supporter messages into T as independent and Dempster-combines all
+//!   three pairwise (legacy behavior).
+//! - **Treatment run** (`AltSetMembership = {A1 -> [A2], A2 -> [A1]}`):
+//!   A1 and A2 share a canonical class. Their messages reduce via
+//!   `combine_alternative_set` (max-Bel/max-Pl, "least restrictive
+//!   alternative"). The reduced BBA then Dempster-combines with A3's.
+//!
+//! Assertions:
+//! 1. The two BetP values differ by at least `1e-3` — the grouping path
+//!    is firing (not a no-op).
+//! 2. `betp_with_alt < betp_no_alt` — max-Pl reduction is less restrictive
+//!    than the product rule, so combined Bel for T is lower.
+//!
+//! Approach A from the plan: drive the engine directly (no DB, no HTTP),
+//! comparing two `run_cdst_bp` calls that differ only in their
+//! `CdstBpConfig.alt_set_membership` field.
+
+use std::collections::{BTreeSet, HashMap};
+
+use epigraph_ds::{FrameOfDiscernment, MassFunction};
+use epigraph_engine::bp::FactorPotential;
+use epigraph_engine::cdst_bp::{run_cdst_bp, AltSetMembership, CdstBpConfig};
+use uuid::Uuid;
+
+const H_SUPPORTED: usize = 0;
+
+fn binary_frame() -> FrameOfDiscernment {
+    FrameOfDiscernment::new("binary", vec!["supported".into(), "unsupported".into()])
+        .expect("binary frame construction must not fail")
+}
+
+fn vacuous() -> MassFunction {
+    MassFunction::vacuous(binary_frame())
+}
+
+fn supported(mass: f64) -> MassFunction {
+    MassFunction::simple(binary_frame(), BTreeSet::from([H_SUPPORTED]), mass)
+        .expect("simple supported mass")
+}
+
+/// Deterministic UUIDs so the canonical-class min picks (a1, a2) the same
+/// way every run, isolating the test from `Uuid::new_v4` ordering quirks.
+fn fixed_uuid(byte: u8) -> Uuid {
+    Uuid::from_bytes([byte; 16])
+}
+
+fn find_betp(result: &epigraph_engine::cdst_bp::CdstBpResult, var: Uuid) -> f64 {
+    result
+        .updated_betps
+        .iter()
+        .find(|(id, _)| *id == var)
+        .map(|(_, p)| *p)
+        .unwrap_or(f64::NAN)
+}
+
+#[test]
+fn alt_set_grouping_shifts_target_betp_below_pure_dempster() {
+    // A1 < A2 < A3 < T by raw byte order, but only the (A1, A2) class
+    // is exercised by the alt-set wiring; A3 and T are not in any class.
+    let a1 = fixed_uuid(0x01);
+    let a2 = fixed_uuid(0x02);
+    let a3 = fixed_uuid(0x03);
+    let t = fixed_uuid(0x04);
+
+    // Initial beliefs: A1, A2, A3 each carry strong "supported" mass;
+    // T starts vacuous. Evidence anchors each supporter to itself and
+    // leaves T unanchored so the graph signal drives its BetP.
+    let mut initial = HashMap::new();
+    initial.insert(a1, supported(0.8));
+    initial.insert(a2, supported(0.8));
+    initial.insert(a3, supported(0.5));
+    initial.insert(t, vacuous());
+
+    let mut evidence = HashMap::new();
+    evidence.insert(a1, supported(0.8));
+    evidence.insert(a2, supported(0.8));
+    evidence.insert(a3, supported(0.5));
+    evidence.insert(t, vacuous());
+
+    // Three EvidentialSupport factors, one per supporter -> T.
+    // `vars = [supporter, T]` matches the route's convention (see
+    // crates/epigraph-api/src/routes/computation.rs factor construction).
+    let factors = vec![
+        (
+            fixed_uuid(0x11),
+            FactorPotential::EvidentialSupport { strength: 0.7 },
+            vec![a1, t],
+        ),
+        (
+            fixed_uuid(0x12),
+            FactorPotential::EvidentialSupport { strength: 0.7 },
+            vec![a2, t],
+        ),
+        (
+            fixed_uuid(0x13),
+            FactorPotential::EvidentialSupport { strength: 0.7 },
+            vec![a3, t],
+        ),
+    ];
+
+    // -- Control: empty AltSetMembership reproduces legacy pure-Dempster path
+    let cfg_control = CdstBpConfig::default();
+    assert!(
+        cfg_control.alt_set_membership.is_empty(),
+        "default CdstBpConfig must seed an empty alt-set; got {} entries",
+        cfg_control.alt_set_membership.len()
+    );
+    let result_control = run_cdst_bp(&factors, &initial, &evidence, &cfg_control);
+    let betp_no_alt = find_betp(&result_control, t);
+
+    // -- Treatment: A1 and A2 in one alt-set equivalence class
+    let mut alt_set: AltSetMembership = HashMap::new();
+    alt_set.insert(a1, vec![a2]);
+    alt_set.insert(a2, vec![a1]);
+    let cfg_treatment = CdstBpConfig {
+        alt_set_membership: alt_set,
+        ..CdstBpConfig::default()
+    };
+    let result_treatment = run_cdst_bp(&factors, &initial, &evidence, &cfg_treatment);
+    let betp_with_alt = find_betp(&result_treatment, t);
+
+    eprintln!(
+        "alt_set_cdst_integration: betp_no_alt={betp_no_alt:.6}, \
+         betp_with_alt={betp_with_alt:.6}, delta={:.6}",
+        betp_with_alt - betp_no_alt
+    );
+
+    // Sanity: both runs must produce a meaningful BetP (not NaN, not 0.5
+    // vacuous — A3 alone still drives T above the prior in both runs).
+    assert!(
+        betp_no_alt.is_finite() && betp_with_alt.is_finite(),
+        "BetP must be finite: no_alt={betp_no_alt}, with_alt={betp_with_alt}"
+    );
+    assert!(
+        betp_no_alt > 0.5 && betp_with_alt > 0.5,
+        "all three supporters push T above 0.5: no_alt={betp_no_alt}, with_alt={betp_with_alt}"
+    );
+
+    // Gate 1: the alt-set grouping path actually fires — BetP shifts.
+    assert!(
+        (betp_with_alt - betp_no_alt).abs() > 1e-3,
+        "alt-set grouping must shift BetP — no_alt={betp_no_alt:.6}, with_alt={betp_with_alt:.6} \
+         (delta {:.6} <= 1e-3 means grouping is a no-op)",
+        betp_with_alt - betp_no_alt
+    );
+
+    // Gate 2: shift direction matches max-Pl semantics — the
+    // least-restrictive-alternative rule is less informative than the
+    // product rule, so combined BetP must be lower with alt-set on.
+    assert!(
+        betp_with_alt < betp_no_alt,
+        "max-Pl reduction should lower combined BetP relative to pure Dempster: \
+         no_alt={betp_no_alt:.6}, with_alt={betp_with_alt:.6}"
+    );
+}

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -54,6 +54,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("scoped_belief", "claims:read"),
     ("search_triples", "claims:read"),
     ("sheaf_cohomology", "claims:read"),
+    ("suggest_alternative_sets", "claims:read"),
     ("system_stats", "claims:read"),
     ("traverse", "claims:read"),
     // ─── claims:write ──────────────────────────────────────────────────

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -310,6 +310,20 @@ impl EpiGraphMcpFull {
         tools::provenance::get_provenance(self, params).await
     }
 
+    // ── Alternative-set candidate finder (1 tool) ──
+
+    #[tool(
+        description = "Suggest candidate alternative_of pairs: supporters of a shared target connected by a contradicts edge that are not already linked by alternative_of. Pure suggestion — operator promotes by submitting an explicit alternative_of edge. Returns ordered candidates with score = min(BetP_A, BetP_B)."
+    )]
+    async fn suggest_alternative_sets(
+        &self,
+        Parameters(params): Parameters<
+            crate::tools::alternative_sets::SuggestAlternativeSetsParams,
+        >,
+    ) -> Result<CallToolResult, McpError> {
+        crate::tools::alternative_sets::suggest_alternative_sets(self, params).await
+    }
+
     // ── Memory (2 tools) ──
 
     #[tool(

--- a/crates/epigraph-mcp/src/tools/alternative_sets.rs
+++ b/crates/epigraph-mcp/src/tools/alternative_sets.rs
@@ -1,0 +1,142 @@
+//! `mcp__epigraph__suggest_alternative_sets` — surface candidate
+//! `alternative_of` pairs by finding `contradicts` edges between supporters of
+//! a shared target.
+//!
+//! Pure suggestion: the operator promotes a pair by submitting an explicit
+//! `alternative_of` edge. Auto-promotion would risk false positives (two
+//! claims that contradict each other on a different axis may still both be
+//! valid independent supporters of T).
+//!
+//! v1 keeps the candidate-finder SQL inline rather than threading it through
+//! `epigraph-db` repos because the cross-supporter / dual-relationship
+//! heuristic has no existing repo equivalent; promote to a repo helper if a
+//! second caller ever appears.
+
+use rmcp::model::{CallToolResult, Content};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::errors::{internal_error, parse_uuid, McpError};
+use crate::server::EpiGraphMcpFull;
+
+fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(value).map_err(internal_error)?,
+    )]))
+}
+
+fn default_min_strength() -> f64 {
+    0.5
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SuggestAlternativeSetsParams {
+    /// Restrict suggestions to candidate pairs that both support this target.
+    /// Omit to scan the whole graph.
+    pub target_claim_id: Option<String>,
+
+    /// Minimum `min(BetP_a, BetP_b)` to surface a candidate. Default `0.5`.
+    #[serde(default = "default_min_strength")]
+    pub min_pair_strength: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SuggestedAlternativePair {
+    pub claim_a: Uuid,
+    pub claim_b: Uuid,
+    pub target_claim: Uuid,
+    pub score: f64,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SuggestAlternativeSetsResponse {
+    pub candidates: Vec<SuggestedAlternativePair>,
+}
+
+pub async fn suggest_alternative_sets(
+    server: &EpiGraphMcpFull,
+    params: SuggestAlternativeSetsParams,
+) -> Result<CallToolResult, McpError> {
+    let target_filter = match params.target_claim_id.as_deref() {
+        Some(s) => Some(parse_uuid(s)?),
+        None => None,
+    };
+    let min_strength = params.min_pair_strength.clamp(0.0, 1.0);
+
+    let candidates = scan_candidates(&server.pool, target_filter, min_strength)
+        .await
+        .map_err(internal_error)?;
+
+    success_json(&SuggestAlternativeSetsResponse { candidates })
+}
+
+/// Find pairs `(A, B)` such that
+/// - both `A` and `B` have a `supports` edge to a common target `T`,
+/// - there exists a `contradicts` edge between `A` and `B` in either direction,
+/// - no explicit `alternative_of` edge between `A` and `B` already exists, and
+/// - `min(BetP_A, BetP_B) >= min_strength`.
+///
+/// Pairs are de-duplicated symmetrically with `s1.source_id < s2.source_id`
+/// in the WHERE clause; the SELECT's `LEAST`/`GREATEST` keep the returned
+/// `(claim_a, claim_b)` ordering canonical even if the upstream invariant
+/// ever drifts. Ordered by `score DESC`, capped at 200 rows per call.
+async fn scan_candidates(
+    pool: &PgPool,
+    target_filter: Option<Uuid>,
+    min_strength: f64,
+) -> Result<Vec<SuggestedAlternativePair>, sqlx::Error> {
+    let rows: Vec<(Uuid, Uuid, Uuid, f64)> = sqlx::query_as(
+        r#"
+        SELECT
+            LEAST(s1.source_id, s2.source_id)   AS claim_a,
+            GREATEST(s1.source_id, s2.source_id) AS claim_b,
+            s1.target_id                         AS target_claim,
+            LEAST(
+                COALESCE(ca.pignistic_prob, 0.0),
+                COALESCE(cb.pignistic_prob, 0.0)
+            ) AS score
+        FROM edges s1
+        JOIN edges s2
+          ON s2.target_id = s1.target_id
+         AND s2.relationship = 'supports'
+         AND s2.source_id <> s1.source_id
+        JOIN edges contr
+          ON ((contr.source_id = s1.source_id AND contr.target_id = s2.source_id)
+            OR (contr.source_id = s2.source_id AND contr.target_id = s1.source_id))
+         AND contr.relationship = 'contradicts'
+        JOIN claims ca ON ca.id = s1.source_id
+        JOIN claims cb ON cb.id = s2.source_id
+        LEFT JOIN edges existing
+          ON existing.relationship = 'alternative_of'
+         AND ((existing.source_id = s1.source_id AND existing.target_id = s2.source_id)
+           OR (existing.source_id = s2.source_id AND existing.target_id = s1.source_id))
+        WHERE s1.relationship = 'supports'
+          AND s1.source_id < s2.source_id  -- symmetric self-join dedup
+          AND ($1::uuid IS NULL OR s1.target_id = $1)
+          AND existing.id IS NULL
+          AND LEAST(
+                COALESCE(ca.pignistic_prob, 0.0),
+                COALESCE(cb.pignistic_prob, 0.0)
+              ) >= $2
+        ORDER BY score DESC
+        LIMIT 200
+        "#,
+    )
+    .bind(target_filter)
+    .bind(min_strength)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(a, b, t, score)| SuggestedAlternativePair {
+            claim_a: a,
+            claim_b: b,
+            target_claim: t,
+            score,
+            reason: format!("contradicts edge between supporters of {t}"),
+        })
+        .collect())
+}

--- a/crates/epigraph-mcp/src/tools/mod.rs
+++ b/crates/epigraph-mcp/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod alternative_sets;
 pub mod batch;
 pub mod challenges;
 pub mod claims;

--- a/crates/epigraph-mcp/tests/suggest_alternative_sets.rs
+++ b/crates/epigraph-mcp/tests/suggest_alternative_sets.rs
@@ -1,0 +1,111 @@
+//! Integration tests for `mcp__epigraph__suggest_alternative_sets`.
+//!
+//! Two scenarios:
+//! 1. Three supporters of T; two of them are linked by `contradicts`. The
+//!    tool returns exactly that one pair, scored. The third supporter does
+//!    not appear in any candidate.
+//! 2. Same shape but with an explicit `alternative_of` edge already in place
+//!    — the tool must not re-suggest it.
+
+mod common;
+
+use common::{build_test_server, first_text, insert_claim_edge, seed_claim};
+use epigraph_mcp::tools::alternative_sets::{
+    suggest_alternative_sets, SuggestAlternativeSetsParams,
+};
+use sqlx::PgPool;
+use std::collections::BTreeSet;
+use uuid::Uuid;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn suggest_returns_only_contradicts_pair(pool: PgPool) {
+    let target = seed_claim(&pool, "Target", 0.5).await;
+    let a1 = seed_claim(&pool, "A1", 0.7).await;
+    let a2 = seed_claim(&pool, "A2", 0.6).await;
+    let a3 = seed_claim(&pool, "A3", 0.5).await;
+
+    insert_claim_edge(&pool, a1, target, "supports").await;
+    insert_claim_edge(&pool, a2, target, "supports").await;
+    insert_claim_edge(&pool, a3, target, "supports").await;
+    insert_claim_edge(&pool, a1, a2, "contradicts").await;
+
+    let server = build_test_server(pool.clone());
+    let result = suggest_alternative_sets(
+        &server,
+        SuggestAlternativeSetsParams {
+            target_claim_id: Some(target.to_string()),
+            // `pignistic_prob` is NULL on fresh-seeded claims; SQL coalesces to
+            // 0.0, so a 0.0 threshold is the only way the candidate surfaces
+            // here without driving a BP recompute first.
+            min_pair_strength: 0.0,
+        },
+    )
+    .await
+    .expect("tool call ok");
+
+    let payload = first_text(&result);
+    let candidates = payload["candidates"]
+        .as_array()
+        .expect("`candidates` must be a JSON array");
+    assert_eq!(
+        candidates.len(),
+        1,
+        "expected exactly 1 candidate, got {candidates:?}"
+    );
+
+    let cand = &candidates[0];
+    let ids: BTreeSet<Uuid> = [
+        Uuid::parse_str(cand["claim_a"].as_str().unwrap()).unwrap(),
+        Uuid::parse_str(cand["claim_b"].as_str().unwrap()).unwrap(),
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(
+        ids,
+        BTreeSet::from([a1, a2]),
+        "candidate pair must be exactly {{A1, A2}}, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&a3),
+        "A3 must not appear (no contradicts edge), got {ids:?}"
+    );
+
+    let target_claim = Uuid::parse_str(cand["target_claim"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        target_claim, target,
+        "target_claim must equal the seeded target"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn suggest_skips_pairs_with_existing_alternative_of(pool: PgPool) {
+    let target = seed_claim(&pool, "Target", 0.5).await;
+    let a1 = seed_claim(&pool, "A1", 0.7).await;
+    let a2 = seed_claim(&pool, "A2", 0.6).await;
+
+    insert_claim_edge(&pool, a1, target, "supports").await;
+    insert_claim_edge(&pool, a2, target, "supports").await;
+    insert_claim_edge(&pool, a1, a2, "contradicts").await;
+    // Already-known alt-set: tool must not re-suggest it.
+    insert_claim_edge(&pool, a1, a2, "alternative_of").await;
+
+    let server = build_test_server(pool.clone());
+    let result = suggest_alternative_sets(
+        &server,
+        SuggestAlternativeSetsParams {
+            target_claim_id: Some(target.to_string()),
+            min_pair_strength: 0.0,
+        },
+    )
+    .await
+    .expect("tool call ok");
+
+    let payload = first_text(&result);
+    let candidates = payload["candidates"]
+        .as_array()
+        .expect("`candidates` must be a JSON array");
+    assert!(
+        candidates.is_empty(),
+        "alternative_of pair must not be re-suggested, got {candidates:?}"
+    );
+}

--- a/docs/superpowers/plans/2026-05-27-alternative-of-and-max-pl-combine.md
+++ b/docs/superpowers/plans/2026-05-27-alternative-of-and-max-pl-combine.md
@@ -1,0 +1,1030 @@
+# `alternative_of` Edge + Max-Pl Combine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an explicit `alternative_of` edge type for mutually-exclusive supporters of a shared target. Teach CDST BP to combine alt-set members via max-Bel / max-Pl ("least restrictive alternative") before Dempster-combining with non-alt supporters. Expose an MCP candidate-finder tool that surfaces likely alt pairs as operator suggestions (no auto-creation). Closes #140 and #141.
+
+**Architecture:** Three layers. **Schema:** new migration adds a partial unique index canonicalizing endpoint order, plus an `alternative_set` view exposing the equivalence class under transitive closure. **Engine:** `combine_alternative_set(bbas, target)` lives in `epigraph-ds`; CDST groups a target's incoming supporters by alt-set membership, reduces each group with the new combine, then Dempster-combines the per-group BBAs as today. **Suggestion tool:** an MCP tool returning candidate (claim_a, claim_b, score, reason) pairs from existing graph state.
+
+**Tech Stack:** Postgres (recursive CTE view, partial unique index), Rust, sqlx, `epigraph-ds`, `epigraph-engine` CDST BP, `epigraph-mcp`, `epigraph-api`.
+
+---
+
+## Setup
+
+**Branch.** Branch from `origin/main`:
+
+```bash
+cd /home/jeremy/epigraph
+git fetch origin main
+git checkout -b feat/alternative-of-and-max-pl origin/main
+```
+
+This plan is independent of the locality-aware-discounting plan; they touch disjoint surfaces and can land in either order.
+
+**Test database.** `epigraph_db_repo_test`.
+
+**Migration slot.** `main` ends at `040_workflows_goal_embedding.sql`. This plan uses `042` to leave room for the locality plan's `041`. If both plans land out of order, the executor adjusts the slot via `chore: renumber` per the pattern established in PRs #177/#178.
+
+**Spec reference.** `docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md` § 1, 3, 4, 5.
+
+---
+
+### Task 1: Add `alternative_of` to the relationship allow-list
+
+**Files:**
+- Modify: `crates/epigraph-api/src/routes/edges.rs:65-119` (`VALID_RELATIONSHIPS` array)
+- Modify: `crates/epigraph-api/src/routes/edges.rs:2554-2572` (`is_valid_relationship` test)
+
+- [ ] **Step 1: Add the constant**
+
+In `crates/epigraph-api/src/routes/edges.rs`, insert into `VALID_RELATIONSHIPS` (alphabetical-ish, next to `"asserts"`, `"same_source"` etc.):
+
+```rust
+    "alternative_of",        // claim ↔ claim (symmetric — mutually-exclusive supporters of a shared target)
+```
+
+- [ ] **Step 2: Extend the test**
+
+In `crates/epigraph-api/src/routes/edges.rs`, in the existing `is_valid_relationship` test:
+
+```rust
+        assert!(is_valid_relationship("alternative_of"));
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+cd /home/jeremy/epigraph
+cargo test -p epigraph-api routes::edges_validation -- --nocapture
+# or whatever the existing test module path is — falls back to:
+cargo test -p epigraph-api is_valid_relationship -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-api/src/routes/edges.rs
+git commit -m "feat(api): admit alternative_of relationship in VALID_RELATIONSHIPS"
+```
+
+---
+
+### Task 2: Migration — symmetric unique index + `alternative_set` view
+
+**Files:**
+- Create: `migrations/042_alternative_of_edge_type.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 042_alternative_of_edge_type.sql
+--
+-- Symmetric uniqueness for alternative_of edges (the application-level
+-- allow-list in routes/edges.rs admits the relationship; here we enforce
+-- the symmetry contract at the schema level).
+--
+-- Plus a view materializing the transitive-closure equivalence class. CDST
+-- BP reads this view to group supporters of a target into alternative
+-- sets before max-Pl combining (see crates/epigraph-engine/src/cdst_bp.rs).
+
+CREATE UNIQUE INDEX IF NOT EXISTS edges_alternative_of_symmetric_uniq
+  ON edges (LEAST(source_id, target_id), GREATEST(source_id, target_id))
+  WHERE relationship = 'alternative_of';
+
+CREATE OR REPLACE VIEW alternative_set AS
+WITH RECURSIVE pairs AS (
+  SELECT source_id AS a, target_id AS b
+    FROM edges WHERE relationship = 'alternative_of'
+  UNION
+  SELECT target_id, source_id
+    FROM edges WHERE relationship = 'alternative_of'
+), closure AS (
+  SELECT a, b FROM pairs
+  UNION
+  SELECT c.a, p.b FROM closure c JOIN pairs p ON c.b = p.a
+)
+SELECT a AS claim_id,
+       array_agg(DISTINCT b ORDER BY b) AS alt_members
+  FROM closure
+ GROUP BY a;
+
+COMMENT ON VIEW alternative_set IS
+'Equivalence class under the symmetric closure of alternative_of. Each row '
+'maps a claim_id to the sorted list of claims it is mutually-exclusive with '
+'(itself excluded). Drives max-Pl combine in CDST BP.';
+```
+
+- [ ] **Step 2: Apply and confirm**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  sqlx migrate run
+psql "$DATABASE_URL" -c "\\d+ alternative_set"
+psql "$DATABASE_URL" -c "\\d edges" | grep edges_alternative_of_symmetric_uniq
+```
+
+Expected: view exists with `claim_id, alt_members` columns; index appears in the table-indexes list.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add migrations/042_alternative_of_edge_type.sql
+git commit -m "feat(db): symmetric uniqueness + alternative_set view for alternative_of"
+```
+
+---
+
+### Task 3: Symmetric dedup + view tests
+
+**Files:**
+- Create: `crates/epigraph-api/tests/alternative_of_symmetric_dedup.rs`
+- Create: `crates/epigraph-api/tests/alternative_set_view_closure.rs`
+
+- [ ] **Step 1: Write the dedup test**
+
+```rust
+//! Inserting alternative_of(A,B) and alternative_of(B,A) must produce
+//! exactly one edge row (the second insertion is a dedup hit on the
+//! symmetric uniqueness index from migration 042).
+
+mod common;
+
+use uuid::Uuid;
+
+#[tokio::test]
+async fn alternative_of_dedupes_under_endpoint_swap() {
+    let pool = common::test_pool().await;
+    let a = common::seed_claim(&pool, "A").await;
+    let b = common::seed_claim(&pool, "B").await;
+
+    let id1 = common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
+    // Reversed direction — should be rejected by the unique index, not
+    // silently double-recorded.
+    let res = sqlx::query(
+        "INSERT INTO edges (source_id, target_id, source_type, target_type, relationship) \
+         VALUES ($1, $2, 'claim', 'claim', 'alternative_of')",
+    )
+    .bind(b)
+    .bind(a)
+    .execute(&pool)
+    .await;
+    assert!(
+        res.is_err(),
+        "reversed alternative_of insert must hit unique index, got: {res:?}"
+    );
+
+    let cnt: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM edges WHERE relationship = 'alternative_of' \
+         AND ((source_id = $1 AND target_id = $2) OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(a)
+    .bind(b)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(cnt.0, 1, "exactly one row, got {}", cnt.0);
+    let _ = id1; // suppresses unused warning
+}
+```
+
+- [ ] **Step 2: Write the view closure test**
+
+```rust
+//! 3-cycle (A↔B, B↔C) under alternative_of must collapse into one
+//! equivalence class — every member's alt_members lists the other two.
+
+mod common;
+
+#[tokio::test]
+async fn alternative_set_view_transitive_closure() {
+    let pool = common::test_pool().await;
+    let a = common::seed_claim(&pool, "A").await;
+    let b = common::seed_claim(&pool, "B").await;
+    let c = common::seed_claim(&pool, "C").await;
+
+    common::insert_edge(&pool, a, b, "claim", "claim", "alternative_of").await;
+    common::insert_edge(&pool, b, c, "claim", "claim", "alternative_of").await;
+
+    let row_a: (Vec<uuid::Uuid>,) = sqlx::query_as(
+        "SELECT alt_members FROM alternative_set WHERE claim_id = $1",
+    )
+    .bind(a)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(row_a.0.contains(&b), "A's alt_members must include B");
+    assert!(row_a.0.contains(&c), "A's alt_members must include C (transitive)");
+
+    let row_c: (Vec<uuid::Uuid>,) = sqlx::query_as(
+        "SELECT alt_members FROM alternative_set WHERE claim_id = $1",
+    )
+    .bind(c)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(row_c.0.contains(&a), "C's alt_members must include A (transitive)");
+    assert!(row_c.0.contains(&b), "C's alt_members must include B");
+}
+```
+
+If `crates/epigraph-api/tests/common/` lacks `seed_claim` / `insert_edge` / `test_pool`, port from existing tests (e.g., `crates/epigraph-api/tests/graph_neighborhoods_test.rs` has comparable fixtures).
+
+- [ ] **Step 3: Run both tests**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test -p epigraph-api \
+    --test alternative_of_symmetric_dedup \
+    --test alternative_set_view_closure \
+  -- --nocapture
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/epigraph-api/tests/alternative_of_symmetric_dedup.rs \
+        crates/epigraph-api/tests/alternative_set_view_closure.rs \
+        crates/epigraph-api/tests/common/
+git commit -m "test(api): alternative_of symmetric dedup + view transitive closure"
+```
+
+---
+
+### Task 4: `combine_alternative_set` in `epigraph-ds`
+
+**Files:**
+- Modify: `crates/epigraph-ds/src/combination.rs` (append function + tests)
+- Modify: `crates/epigraph-ds/src/lib.rs` (re-export if needed)
+
+- [ ] **Step 1: Write the unit tests first (TDD)**
+
+Append to `crates/epigraph-ds/src/combination.rs` test module (or create the test block if it does not exist):
+
+```rust
+#[cfg(test)]
+mod combine_alternative_set_tests {
+    use super::combine_alternative_set;
+    use crate::{measures::{belief, plausibility}, FocalElement, FrameOfDiscernment, MassFunction};
+    use std::collections::BTreeSet;
+
+    fn binary() -> FrameOfDiscernment {
+        FrameOfDiscernment::new("alt-set-test", vec!["supported".into(), "unsupported".into()])
+            .unwrap()
+    }
+
+    fn target() -> FocalElement {
+        FocalElement::positive(BTreeSet::from([0])) // {supported}
+    }
+
+    #[test]
+    fn singleton_returns_input_unchanged() {
+        let frame = binary();
+        let m = MassFunction::simple(frame, BTreeSet::from([0]), 0.6).unwrap();
+        let combined = combine_alternative_set(std::slice::from_ref(&m), &target()).unwrap();
+        assert!((belief(&combined, &target()) - 0.6).abs() < 1e-9);
+        assert!((plausibility(&combined, &target()) - 1.0).abs() < 1e-9); // simple gives m(Θ) = 0.4
+    }
+
+    #[test]
+    fn two_member_set_picks_max_bel_and_max_pl() {
+        let frame = binary();
+        // Member A: BBA pushing strongly toward {supported}: Bel=0.7, Pl=1.0 (ignorance 0.3 on Θ)
+        let a = MassFunction::simple(frame.clone(), BTreeSet::from([0]), 0.7).unwrap();
+        // Member B: BBA pushing weakly toward {supported}: Bel=0.3, Pl=1.0
+        let b = MassFunction::simple(frame, BTreeSet::from([0]), 0.3).unwrap();
+        let combined = combine_alternative_set(&[a, b], &target()).unwrap();
+        let bel = belief(&combined, &target());
+        let pl = plausibility(&combined, &target());
+        assert!(
+            (bel - 0.7).abs() < 1e-9,
+            "max_Bel should equal max(0.7, 0.3) = 0.7, got {bel}"
+        );
+        assert!(
+            (pl - 1.0).abs() < 1e-9,
+            "max_Pl should equal max(1.0, 1.0) = 1.0, got {pl}"
+        );
+    }
+
+    #[test]
+    fn mixed_alt_vs_independent_differs_from_dempster() {
+        use crate::combination::combine_multiple;
+        let frame = binary();
+        // Alt members A1, A2 — same shape as previous test
+        let a1 = MassFunction::simple(frame.clone(), BTreeSet::from([0]), 0.7).unwrap();
+        let a2 = MassFunction::simple(frame.clone(), BTreeSet::from([0]), 0.3).unwrap();
+        // Independent A3
+        let a3 = MassFunction::simple(frame, BTreeSet::from([0]), 0.5).unwrap();
+
+        let alt_combined = combine_alternative_set(&[a1.clone(), a2.clone()], &target()).unwrap();
+        let (mixed, _) = combine_multiple(&[alt_combined, a3.clone()], 0.1).unwrap();
+        let (pure_dempster, _) = combine_multiple(&[a1, a2, a3], 0.1).unwrap();
+
+        let mixed_bel = belief(&mixed, &target());
+        let pure_bel = belief(&pure_dempster, &target());
+        assert!(
+            (mixed_bel - pure_bel).abs() > 1e-3,
+            "max-Pl ⊕ Dempster must differ from pure-Dempster: mixed={mixed_bel}, pure={pure_bel}"
+        );
+        // Sanity: max-Pl path should not over-combine, so mixed_bel < pure_bel
+        assert!(
+            mixed_bel < pure_bel,
+            "max-Pl reduction should yield lower combined Bel than pure Dempster"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run them — expect failure with "function not defined"**
+
+```bash
+cd /home/jeremy/epigraph
+cargo test -p epigraph-ds combine_alternative_set_tests -- --nocapture
+```
+
+Expected: `error[E0425]: cannot find function combine_alternative_set`.
+
+- [ ] **Step 3: Implement the function**
+
+Append to `crates/epigraph-ds/src/combination.rs` (above the `#[cfg(test)]` blocks):
+
+```rust
+/// Reduce a set of mutually-exclusive supporter BBAs to a single representative
+/// BBA via max-Bel / max-Pl on the projected belief interval toward `target`.
+///
+/// Used by CDST BP for alternative-set members: independence has failed (these
+/// claims compete to support the same target), so the product rule
+/// (`combine_multiple`) over-combines. Max-Pl is the "least restrictive
+/// alternative" rule from regulatory/legal reasoning: the combined belief is
+/// bounded by the most permissive single alternative.
+///
+/// Members are passed *post-discount* — the caller applies any per-BBA
+/// `source_strength` reliability discount via [`discount`] before invoking
+/// this function.
+///
+/// Returns the singleton input unchanged.
+///
+/// # Errors
+/// Returns [`DsError::IncompatibleFrames`] if BBAs span different frames.
+pub fn combine_alternative_set(
+    bbas: &[MassFunction],
+    target: &FocalElement,
+) -> Result<MassFunction, DsError> {
+    if bbas.is_empty() {
+        return Err(DsError::EmptyInput);
+    }
+    if bbas.len() == 1 {
+        return Ok(bbas[0].clone());
+    }
+    let frame = bbas[0].frame().clone();
+    for m in &bbas[1..] {
+        if m.frame() != &frame {
+            return Err(DsError::IncompatibleFrames);
+        }
+    }
+
+    let max_bel = bbas
+        .iter()
+        .map(|m| crate::measures::belief(m, target))
+        .fold(0.0_f64, f64::max);
+    let max_pl = bbas
+        .iter()
+        .map(|m| crate::measures::plausibility(m, target))
+        .fold(0.0_f64, f64::max);
+    let max_bel = max_bel.clamp(0.0, 1.0);
+    let max_pl = max_pl.clamp(max_bel, 1.0); // Pl >= Bel by definition
+
+    // Construct: m({target}) = max_bel, m(Θ) = max_pl - max_bel,
+    //            m(complement(target)) = 1 - max_pl
+    use std::collections::BTreeMap;
+    let mut masses: BTreeMap<FocalElement, f64> = BTreeMap::new();
+    if max_bel > 0.0 {
+        masses.insert(target.clone(), max_bel);
+    }
+    let ignorance = max_pl - max_bel;
+    if ignorance > 1e-12 {
+        // Θ = full frame
+        let theta: std::collections::BTreeSet<usize> = (0..frame.cardinality()).collect();
+        masses.insert(FocalElement::positive(theta), ignorance);
+    }
+    let neg_mass = 1.0 - max_pl;
+    if neg_mass > 1e-12 {
+        // complement of target within the frame
+        let comp: std::collections::BTreeSet<usize> = (0..frame.cardinality())
+            .filter(|i| !target.subset.contains(i))
+            .collect();
+        if !comp.is_empty() {
+            masses.insert(FocalElement::positive(comp), neg_mass);
+        }
+    }
+
+    MassFunction::from_masses(frame, masses).map_err(|_| DsError::MassNormalizationFailed)
+}
+```
+
+If any of `DsError::EmptyInput`, `DsError::IncompatibleFrames`, `DsError::MassNormalizationFailed`, or `MassFunction::from_masses` do not exist with those exact names, look up the actual names with:
+
+```bash
+grep -n "pub enum DsError\|pub fn from_masses\|pub fn frame\|pub fn cardinality" \
+     crates/epigraph-ds/src/{errors,mass,frame}.rs
+```
+
+and substitute the actual symbols. (The shape of the construction does not change — only the names.)
+
+- [ ] **Step 4: Run the tests, expect PASS**
+
+```bash
+cargo test -p epigraph-ds combine_alternative_set_tests -- --nocapture
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Re-export from the crate**
+
+In `crates/epigraph-ds/src/lib.rs`, ensure `combination::combine_alternative_set` is reachable from the crate's top-level — if other combine functions are re-exported there, add this one too.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/epigraph-ds/src/combination.rs crates/epigraph-ds/src/lib.rs
+git commit -m "feat(ds): combine_alternative_set (max-Bel/max-Pl reduction)"
+```
+
+---
+
+### Task 5: CDST BP integration — group supporters by alt-set before combining
+
+**Files:**
+- Modify: `crates/epigraph-engine/src/cdst_bp.rs`
+- (Possibly) Modify: `crates/epigraph-api/src/routes/computation.rs` where the BP factors are loaded — only if the alt-set membership has to be threaded through the factor representation.
+
+- [ ] **Step 1: Find the supporter-grouping site**
+
+```bash
+grep -n "fn run_cdst_bp\|combine_multiple\|combine_evidences\|fn compute_cdst_factor_message" \
+     crates/epigraph-engine/src/cdst_bp.rs
+```
+
+The combine of incoming supporter BBAs happens inside `run_cdst_bp` (or `compute_cdst_factor_message`). The change is: before the existing `combine_multiple` over supporters of target T, partition the supporter BBAs into alt-set groups using the `alternative_set` view, reduce each multi-member group with `combine_alternative_set(group, target)`, then `combine_multiple` over the per-group BBAs.
+
+- [ ] **Step 2: Plumb alt-set membership into the engine call site**
+
+The engine is pure (no DB access). The route handler that calls into `run_cdst_bp` (`crates/epigraph-api/src/routes/computation.rs`) must load the alt-set view *once* per request and pass it down. Define a new type in `crates/epigraph-engine/src/cdst_bp.rs`:
+
+```rust
+/// Per-claim alternative-set membership loaded from the `alternative_set` view.
+///
+/// Map keys are claim IDs; values are the sorted equivalence-class members
+/// (excluding the key itself). Engine consumers route a target T's incoming
+/// supporters through `combine_alternative_set` when two or more supporters
+/// share a class.
+pub type AltSetMembership = std::collections::HashMap<uuid::Uuid, Vec<uuid::Uuid>>;
+```
+
+Extend `run_cdst_bp`'s signature (or `CdstBpConfig`) to accept `&AltSetMembership` — preferring the config struct so external callers don't break:
+
+```rust
+pub struct CdstBpConfig {
+    // ... existing fields ...
+    pub alt_set_membership: AltSetMembership,
+}
+```
+
+with a `Default` that returns an empty map (engine behavior unchanged on empty config — no alt-set grouping, identical to today).
+
+- [ ] **Step 3: Apply the grouping in the combine path**
+
+In `run_cdst_bp` (or wherever incoming supporter BBAs are combined for a target T), replace the current straight-line `combine_multiple(&supporter_bbas, ...)` with:
+
+```rust
+use std::collections::HashMap;
+use epigraph_ds::FocalElement;
+
+// Canonical-class id per claim: the minimum claim_id in the equivalence class
+// (used as the group key). Singletons map to themselves.
+let canonical_class = |claim_id: &uuid::Uuid| -> uuid::Uuid {
+    match config.alt_set_membership.get(claim_id) {
+        Some(members) => *std::iter::once(claim_id).chain(members.iter()).min().unwrap(),
+        None => *claim_id,
+    }
+};
+
+// Group (supporter_claim_id, bba) pairs by canonical class.
+let mut groups: HashMap<uuid::Uuid, Vec<MassFunction>> = HashMap::new();
+for (supporter_id, bba) in &supporter_bbas_with_ids {
+    groups.entry(canonical_class(supporter_id)).or_default().push(bba.clone());
+}
+
+// Reduce alt-set groups; singletons pass through.
+let target_focal = FocalElement::positive(std::collections::BTreeSet::from([H_SUPPORTED]));
+let per_group_bbas: Vec<MassFunction> = groups
+    .into_values()
+    .map(|grp| {
+        if grp.len() == 1 {
+            grp.into_iter().next().unwrap()
+        } else {
+            epigraph_ds::combination::combine_alternative_set(&grp, &target_focal)
+                .unwrap_or_else(|_| vacuous())
+        }
+    })
+    .collect();
+
+let (combined, _) = epigraph_ds::combination::combine_multiple(&per_group_bbas, 0.1)?;
+```
+
+If `run_cdst_bp` currently loses the per-supporter `claim_id` before combine (i.e., it collects raw BBAs without tracking which claim each came from), extend the upstream collection to keep `(supporter_id, bba)` pairs. This may require touching the factor-message machinery; preserve the call site's existing variable names and add an `_ids: &[uuid::Uuid]` parameter alongside the existing BBA slice rather than introducing a new tuple type.
+
+- [ ] **Step 4: Load and pass the alt-set view from the route**
+
+In `crates/epigraph-api/src/routes/computation.rs`, where the CDST branch builds `cdst_config` (around `:597`), load the membership map before the engine call:
+
+```rust
+let alt_set_rows: Vec<(Uuid, Vec<Uuid>)> = sqlx::query_as(
+    "SELECT claim_id, alt_members FROM alternative_set",
+)
+.fetch_all(&state.db_pool)
+.await
+.unwrap_or_default();
+
+let mut alt_set_membership: epigraph_engine::cdst_bp::AltSetMembership = HashMap::new();
+for (claim_id, members) in alt_set_rows {
+    alt_set_membership.insert(claim_id, members);
+}
+
+let cdst_config = epigraph_engine::cdst_bp::CdstBpConfig {
+    max_iterations: config.max_iterations,
+    convergence_threshold: config.convergence_threshold,
+    damping: config.damping,
+    alt_set_membership,
+    ..epigraph_engine::cdst_bp::CdstBpConfig::default()
+};
+```
+
+`unwrap_or_default()` is intentional: the alt-set view returns zero rows on a fresh graph, and BP should not fail if the view is empty.
+
+- [ ] **Step 5: Compile, fix any signature drift**
+
+```bash
+SQLX_OFFLINE=true cargo check --workspace
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo sqlx prepare --workspace -- --tests
+```
+
+- [ ] **Step 6: Do NOT commit yet — Task 6 covers the regression test that proves the integration works**
+
+---
+
+### Task 6: CDST integration regression test
+
+**Files:**
+- Create: `crates/epigraph-engine/tests/alt_set_cdst_integration.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+//! Alt set {A1, A2} + independent A3 all supporting T.
+//! Combined T BetP must equal `dempster(maxPl({A1,A2}), A3)`, not
+//! `dempster(A1, A2, A3)`. This proves the alt-set grouping is being
+//! applied rather than silently dropping back to Dempster.
+
+mod common;
+
+use uuid::Uuid;
+
+#[tokio::test]
+async fn alt_set_combine_differs_from_pure_dempster() {
+    let pool = common::test_pool().await;
+    let t  = common::seed_claim(&pool, "Target").await;
+    let a1 = common::seed_claim_with_truth(&pool, "A1", 0.7).await;
+    let a2 = common::seed_claim_with_truth(&pool, "A2", 0.3).await;
+    let a3 = common::seed_claim_with_truth(&pool, "A3", 0.5).await;
+
+    // a1, a2, a3 each support T
+    common::insert_edge(&pool, a1, t, "claim", "claim", "supports").await;
+    common::insert_edge(&pool, a2, t, "claim", "claim", "supports").await;
+    common::insert_edge(&pool, a3, t, "claim", "claim", "supports").await;
+
+    // Record BetP without alt_set wired (control: insert nothing into alternative_of)
+    let betp_no_alt: f64 = sqlx::query_scalar(
+        "SELECT pignistic_prob FROM claims WHERE id = $1"
+    ).bind(t).fetch_one(&pool).await.unwrap().unwrap();
+
+    // Now mark A1, A2 as alternative_of
+    common::insert_edge(&pool, a1, a2, "claim", "claim", "alternative_of").await;
+
+    // Trigger BP recompute (POST /api/v1/graph/recompute_beliefs apply=true)
+    common::run_cdst_recompute(&pool).await;
+
+    let betp_with_alt: f64 = sqlx::query_scalar(
+        "SELECT pignistic_prob FROM claims WHERE id = $1"
+    ).bind(t).fetch_one(&pool).await.unwrap().unwrap();
+
+    assert!(
+        (betp_with_alt - betp_no_alt).abs() > 1e-3,
+        "alt_set grouping must shift BetP — without={betp_no_alt}, with={betp_with_alt}"
+    );
+    assert!(
+        betp_with_alt < betp_no_alt,
+        "alt_set max-Pl reduction should lower combined BetP relative to pure Dempster"
+    );
+}
+```
+
+`common::seed_claim_with_truth` writes the truth_value at insert. `common::run_cdst_recompute` POSTs to the API recompute endpoint (or directly invokes `run_cdst_bp`); use whichever is cleaner against the existing engine test fixtures.
+
+- [ ] **Step 2: Run the test, expect PASS against the Task 5 integration**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test -p epigraph-engine --test alt_set_cdst_integration -- --nocapture
+```
+
+Expected: PASS. Both assertions hold (the alt-set BetP is lower than the no-alt-set BetP).
+
+- [ ] **Step 3: Commit Tasks 5 + 6 together**
+
+```bash
+git add crates/epigraph-engine/src/cdst_bp.rs \
+        crates/epigraph-engine/tests/alt_set_cdst_integration.rs \
+        crates/epigraph-engine/tests/common/ \
+        crates/epigraph-api/src/routes/computation.rs \
+        .sqlx/
+git commit -m "feat(engine): CDST groups supporters by alt-set before Dempster combine"
+```
+
+---
+
+### Task 7: Candidate-finder MCP tool
+
+**Files:**
+- Create: `crates/epigraph-mcp/src/tools/alternative_sets.rs`
+- Modify: `crates/epigraph-mcp/src/server.rs` (register the tool)
+- Modify: `crates/epigraph-mcp/src/scope_map.rs` (add entry under `claims:read`)
+- Create: `crates/epigraph-mcp/tests/suggest_alternative_sets.rs`
+
+- [ ] **Step 1: Write the tool implementation**
+
+Create `crates/epigraph-mcp/src/tools/alternative_sets.rs`:
+
+```rust
+//! mcp__epigraph__suggest_alternative_sets — surface candidate alternative_of
+//! pairs by finding contradicts edges between supporters of a shared target.
+//!
+//! Pure suggestion: the operator promotes by submitting an explicit
+//! `alternative_of` edge. Auto-promotion would risk false positives (two
+//! claims that contradict each other on a different axis may both be valid
+//! independent supporters of T).
+
+use rmcp::model::CallToolResult;
+use rmcp::ErrorData as McpError;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::types::EpiGraphMcpFull;
+use crate::utils::{internal_error, parse_uuid, success_json};
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SuggestAlternativeSetsParams {
+    /// Restrict suggestions to candidate pairs that both support this target.
+    /// Omit to scan the whole graph.
+    pub target_claim_id: Option<String>,
+
+    /// Minimum `min(BetP_a, BetP_b)` to surface a candidate. Default 0.5.
+    #[serde(default = "default_min_strength")]
+    pub min_pair_strength: f64,
+}
+
+fn default_min_strength() -> f64 {
+    0.5
+}
+
+#[derive(Debug, Serialize)]
+pub struct SuggestedAlternativePair {
+    pub claim_a: Uuid,
+    pub claim_b: Uuid,
+    pub target_claim: Uuid,
+    pub score: f64,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SuggestAlternativeSetsResponse {
+    pub candidates: Vec<SuggestedAlternativePair>,
+}
+
+pub async fn suggest_alternative_sets(
+    server: &EpiGraphMcpFull,
+    params: SuggestAlternativeSetsParams,
+) -> Result<CallToolResult, McpError> {
+    let target_filter = match params.target_claim_id.as_deref() {
+        Some(s) => Some(parse_uuid(s)?),
+        None => None,
+    };
+    let min_strength = params.min_pair_strength.clamp(0.0, 1.0);
+
+    let candidates = scan_candidates(&server.pool, target_filter, min_strength)
+        .await
+        .map_err(internal_error)?;
+
+    success_json(&SuggestAlternativeSetsResponse { candidates })
+}
+
+async fn scan_candidates(
+    pool: &PgPool,
+    target_filter: Option<Uuid>,
+    min_strength: f64,
+) -> Result<Vec<SuggestedAlternativePair>, sqlx::Error> {
+    // Pair (A, B) such that:
+    //   - both A and B `supports` the same target T
+    //   - there exists a `contradicts` edge between A and B (either direction)
+    //   - no explicit alternative_of edge between A and B already exists
+    //   - min(pignistic_prob_A, pignistic_prob_B) >= min_strength
+    let rows: Vec<(Uuid, Uuid, Uuid, f64)> = sqlx::query_as(
+        r#"
+        SELECT
+            LEAST(s1.source_id, s2.source_id)  AS claim_a,
+            GREATEST(s1.source_id, s2.source_id) AS claim_b,
+            s1.target_id                        AS target_claim,
+            LEAST(
+                COALESCE(ca.pignistic_prob, 0.0),
+                COALESCE(cb.pignistic_prob, 0.0)
+            ) AS score
+        FROM edges s1
+        JOIN edges s2
+          ON s2.target_id = s1.target_id
+         AND s2.relationship = 'supports'
+         AND s2.source_id <> s1.source_id
+        JOIN edges contr
+          ON ((contr.source_id = s1.source_id AND contr.target_id = s2.source_id)
+           OR (contr.source_id = s2.source_id AND contr.target_id = s1.source_id))
+         AND contr.relationship = 'contradicts'
+        JOIN claims ca ON ca.id = s1.source_id
+        JOIN claims cb ON cb.id = s2.source_id
+        LEFT JOIN edges existing
+          ON existing.relationship = 'alternative_of'
+         AND ((existing.source_id = s1.source_id AND existing.target_id = s2.source_id)
+           OR (existing.source_id = s2.source_id AND existing.target_id = s1.source_id))
+        WHERE s1.relationship = 'supports'
+          AND s1.source_id < s2.source_id  -- de-dupe the symmetric self-join
+          AND ($1::uuid IS NULL OR s1.target_id = $1)
+          AND existing.id IS NULL
+          AND LEAST(
+                COALESCE(ca.pignistic_prob, 0.0),
+                COALESCE(cb.pignistic_prob, 0.0)
+              ) >= $2
+        ORDER BY score DESC
+        LIMIT 200
+        "#,
+    )
+    .bind(target_filter)
+    .bind(min_strength)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(a, b, t, score)| SuggestedAlternativePair {
+            claim_a: a,
+            claim_b: b,
+            target_claim: t,
+            score,
+            reason: format!("contradicts edge between supporters of {t}"),
+        })
+        .collect())
+}
+```
+
+(If `crate::types::EpiGraphMcpFull` / `crate::utils::*` / `success_json` use different names in your tree, mirror the imports from a sibling tool — e.g., `crates/epigraph-mcp/src/tools/claims.rs`.)
+
+- [ ] **Step 2: Register the tool in `server.rs`**
+
+In `crates/epigraph-mcp/src/server.rs`, register `suggest_alternative_sets` following the existing pattern (`update_with_evidence` at `:233` is a good reference). The body wires `params` into `tools::alternative_sets::suggest_alternative_sets(self, params).await`.
+
+- [ ] **Step 3: Add the scope-map entry**
+
+In `crates/epigraph-mcp/src/scope_map.rs`, add (under `claims:read`, alphabetically near the existing entries at `:25-39`):
+
+```rust
+    ("suggest_alternative_sets", "claims:read"),
+```
+
+- [ ] **Step 4: Write the integration test**
+
+```rust
+//! Three supporters of T; two of them are linked by contradicts. Tool
+//! returns exactly that one pair, scored. The third supporter does not
+//! appear in any candidate.
+
+mod common;
+
+use uuid::Uuid;
+
+#[tokio::test]
+async fn suggest_returns_only_contradicts_pair() {
+    let server = common::TestServer::start().await;
+    let t  = common::seed_claim(&server.pool, "Target").await;
+    let a1 = common::seed_claim_with_truth(&server.pool, "A1", 0.7).await;
+    let a2 = common::seed_claim_with_truth(&server.pool, "A2", 0.6).await;
+    let a3 = common::seed_claim_with_truth(&server.pool, "A3", 0.5).await;
+
+    common::insert_edge(&server.pool, a1, t, "claim", "claim", "supports").await;
+    common::insert_edge(&server.pool, a2, t, "claim", "claim", "supports").await;
+    common::insert_edge(&server.pool, a3, t, "claim", "claim", "supports").await;
+    common::insert_edge(&server.pool, a1, a2, "claim", "claim", "contradicts").await;
+    // BP recompute so pignistic_prob is populated
+    common::run_cdst_recompute(&server.pool).await;
+
+    let resp = server
+        .suggest_alternative_sets(
+            epigraph_mcp::tools::alternative_sets::SuggestAlternativeSetsParams {
+                target_claim_id: Some(t.to_string()),
+                min_pair_strength: 0.0,
+            },
+        )
+        .await
+        .expect("tool call ok");
+
+    let payload = common::unwrap_call_result(&resp);
+    let candidates = payload["candidates"].as_array().unwrap();
+    assert_eq!(candidates.len(), 1, "expected 1 candidate, got {:?}", candidates);
+
+    let cand = &candidates[0];
+    let ids: std::collections::BTreeSet<Uuid> = [
+        Uuid::parse_str(cand["claim_a"].as_str().unwrap()).unwrap(),
+        Uuid::parse_str(cand["claim_b"].as_str().unwrap()).unwrap(),
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(ids, std::collections::BTreeSet::from([a1, a2]));
+    assert!(!ids.contains(&a3), "A3 must not appear (no contradicts edge)");
+}
+
+#[tokio::test]
+async fn suggest_skips_pairs_with_existing_alternative_of() {
+    let server = common::TestServer::start().await;
+    let t  = common::seed_claim(&server.pool, "Target").await;
+    let a1 = common::seed_claim_with_truth(&server.pool, "A1", 0.7).await;
+    let a2 = common::seed_claim_with_truth(&server.pool, "A2", 0.6).await;
+    common::insert_edge(&server.pool, a1, t, "claim", "claim", "supports").await;
+    common::insert_edge(&server.pool, a2, t, "claim", "claim", "supports").await;
+    common::insert_edge(&server.pool, a1, a2, "claim", "claim", "contradicts").await;
+    common::insert_edge(&server.pool, a1, a2, "claim", "claim", "alternative_of").await;
+
+    let resp = server
+        .suggest_alternative_sets(
+            epigraph_mcp::tools::alternative_sets::SuggestAlternativeSetsParams {
+                target_claim_id: Some(t.to_string()),
+                min_pair_strength: 0.0,
+            },
+        )
+        .await
+        .expect("tool call ok");
+
+    let payload = common::unwrap_call_result(&resp);
+    let candidates = payload["candidates"].as_array().unwrap();
+    assert!(
+        candidates.is_empty(),
+        "alternative_of pair must not be re-suggested, got {candidates:?}"
+    );
+}
+```
+
+- [ ] **Step 5: Run the tool tests**
+
+```bash
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test -p epigraph-mcp --test suggest_alternative_sets -- --nocapture
+```
+
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/epigraph-mcp/src/tools/alternative_sets.rs \
+        crates/epigraph-mcp/src/server.rs \
+        crates/epigraph-mcp/src/scope_map.rs \
+        crates/epigraph-mcp/tests/suggest_alternative_sets.rs \
+        crates/epigraph-mcp/tests/common/
+git commit -m "feat(mcp): suggest_alternative_sets candidate-finder tool"
+```
+
+---
+
+### Task 8: Workspace verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Full workspace lint + tests**
+
+```bash
+SQLX_OFFLINE=true cargo check --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+DATABASE_URL='postgres://epigraph:epigraph@localhost/epigraph_db_repo_test' \
+  cargo test --workspace
+```
+
+Expected: clean across all four.
+
+- [ ] **Step 2: Commit any cleanup**
+
+```bash
+git status -sb
+# If anything needs committing:
+git add .sqlx/
+git commit -m "chore: cargo sqlx prepare after alternative_of + max-pl work"
+```
+
+---
+
+### Task 9: Push and open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/alternative-of-and-max-pl
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --repo epigraph-io/epigraph \
+  --title "feat: alternative_of edge + max-Pl combine + suggest_alternative_sets (#140, #141)" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `alternative_of` relationship admitted by `is_valid_relationship` and the application allow-list.
+- Migration 042: symmetric partial unique index on the canonicalized endpoint pair + `alternative_set` view exposing the transitive-closure equivalence class.
+- `epigraph_ds::combination::combine_alternative_set(bbas, target)` — max-Bel/max-Pl reduction.
+- CDST BP groups a target's incoming supporters by alt-set canonical class, reduces each multi-member group with the new combine, then Dempster-combines the per-group BBAs.
+- `mcp__epigraph__suggest_alternative_sets` returns candidate (claim_a, claim_b, target, score, reason) pairs from supporter contradictions; pure suggestion — no auto-creation.
+
+## Why
+The Dempster product rule over-combines mutually-exclusive supporters of a shared target (the legal/regulatory "least restrictive alternative" semantics). Without an alt-set primitive the engine treats two competing hypotheses as if their evidence stacked. Max-Pl reduction is the correct rule when independence has failed.
+
+See `docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md` § 1, 3, 4, 5.
+
+## Test plan
+- [x] `cargo test -p epigraph-api alternative_of_symmetric_dedup` — reversed-direction insert rejected
+- [x] `cargo test -p epigraph-api alternative_set_view_closure` — 3-cycle transitive closure
+- [x] `cargo test -p epigraph-ds combine_alternative_set_tests` — singleton, two-member, mixed
+- [x] `cargo test -p epigraph-engine alt_set_cdst_integration` — alt-set BetP differs from pure Dempster
+- [x] `cargo test -p epigraph-mcp suggest_alternative_sets` — only contradicts pairs surfaced; existing alternative_of skipped
+- [x] `cargo test --workspace`
+- [x] `cargo fmt --check` / `cargo clippy --all-targets -D warnings`
+
+Closes #140, #141.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify PR**
+
+```bash
+gh pr view --repo epigraph-io/epigraph --json url,number,title
+```
+
+- [ ] **Step 4: Retire backlog claims**
+
+Per `CLAUDE.md`:
+
+```python
+mcp__epigraph__resolve_backlog_item(
+    original_id="46410d7c-5c17-4f81-9284-98fd879f5dac",  # alternative_of edge type
+    resolution_content=(
+        "Resolves 46410d7c: alternative_of admitted by VALID_RELATIONSHIPS, "
+        "symmetric uniqueness enforced by partial unique index, equivalence "
+        "class exposed via alternative_set view. Ingestion guidance for "
+        "emitting alternative_of and the candidate-finder MCP tool ship in "
+        "the same PR. See PR #<NN>."
+    ),
+)
+
+mcp__epigraph__resolve_backlog_item(
+    original_id="4812b044-a491-4e59-8214-7aeec8374f10",  # max-Pl combine
+    resolution_content=(
+        "Resolves 4812b044: combine_alternative_set in epigraph-ds applies "
+        "max-Bel/max-Pl on the projected belief interval toward the target. "
+        "CDST BP groups supporters by alt-set canonical class before "
+        "Dempster combine. Mixed alt+independent regression test in "
+        "alt_set_cdst_integration confirms divergence from pure Dempster. "
+        "See PR #<NN>."
+    ),
+)
+```
+
+---
+
+## Done
+
+- `alternative_of` is a first-class edge type.
+- The engine consumes it correctly.
+- Operators can find candidate alt pairs without committing to them.
+- Mutually-exclusive supporters no longer over-combine.

--- a/migrations/042_alternative_of_edge_type.sql
+++ b/migrations/042_alternative_of_edge_type.sql
@@ -1,0 +1,35 @@
+-- 042_alternative_of_edge_type.sql
+--
+-- Symmetric uniqueness for alternative_of edges (the application-level
+-- allow-list in routes/edges.rs admits the relationship; here we enforce
+-- the symmetry contract at the schema level).
+--
+-- Plus a view materializing the transitive-closure equivalence class. CDST
+-- BP reads this view to group supporters of a target into alternative
+-- sets before max-Pl combining (see crates/epigraph-engine/src/cdst_bp.rs).
+
+CREATE UNIQUE INDEX IF NOT EXISTS edges_alternative_of_symmetric_uniq
+  ON edges (LEAST(source_id, target_id), GREATEST(source_id, target_id))
+  WHERE relationship = 'alternative_of';
+
+CREATE OR REPLACE VIEW alternative_set AS
+WITH RECURSIVE pairs AS (
+  SELECT source_id AS a, target_id AS b
+    FROM edges WHERE relationship = 'alternative_of'
+  UNION
+  SELECT target_id, source_id
+    FROM edges WHERE relationship = 'alternative_of'
+), closure AS (
+  SELECT a, b FROM pairs
+  UNION
+  SELECT c.a, p.b FROM closure c JOIN pairs p ON c.b = p.a
+)
+SELECT a AS claim_id,
+       array_agg(DISTINCT b ORDER BY b) AS alt_members
+  FROM closure
+ GROUP BY a;
+
+COMMENT ON VIEW alternative_set IS
+'Equivalence class under the symmetric closure of alternative_of. Each row '
+'maps a claim_id to the sorted list of claims it is mutually-exclusive with '
+'(itself excluded). Drives max-Pl combine in CDST BP.';


### PR DESCRIPTION
## Summary
- New `alternative_of` relationship admitted by `is_valid_relationship` and `VALID_RELATIONSHIPS`.
- Migration `042`: partial unique index `edges_alternative_of_symmetric_uniq` on the canonicalized endpoint pair (`LEAST, GREATEST`), and `alternative_set` view exposing the transitive-closure equivalence class.
- `epigraph_ds::combination::combine_alternative_set(bbas, target)` — max-Bel/max-Pl reduction with 3 adversarial unit tests (singleton, two-member, mixed-alt-vs-independent).
- CDST BP groups a target's incoming factor-messages by canonical alt-set class (min UUID in the equivalence class), reduces multi-member groups via `combine_alternative_set` before the existing `adaptive_combine` loop. Empty-config invariant: existing callers see zero behavior change.
- `mcp__epigraph__suggest_alternative_sets` returns candidate `(claim_a, claim_b, target, score, reason)` pairs from supporter pairs linked by `contradicts` but not already by `alternative_of`. Pure suggestion — no auto-creation.

## Why
Issue #141 reported that mutually-exclusive supporters (two competing hypotheses both `supports`-linked to the same target) get product-combined by CDST as if their evidence stacked. Real semantics: T's belief should be bounded by the most permissive single alternative, not the conjunctive product (the "least restrictive alternative" rule from regulatory/legal reasoning).

Issue #140 requested the vocabulary primitive (`alternative_of`) needed to mark such pairs. This PR ships both as a coherent layer — the vocab, the engine combine rule, and a candidate-finder tool that lets operators surface pairs from existing data without blanket auto-promotion (which would risk false positives — two claims that contradict each other on a different axis may both be valid independent supporters of T).

See `docs/superpowers/specs/2026-05-27-alternative-and-dependency-edges-design.md` § 1, 3, 4, 5.

## Integration test result
Pure-engine A1 + A2 + A3 → T topology. With empty `AltSetMembership` (control): `BetP(T) = 0.970381`. With `{A1: [A2], A2: [A1]}` (treatment): `BetP(T) = 0.910867`. Delta `-0.0595` — 60× above the 1e-3 gate, in the correct direction (max-Pl is less restrictive than pure Dempster).

## Test plan
- [x] `cargo test -p epigraph-ds combine_alternative_set_tests` — 3 helper unit tests
- [x] `cargo test -p epigraph-api --test alternative_of_symmetric_dedup` — reversed-direction insert rejected
- [x] `cargo test -p epigraph-api --test alternative_set_view_closure` — 3-cycle transitive closure
- [x] `cargo test -p epigraph-engine --test alt_set_cdst_integration` — BetP shifts from 0.970 → 0.911 with alt-set wiring
- [x] `cargo test -p epigraph-mcp --test suggest_alternative_sets` — only contradicts pairs surfaced; existing alternative_of skipped
- [x] 14 cdst_bp unit tests + 4 cdst_corroborates_aggregation integration tests pass unchanged (empty-config invariant)
- [x] `SQLX_OFFLINE=true cargo check --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Per-crate `cargo clippy --lib -- -D warnings` clean for epigraph-ds / -api / -engine / -mcp

## Migration coordination
This PR uses slot `042`. Plan A (PR #185, locality-aware discounting) uses `041`. If the two PRs merge out of order, the later merger needs to renumber its migration via the established `chore(db): renumber migration NN→MM` pattern.

## Out of scope
Auto-promotion of suggested alt-set pairs into explicit edges — operator-mediated only. Alt-set semantics on `refutes`/`contradicts` edges — symmetric case is a follow-up if needed.

Closes #140, #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)