### PR TITLE
fix(mcp): memorize persists tags to claims.labels

### DIFF
--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -327,7 +327,7 @@ impl EpiGraphMcpFull {
     // ── Memory (2 tools) ──
 
     #[tool(
-        description = "Quick-store a memory as a testimonial claim (0.6x evidence weight). For facts you want to recall later."
+        description = "Quick-store a memory as a testimonial claim (0.6x evidence weight). For facts you want to recall later. Tags are persisted as claim labels — queryable via `query_claims_by_label`."
     )]
     async fn memorize(
         &self,

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -42,6 +42,15 @@ pub async fn memorize(
         crate::claim_helper::create_claim_idempotent(&server.pool, &claim, "memorize").await?;
     let claim_uuid = claim.id.as_uuid();
 
+    // Persist tags as claim labels so `query_claims_by_label` can surface them.
+    // Apply on dedup-hit too — labels accumulate non-destructively via the repo's
+    // SELECT DISTINCT, so re-memorizing existing content with new tags is additive.
+    if !tags.is_empty() {
+        if let Err(e) = ClaimRepository::update_labels(&server.pool, claim_uuid, &tags, &[]).await {
+            tracing::warn!(claim_id = %claim_uuid, "memorize: update_labels failed: {e}");
+        }
+    }
+
     let (final_truth, ds, embedded) = if was_created {
         let evidence_text = if tags.is_empty() {
             "Memory stored via MCP memorize tool".to_string()

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -144,7 +144,9 @@ pub struct MemorizeParams {
     pub confidence: Option<f64>,
 
     #[schemars(
-        description = "Tags for categorization, e.g. ['code', 'rust'] or ['decision', 'architecture']"
+        description = "Tags for categorization, e.g. ['code', 'rust'] or ['decision', 'architecture']. \
+                       Persisted as claim labels — discoverable via `query_claims_by_label`. \
+                       Labels accumulate non-destructively when memorize is called more than once on the same content."
     )]
     #[serde(default, deserialize_with = "deserialize_opt_string_array")]
     pub tags: Option<Vec<String>>,

--- a/crates/epigraph-mcp/tests/memorize_persists_labels.rs
+++ b/crates/epigraph-mcp/tests/memorize_persists_labels.rs
@@ -1,0 +1,162 @@
+//! Regression: `mcp__epigraph__memorize`'s `tags` parameter must populate
+//! `claims.labels` so the resulting claim is discoverable via
+//! `query_claims_by_label`. Pre-fix, `tags` only appeared in the evidence
+//! text + response payload, not on the claim row — `query_claims_by_label`
+//! returned empty for memorize'd claims.
+
+#[macro_use]
+mod common;
+
+use common::*;
+use epigraph_crypto::{AgentSigner, ContentHasher};
+use epigraph_mcp::types::MemorizeParams;
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn build_test_server(pool: PgPool, signer_seed: [u8; 32]) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&signer_seed).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+async fn server_agent_uuid(pool: &PgPool, signer_seed: [u8; 32]) -> Uuid {
+    let signer = AgentSigner::from_bytes(&signer_seed).expect("signer");
+    let pub_key = signer.public_key();
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM agents WHERE public_key = $1")
+        .bind(pub_key.as_slice())
+        .fetch_one(pool)
+        .await
+        .expect("server agent must exist")
+}
+
+#[tokio::test]
+async fn memorize_with_tags_populates_claims_labels() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0xA1u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    let content = format!("memorize-labels test {}", Uuid::new_v4());
+    let params = MemorizeParams {
+        content: content.clone(),
+        confidence: Some(0.7),
+        tags: Some(vec!["backlog".to_string(), "alt-set-extension".to_string()]),
+    };
+
+    tools::memory::memorize(&server, params)
+        .await
+        .expect("memorize");
+
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let content_hash = ContentHasher::hash(content.as_bytes());
+
+    let row: (Vec<String>,) =
+        sqlx::query_as("SELECT labels FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(content_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .expect("claim row");
+
+    let labels = row.0;
+    assert!(
+        labels.contains(&"backlog".to_string()),
+        "labels must include 'backlog', got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"alt-set-extension".to_string()),
+        "labels must include 'alt-set-extension', got {labels:?}"
+    );
+}
+
+#[tokio::test]
+async fn memorize_resubmit_accumulates_labels() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0xA2u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    let content = format!("memorize-accum test {}", Uuid::new_v4());
+
+    // First call: tags = ["one"]
+    tools::memory::memorize(
+        &server,
+        MemorizeParams {
+            content: content.clone(),
+            confidence: Some(0.7),
+            tags: Some(vec!["one".to_string()]),
+        },
+    )
+    .await
+    .expect("first memorize");
+
+    // Second call (dedup hit): tags = ["two"]
+    tools::memory::memorize(
+        &server,
+        MemorizeParams {
+            content: content.clone(),
+            confidence: Some(0.7),
+            tags: Some(vec!["two".to_string()]),
+        },
+    )
+    .await
+    .expect("second memorize");
+
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let content_hash = ContentHasher::hash(content.as_bytes());
+
+    let row: (Vec<String>,) =
+        sqlx::query_as("SELECT labels FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(content_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .expect("claim row");
+
+    let labels = row.0;
+    assert!(
+        labels.contains(&"one".to_string()) && labels.contains(&"two".to_string()),
+        "labels must accumulate across memorize calls, got {labels:?}"
+    );
+}
+
+#[tokio::test]
+async fn memorize_without_tags_leaves_labels_empty() {
+    let pool = test_pool_or_skip!();
+    drop_unique_constraint(&pool).await;
+
+    let signer_seed = [0xA3u8; 32];
+    let server = build_test_server(pool.clone(), signer_seed).await;
+
+    let content = format!("memorize-no-tags test {}", Uuid::new_v4());
+    tools::memory::memorize(
+        &server,
+        MemorizeParams {
+            content: content.clone(),
+            confidence: Some(0.7),
+            tags: None,
+        },
+    )
+    .await
+    .expect("memorize");
+
+    let agent_id = server_agent_uuid(&pool, signer_seed).await;
+    let content_hash = ContentHasher::hash(content.as_bytes());
+
+    let row: (Vec<String>,) =
+        sqlx::query_as("SELECT labels FROM claims WHERE content_hash = $1 AND agent_id = $2")
+            .bind(content_hash.as_slice())
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .expect("claim row");
+
+    assert!(
+        row.0.is_empty(),
+        "no tags → empty labels, got {labels:?}",
+        labels = row.0
+    );
+}


### PR DESCRIPTION
## Summary
- `mcp__epigraph__memorize` now calls `ClaimRepository::update_labels` to persist its `tags` param to `claims.labels`. Pre-fix, tags only appeared in the evidence text and response payload, so `query_claims_by_label` returned empty for memorize'd claims.
- Labels accumulate non-destructively across re-memorize on the same content (dedup-hit path), via the repo's existing SELECT DISTINCT logic.
- Tool docstring (`#[tool(description=…)]`) and the `MemorizeParams.tags` schemars description both updated to tell MCP clients that tags become queryable claim labels.
- 3 new integration tests in `crates/epigraph-mcp/tests/memorize_persists_labels.rs`:
  - `memorize_with_tags_populates_claims_labels` — first call writes labels.
  - `memorize_resubmit_accumulates_labels` — second call with new tags adds to the existing labels (non-destructive).
  - `memorize_without_tags_leaves_labels_empty` — no tags → empty labels (no regression).

## Why
Surfaced while filing backlog claims (B) and (C) from PR #189. Two `memorize` calls returned what looked like a successful response (echoed `tags` field, claim IDs), but `query_claims_by_label(labels=["alt-set-extension"])` returned empty. A follow-up `update_labels` was required to make the claims discoverable — a footgun that already cost time once, will keep costing time, and was tucked behind a successful-looking response.

## Test plan
- [x] `cargo test -p epigraph-mcp --test memorize_persists_labels` — 3 passed against a fresh `epigraph_db_memorize_test` DB.
- [x] `SQLX_OFFLINE=true cargo check -p epigraph-mcp` clean.
- [x] `cargo clippy -p epigraph-mcp --lib -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] Existing `memorize_resubmit_option_a_skip` test still passes (verifies AUTHORED-on-resubmit semantics unchanged — should be unaffected by the additive label PATCH).

## Notes
- Failure to PATCH labels is logged (`tracing::warn!`) but does not fail the `memorize` call. The claim is still durable; the operator can re-run `update_labels` to remediate if a transient DB error swallowed the patch.
- This pattern can be applied to other MCP tools with `tags` / `labels` params if similar footguns surface (none observed yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)