### PR TITLE
feat(locality): per-frame intra_evidence_locality_factor override

### DIFF
--- a/crates/epigraph-db/src/repos/frame.rs
+++ b/crates/epigraph-db/src/repos/frame.rs
@@ -8,7 +8,13 @@ use sqlx::{FromRow, PgPool};
 use tracing::instrument;
 use uuid::Uuid;
 
-/// A row from the frames table
+/// A row from the frames table.
+///
+/// `properties` is a JSONB bag for per-frame epistemic overrides — see
+/// `migrations/044_frames_properties.sql`. Conventional keys:
+///   * `intra_evidence_locality_factor` (float) — locality-discount
+///     multiplier for this frame; overrides `calibration.toml`'s global
+///     default when set.
 #[derive(Debug, Clone, FromRow)]
 pub struct FrameRow {
     pub id: Uuid,
@@ -19,6 +25,7 @@ pub struct FrameRow {
     pub is_refinable: bool,
     pub version: i32,
     pub created_at: DateTime<Utc>,
+    pub properties: serde_json::Value,
 }
 
 /// A row from the claim_frames junction table
@@ -49,7 +56,7 @@ impl FrameRepository {
             r#"
             INSERT INTO frames (name, description, hypotheses)
             VALUES ($1, $2, $3)
-            RETURNING id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+            RETURNING id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
             "#,
         )
         .bind(name)
@@ -69,7 +76,7 @@ impl FrameRepository {
     pub async fn get_by_id(pool: &PgPool, id: Uuid) -> Result<Option<FrameRow>, DbError> {
         let row: Option<FrameRow> = sqlx::query_as(
             r#"
-            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
             FROM frames
             WHERE id = $1
             "#,
@@ -89,7 +96,7 @@ impl FrameRepository {
     pub async fn get_by_name(pool: &PgPool, name: &str) -> Result<Option<FrameRow>, DbError> {
         let row: Option<FrameRow> = sqlx::query_as(
             r#"
-            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
             FROM frames
             WHERE name = $1
             "#,
@@ -109,7 +116,7 @@ impl FrameRepository {
     pub async fn list(pool: &PgPool, limit: i64, offset: i64) -> Result<Vec<FrameRow>, DbError> {
         let rows: Vec<FrameRow> = sqlx::query_as(
             r#"
-            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
             FROM frames
             ORDER BY created_at DESC
             LIMIT $1 OFFSET $2
@@ -197,7 +204,7 @@ impl FrameRepository {
             r#"
             INSERT INTO frames (name, description, hypotheses, parent_frame_id)
             VALUES ($1, $2, $3, $4)
-            RETURNING id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+            RETURNING id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
             "#,
         )
         .bind(name)
@@ -218,7 +225,7 @@ impl FrameRepository {
     pub async fn get_children(pool: &PgPool, frame_id: Uuid) -> Result<Vec<FrameRow>, DbError> {
         let rows: Vec<FrameRow> = sqlx::query_as(
             r#"
-            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
             FROM frames
             WHERE parent_frame_id = $1
             ORDER BY created_at ASC
@@ -243,15 +250,15 @@ impl FrameRepository {
         let rows: Vec<FrameRow> = sqlx::query_as(
             r#"
             WITH RECURSIVE ancestry AS (
-                SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+                SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
                 FROM frames
                 WHERE id = $1
                 UNION ALL
-                SELECT f.id, f.name, f.description, f.hypotheses, f.parent_frame_id, f.is_refinable, f.version, f.created_at
+                SELECT f.id, f.name, f.description, f.hypotheses, f.parent_frame_id, f.is_refinable, f.version, f.created_at, f.properties
                 FROM frames f
                 JOIN ancestry a ON f.id = a.parent_frame_id
             )
-            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at
+            SELECT id, name, description, hypotheses, parent_frame_id, is_refinable, version, created_at, properties
             FROM ancestry
             "#,
         )
@@ -301,6 +308,72 @@ impl FrameRepository {
 
         Ok(row.0)
     }
+
+    /// Read the per-frame `intra_evidence_locality_factor` override, if any.
+    ///
+    /// Returns `Ok(None)` when:
+    ///   * the frame row doesn't exist,
+    ///   * `properties` does not contain the `intra_evidence_locality_factor`
+    ///     key,
+    ///   * the key's value isn't a number (i.e. the operator wrote
+    ///     garbage — we treat that as "no override" rather than panic).
+    ///
+    /// Callers should fall back to the global default from
+    /// `calibration.toml::evidence_locality.intra_evidence_locality_factor`.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` only on actual DB failure. Missing
+    /// rows / missing keys return `Ok(None)`, not an error — the consumer
+    /// is expected to use a calibration default in that case.
+    #[instrument(skip(pool))]
+    pub async fn get_intra_evidence_locality_factor(
+        pool: &PgPool,
+        frame_id: Uuid,
+    ) -> Result<Option<f64>, DbError> {
+        // `properties->>'intra_evidence_locality_factor'` returns TEXT.
+        // Casting to FLOAT8 inside the SQL would panic on malformed
+        // values; safer to fetch the TEXT and parse in Rust so the worst
+        // case is a benign None.
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT properties->>'intra_evidence_locality_factor' FROM frames WHERE id = $1",
+        )
+        .bind(frame_id)
+        .fetch_optional(pool)
+        .await?;
+        let Some((Some(raw),)) = row else {
+            return Ok(None);
+        };
+        Ok(raw.parse::<f64>().ok())
+    }
+
+    /// Set a single key on `frames.properties`. Operator/admin use; the
+    /// main intent is per-frame `intra_evidence_locality_factor` overrides.
+    ///
+    /// Uses `||` (JSONB merge) so existing keys are preserved.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool, value))]
+    pub async fn set_property(
+        pool: &PgPool,
+        frame_id: Uuid,
+        key: &str,
+        value: &serde_json::Value,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            r#"
+            UPDATE frames
+               SET properties = properties || jsonb_build_object($2::text, $3::jsonb)
+             WHERE id = $1
+            "#,
+        )
+        .bind(frame_id)
+        .bind(key)
+        .bind(value)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -318,6 +391,7 @@ mod tests {
             is_refinable: true,
             version: 1,
             created_at: Utc::now(),
+            properties: serde_json::json!({}),
         };
     }
 

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -142,14 +142,30 @@ pub async fn auto_wire_ds_for_edge(
     .fetch_one(pool)
     .await
     .map_err(|e| format!("intra-source evidence lookup: {e}"))?;
-    let intra_factor = crate::calibration::CalibrationConfig::from_workspace_root()
-        .ok()
-        .map(|c| c.evidence_locality.intra_evidence_locality_factor)
-        .unwrap_or(0.3);
+    // Resolution order for the intra-evidence locality factor:
+    //   1. Per-frame override (frames.properties->>'intra_evidence_locality_factor').
+    //      Lets operators tune locality discounting per epistemic context
+    //      (binary_truth vs textbook_veracity_* vs research_validity etc.)
+    //      without code releases. Set via FrameRepository::set_property.
+    //   2. Global default from calibration.toml.
+    //   3. Hardcoded fallback 0.3 if calibration.toml is unreadable.
+    //
+    // Edge BBAs all land on the binary_truth frame today (see ensure_binary_frame
+    // below); if a future edge_factor path writes to a different frame, the
+    // per-frame override naturally follows because we look up by frame_id.
+    let frame_id = ensure_binary_frame(pool).await?;
+    let per_frame_factor = FrameRepository::get_intra_evidence_locality_factor(pool, frame_id)
+        .await
+        .map_err(|e| format!("per-frame locality factor lookup: {e}"))?;
+    let intra_factor = per_frame_factor.unwrap_or_else(|| {
+        crate::calibration::CalibrationConfig::from_workspace_root()
+            .ok()
+            .map(|c| c.evidence_locality.intra_evidence_locality_factor)
+            .unwrap_or(0.3)
+    });
     let locality_factor = if is_intra { intra_factor } else { 1.0 };
     let source_strength = transmission_factor * locality_factor;
 
-    let frame_id = ensure_binary_frame(pool).await?;
     let frame = binary_frame()?;
     let bba = restricted
         .to_mass_function(&frame)

--- a/crates/epigraph-engine/tests/intra_source_discount_regression.rs
+++ b/crates/epigraph-engine/tests/intra_source_discount_regression.rs
@@ -358,3 +358,135 @@ async fn cross_source_19_supporters_keeps_high_betp(pool: PgPool) {
         "cross-source 19-supporter BetP should stay > 0.9, got {betp}"
     );
 }
+
+// ── Per-frame override: intra-source with a custom locality factor ─────────
+
+/// Verifies the `frames.properties->>'intra_evidence_locality_factor'`
+/// override actually flows through `edge_factor::auto_wire_ds_for_edge`.
+/// Two supporters seeded the same way; we set the binary_truth frame's
+/// per-frame factor to 0.9 (much weaker discount than the calibration
+/// default 0.3) and assert the resulting source_strength reflects that.
+///
+/// Without the per-frame override path, edge_factor would discount with
+/// the global 0.3 and the source_strength on each BBA would land near
+/// 0.7 * 0.3 = 0.21. With the per-frame 0.9 override applied, it should
+/// land near 0.7 * 0.9 = 0.63.
+#[sqlx::test(migrations = "../../migrations")]
+async fn per_frame_locality_factor_override_applied(pool: PgPool) {
+    use epigraph_db::FrameRepository;
+
+    let agent = seed_agent(&pool, 0xC0_0001).await;
+    let target_doi = "10.perframe/p1";
+    let paper = seed_paper(&pool, target_doi, "per-frame override").await;
+
+    let target_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current) \
+         VALUES ($1, $2, $3, $4, 0.5, true)",
+    )
+    .bind(target_id)
+    .bind("per-frame override target")
+    .bind(distinct_hash(0x50_0000))
+    .bind(agent)
+    .execute(&pool)
+    .await
+    .expect("seed target");
+    insert_edge(&pool, paper, target_id, "paper", "claim", "asserts").await;
+
+    // ensure_binary_frame() inside edge_factor creates the binary_truth
+    // frame lazily, but we need it materialized BEFORE the edge writes so
+    // we can set the per-frame property. Fire one supporter just to
+    // materialize the frame row, then set the override, then run the
+    // real check.
+    let primer = seed_claim_with_belief(
+        &pool,
+        agent,
+        "primer supporter",
+        0x51_0000,
+        NEMS_BELIEF,
+        NEMS_BELIEF,
+        NEMS_BELIEF,
+    )
+    .await;
+    seed_doi_evidence(&pool, primer, target_doi, 0x71_0000).await;
+    let primer_edge =
+        insert_edge(&pool, primer, target_id, "claim", "claim", "supports").await;
+    auto_wire_ds_for_edge(&pool, primer_edge, agent, primer, target_id, "supports")
+        .await
+        .expect("auto_wire primer");
+
+    // Now binary_truth exists. Override its locality factor.
+    let frame = FrameRepository::get_by_name(&pool, "binary_truth")
+        .await
+        .expect("query binary_truth")
+        .expect("binary_truth must exist after primer wire");
+    FrameRepository::set_property(
+        &pool,
+        frame.id,
+        "intra_evidence_locality_factor",
+        &serde_json::json!(0.9),
+    )
+    .await
+    .expect("set frame property");
+
+    // Fire a fresh supporter under the override. It should receive a
+    // less-discounted source_strength than the primer.
+    let supporter = seed_claim_with_belief(
+        &pool,
+        agent,
+        "override-affected supporter",
+        0x52_0000,
+        NEMS_BELIEF,
+        NEMS_BELIEF,
+        NEMS_BELIEF,
+    )
+    .await;
+    seed_doi_evidence(&pool, supporter, target_doi, 0x72_0000).await;
+    let edge_id =
+        insert_edge(&pool, supporter, target_id, "claim", "claim", "supports").await;
+    let outcome =
+        auto_wire_ds_for_edge(&pool, edge_id, agent, supporter, target_id, "supports")
+            .await
+            .expect("auto_wire override");
+    assert_eq!(outcome, EdgeFactorOutcome::Wired);
+
+    // The new BBA's source_strength is the one written via perspective_id =
+    // edge_id (see PerspectiveRepository::ensure_edge_perspective). Reading
+    // by perspective_id gives us an exact handle independent of the primer
+    // row that landed at the default factor.
+    let ss: f64 = sqlx::query_scalar(
+        "SELECT source_strength FROM mass_functions WHERE perspective_id = $1",
+    )
+    .bind(edge_id)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch override BBA's source_strength");
+    eprintln!("[per_frame_locality_factor_override_applied] source_strength = {ss}");
+
+    // Expected: 0.7 (transmission) * 0.9 (per-frame factor) = 0.63.
+    // Band [0.50, 0.75] tracks plausible transmission drift but excludes
+    // both the global-default outcome (~0.21) and the un-discounted
+    // outcome (~0.7).
+    assert!(
+        (0.50..=0.75).contains(&ss),
+        "expected per-frame override (factor 0.9) to land source_strength in [0.50, 0.75], got {ss}"
+    );
+
+    // Cross-check: the primer BBA (written BEFORE the override) lives at
+    // the default factor 0.3, so its source_strength is ~0.21. Both BBAs
+    // sit on the same target frame; the override only affects writes
+    // AFTER `set_property`. (Per-frame factor is read at write time, not
+    // stored on the BBA, so a later override doesn't retroactively
+    // change historical rows — backfill script's job.)
+    let primer_ss: f64 = sqlx::query_scalar(
+        "SELECT source_strength FROM mass_functions WHERE perspective_id = $1",
+    )
+    .bind(primer_edge)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch primer BBA's source_strength");
+    assert!(
+        primer_ss < 0.30,
+        "primer BBA (written pre-override) should still carry default-factor discount (<0.30), got {primer_ss}"
+    );
+}

--- a/crates/epigraph-engine/tests/intra_source_discount_regression.rs
+++ b/crates/epigraph-engine/tests/intra_source_discount_regression.rs
@@ -409,8 +409,7 @@ async fn per_frame_locality_factor_override_applied(pool: PgPool) {
     )
     .await;
     seed_doi_evidence(&pool, primer, target_doi, 0x71_0000).await;
-    let primer_edge =
-        insert_edge(&pool, primer, target_id, "claim", "claim", "supports").await;
+    let primer_edge = insert_edge(&pool, primer, target_id, "claim", "claim", "supports").await;
     auto_wire_ds_for_edge(&pool, primer_edge, agent, primer, target_id, "supports")
         .await
         .expect("auto_wire primer");
@@ -442,25 +441,22 @@ async fn per_frame_locality_factor_override_applied(pool: PgPool) {
     )
     .await;
     seed_doi_evidence(&pool, supporter, target_doi, 0x72_0000).await;
-    let edge_id =
-        insert_edge(&pool, supporter, target_id, "claim", "claim", "supports").await;
-    let outcome =
-        auto_wire_ds_for_edge(&pool, edge_id, agent, supporter, target_id, "supports")
-            .await
-            .expect("auto_wire override");
+    let edge_id = insert_edge(&pool, supporter, target_id, "claim", "claim", "supports").await;
+    let outcome = auto_wire_ds_for_edge(&pool, edge_id, agent, supporter, target_id, "supports")
+        .await
+        .expect("auto_wire override");
     assert_eq!(outcome, EdgeFactorOutcome::Wired);
 
     // The new BBA's source_strength is the one written via perspective_id =
     // edge_id (see PerspectiveRepository::ensure_edge_perspective). Reading
     // by perspective_id gives us an exact handle independent of the primer
     // row that landed at the default factor.
-    let ss: f64 = sqlx::query_scalar(
-        "SELECT source_strength FROM mass_functions WHERE perspective_id = $1",
-    )
-    .bind(edge_id)
-    .fetch_one(&pool)
-    .await
-    .expect("fetch override BBA's source_strength");
+    let ss: f64 =
+        sqlx::query_scalar("SELECT source_strength FROM mass_functions WHERE perspective_id = $1")
+            .bind(edge_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch override BBA's source_strength");
     eprintln!("[per_frame_locality_factor_override_applied] source_strength = {ss}");
 
     // Expected: 0.7 (transmission) * 0.9 (per-frame factor) = 0.63.
@@ -478,13 +474,12 @@ async fn per_frame_locality_factor_override_applied(pool: PgPool) {
     // AFTER `set_property`. (Per-frame factor is read at write time, not
     // stored on the BBA, so a later override doesn't retroactively
     // change historical rows — backfill script's job.)
-    let primer_ss: f64 = sqlx::query_scalar(
-        "SELECT source_strength FROM mass_functions WHERE perspective_id = $1",
-    )
-    .bind(primer_edge)
-    .fetch_one(&pool)
-    .await
-    .expect("fetch primer BBA's source_strength");
+    let primer_ss: f64 =
+        sqlx::query_scalar("SELECT source_strength FROM mass_functions WHERE perspective_id = $1")
+            .bind(primer_edge)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch primer BBA's source_strength");
     assert!(
         primer_ss < 0.30,
         "primer BBA (written pre-override) should still carry default-factor discount (<0.30), got {primer_ss}"

--- a/migrations/044_frames_properties.sql
+++ b/migrations/044_frames_properties.sql
@@ -1,0 +1,30 @@
+-- 044_frames_properties.sql
+--
+-- Add a JSONB properties column to `frames` so operators can configure
+-- per-frame epistemic parameters at runtime without code releases. The
+-- canonical use case is locality-aware discounting: different frames
+-- (binary_truth, textbook_veracity_*, research_validity, ...) carry
+-- different epistemological commitments about what intra-source evidence
+-- means for independence.
+--
+-- Conventional keys (consumed by `crates/epigraph-engine`):
+--   * `intra_evidence_locality_factor` :: float -- multiplier applied
+--     to per-BBA source_strength when the supporting evidence is
+--     intra-source within this frame. Overrides the global default
+--     in calibration.toml::evidence_locality.intra_evidence_locality_factor.
+--     Range conventionally (0.0, 1.0]; 1.0 means "no locality discount
+--     for this frame" (e.g. textbook frames where same-source is the
+--     point, not a correlation concern); 0.3 is the global default.
+--
+-- Operators set per-frame overrides via:
+--   UPDATE frames SET properties = properties ||
+--     jsonb_build_object('intra_evidence_locality_factor', 0.5)
+--   WHERE name = 'research_validity';
+
+ALTER TABLE frames
+    ADD COLUMN properties JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN frames.properties IS
+'Per-frame configuration overrides consumed by epigraph-engine. '
+'Conventional keys: intra_evidence_locality_factor (float, locality-discount '
+'multiplier; falls back to calibration.toml when absent). See migration 044.';

--- a/scripts/backfill_intra_source_evidence_discount.py
+++ b/scripts/backfill_intra_source_evidence_discount.py
@@ -15,6 +15,16 @@ single-value 0.25 the original #185 script REPLACED with), but an
 empirical/intra BBA at 1.0 lands at 0.30 — preserving the evidence-type
 ordering. Cross-source BBAs are left untouched.
 
+Per-frame override: `frames.properties->>'intra_evidence_locality_factor'`,
+if set, takes precedence over the calibration.toml global default for BBAs
+on that frame (migration 044). Mirrors the resolution order in
+`edge_factor.rs`, so the backfill applies the same locality model new edge
+writes use. Operators set per-frame overrides via
+FrameRepository::set_property or directly:
+    UPDATE frames SET properties = properties ||
+      jsonb_build_object('intra_evidence_locality_factor', 0.5)
+     WHERE name = 'research_validity';
+
 Schema bridge:
   mass_functions.claim_id -> evidence.claim_id
   evidence.properties->>'doi' = (paper that asserts mass_functions.claim_id)
@@ -108,18 +118,56 @@ def in_clause(values: tuple[float, ...]) -> str:
     return "(" + ", ".join(f"{v}" for v in values) + ")"
 
 
+# Numeric-literal regex for parsing per-frame property values. Mirrors the
+# Rust `f64::parse` behaviour the engine uses, so the SQL and the engine
+# agree on which property values are "valid" overrides.
+_FACTOR_REGEX = r"^-?[0-9]+(\\.[0-9]+)?$"
+
+
+def effective_factor_sql(global_default_placeholder: str = "%s") -> str:
+    """SQL expression that resolves the per-frame factor for `mf`.
+
+    Returns a SQL fragment that evaluates to:
+      * (frames.properties->>'intra_evidence_locality_factor')::float8
+        when the override is present AND parses as a number,
+      * the global default placeholder otherwise.
+
+    The caller is responsible for binding the global default as a
+    parameter at the placeholder.
+    """
+    return (
+        "CASE "
+        f"WHEN f.properties ? 'intra_evidence_locality_factor' "
+        f"AND (f.properties->>'intra_evidence_locality_factor') ~ '{_FACTOR_REGEX}' "
+        f"THEN (f.properties->>'intra_evidence_locality_factor')::float8 "
+        f"ELSE {global_default_placeholder} "
+        "END"
+    )
+
+
 def candidate_query(scope_tiers: tuple[float, ...]) -> str:
     """SELECT for in-scope BBAs. `scope_tiers` filters `mf.source_strength`.
 
     Match criterion: BBA's claim has at least one evidence row whose
     `properties->>'doi'` equals the doi of the paper that asserts the
     claim. The set of post-composition tier values is disjoint from
-    `scope_tiers` for any intra factor < 1.0, giving natural idempotency.
+    `scope_tiers` for any intra factor < 1.0, giving natural idempotency
+    (with the additional caveat that a per-frame override at the global
+    default value won't move BBAs at that tier — operators setting
+    overrides at non-default values get clean re-runs as well).
+
+    The JOIN to `frames` lets us pull the per-frame
+    `intra_evidence_locality_factor` override when set; the
+    `effective_factor` column carries the resolved value (per-frame or
+    global default) so the caller can group preview output by it.
     """
     tier_filter = f"mf.source_strength IN {in_clause(scope_tiers)}"
+    factor_expr = effective_factor_sql()
     return f"""
-        SELECT mf.id, mf.claim_id, mf.source_strength
+        SELECT mf.id, mf.claim_id, mf.source_strength,
+               {factor_expr} AS effective_factor
           FROM mass_functions mf
+          JOIN frames f ON f.id = mf.frame_id
          WHERE {tier_filter}
            AND EXISTS (
                SELECT 1
@@ -140,44 +188,60 @@ def candidate_query(scope_tiers: tuple[float, ...]) -> str:
 def preview_distribution(
     conn, scope_tiers: tuple[float, ...], intra_factor: float
 ) -> tuple[int, int]:
-    """Show what would be written, grouped by source_strength."""
+    """Show what would be written, grouped by (source_strength, effective_factor).
+
+    The effective_factor varies when frames carry a per-frame
+    `intra_evidence_locality_factor` override. Reporting both columns
+    surfaces those overrides explicitly instead of hiding them inside a
+    single "post" number that conflates frame-level differences.
+    """
     sql = candidate_query(scope_tiers)
     with conn.cursor() as cur:
-        cur.execute(sql)
+        cur.execute(sql, (intra_factor,))
         rows = cur.fetchall()
     n_rows = len(rows)
     n_claims = len({r[1] for r in rows})
     if n_rows == 0:
         return n_rows, n_claims
 
-    # Group by source_strength tier and show pre / post values.
-    by_tier: dict[float, int] = {}
-    for _, _, ss in rows:
-        ss_f = float(ss)
-        by_tier[ss_f] = by_tier.get(ss_f, 0) + 1
+    # Group by (source_strength, effective_factor) so per-frame overrides
+    # show up as distinct buckets.
+    by_bucket: dict[tuple[float, float], int] = {}
+    for _, _, ss, factor in rows:
+        key = (float(ss), float(factor))
+        by_bucket[key] = by_bucket.get(key, 0) + 1
 
-    print(f"{'pre':>9} {'post':>9} {'rows':>10}")
-    print("-" * 32)
-    for tier in sorted(by_tier.keys(), reverse=True):
-        post = tier * intra_factor
-        print(f"{tier:>9.4f} {post:>9.4f} {by_tier[tier]:>10}")
-    print("-" * 32)
+    print(f"{'pre':>9} {'factor':>9} {'post':>9} {'rows':>10}")
+    print("-" * 42)
+    for (tier, factor) in sorted(by_bucket.keys(), reverse=True):
+        post = tier * factor
+        marker = " *" if abs(factor - intra_factor) > 1e-9 else ""
+        print(f"{tier:>9.4f} {factor:>9.4f} {post:>9.4f} {by_bucket[(tier, factor)]:>10}{marker}")
+    print("-" * 42)
     print(f"total rows: {n_rows}, distinct claims: {n_claims}")
+    print(f"  (global default factor: {intra_factor}; '*' = per-frame override)")
     return n_rows, n_claims
 
 
 def execute_backfill(
     conn, scope_tiers: tuple[float, ...], intra_factor: float
 ) -> tuple[int, list]:
-    """Multiply source_strength by intra_factor for in-scope BBAs.
+    """Multiply source_strength by the resolved per-frame factor for in-scope BBAs.
+
+    Effective factor per row = per-frame override if set, else `intra_factor`
+    (the global default from calibration.toml). Mirrors the resolution
+    order in `edge_factor::wire_evidential_edge_factor`.
 
     Returns (n_rows_updated, sorted_unique_affected_claim_ids).
     """
     tier_filter = f"mf.source_strength IN {in_clause(scope_tiers)}"
+    factor_expr = effective_factor_sql()
     sql = f"""
         UPDATE mass_functions mf
-           SET source_strength = source_strength * %s
-         WHERE {tier_filter}
+           SET source_strength = source_strength * ({factor_expr})
+          FROM frames f
+         WHERE f.id = mf.frame_id
+           AND {tier_filter}
            AND EXISTS (
                SELECT 1
                  FROM evidence e


### PR DESCRIPTION
Stacked on **#192**. Will only review cleanly after #192 lands; the diff here is just the per-frame layer on top.

## Why
EpiGraph already runs 124 distinct frames in production (binary_truth, textbook_veracity_openstax_*, research_validity, nanotech_mechanosynthesis_progress, funder_narrative_weight, hypothesis_assessment, praxis-claim-*, ...). #192's single global `intra_evidence_locality_factor` hardwires the same locality discount across all of them, which doesn't actually fit:

- **textbook_veracity_***: same-source citation IS the point, not a correlation concern; an aggressive 0.3 discount destroys signal.
- **research_validity**: same-paper supporters in a methods section ARE correlated and may want stronger discount than 0.3.
- **binary_truth** (the catch-all): 0.3 is reasonable.

This PR lets operators tune locality per epistemic context at runtime, no code release required.

## Resolution order (forward write path AND backfill)
1. `frames.properties->>'intra_evidence_locality_factor'` (per-frame, set via `FrameRepository::set_property` or direct SQL)
2. `calibration.toml::evidence_locality.intra_evidence_locality_factor` (global default, currently 0.3)
3. Hardcoded `0.3` fallback if calibration.toml is unreadable

## Test plan
- [x] `cargo test -p epigraph-engine --test intra_source_discount_regression` — 3/3 including the new `per_frame_locality_factor_override_applied` (sets `intra_evidence_locality_factor = 0.9` on `binary_truth` mid-test, fires a fresh supporter, asserts new BBA's source_strength lands in [0.50, 0.75] ≈ 0.7×0.9; cross-checks the primer BBA stayed at the default ≈0.21, proving the override is read at write-time and doesn't retroactively rewrite historical rows)
- [x] `cargo test -p epigraph-engine --test intra_source_discount_calibration` — 1/1
- [x] `cargo test -p epigraph-engine --lib` — 332/332
- [x] `cargo test -p epigraph-db --lib` — 72/72 (10 pre-existing ignored)
- [x] `cargo test -p epigraph-engine --test diverse_retrieval_integration --test diverse_retrieval_layering` — 7/7 + 1/1
- [x] `cargo test -p epigraph-db --test same_source_papers_truth_table` — 1/1
- [ ] Production dry-run BLOCKED until merge — migration 044 isn't applied to prod yet (will run on the next API restart after merge). The script throws `column f.properties does not exist` until then, which is the correct failure mode for "you need to deploy this first."

## Files changed
| File | Why |
|---|---|
| `migrations/044_frames_properties.sql` | adds `frames.properties JSONB NOT NULL DEFAULT '{}'`. Comment documents the convention key. |
| `crates/epigraph-db/src/repos/frame.rs` | `FrameRow.properties` field; widens 9 column lists; new `get_intra_evidence_locality_factor` + `set_property` repo methods |
| `crates/epigraph-engine/src/edge_factor.rs` | per-frame → global → hardcoded fallback chain; `ensure_binary_frame` moved up so the frame_id is available for the lookup |
| `crates/epigraph-engine/tests/intra_source_discount_regression.rs` | adds `per_frame_locality_factor_override_applied` (new behavior); leaves the two existing regressions unchanged (validate default-factor path) |
| `scripts/backfill_intra_source_evidence_discount.py` | SQL JOINs `frames` + CASE expression to resolve per-frame factor; preview groups by `(tier, factor)` so overrides surface explicitly |

## Notes
- **`get_intra_evidence_locality_factor` returns `Ok(None)` for malformed values**, not `Err`. Operators who type garbage get the global default, not a runtime panic. Same convention applies in the script's SQL CASE expression (regex-guarded cast).
- **Override is read at write-time, NOT retroactive**. Setting a per-frame override doesn't rewrite existing BBAs — the backfill script's job. Test `per_frame_locality_factor_override_applied` verifies this explicitly by checking the primer BBA stayed at the pre-override value.
- **No breaking change to migration ordering**: PR collision with #189's `042_alternative_of_edge_type.sql` resolved by renaming this migration to 044 (043 is `alt_set_decisions_view` from another PR).
- **Migration 041 (`same_source_papers`) stays in the tree** — not on the forward path anymore, but the truth-table test still exercises it as a utility. Could be retired in a future cleanup; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)