### PR TITLE
feat: per-perspective source-reliability frame function (compute-on-read)

### DIFF
--- a/crates/epigraph-api/src/routes/belief.rs
+++ b/crates/epigraph-api/src/routes/belief.rs
@@ -102,6 +102,13 @@ pub struct SubmitEvidenceRequest {
     /// Reliability discount factor [0, 1]. 1.0 = fully reliable.
     #[serde(default = "default_reliability")]
     pub reliability: f64,
+    /// Optional evidence-source tag (e.g. "western_clinical",
+    /// "practitioner_interview") stored on the BBA so per-perspective
+    /// source-reliability maps (the frame function) can re-weight this evidence
+    /// per observer at query time. See
+    /// `epigraph_engine::belief_query::get_perspective_belief`.
+    #[serde(default)]
+    pub evidence_type: Option<String>,
     /// Conflict threshold for adaptive combination
     #[serde(default = "default_conflict_threshold")]
     pub conflict_threshold: f64,
@@ -1064,7 +1071,7 @@ pub async fn submit_evidence(
         None,
         Some("discount"),
         Some(request.reliability),
-        None,
+        request.evidence_type.as_deref(),
         "unknown", // locality not known at HTTP belief endpoint; see issue #197
         None,      // HTTP belief endpoint has no evidence row in scope (issue #197 Phase 3)
     )

--- a/crates/epigraph-db/src/repos/perspective.rs
+++ b/crates/epigraph-db/src/repos/perspective.rs
@@ -19,7 +19,44 @@ pub struct PerspectiveRow {
     pub frame_ids: Option<Vec<Uuid>>,
     pub extraction_method: Option<String>,
     pub confidence_calibration: Option<f64>,
+    /// Free-form jsonb. The frame-function feature reads
+    /// `properties->'source_reliability'` — a map of evidence-type tag →
+    /// reliability α ∈ [0,1] — to discount a shared evidence corpus from this
+    /// perspective's viewpoint. See [`PerspectiveRow::source_reliability`].
+    pub properties: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
+}
+
+impl PerspectiveRow {
+    /// Per-perspective source-reliability map: evidence-type tag → α ∈ [0,1],
+    /// read from `properties->'source_reliability'`.
+    ///
+    /// This is the "frame function": it lets one observer down-weight, say,
+    /// `practitioner_interview` evidence to 0.4 while another trusts it at 1.0,
+    /// yielding different beliefs over the *same* evidence. Returns `None` when
+    /// the key is absent (the perspective falls back to legacy own-BBA scoping)
+    /// and silently skips any entry whose value is not a finite number in
+    /// `[0, 1]`.
+    #[must_use]
+    pub fn source_reliability(&self) -> Option<std::collections::HashMap<String, f64>> {
+        let obj = self
+            .properties
+            .as_ref()?
+            .get("source_reliability")?
+            .as_object()?;
+        let map: std::collections::HashMap<String, f64> = obj
+            .iter()
+            .filter_map(|(k, v)| {
+                let a = v.as_f64()?;
+                (a.is_finite() && (0.0..=1.0).contains(&a)).then(|| (k.clone(), a))
+            })
+            .collect();
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
+        }
+    }
 }
 
 /// Repository for Perspective operations
@@ -49,7 +86,7 @@ impl PerspectiveRepository {
                  extraction_method, confidence_calibration)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING id, name, description, owner_agent_id, perspective_type,
-                      frame_ids, extraction_method, confidence_calibration, created_at
+                      frame_ids, extraction_method, confidence_calibration, properties, created_at
             "#,
         )
         .bind(name)
@@ -63,6 +100,42 @@ impl PerspectiveRepository {
         .await?;
 
         Ok(row)
+    }
+
+    /// Set this perspective's source-reliability map (the frame function),
+    /// merging it into `properties` under the `source_reliability` key without
+    /// disturbing other `properties` entries.
+    ///
+    /// `reliability` maps an evidence-type tag (matching `mass_functions.
+    /// evidence_type`) to α ∈ [0,1]. Pass an empty map to clear the override
+    /// (the perspective then falls back to legacy own-BBA scoping).
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool, reliability))]
+    pub async fn set_source_reliability(
+        pool: &PgPool,
+        id: Uuid,
+        reliability: &std::collections::HashMap<String, f64>,
+    ) -> Result<(), DbError> {
+        let value = serde_json::to_value(reliability).unwrap_or(serde_json::Value::Null);
+        sqlx::query(
+            r#"
+            UPDATE perspectives
+            SET properties = jsonb_set(
+                COALESCE(properties, '{}'::jsonb),
+                '{source_reliability}',
+                $2::jsonb,
+                true
+            )
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .bind(value)
+        .execute(pool)
+        .await?;
+        Ok(())
     }
 
     /// Ensure a synthetic "evidence_grounded" perspective row exists with the
@@ -132,7 +205,7 @@ impl PerspectiveRepository {
         let row: Option<PerspectiveRow> = sqlx::query_as(
             r#"
             SELECT id, name, description, owner_agent_id, perspective_type,
-                   frame_ids, extraction_method, confidence_calibration, created_at
+                   frame_ids, extraction_method, confidence_calibration, properties, created_at
             FROM perspectives
             WHERE id = $1
             "#,
@@ -158,7 +231,7 @@ impl PerspectiveRepository {
         let rows: Vec<PerspectiveRow> = sqlx::query_as(
             r#"
             SELECT id, name, description, owner_agent_id, perspective_type,
-                   frame_ids, extraction_method, confidence_calibration, created_at
+                   frame_ids, extraction_method, confidence_calibration, properties, created_at
             FROM perspectives
             WHERE owner_agent_id = $1
             ORDER BY created_at DESC
@@ -187,7 +260,7 @@ impl PerspectiveRepository {
         let rows: Vec<PerspectiveRow> = sqlx::query_as(
             r#"
             SELECT id, name, description, owner_agent_id, perspective_type,
-                   frame_ids, extraction_method, confidence_calibration, created_at
+                   frame_ids, extraction_method, confidence_calibration, properties, created_at
             FROM perspectives
             ORDER BY created_at DESC
             LIMIT $1 OFFSET $2
@@ -217,6 +290,7 @@ mod tests {
             frame_ids: Some(vec![Uuid::new_v4()]),
             extraction_method: Some("ai_generated".to_string()),
             confidence_calibration: Some(0.8),
+            properties: Some(serde_json::json!({})),
             created_at: Utc::now(),
         };
     }
@@ -232,7 +306,71 @@ mod tests {
             frame_ids: None,
             extraction_method: None,
             confidence_calibration: None,
+            properties: None,
             created_at: Utc::now(),
         };
+    }
+
+    #[test]
+    fn source_reliability_parses_valid_map() {
+        let row = make_row(Some(serde_json::json!({
+            "source_reliability": {
+                "western_clinical": 0.95,
+                "practitioner_interview": 0.4
+            }
+        })));
+        let map = row.source_reliability().expect("map present");
+        assert!((map["western_clinical"] - 0.95).abs() < f64::EPSILON);
+        assert!((map["practitioner_interview"] - 0.4).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn source_reliability_none_when_key_absent() {
+        let row = make_row(Some(serde_json::json!({"other": 1})));
+        assert!(row.source_reliability().is_none());
+        let row_null = make_row(None);
+        assert!(row_null.source_reliability().is_none());
+    }
+
+    #[test]
+    fn source_reliability_skips_out_of_range_and_nonnumeric() {
+        // 1.5 (>1), -0.2 (<0), and "high" (non-numeric) must be dropped;
+        // only the valid 0.6 entry survives.
+        let row = make_row(Some(serde_json::json!({
+            "source_reliability": {
+                "too_big": 1.5,
+                "negative": -0.2,
+                "stringy": "high",
+                "ok": 0.6
+            }
+        })));
+        let map = row.source_reliability().expect("one valid entry");
+        assert_eq!(map.len(), 1);
+        assert!((map["ok"] - 0.6).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn source_reliability_none_when_all_entries_invalid() {
+        // An object that parses but yields zero valid entries is None, not
+        // Some(empty) — so the caller cleanly falls back to legacy scoping.
+        let row = make_row(Some(serde_json::json!({
+            "source_reliability": { "bad": 2.0 }
+        })));
+        assert!(row.source_reliability().is_none());
+    }
+
+    fn make_row(properties: Option<serde_json::Value>) -> PerspectiveRow {
+        PerspectiveRow {
+            id: Uuid::new_v4(),
+            name: "observer".to_string(),
+            description: None,
+            owner_agent_id: None,
+            perspective_type: Some("analytical".to_string()),
+            frame_ids: None,
+            extraction_method: None,
+            confidence_calibration: None,
+            properties,
+            created_at: Utc::now(),
+        }
     }
 }

--- a/crates/epigraph-engine/src/belief_query.rs
+++ b/crates/epigraph-engine/src/belief_query.rs
@@ -327,7 +327,10 @@ mod tests {
             .unwrap()
             .unwrap();
         let (sb, bb) = (bel_h0(&frame, &s), bel_h0(&frame, &b));
-        assert!(sb < bb, "skeptic {sb} should believe less than believer {bb}");
+        assert!(
+            sb < bb,
+            "skeptic {sb} should believe less than believer {bb}"
+        );
         assert!(sb > 0.0 && bb < 1.0);
     }
 

--- a/crates/epigraph-engine/src/belief_query.rs
+++ b/crates/epigraph-engine/src/belief_query.rs
@@ -9,7 +9,10 @@
 use std::collections::BTreeSet;
 
 use epigraph_core::ClaimId;
-use epigraph_db::{ClaimRepository, FrameRepository, MassFunctionRepository, PgPool};
+use epigraph_db::{
+    ClaimRepository, FrameRepository, MassFunctionRepository, MassFunctionRow,
+    PerspectiveRepository, PgPool,
+};
 use epigraph_ds::{
     combination::{self, CombinationMethod},
     FocalElement, FrameOfDiscernment, MassFunction,
@@ -168,4 +171,207 @@ pub async fn get_belief(
         .ok_or(BeliefQueryError::ClaimNotFound(claim_id))?;
 
     Ok(BeliefInterval::cached_from_truth(claim.truth_value.value()))
+}
+
+/// Compute a **perspective-scoped** belief on demand — the "frame function".
+///
+/// This is `get_belief`'s framed path re-weighted from one observer's
+/// viewpoint: every stored BBA on `(claim, frame)` is Shafer-discounted by the
+/// perspective's reliability for that BBA's `evidence_type` tag before
+/// combination. Because it recomputes from the labelled BBAs, it works
+/// regardless of how the evidence was ingested — there is no cache to populate
+/// and no dependency on a particular write path. A perspective with no
+/// `source_reliability` map (or an absent perspective) discounts nothing, so it
+/// reproduces the global `get_belief` value.
+///
+/// # Errors
+/// `FrameNotFound` if `frame_id` is absent; `ParseMasses`/`Ds` on malformed or
+/// uncombinable BBAs; `Db` on query failure.
+pub async fn get_perspective_belief(
+    pool: &PgPool,
+    claim_id: Uuid,
+    frame_id: Uuid,
+    perspective_id: Uuid,
+) -> Result<BeliefInterval, BeliefQueryError> {
+    let frame_row = FrameRepository::get_by_id(pool, frame_id)
+        .await?
+        .ok_or(BeliefQueryError::FrameNotFound(frame_id))?;
+    let frame = FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone())?;
+
+    let assignment = FrameRepository::get_claim_assignment(pool, claim_id, frame_id).await?;
+    let hypothesis_index = assignment.and_then(|a| a.hypothesis_index).unwrap_or(0) as usize;
+
+    let all_bbas = MassFunctionRepository::get_for_claim_frame(pool, claim_id, frame_id).await?;
+    if all_bbas.is_empty() {
+        return Ok(BeliefInterval::empty_frame(frame.hypothesis_count()));
+    }
+
+    // The perspective's source-reliability map; None when the perspective is
+    // absent or declares no map → no discount → equals the global belief.
+    let reliability = PerspectiveRepository::get_by_id(pool, perspective_id)
+        .await?
+        .and_then(|p| p.source_reliability());
+
+    let combined = combine_perspective_masses(&all_bbas, reliability.as_ref(), &frame)?
+        .expect("all_bbas is non-empty so combination yields Some");
+
+    let target = FocalElement::positive(BTreeSet::from([hypothesis_index]));
+    Ok(BeliefInterval {
+        belief: epigraph_ds::measures::belief(&combined, &target),
+        plausibility: epigraph_ds::measures::plausibility(&combined, &target),
+        pignistic_prob: epigraph_ds::measures::pignistic_probability(&combined, hypothesis_index),
+        mass_on_conflict: combined.mass_of_conflict(),
+        mass_on_missing: combined.mass_of_missing(),
+        framed: true,
+        source: "recomputed_perspective".to_string(),
+    })
+}
+
+/// Discount each BBA by `reliability[evidence_type]` (α = 1.0 when the tag is
+/// `None` or unmapped) and Dempster-combine, mirroring `get_belief`'s framed
+/// combination. Returns `Ok(None)` only when `rows` is empty.
+///
+/// Pure given its inputs (no DB), so the frame-function math is unit-testable
+/// without seeding a claim/frame.
+pub fn combine_perspective_masses(
+    rows: &[MassFunctionRow],
+    reliability: Option<&std::collections::HashMap<String, f64>>,
+    frame: &FrameOfDiscernment,
+) -> Result<Option<MassFunction>, BeliefQueryError> {
+    let mut mass_fns: Vec<MassFunction> = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mf = MassFunction::from_json_masses(frame.clone(), &row.masses)
+            .map_err(BeliefQueryError::ParseMasses)?;
+        let alpha = reliability
+            .and_then(|m| row.evidence_type.as_deref().and_then(|t| m.get(t)))
+            .copied()
+            .unwrap_or(1.0);
+        mass_fns.push(combination::discount(&mf, alpha)?);
+    }
+
+    if mass_fns.is_empty() {
+        return Ok(None);
+    }
+    let combined = if mass_fns.len() == 1 {
+        mass_fns.into_iter().next().expect("checked len == 1")
+    } else {
+        let mut result = mass_fns[0].clone();
+        for mf in &mass_fns[1..] {
+            result = combination::redistribute(&result, mf, CombinationMethod::Dempster, None)?;
+        }
+        result
+    };
+    Ok(Some(combined))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use epigraph_ds::measures;
+    use std::collections::{BTreeMap, HashMap};
+
+    fn binary() -> FrameOfDiscernment {
+        FrameOfDiscernment::new("binary", vec!["H0".to_string(), "H1".to_string()]).unwrap()
+    }
+
+    /// A supporting BBA: `mass` on TRUE (H0), the rest on Θ, tagged `evidence_type`.
+    fn row(frame: &FrameOfDiscernment, evidence_type: Option<&str>, mass: f64) -> MassFunctionRow {
+        let mut bba = BTreeMap::new();
+        bba.insert(FocalElement::positive(BTreeSet::from([0])), mass);
+        bba.insert(FocalElement::theta(frame), 1.0 - mass);
+        let mf = MassFunction::new(frame.clone(), bba).unwrap();
+        MassFunctionRow {
+            id: Uuid::new_v4(),
+            claim_id: Uuid::new_v4(),
+            frame_id: Uuid::new_v4(),
+            source_agent_id: None,
+            perspective_id: None,
+            masses: mf.masses_to_json(),
+            conflict_k: None,
+            combination_method: Some("auto_wire".to_string()),
+            source_strength: Some(1.0),
+            evidence_type: evidence_type.map(str::to_string),
+            locality_tag: "unknown".to_string(),
+            evidence_id: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    fn bel_h0(frame: &FrameOfDiscernment, mf: &MassFunction) -> f64 {
+        let _ = frame;
+        measures::belief(mf, &FocalElement::positive(BTreeSet::from([0])))
+    }
+
+    #[test]
+    fn divergent_beliefs_from_same_evidence() {
+        // Same two BBAs (a clinical result + an interview), two observers who
+        // trust the interview differently → different belief in H0.
+        let frame = binary();
+        let rows = [
+            row(&frame, Some("western_clinical"), 0.6),
+            row(&frame, Some("practitioner_interview"), 0.7),
+        ];
+        let skeptic = HashMap::from([
+            ("western_clinical".to_string(), 1.0),
+            ("practitioner_interview".to_string(), 0.3),
+        ]);
+        let believer = HashMap::from([
+            ("western_clinical".to_string(), 1.0),
+            ("practitioner_interview".to_string(), 1.0),
+        ]);
+
+        let s = combine_perspective_masses(&rows, Some(&skeptic), &frame)
+            .unwrap()
+            .unwrap();
+        let b = combine_perspective_masses(&rows, Some(&believer), &frame)
+            .unwrap()
+            .unwrap();
+        let (sb, bb) = (bel_h0(&frame, &s), bel_h0(&frame, &b));
+        assert!(sb < bb, "skeptic {sb} should believe less than believer {bb}");
+        assert!(sb > 0.0 && bb < 1.0);
+    }
+
+    #[test]
+    fn neutral_perspective_reproduces_global() {
+        // An all-α=1.0 believer and the no-map (global) case must combine
+        // identically — neutral observer == global belief.
+        let frame = binary();
+        let rows = [
+            row(&frame, Some("western_clinical"), 0.6),
+            row(&frame, Some("practitioner_interview"), 0.7),
+        ];
+        let believer = HashMap::from([
+            ("western_clinical".to_string(), 1.0),
+            ("practitioner_interview".to_string(), 1.0),
+        ]);
+        let with_map = combine_perspective_masses(&rows, Some(&believer), &frame)
+            .unwrap()
+            .unwrap();
+        let no_map = combine_perspective_masses(&rows, None, &frame)
+            .unwrap()
+            .unwrap();
+        assert!((bel_h0(&frame, &with_map) - bel_h0(&frame, &no_map)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn untagged_evidence_is_not_discounted() {
+        // A BBA with no evidence_type passes through at α=1.0 even when the
+        // perspective has a (non-matching) map — you can't down-weight what you
+        // can't identify.
+        let frame = binary();
+        let tagged = [row(&frame, None, 0.8)];
+        let map = HashMap::from([("practitioner_interview".to_string(), 0.1)]);
+        let out = combine_perspective_masses(&tagged, Some(&map), &frame)
+            .unwrap()
+            .unwrap();
+        assert!((bel_h0(&frame, &out) - 0.8).abs() < 1e-12);
+    }
+
+    #[test]
+    fn empty_rows_yield_none() {
+        let frame = binary();
+        assert!(combine_perspective_masses(&[], None, &frame)
+            .unwrap()
+            .is_none());
+    }
 }

--- a/crates/epigraph-engine/tests/perspective_frame_function.rs
+++ b/crates/epigraph-engine/tests/perspective_frame_function.rs
@@ -50,7 +50,10 @@ async fn store_bba(
     mass: f64,
 ) {
     let mut bba = std::collections::BTreeMap::new();
-    bba.insert(FocalElement::positive(std::collections::BTreeSet::from([0])), mass);
+    bba.insert(
+        FocalElement::positive(std::collections::BTreeSet::from([0])),
+        mass,
+    );
     bba.insert(FocalElement::theta(frame), 1.0 - mass);
     let mf = MassFunction::new(frame.clone(), bba).unwrap();
     MassFunctionRepository::store_with_perspective(
@@ -88,16 +91,48 @@ async fn get_perspective_belief_diverges_by_observer(pool: PgPool) {
         FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
 
     // Shared corpus: a clinical result + a practitioner interview, both for H0.
-    store_bba(&pool, claim_id, frame_id, agent, &frame, "western_clinical", 0.6).await;
-    store_bba(&pool, claim_id, frame_id, agent, &frame, "practitioner_interview", 0.7).await;
+    store_bba(
+        &pool,
+        claim_id,
+        frame_id,
+        agent,
+        &frame,
+        "western_clinical",
+        0.6,
+    )
+    .await;
+    store_bba(
+        &pool,
+        claim_id,
+        frame_id,
+        agent,
+        &frame,
+        "practitioner_interview",
+        0.7,
+    )
+    .await;
 
     let skeptic = PerspectiveRepository::create(
-        &pool, "skeptic", None, None, Some("analytical"), &[], None, None,
+        &pool,
+        "skeptic",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
     )
     .await
     .expect("skeptic");
     let believer = PerspectiveRepository::create(
-        &pool, "believer", None, None, Some("analytical"), &[], None, None,
+        &pool,
+        "believer",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
     )
     .await
     .expect("believer");
@@ -122,12 +157,16 @@ async fn get_perspective_belief_diverges_by_observer(pool: PgPool) {
     .await
     .expect("believer map");
 
-    let skeptic_belief =
-        epigraph_engine::belief_query::get_perspective_belief(&pool, claim_id, frame_id, skeptic.id)
-            .await
-            .expect("skeptic belief");
+    let skeptic_belief = epigraph_engine::belief_query::get_perspective_belief(
+        &pool, claim_id, frame_id, skeptic.id,
+    )
+    .await
+    .expect("skeptic belief");
     let believer_belief = epigraph_engine::belief_query::get_perspective_belief(
-        &pool, claim_id, frame_id, believer.id,
+        &pool,
+        claim_id,
+        frame_id,
+        believer.id,
     )
     .await
     .expect("believer belief");
@@ -170,16 +209,35 @@ async fn unmapped_perspective_equals_global(pool: PgPool) {
     .expect("frame");
     let frame =
         FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
-    store_bba(&pool, claim_id, frame_row.id, agent, &frame, "practitioner_interview", 0.7).await;
+    store_bba(
+        &pool,
+        claim_id,
+        frame_row.id,
+        agent,
+        &frame,
+        "practitioner_interview",
+        0.7,
+    )
+    .await;
 
     let plain = PerspectiveRepository::create(
-        &pool, "plain", None, None, Some("analytical"), &[], None, None,
+        &pool,
+        "plain",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
     )
     .await
     .expect("plain perspective");
 
     let scoped = epigraph_engine::belief_query::get_perspective_belief(
-        &pool, claim_id, frame_row.id, plain.id,
+        &pool,
+        claim_id,
+        frame_row.id,
+        plain.id,
     )
     .await
     .expect("scoped belief");

--- a/crates/epigraph-engine/tests/perspective_frame_function.rs
+++ b/crates/epigraph-engine/tests/perspective_frame_function.rs
@@ -1,0 +1,190 @@
+//! Integration test for the per-perspective source-reliability "frame
+//! function": `belief_query::get_perspective_belief` must read the claim's
+//! stored BBAs, discount each by the queried perspective's reliability for its
+//! `evidence_type`, and combine — so two observers reach different beliefs from
+//! the SAME evidence, with no dependency on how that evidence was ingested.
+
+use std::collections::HashMap;
+
+use epigraph_db::{FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool};
+use epigraph_ds::{FocalElement, FrameOfDiscernment, MassFunction};
+use uuid::Uuid;
+
+async fn insert_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, created_at, updated_at) \
+         VALUES ($1, sha256($1::text::bytea), NOW(), NOW())",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("agent");
+    id
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let content = format!("claim {id}");
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id) \
+         VALUES ($1, $2, sha256($2::bytea), 0.5, $3)",
+    )
+    .bind(id)
+    .bind(&content)
+    .bind(agent)
+    .execute(pool)
+    .await
+    .expect("claim");
+    id
+}
+
+/// Store a supporting BBA (mass on TRUE=H0, rest on Θ) tagged with `evidence_type`.
+async fn store_bba(
+    pool: &PgPool,
+    claim_id: Uuid,
+    frame_id: Uuid,
+    agent: Uuid,
+    frame: &FrameOfDiscernment,
+    evidence_type: &str,
+    mass: f64,
+) {
+    let mut bba = std::collections::BTreeMap::new();
+    bba.insert(FocalElement::positive(std::collections::BTreeSet::from([0])), mass);
+    bba.insert(FocalElement::theta(frame), 1.0 - mass);
+    let mf = MassFunction::new(frame.clone(), bba).unwrap();
+    MassFunctionRepository::store_with_perspective(
+        pool,
+        claim_id,
+        frame_id,
+        Some(agent),
+        None,
+        &mf.masses_to_json(),
+        None,
+        Some("discount"),
+        Some(1.0),
+        Some(evidence_type),
+        "unknown",
+        None,
+    )
+    .await
+    .expect("store bba");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_perspective_belief_diverges_by_observer(pool: PgPool) {
+    let agent = insert_agent(&pool).await;
+    let claim_id = insert_claim(&pool, agent).await;
+    let frame_row = FrameRepository::create(
+        &pool,
+        "ff_binary",
+        None,
+        &["H0".to_string(), "H1".to_string()],
+    )
+    .await
+    .expect("frame");
+    let frame_id = frame_row.id;
+    let frame =
+        FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
+
+    // Shared corpus: a clinical result + a practitioner interview, both for H0.
+    store_bba(&pool, claim_id, frame_id, agent, &frame, "western_clinical", 0.6).await;
+    store_bba(&pool, claim_id, frame_id, agent, &frame, "practitioner_interview", 0.7).await;
+
+    let skeptic = PerspectiveRepository::create(
+        &pool, "skeptic", None, None, Some("analytical"), &[], None, None,
+    )
+    .await
+    .expect("skeptic");
+    let believer = PerspectiveRepository::create(
+        &pool, "believer", None, None, Some("analytical"), &[], None, None,
+    )
+    .await
+    .expect("believer");
+    PerspectiveRepository::set_source_reliability(
+        &pool,
+        skeptic.id,
+        &HashMap::from([
+            ("western_clinical".to_string(), 1.0),
+            ("practitioner_interview".to_string(), 0.3),
+        ]),
+    )
+    .await
+    .expect("skeptic map");
+    PerspectiveRepository::set_source_reliability(
+        &pool,
+        believer.id,
+        &HashMap::from([
+            ("western_clinical".to_string(), 1.0),
+            ("practitioner_interview".to_string(), 1.0),
+        ]),
+    )
+    .await
+    .expect("believer map");
+
+    let skeptic_belief =
+        epigraph_engine::belief_query::get_perspective_belief(&pool, claim_id, frame_id, skeptic.id)
+            .await
+            .expect("skeptic belief");
+    let believer_belief = epigraph_engine::belief_query::get_perspective_belief(
+        &pool, claim_id, frame_id, believer.id,
+    )
+    .await
+    .expect("believer belief");
+
+    // Same stored evidence, different observer reliability → different belief.
+    assert!(
+        skeptic_belief.belief < believer_belief.belief,
+        "skeptic ({}) should believe H0 less than believer ({})",
+        skeptic_belief.belief,
+        believer_belief.belief
+    );
+    assert_eq!(skeptic_belief.source, "recomputed_perspective");
+
+    // The all-α=1.0 believer must equal the global (no-perspective) belief —
+    // a neutral observer adds no discount.
+    let global = epigraph_engine::belief_query::get_belief(&pool, claim_id, Some(frame_id))
+        .await
+        .expect("global belief");
+    assert!(
+        (believer_belief.belief - global.belief).abs() < 1e-9,
+        "neutral believer ({}) must match global ({})",
+        believer_belief.belief,
+        global.belief
+    );
+}
+
+/// A perspective with no source_reliability map must reproduce the global
+/// belief exactly (no silent divergence for un-configured observers).
+#[sqlx::test(migrations = "../../migrations")]
+async fn unmapped_perspective_equals_global(pool: PgPool) {
+    let agent = insert_agent(&pool).await;
+    let claim_id = insert_claim(&pool, agent).await;
+    let frame_row = FrameRepository::create(
+        &pool,
+        "ff_binary2",
+        None,
+        &["H0".to_string(), "H1".to_string()],
+    )
+    .await
+    .expect("frame");
+    let frame =
+        FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
+    store_bba(&pool, claim_id, frame_row.id, agent, &frame, "practitioner_interview", 0.7).await;
+
+    let plain = PerspectiveRepository::create(
+        &pool, "plain", None, None, Some("analytical"), &[], None, None,
+    )
+    .await
+    .expect("plain perspective");
+
+    let scoped = epigraph_engine::belief_query::get_perspective_belief(
+        &pool, claim_id, frame_row.id, plain.id,
+    )
+    .await
+    .expect("scoped belief");
+    let global = epigraph_engine::belief_query::get_belief(&pool, claim_id, Some(frame_row.id))
+        .await
+        .expect("global belief");
+    assert!((scoped.belief - global.belief).abs() < 1e-9);
+}

--- a/crates/epigraph-mcp/src/tools/ds.rs
+++ b/crates/epigraph-mcp/src/tools/ds.rs
@@ -406,6 +406,42 @@ pub async fn scoped_belief(
         }
     };
 
+    // Frame function: when a frame is given for a perspective scope, compute the
+    // belief live from the claim's labelled BBAs — each discounted by this
+    // perspective's source-reliability map — rather than reading the cache. This
+    // reflects current evidence no matter how it was ingested.
+    if scope_type == "perspective" {
+        if let Some(frame_id_str) = params.frame_id.as_deref() {
+            let frame_id = parse_uuid(frame_id_str)?;
+            let interval = epigraph_engine::belief_query::get_perspective_belief(
+                &server.pool,
+                claim_id,
+                frame_id,
+                scope_id,
+            )
+            .await
+            .map_err(|e| match e {
+                epigraph_engine::BeliefQueryError::FrameNotFound(id) => {
+                    invalid_params(format!("frame {id} not found"))
+                }
+                epigraph_engine::BeliefQueryError::ParseMasses(msg) => {
+                    invalid_params(format!("invalid mass function: {msg}"))
+                }
+                other => internal_error(other),
+            })?;
+            return success_json(&ScopedBeliefResponse {
+                claim_id: claim_id.to_string(),
+                scope_type: scope_type.to_string(),
+                scope_id: scope_id.to_string(),
+                belief: interval.belief,
+                plausibility: interval.plausibility,
+                mass_on_conflict: interval.mass_on_conflict,
+                mass_on_missing: interval.mass_on_missing,
+                pignistic_prob: Some(interval.pignistic_prob),
+            });
+        }
+    }
+
     let row = ScopedBeliefRepository::get(&server.pool, claim_id, scope_type, Some(scope_id))
         .await
         .map_err(internal_error)?

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -582,6 +582,16 @@ pub struct ScopedBeliefParams {
 
     #[schemars(description = "UUID of the perspective or community")]
     pub scope_id: String,
+
+    #[schemars(
+        description = "Optional frame UUID. When set with scope_type='perspective', the \
+                       belief is computed live from the claim's BBAs, each discounted by \
+                       this perspective's source-reliability map (the frame function), so \
+                       it reflects current evidence regardless of ingest path. When \
+                       omitted, returns the cached scoped belief if one exists."
+    )]
+    #[serde(default)]
+    pub frame_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]


### PR DESCRIPTION
## What

Lets different observers reach **different beliefs from the same evidence** by labelling evidence with a source type and discounting each BBA by the *querying perspective's* reliability for that type — computed live at query time. There is no cache to populate and no dependency on a particular write/ingest path: if the BBAs are labelled, any perspective can re-weight them.

This generalises `get_belief` (global, compute-on-read) to a per-observer lens.

## How

- **epigraph-db** — `PerspectiveRow` gains a `properties` jsonb column accessor `source_reliability()` that parses `properties->'source_reliability'` (evidence-type tag → α ∈ [0,1]), dropping out-of-range/non-numeric entries and returning `None` when absent so callers fall back cleanly. `PerspectiveRepository::set_source_reliability` writes the map via `jsonb_set` without disturbing other `properties`.
- **epigraph-engine** — `belief_query::get_perspective_belief` mirrors `get_belief`'s framed path, Shafer-discounting each stored BBA by the perspective's α for its `evidence_type` before Dempster combination. The pure core `combine_perspective_masses` is unit-tested. A perspective with **no map** (or an untagged BBA) discounts nothing, so it reproduces the global belief exactly.
- **epigraph-mcp** — `scoped_belief` accepts an optional `frame_id`; with it, a `perspective` scope is computed live via the engine rather than read from the `ds_combined_beliefs` cache.
- **epigraph-api** — `SubmitEvidenceRequest` accepts an optional `evidence_type`, stored on the BBA so submitted evidence carries a source tag.

## Semantics

- α = retained reliability (1.0 = identity). Neutral / unmapped perspective ⇒ global belief.
- Untagged or unmapped sources pass through at α = 1.0 — you can't down-weight what you can't identify.
- The perspective path combines via `combine_multiple`/Dempster like the existing scope; for **independent** evidence a neutral perspective matches the global belief (they can diverge for dependent evidence, same as the prior scope behaviour).

## Tests

- 4 unit — `source_reliability()` parsing/validation (valid map, absent key, out-of-range/non-numeric dropped, all-invalid ⇒ None).
- 4 unit — `combine_perspective_masses`: divergent beliefs from same evidence, neutral == global, untagged passthrough, empty ⇒ None.
- 2 `#[sqlx::test]` integration — `get_perspective_belief` diverges by observer over identical stored evidence; an unmapped perspective equals the global belief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)