### PR TITLE
feat(db): mass_functions.locality_tag column + write-path plumbing (Phase 1a of #197)

### DIFF
--- a/crates/epigraph-api/src/routes/assess.rs
+++ b/crates/epigraph-api/src/routes/assess.rs
@@ -221,6 +221,7 @@ pub async fn assess_claim(
         Some("discount"),
         None,
         None,
+        "unknown", // assess endpoint lacks the source/target paper context (issue #197)
     )
     .await?;
 
@@ -353,6 +354,7 @@ pub async fn assess_claim(
         &combined_json,
         final_k,
         final_method,
+        "unknown", // combined result; locality is per-input, not aggregate (issue #197)
     )
     .await;
 

--- a/crates/epigraph-api/src/routes/belief.rs
+++ b/crates/epigraph-api/src/routes/belief.rs
@@ -1065,6 +1065,7 @@ pub async fn submit_evidence(
         Some("discount"),
         Some(request.reliability),
         None,
+        "unknown", // locality not known at HTTP belief endpoint; see issue #197
     )
     .await?;
 
@@ -1296,6 +1297,7 @@ pub async fn submit_evidence(
         &combined_json,
         final_k,
         final_method,
+        "unknown", // combined result; locality is per-input, not aggregate (issue #197)
     )
     .await;
 

--- a/crates/epigraph-api/src/routes/experiment_loop.rs
+++ b/crates/epigraph-api/src/routes/experiment_loop.rs
@@ -410,6 +410,7 @@ pub async fn analyze_result(
         &masses_json,
         None,
         Some("error_derived"),
+        "unknown", // experiment-derived; no evidence-DOI vs paper comparison (issue #197)
     )
     .await
     .map_err(|e| ApiError::InternalError {

--- a/crates/epigraph-api/src/routes/hypothesis.rs
+++ b/crates/epigraph-api/src/routes/hypothesis.rs
@@ -153,6 +153,7 @@ pub async fn create_hypothesis(
         &vacuous_masses,
         None,
         Some("prior"),
+        "unknown", // vacuous prior; no evidence yet (issue #197)
     )
     .await
     .map_err(|e| ApiError::InternalError {

--- a/crates/epigraph-cli/src/bin/experiment.rs
+++ b/crates/epigraph-cli/src/bin/experiment.rs
@@ -485,6 +485,7 @@ async fn analyze(
         &masses_json,
         None,
         Some("error_derived"),
+        "unknown", // experiment-derived; no evidence-DOI vs paper comparison (issue #197)
     )
     .await?;
 

--- a/crates/epigraph-cli/src/bin/hypothesis.rs
+++ b/crates/epigraph-cli/src/bin/hypothesis.rs
@@ -194,6 +194,7 @@ async fn create(
         &vacuous_masses,
         None,
         Some("prior"),
+        "unknown", // vacuous prior; no evidence yet (issue #197)
     )
     .await?;
 

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -41,6 +41,7 @@ impl MassFunctionRepository {
     ///
     /// # Errors
     /// Returns `DbError::QueryFailed` if the database query fails.
+    #[allow(clippy::too_many_arguments)]
     #[instrument(skip(pool, masses_json))]
     pub async fn store(
         pool: &PgPool,

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -21,6 +21,13 @@ pub struct MassFunctionRow {
     pub combination_method: Option<String>,
     pub source_strength: Option<f64>, // NEW: Shafer reliability discount weight
     pub evidence_type: Option<String>, // NEW: evidence classification tag
+    /// Locality classification of this BBA's evidence vs. its claim's
+    /// asserting paper. Values: 'intra', 'cross', 'unknown'. Populated
+    /// by `wire_evidential_edge_factor` (via `auto_wire_ds_for_edge`)
+    /// when the source claim's evidence DOI matches the target's paper.
+    /// Defaults to 'unknown' on the column; not nullable. See issue #197
+    /// and migration 045_mass_functions_locality_tag.sql.
+    pub locality_tag: String,
     pub created_at: DateTime<Utc>,
 }
 
@@ -43,6 +50,7 @@ impl MassFunctionRepository {
         masses_json: &serde_json::Value,
         conflict_k: Option<f64>,
         combination_method: Option<&str>,
+        locality_tag: &str, // 'intra' | 'cross' | 'unknown' (issue #197)
     ) -> Result<Uuid, DbError> {
         Self::store_with_perspective(
             pool,
@@ -55,6 +63,7 @@ impl MassFunctionRepository {
             combination_method,
             None,
             None,
+            locality_tag,
         )
         .await
     }
@@ -76,20 +85,22 @@ impl MassFunctionRepository {
         masses_json: &serde_json::Value,
         conflict_k: Option<f64>,
         combination_method: Option<&str>,
-        source_strength: Option<f64>, // NEW: Shafer reliability discount weight
-        evidence_type: Option<&str>,  // NEW: evidence classification tag
+        source_strength: Option<f64>, // Shafer reliability discount weight
+        evidence_type: Option<&str>,  // evidence classification tag
+        locality_tag: &str, // 'intra' | 'cross' | 'unknown'; column NOT NULL default 'unknown' (issue #197)
     ) -> Result<Uuid, DbError> {
         let row: (Uuid,) = sqlx::query_as(
             r#"
             INSERT INTO mass_functions
-                (claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                (claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, locality_tag)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (claim_id, frame_id, source_agent_id, perspective_id) DO UPDATE
             SET masses = EXCLUDED.masses,
                 conflict_k = EXCLUDED.conflict_k,
                 combination_method = EXCLUDED.combination_method,
                 source_strength = EXCLUDED.source_strength,
                 evidence_type = EXCLUDED.evidence_type,
+                locality_tag = EXCLUDED.locality_tag,
                 created_at = NOW()
             RETURNING id
             "#,
@@ -103,6 +114,7 @@ impl MassFunctionRepository {
         .bind(combination_method)
         .bind(source_strength)
         .bind(evidence_type)
+        .bind(locality_tag)
         .fetch_one(pool)
         .await?;
 
@@ -123,7 +135,7 @@ impl MassFunctionRepository {
     ) -> Result<Vec<MassFunctionRow>, DbError> {
         let rows: Vec<MassFunctionRow> = sqlx::query_as(
             r#"
-            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, created_at
+            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, locality_tag, created_at
             FROM mass_functions
             WHERE claim_id = $1 AND frame_id = $2
             ORDER BY created_at ASC
@@ -145,7 +157,7 @@ impl MassFunctionRepository {
     pub async fn get_by_id(pool: &PgPool, id: Uuid) -> Result<Option<MassFunctionRow>, DbError> {
         let row: Option<MassFunctionRow> = sqlx::query_as(
             r#"
-            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, created_at
+            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, locality_tag, created_at
             FROM mass_functions
             WHERE id = $1
             "#,
@@ -169,7 +181,7 @@ impl MassFunctionRepository {
     ) -> Result<Vec<MassFunctionRow>, DbError> {
         let rows: Vec<MassFunctionRow> = sqlx::query_as(
             r#"
-            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, created_at
+            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, locality_tag, created_at
             FROM mass_functions
             WHERE claim_id = $1
             ORDER BY frame_id, created_at ASC
@@ -195,7 +207,7 @@ impl MassFunctionRepository {
     ) -> Result<Vec<MassFunctionRow>, DbError> {
         let rows: Vec<MassFunctionRow> = sqlx::query_as(
             r#"
-            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, created_at
+            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, locality_tag, created_at
             FROM mass_functions
             WHERE claim_id = $1 AND frame_id = $2 AND perspective_id = $3
             ORDER BY created_at ASC
@@ -223,7 +235,7 @@ impl MassFunctionRepository {
     ) -> Result<Vec<MassFunctionRow>, DbError> {
         let rows: Vec<MassFunctionRow> = sqlx::query_as(
             r#"
-            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, created_at
+            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, locality_tag, created_at
             FROM mass_functions
             WHERE claim_id = $1 AND frame_id = $2 AND perspective_id = ANY($3)
             ORDER BY created_at ASC
@@ -348,7 +360,7 @@ impl MassFunctionRepository {
     ) -> Result<Vec<MassFunctionRow>, DbError> {
         let rows: Vec<MassFunctionRow> = sqlx::query_as(
             r#"
-            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, created_at
+            SELECT id, claim_id, frame_id, source_agent_id, perspective_id, masses, conflict_k, combination_method, source_strength, evidence_type, locality_tag, created_at
             FROM mass_functions
             WHERE frame_id = $1
             ORDER BY claim_id, created_at ASC
@@ -374,7 +386,7 @@ impl MassFunctionRepository {
             r#"
             SELECT id, claim_id, frame_id, source_agent_id, perspective_id,
                    masses, conflict_k, combination_method,
-                   source_strength, evidence_type, created_at
+                   source_strength, evidence_type, locality_tag, created_at
             FROM mass_functions
             WHERE claim_id = ANY($1)
             ORDER BY claim_id, created_at ASC
@@ -425,6 +437,7 @@ mod tests {
             &masses,
             None,
             Some("test"),
+            "unknown",
         )
         .await
         .unwrap();
@@ -436,6 +449,7 @@ mod tests {
             &masses,
             None,
             Some("test"),
+            "unknown",
         )
         .await
         .unwrap();
@@ -495,6 +509,7 @@ mod tests {
             Some("first"),
             Some(0.7),
             Some("auto_wire"),
+            "unknown",
         )
         .await
         .unwrap();
@@ -510,6 +525,7 @@ mod tests {
             Some("second"),
             Some(0.9),
             Some("auto_wire"),
+            "unknown",
         )
         .await
         .unwrap();
@@ -649,6 +665,7 @@ mod tests {
             combination_method: Some("dempster".to_string()),
             source_strength: Some(0.9),
             evidence_type: Some("rct".to_string()),
+            locality_tag: "unknown".to_string(),
             created_at: Utc::now(),
         };
     }

--- a/crates/epigraph-db/tests/mass_function_locality_tag_roundtrip.rs
+++ b/crates/epigraph-db/tests/mass_function_locality_tag_roundtrip.rs
@@ -1,0 +1,197 @@
+//! Round-trip test for `mass_functions.locality_tag` (Phase 1a of issue #197).
+//!
+//! Asserts that the column persists end-to-end:
+//!   * `store_with_perspective("intra")` → row reads back `locality_tag = "intra"`
+//!   * Same for `"cross"` and `"unknown"`
+//!   * A raw INSERT that omits the column lets the NOT NULL DEFAULT 'unknown'
+//!     fire — covers the migration 045 default, which is the legacy/backfill
+//!     path that EVERY one of the 279 894 existing BBAs will land on at
+//!     deploy time (before Phase 1b backfill SQL rewrites them).
+//!
+//! Layered against the regression test in `epigraph-engine`: that one
+//! verifies the edge_factor path emits `intra` / `cross` correctly through
+//! the full write-and-discount pipeline. This one is the tight unit-level
+//! round-trip on the repo signature itself, so a future widening of the
+//! `MassFunctionRow` struct or the INSERT column list doesn't silently drop
+//! the tag and pass only the higher-level integration test by accident.
+
+use epigraph_db::{MassFunctionRepository, MassFunctionRow};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn distinct_hash(tag: u32) -> Vec<u8> {
+    let mut h = vec![0u8; 32];
+    h[0] = (tag & 0xff) as u8;
+    h[1] = ((tag >> 8) & 0xff) as u8;
+    h[2] = ((tag >> 16) & 0xff) as u8;
+    h
+}
+
+async fn seed_agent(pool: &PgPool, tag: u32) -> Uuid {
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, $2)")
+        .bind(agent_id)
+        .bind(distinct_hash(tag))
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    agent_id
+}
+
+async fn seed_claim(pool: &PgPool, agent_id: Uuid, tag: u32) -> Uuid {
+    let claim_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current) \
+         VALUES ($1, $2, $3, $4, 0.5, true)",
+    )
+    .bind(claim_id)
+    .bind(format!("locality-roundtrip-claim-{tag:x}"))
+    .bind(distinct_hash(tag))
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("seed claim");
+    claim_id
+}
+
+async fn seed_frame(pool: &PgPool, tag: u32) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO frames (name, hypotheses) VALUES ($1, '{\"TRUE\",\"FALSE\"}') RETURNING id",
+    )
+    .bind(format!("locality-roundtrip-frame-{tag:x}"))
+    .fetch_one(pool)
+    .await
+    .expect("seed frame")
+}
+
+async fn fetch_row(pool: &PgPool, claim_id: Uuid, frame_id: Uuid) -> MassFunctionRow {
+    let rows = MassFunctionRepository::get_for_claim_frame(pool, claim_id, frame_id)
+        .await
+        .expect("get_for_claim_frame");
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected exactly one BBA after a single store call, got {}",
+        rows.len()
+    );
+    rows.into_iter().next().unwrap()
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn store_with_perspective_roundtrips_intra_tag(pool: PgPool) {
+    let agent = seed_agent(&pool, 0xE1_0001).await;
+    let claim = seed_claim(&pool, agent, 0xE1_0002).await;
+    let frame = seed_frame(&pool, 0xE1_0003).await;
+    let masses = json!({"0": 0.6, "0,1": 0.4});
+
+    MassFunctionRepository::store_with_perspective(
+        &pool,
+        claim,
+        frame,
+        Some(agent),
+        None,
+        &masses,
+        None,
+        Some("test"),
+        Some(0.21),
+        Some("supports"),
+        "intra",
+    )
+    .await
+    .expect("store intra");
+
+    let row = fetch_row(&pool, claim, frame).await;
+    assert_eq!(row.locality_tag, "intra");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn store_with_perspective_roundtrips_cross_tag(pool: PgPool) {
+    let agent = seed_agent(&pool, 0xE2_0001).await;
+    let claim = seed_claim(&pool, agent, 0xE2_0002).await;
+    let frame = seed_frame(&pool, 0xE2_0003).await;
+    let masses = json!({"0": 0.6, "0,1": 0.4});
+
+    MassFunctionRepository::store_with_perspective(
+        &pool,
+        claim,
+        frame,
+        Some(agent),
+        None,
+        &masses,
+        None,
+        Some("test"),
+        Some(0.7),
+        Some("supports"),
+        "cross",
+    )
+    .await
+    .expect("store cross");
+
+    let row = fetch_row(&pool, claim, frame).await;
+    assert_eq!(row.locality_tag, "cross");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn store_with_perspective_roundtrips_unknown_tag(pool: PgPool) {
+    let agent = seed_agent(&pool, 0xE3_0001).await;
+    let claim = seed_claim(&pool, agent, 0xE3_0002).await;
+    let frame = seed_frame(&pool, 0xE3_0003).await;
+    let masses = json!({"0": 0.6, "0,1": 0.4});
+
+    MassFunctionRepository::store_with_perspective(
+        &pool,
+        claim,
+        frame,
+        Some(agent),
+        None,
+        &masses,
+        None,
+        Some("test"),
+        None,
+        None,
+        "unknown",
+    )
+    .await
+    .expect("store unknown");
+
+    let row = fetch_row(&pool, claim, frame).await;
+    assert_eq!(row.locality_tag, "unknown");
+}
+
+/// Verifies migration 045's column default. A raw INSERT that omits
+/// `locality_tag` from the column list must let the DEFAULT 'unknown'
+/// fire — this is the path every legacy row will take at deploy until the
+/// Phase 1b backfill SQL rewrites them.
+///
+/// Important: this test does NOT route through `store_with_perspective`,
+/// because that function explicitly binds `locality_tag` to every INSERT.
+/// We need raw SQL to test the column default itself.
+#[sqlx::test(migrations = "../../migrations")]
+async fn raw_insert_without_locality_tag_defaults_to_unknown(pool: PgPool) {
+    let agent = seed_agent(&pool, 0xE4_0001).await;
+    let claim = seed_claim(&pool, agent, 0xE4_0002).await;
+    let frame = seed_frame(&pool, 0xE4_0003).await;
+    let masses = json!({"0": 0.6, "0,1": 0.4});
+
+    // Direct INSERT omitting `locality_tag` from the column list.
+    // The NOT NULL constraint must be satisfied by the column DEFAULT
+    // 'unknown' set in migration 045.
+    sqlx::query(
+        "INSERT INTO mass_functions (claim_id, frame_id, source_agent_id, masses) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(claim)
+    .bind(frame)
+    .bind(agent)
+    .bind(&masses)
+    .execute(&pool)
+    .await
+    .expect("raw INSERT without locality_tag should rely on column DEFAULT");
+
+    let row = fetch_row(&pool, claim, frame).await;
+    assert_eq!(
+        row.locality_tag, "unknown",
+        "column DEFAULT 'unknown' must fire when INSERT omits locality_tag"
+    );
+}

--- a/crates/epigraph-db/tests/perspective_evidence_fk_tests.rs
+++ b/crates/epigraph-db/tests/perspective_evidence_fk_tests.rs
@@ -112,6 +112,7 @@ async fn mass_function_store_with_synthetic_perspective_succeeds(pool: PgPool) -
         Some("auto_wire"),
         Some(0.7),
         Some("observation"),
+        "unknown",
     )
     .await;
     assert!(
@@ -134,6 +135,7 @@ async fn mass_function_store_with_synthetic_perspective_succeeds(pool: PgPool) -
         Some("auto_wire"),
         Some(0.7),
         Some("observation"),
+        "unknown",
     )
     .await
     .expect("store with materialized perspective should succeed");

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -179,6 +179,13 @@ pub async fn auto_wire_ds_for_edge(
         .await
         .map_err(|e| format!("ensure_edge_perspective: {e}"))?;
 
+    // Phase 1a (issue #197): persist the locality classification we just
+    // computed into a dedicated column. The current combine path still reads
+    // `source_strength` (which is already composed with `locality_factor`
+    // above); the tag is metadata so the backfill script and Phase 2 combine
+    // path can stop inferring typing from the numeric value-set.
+    let locality_tag = if is_intra { "intra" } else { "cross" };
+
     MassFunctionRepository::store_with_perspective(
         pool,
         target_id,
@@ -190,6 +197,7 @@ pub async fn auto_wire_ds_for_edge(
         Some("edge_factor"),
         Some(source_strength),
         Some(relationship),
+        locality_tag,
     )
     .await
     .map_err(|e| format!("store BBA: {e}"))?;

--- a/crates/epigraph-engine/tests/intra_source_discount_regression.rs
+++ b/crates/epigraph-engine/tests/intra_source_discount_regression.rs
@@ -260,6 +260,25 @@ async fn intra_source_19_supporters_betp_in_band(pool: PgPool) {
         "expected all 19 BBAs to carry the composed intra-source discount, got {composed_count}"
     );
 
+    // Phase 1a (#197): every supporter BBA was written through edge_factor
+    // with is_intra = true, so locality_tag must persist as 'intra'. This
+    // assertion locks the typing column independent of the numeric
+    // source_strength band — a future calibration shift that nudged the
+    // composed value outside [0.075, 0.405] would not break the typing
+    // contract.
+    let intra_tag_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mass_functions \
+         WHERE claim_id = $1 AND locality_tag = 'intra'",
+    )
+    .bind(target_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count locality_tag = intra rows");
+    assert_eq!(
+        intra_tag_count, 19,
+        "expected all 19 BBAs to carry locality_tag = 'intra', got {intra_tag_count}"
+    );
+
     let betp = read_betp(&pool, target_id)
         .await
         .expect("target should have computed BetP after 19 supporter wires");
@@ -347,6 +366,20 @@ async fn cross_source_19_supporters_keeps_high_betp(pool: PgPool) {
     assert_eq!(
         cross_row_count, 19,
         "expected all 19 BBAs to land in the cross-source transmission band [0.5, 0.9], got {cross_row_count}"
+    );
+
+    // Phase 1a (#197): typing column must reflect cross-source classification.
+    let cross_tag_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mass_functions \
+         WHERE claim_id = $1 AND locality_tag = 'cross'",
+    )
+    .bind(target_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count locality_tag = cross rows");
+    assert_eq!(
+        cross_tag_count, 19,
+        "expected all 19 BBAs to carry locality_tag = 'cross', got {cross_tag_count}"
     );
 
     let betp = read_betp(&pool, target_id)
@@ -483,5 +516,33 @@ async fn per_frame_locality_factor_override_applied(pool: PgPool) {
     assert!(
         primer_ss < 0.30,
         "primer BBA (written pre-override) should still carry default-factor discount (<0.30), got {primer_ss}"
+    );
+
+    // Phase 1a (#197): both primer (pre-override, default 0.3 factor) and
+    // override-affected supporter (per-frame 0.9 factor) seeded
+    // doi-evidence rows pointing at the target's paper, so both went
+    // through the is_intra = true branch of edge_factor. Per-frame override
+    // changes the discount factor, NOT the locality classification — that
+    // invariant is what this assertion locks.
+    let primer_tag: String =
+        sqlx::query_scalar("SELECT locality_tag FROM mass_functions WHERE perspective_id = $1")
+            .bind(primer_edge)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch primer locality_tag");
+    assert_eq!(
+        primer_tag, "intra",
+        "primer BBA must carry locality_tag = 'intra' (intra evidence regardless of per-frame factor)"
+    );
+
+    let override_tag: String =
+        sqlx::query_scalar("SELECT locality_tag FROM mass_functions WHERE perspective_id = $1")
+            .bind(edge_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch override locality_tag");
+    assert_eq!(
+        override_tag, "intra",
+        "override BBA must carry locality_tag = 'intra' (per-frame factor changes only the discount, not the classification)"
     );
 }

--- a/crates/epigraph-mcp/src/tools/ds.rs
+++ b/crates/epigraph-mcp/src/tools/ds.rs
@@ -166,6 +166,7 @@ pub async fn submit_ds_evidence(
         Some(&method_name),
         None,
         None,
+        "unknown", // MCP ds entrypoint lacks evidence-DOI vs paper context (issue #197)
     )
     .await
     .map_err(internal_error)?;

--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -192,6 +192,7 @@ pub async fn auto_wire_ds_for_claim(
         Some("auto_wire"),
         Some(weight),  // source_strength = evidence-type reliability
         evidence_type, // evidence_type
+        "unknown",     // ds_auto single-evidence path; locality lives on edge_factor (issue #197)
     )
     .await
     .map_err(|e| format!("store BBA: {e}"))?;
@@ -284,6 +285,7 @@ pub async fn auto_wire_ds_update(
         Some("auto_wire"),
         Some(weight),      // source_strength = evidence-type reliability
         evidence_type_str, // evidence_type
+        "unknown",         // ds_auto evidence path; locality not derived here (issue #197)
     )
     .await
     .map_err(|e| format!("store BBA: {e}"))?;
@@ -399,6 +401,7 @@ async fn wire_single_batch_entry(
         Some("auto_wire"),
         Some(entry.weight), // source_strength = evidence-type reliability
         None,               // evidence_type (not threaded through batch yet)
+        "unknown",          // batch ds_auto path; no per-entry locality (issue #197)
     )
     .await
     .map_err(|e| format!("store BBA: {e}"))?;

--- a/migrations/045_mass_functions_locality_tag.sql
+++ b/migrations/045_mass_functions_locality_tag.sql
@@ -1,0 +1,20 @@
+-- Migration 045: add mass_functions.locality_tag for explicit BBA typing.
+--
+-- See issue #197 and docs/superpowers/plans/2026-05-28-locality-tag-schema.md.
+--
+-- Phase 1a of the locality-tag work: additive column + index + default.
+-- Forward write paths populate this column in the same PR; backfill of the
+-- existing 279 894 rows is a separate one-shot SQL (Phase 1b) AFTER deploy.
+
+ALTER TABLE mass_functions
+    ADD COLUMN locality_tag varchar(20) NOT NULL DEFAULT 'unknown';
+
+CREATE INDEX idx_mass_functions_locality_tag ON mass_functions(locality_tag);
+
+COMMENT ON COLUMN mass_functions.locality_tag IS
+    'Locality classification of this BBA''s underlying evidence relative '
+    'to its claim''s asserting paper. Values: intra (evidence cites the '
+    'same paper that asserts the claim), cross (evidence is from a '
+    'different paper), unknown (no evidence row attached, or pre-locality '
+    'classification). Read at combine-time with evidence_type to compute '
+    'effective source_strength dynamically. See issue #197.';


### PR DESCRIPTION
## Summary

Phase 1a of #197 — stop inferring BBA typing from `source_strength` (the
tier-collision idempotency bug: `1.0 × 0.3 = 0.3 = conversational tier`).

This PR is purely additive — schema + forward write-path + tests. No math
changes. Phase 1b (backfill SQL for the 279k existing rows) and Phase 2
(combine path reads the tag) follow in separate PRs.

## What changed

- **`migrations/045_mass_functions_locality_tag.sql`**: adds
  `locality_tag varchar(20) NOT NULL DEFAULT 'unknown'` + index + comment.
- **`crates/epigraph-db/src/repos/mass_function.rs`**:
  - `MassFunctionRow.locality_tag: String` (non-optional — column has a default)
  - All 8 `SELECT` lists widened
  - `store_with_perspective(.., locality_tag: &str)` — added to INSERT
    column list AND the `ON CONFLICT DO UPDATE SET` list (so re-upserts
    persist the tag too)
  - `store(.., locality_tag: &str)` thin wrapper updated to match
- **`crates/epigraph-engine/src/edge_factor.rs::auto_wire_ds_for_edge`**:
  passes the `is_intra` it already computes as `"intra"` / `"cross"`.
- **All other callers** (`ds_auto.rs` ×3, `ds.rs`, `assess.rs` ×2,
  `belief.rs` ×2, `experiment_loop.rs`, `hypothesis.rs`,
  `cli/experiment.rs`, `cli/hypothesis.rs`, `perspective_evidence_fk_tests.rs` ×2):
  pass `"unknown"` — they lack the source/target paper context to derive
  locality.

## Tests

- **`intra_source_discount_regression.rs`** (existing): adds three new
  assertions — 19 BBAs `locality_tag = 'intra'` in the intra case, 19
  `'cross'` in the cross case, and BOTH primer + override BBAs `'intra'`
  in the per-frame override case (override changes the discount factor,
  not the locality classification).
- **`mass_function_locality_tag_roundtrip.rs`** (new): four tests —
  round-trip `'intra'`, `'cross'`, `'unknown'` through
  `store_with_perspective`, plus a raw-SQL INSERT case that verifies the
  migration's column DEFAULT fires (the path every legacy row will land
  on before Phase 1b).

## sqlx prepare

Not needed — `mass_function.rs` uses runtime `sqlx::query_as("...")`
strings, not the `query_as!` macro.

## Verification (5 commands per the dispatch plan)

```
cargo build -p epigraph-db -p epigraph-engine -p epigraph-mcp -p epigraph-api -p epigraph-cli
→ Finished `dev` profile [unoptimized + debuginfo] target(s)

DATABASE_URL=postgres://epigraph:epigraph@localhost:5432/epigraph_db_repo_test cargo test -p epigraph-engine --test intra_source_discount_regression
→ running 3 tests
  test cross_source_19_supporters_keeps_high_betp ... ok
  test intra_source_19_supporters_betp_in_band ... ok
  test per_frame_locality_factor_override_applied ... ok
  test result: ok. 3 passed; 0 failed; 0 ignored

DATABASE_URL=postgres://epigraph:epigraph@localhost:5432/epigraph_db_repo_test cargo test -p epigraph-db --test mass_function_locality_tag_roundtrip
→ running 4 tests
  test raw_insert_without_locality_tag_defaults_to_unknown ... ok
  test store_with_perspective_roundtrips_cross_tag ... ok
  test store_with_perspective_roundtrips_intra_tag ... ok
  test store_with_perspective_roundtrips_unknown_tag ... ok
  test result: ok. 4 passed; 0 failed; 0 ignored

cargo test -p epigraph-engine --lib
→ test result: ok. 332 passed; 0 failed; 0 ignored

cargo test -p epigraph-db --lib  (with DATABASE_URL same as above)
→ test result: ok. 72 passed; 0 failed; 10 ignored

cargo fmt --check
→ EXIT=0
```

## Out of scope (deferred to follow-ups, not this PR)

- Backfilling `locality_tag` on the 279 894 existing rows (Phase 1b — one-shot SQL after deploy)
- Changing combine math to compute `effective_source_strength` from the tag (Phase 2)
- `mass_functions.evidence_id` FK (Phase 3)

Refs #197.