### PR TITLE
feat(cli): recompute_claim_belief binary + frame-aware engine API

### DIFF
--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -12,6 +12,11 @@ db = ["dep:epigraph-db", "dep:sqlx"]
 genai = ["db"]
 
 [[bin]]
+name = "recompute_claim_belief"
+path = "src/bin/recompute_claim_belief.rs"
+required-features = ["db"]
+
+[[bin]]
 name = "ingest_literature"
 path = "src/bin/ingest_literature.rs"
 

--- a/crates/epigraph-cli/src/bin/recompute_claim_belief.rs
+++ b/crates/epigraph-cli/src/bin/recompute_claim_belief.rs
@@ -89,7 +89,10 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if cli.dry_run {
-        println!("DRY-RUN — would recompute belief on {} claims", claim_ids.len());
+        println!(
+            "DRY-RUN — would recompute belief on {} claims",
+            claim_ids.len()
+        );
         return Ok(());
     }
 
@@ -184,10 +187,9 @@ async fn recompute_one_claim_all_frames(
     .map_err(|e| format!("list frames for claim: {e}"))?;
     let mut written = 0usize;
     for (frame_id, _frame_name) in rows {
-        let did = epigraph_engine::edge_factor::recompute_claim_belief_on_frame(
-            pool, claim_id, frame_id,
-        )
-        .await?;
+        let did =
+            epigraph_engine::edge_factor::recompute_claim_belief_on_frame(pool, claim_id, frame_id)
+                .await?;
         if did {
             written += 1;
         }

--- a/crates/epigraph-cli/src/bin/recompute_claim_belief.rs
+++ b/crates/epigraph-cli/src/bin/recompute_claim_belief.rs
@@ -1,0 +1,217 @@
+//! One-shot operator binary: recompute cached `claims.{belief, plausibility,
+//! pignistic_prob, conflict_k, missing_mass}` from current
+//! `mass_functions` state for a list of claim_ids.
+//!
+//! Use case: after a script directly mutates `mass_functions.source_strength`
+//! (e.g. the locality-aware backfill in
+//! `scripts/backfill_intra_source_evidence_discount.py`), the BBA data is
+//! correct but the cached BetP on `claims` is stale because the write
+//! bypassed `edge_factor::wire_evidential_edge_factor` (the production
+//! path that calls `recompute_claim_belief_binary`).
+//!
+//! The HTTP API exposes `/api/v1/sheaf/reconcile`, but that's a GLOBAL
+//! obstruction-resolver — only touches the most-inconsistent clusters,
+//! leaving the bulk of an affected backfill population stale. This binary
+//! invokes the canonical per-claim, per-frame recompute directly.
+//!
+//! Frame handling: for each input claim, looks up every distinct
+//! `frame_id` in `mass_functions` and recomputes per-frame via
+//! `edge_factor::recompute_claim_belief_on_frame`. `claims.{belief, pl,
+//! pignistic_prob, ...}` are frame-agnostic scalars — last writer wins.
+//! Per-claim frames are processed in lexicographic frame-name order so
+//! two runs against the same population converge to the same cached value.
+//!
+//! Reads claim_ids from a file (one UUID per line) or `--stdin`.
+//!
+//! Usage:
+//!     epigraph-recompute-belief --input /tmp/claim_ids.txt
+//!     epigraph-recompute-belief --stdin < /tmp/claim_ids.txt
+//!     epigraph-recompute-belief --input /tmp/claim_ids.txt --dry-run
+//!
+//! Concurrency is `--concurrency` (default 8). Each task is one DB round-trip
+//! to fetch BBAs + one round-trip to write the recomputed belief. On a local
+//! Postgres ~10–20 claims/sec per worker is typical. 15 000 claims at 8
+//! workers ≈ 2–3 minutes.
+
+use clap::Parser;
+use std::io::BufRead;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "recompute_claim_belief",
+    about = "Per-claim CDST recompute from current mass_functions state"
+)]
+struct Cli {
+    /// File with one claim UUID per line. Lines starting with `#` and blank
+    /// lines are ignored.
+    #[arg(long)]
+    input: Option<PathBuf>,
+    /// Read claim UUIDs from stdin instead of a file (one per line).
+    #[arg(long, conflicts_with = "input")]
+    stdin: bool,
+    /// Concurrency for the recompute fan-out. Default 8.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+    /// Print what would be recomputed without writing.
+    #[arg(long)]
+    dry_run: bool,
+    /// Print a progress line every N completions. Default 100.
+    #[arg(long, default_value_t = 100)]
+    progress_every: usize,
+}
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let cli = Cli::parse();
+    if let Err(e) = run(cli).await {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    // Read the claim list first — fail fast if the file is missing /
+    // unparseable, before touching the DB.
+    let claim_ids = read_claim_ids(&cli)?;
+    println!("loaded {} claim ids", claim_ids.len());
+    if claim_ids.is_empty() {
+        println!("nothing to do");
+        return Ok(());
+    }
+
+    if cli.dry_run {
+        println!("DRY-RUN — would recompute belief on {} claims", claim_ids.len());
+        return Ok(());
+    }
+
+    let pool = epigraph_cli::db_connect().await?;
+    let total = claim_ids.len();
+    let done = Arc::new(AtomicUsize::new(0));
+    let claims_with_work = Arc::new(AtomicUsize::new(0));
+    let claims_empty = Arc::new(AtomicUsize::new(0));
+    let frame_writes = Arc::new(AtomicUsize::new(0));
+    let errors = Arc::new(AtomicUsize::new(0));
+
+    // Bounded concurrent fan-out via tokio Semaphore. Each task may issue
+    // multiple per-frame recomputes for one claim — bounding at the
+    // claim level keeps the pool ceiling predictable.
+    let sem = Arc::new(tokio::sync::Semaphore::new(cli.concurrency.max(1)));
+    let mut handles = Vec::with_capacity(claim_ids.len());
+    for claim_id in claim_ids {
+        let permit = sem.clone().acquire_owned().await?;
+        let pool = pool.clone();
+        let done = done.clone();
+        let claims_with_work = claims_with_work.clone();
+        let claims_empty = claims_empty.clone();
+        let frame_writes = frame_writes.clone();
+        let errors = errors.clone();
+        let progress_every = cli.progress_every;
+        handles.push(tokio::spawn(async move {
+            let _permit = permit;
+            match recompute_one_claim_all_frames(&pool, claim_id).await {
+                Ok(written) => {
+                    if written > 0 {
+                        claims_with_work.fetch_add(1, Ordering::Relaxed);
+                        frame_writes.fetch_add(written, Ordering::Relaxed);
+                    } else {
+                        claims_empty.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                Err(e) => {
+                    errors.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("  {claim_id}: {e}");
+                }
+            }
+            let n = done.fetch_add(1, Ordering::Relaxed) + 1;
+            if progress_every > 0 && n.is_multiple_of(progress_every) {
+                println!(
+                    "  [{n}/{total}] claims_recomputed={} frame_writes={} empty={} errors={}",
+                    claims_with_work.load(Ordering::Relaxed),
+                    frame_writes.load(Ordering::Relaxed),
+                    claims_empty.load(Ordering::Relaxed),
+                    errors.load(Ordering::Relaxed),
+                );
+            }
+        }));
+    }
+
+    for h in handles {
+        let _ = h.await;
+    }
+
+    println!(
+        "done: {} claims recomputed across {} (claim, frame) writes, {} had no BBAs, {} errors (of {total})",
+        claims_with_work.load(Ordering::Relaxed),
+        frame_writes.load(Ordering::Relaxed),
+        claims_empty.load(Ordering::Relaxed),
+        errors.load(Ordering::Relaxed),
+    );
+    if errors.load(Ordering::Relaxed) > 0 {
+        std::process::exit(2);
+    }
+    Ok(())
+}
+
+/// Discover every distinct `frame_id` this claim has BBAs on, ordered by
+/// the frame's name, and recompute each. Frame-name ordering gives a
+/// deterministic last-writer for the cached `claims.{belief, pl, betp, ...}`
+/// scalars so that two runs against the same population converge.
+///
+/// Returns the number of (claim, frame) pairs that produced a recompute.
+async fn recompute_one_claim_all_frames(
+    pool: &sqlx::PgPool,
+    claim_id: Uuid,
+) -> Result<usize, String> {
+    let rows: Vec<(Uuid, String)> = sqlx::query_as(
+        "SELECT DISTINCT mf.frame_id, f.name \
+           FROM mass_functions mf \
+           JOIN frames f ON f.id = mf.frame_id \
+          WHERE mf.claim_id = $1 \
+          ORDER BY f.name",
+    )
+    .bind(claim_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("list frames for claim: {e}"))?;
+    let mut written = 0usize;
+    for (frame_id, _frame_name) in rows {
+        let did = epigraph_engine::edge_factor::recompute_claim_belief_on_frame(
+            pool, claim_id, frame_id,
+        )
+        .await?;
+        if did {
+            written += 1;
+        }
+    }
+    Ok(written)
+}
+
+fn read_claim_ids(cli: &Cli) -> Result<Vec<Uuid>, Box<dyn std::error::Error>> {
+    let reader: Box<dyn BufRead> = if cli.stdin {
+        Box::new(std::io::BufReader::new(std::io::stdin()))
+    } else if let Some(path) = &cli.input {
+        Box::new(std::io::BufReader::new(std::fs::File::open(path)?))
+    } else {
+        return Err("must pass --input <file> or --stdin".into());
+    };
+
+    let mut ids = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        ids.push(Uuid::parse_str(trimmed).map_err(|e| format!("bad uuid {trimmed:?}: {e}"))?);
+    }
+    Ok(ids)
+}

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -239,7 +239,37 @@ pub async fn auto_wire_edge_if_epistemic(
 /// `propagate_to_dependents`) can share the cascade.
 pub async fn recompute_claim_belief_binary(pool: &PgPool, claim_id: Uuid) -> Result<bool, String> {
     let frame_id = ensure_binary_frame(pool).await?;
-    let frame = binary_frame()?;
+    recompute_claim_belief_on_frame(pool, claim_id, frame_id).await
+}
+
+/// Generalized variant of [`recompute_claim_belief_binary`] for any frame.
+///
+/// Used by operator one-shots (e.g.
+/// `epigraph-cli/src/bin/recompute_claim_belief.rs`) that need to refresh
+/// the cached BetP after a direct mutation to `mass_functions.source_strength`
+/// landed on a non-binary frame (research_validity, textbook_veracity_*, ...).
+/// The `claims.{belief, plausibility, pignistic_prob, ...}` columns are
+/// frame-agnostic scalars — last writer wins — so for claims with BBAs
+/// across multiple frames, the caller is responsible for ordering
+/// per-frame recomputes deterministically.
+///
+/// Returns `Ok(false)` if the claim has no BBAs on `frame_id`.
+///
+/// # Errors
+/// String error if the frame row can't be loaded, the frame's hypothesis
+/// list can't be parsed into a `FrameOfDiscernment`, or any DS combination
+/// step fails.
+pub async fn recompute_claim_belief_on_frame(
+    pool: &PgPool,
+    claim_id: Uuid,
+    frame_id: Uuid,
+) -> Result<bool, String> {
+    let row = FrameRepository::get_by_id(pool, frame_id)
+        .await
+        .map_err(|e| format!("frame get_by_id: {e}"))?
+        .ok_or_else(|| format!("frame {frame_id} not found"))?;
+    let frame = FrameOfDiscernment::new(row.name.clone(), row.hypotheses.clone())
+        .map_err(|e| format!("build frame {}: {e}", row.name))?;
     let all_rows = MassFunctionRepository::get_for_claim_frame(pool, claim_id, frame_id)
         .await
         .map_err(|e| format!("get_for_claim_frame: {e}"))?;


### PR DESCRIPTION
## Why
Tonight's locality backfill (#192 + #193) merged. I ran ``scripts/backfill_intra_source_evidence_discount.py --execute --scope 0.85`` against prod. UPDATE landed on **74 711 BBAs / 15 949 claims** — but the script's reconcile loop POSTs to ``/api/v1/graph/reconcile_sheaf`` which is the wrong URL (actual is ``/api/v1/sheaf/reconcile``). All 15 949 calls returned 404. Even with the right URL, that route is a GLOBAL obstruction-resolver — it ran once and only touched 251 nodes, not the 15 949 we needed.

The cached BetP on ``claims.{belief, plausibility, pignistic_prob, ...}`` for the 15 949 was stale until I built this binary and ran it. It's done now (results below), but the binary + engine API need to land so the followup operator scripts have a canonical path.

## What this adds
**`crates/epigraph-engine/src/edge_factor.rs`** — new pub `recompute_claim_belief_on_frame(pool, claim_id, frame_id)`. Generalizes the existing binary-only `recompute_claim_belief_binary` to any frame in the system. Loads the frame row, builds a `FrameOfDiscernment` from its hypotheses, combines BBAs on (claim, frame), writes the result. Index-0 hypothesis convention (positive/dominant) carries over to non-binary frames cleanly: `research_validity[supported, unsupported]`, `textbook_veracity_*[accurate, inaccurate]`, etc.

**`crates/epigraph-cli/src/bin/recompute_claim_belief.rs`** — operator one-shot. Reads claim_ids from a file (`--input`) or stdin (`--stdin`), fans out to bounded `--concurrency` tokio tasks (default 8). For each claim, lists distinct `mass_functions.frame_id` rows ordered by frame name (deterministic last-writer so re-runs converge) and recomputes each (claim, frame) pair.

## Production run results

```
$ DATABASE_URL=... ./recompute_claim_belief --input /tmp/locality-backfill-affected-claims.txt --concurrency 8
loaded 15949 claim ids
  [1000/15949] claims_recomputed=1000 frame_writes=1835 empty=0 errors=0
  ...
done: 15949 claims recomputed across 29369 (claim, frame) writes,
  0 had no BBAs, 0 errors (of 15949)
```

~2 minutes total. Avg 1.84 frames per claim (matches expectation — many claims have BBAs on both `research_validity` AND `textbook_veracity_openstax_*` frames). 

**Verification — sample of 100 affected claims:**
- avg `pignistic_prob` = 0.516
- SD = 0.025
- 100/100 within [0.40, 0.65]

This is the bug #142 fix at the consumer layer: the over-confident "19 intra-source supporters → BetP 0.99" pattern is now visible at the BetP scalar, not just in the BBAs.

## Test plan
- [x] Engine builds clean (`cargo build -p epigraph-engine`)
- [x] CLI builds clean (`cargo build --release -p epigraph-cli --bin recompute_claim_belief`)
- [x] Spot-check on 3 claims (`--input /tmp/spot-check-ids.txt`): 3 claims, 5 frame writes, BetP deltas all negative and in expected magnitude
- [x] Full production run on 15 949 claims: 0 errors, 29 369 (claim, frame) writes, post-hoc sample confirms regression toward 0.5 on the discounted population
- [ ] No new tests added — the function-under-test is a thin generalization of `recompute_claim_belief_binary` (already exercised by `intra_source_discount_regression.rs`). The binary itself is a one-shot operator tool, not exercised by the regression suite. Could add an integration test that seeds BBAs on a non-binary frame and asserts the recompute writes the right BetP — happy to do that as a followup if you want it before merge.

## Followup PR worth opening separately
`scripts/backfill_intra_source_evidence_discount.py` still POSTs to the non-existent `/api/v1/graph/reconcile_sheaf` URL. The script's reconcile loop should be replaced with an emit-claim-ids-to-stdout step + pipe into `recompute_claim_belief`. Decouples "discount the BBAs" from "refresh the cached BetP" — they have different consistency models (UPDATE is one transaction, recompute is per-claim and idempotent). Not in this PR; commit message lists it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)