### PR TITLE
feat(engine): per-frame evidence-type weight overrides (Phase 4 of #197)

### DIFF
--- a/crates/epigraph-db/src/repos/frame.rs
+++ b/crates/epigraph-db/src/repos/frame.rs
@@ -5,7 +5,8 @@
 use crate::errors::DbError;
 use chrono::{DateTime, Utc};
 use sqlx::{FromRow, PgPool};
-use tracing::instrument;
+use std::collections::HashMap;
+use tracing::{instrument, warn};
 use uuid::Uuid;
 
 /// A row from the frames table.
@@ -15,6 +16,13 @@ use uuid::Uuid;
 ///   * `intra_evidence_locality_factor` (float) — locality-discount
 ///     multiplier for this frame; overrides `calibration.toml`'s global
 ///     default when set.
+///   * `evidence_type_weights` (object) — per-frame override map for
+///     evidence-type weights (Phase 4 of issue #197). Keys are
+///     evidence-type strings (lowercased on read), values are floats
+///     in `[0.0, 1.0]`. Patches the global `calibration.toml`
+///     `[evidence_type_weights]` table at combine time for this frame
+///     only. See `get_per_frame_evidence_type_weights` /
+///     `set_evidence_type_weight`.
 #[derive(Debug, Clone, FromRow)]
 pub struct FrameRow {
     pub id: Uuid,
@@ -373,6 +381,133 @@ impl FrameRepository {
         .execute(pool)
         .await?;
         Ok(())
+    }
+
+    /// Read the per-frame `evidence_type_weights` override map, if any.
+    /// Phase 4 of issue #197.
+    ///
+    /// Returns `Ok(None)` when:
+    ///   * the frame row doesn't exist,
+    ///   * `properties` does not contain the `evidence_type_weights` key,
+    ///   * the key's value is not a JSON object (operator wrote garbage),
+    ///   * the JSON object is empty after parsing (no usable entries).
+    ///
+    /// Object entries are parsed:
+    ///   * key normalised to lowercase (matches
+    ///     `CalibrationConfig::get_evidence_type_weight`),
+    ///   * value coerced via `as_f64()`; non-numeric values are dropped
+    ///     with a `warn!` log (operator misspelled the weight),
+    ///   * values outside `[0.0, 1.0]` are dropped with a `warn!` log.
+    ///     The `[0.0, 1.0]` clamp matches Shafer's reliability semantics
+    ///     (a discount, not an amplification). This is the Phase 4 Q10
+    ///     locked decision — operators wanting `reference > 1.0` for
+    ///     textbook frames are out of scope; widen later if needed.
+    ///
+    /// Callers fall back to `CalibrationConfig::get_evidence_type_weight`
+    /// when this returns `None` or when the returned map does not contain
+    /// the BBA's evidence-type key.
+    ///
+    /// **Vocabulary warning**: this accessor does NOT warn on unknown
+    /// keys (keys not in `calibration.evidence_type_weights` ∪ aliases ∪
+    /// relationship-vocab). That warning happens at the call-site in
+    /// `recompute_combined_belief`, which has the `CalibrationConfig`
+    /// loaded — keeping the repo layer dependency-free of engine types.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` only on actual DB failure. Missing
+    /// rows / missing keys / malformed JSON return `Ok(None)`, not an
+    /// error — the consumer is expected to fall back to the global
+    /// calibration in that case.
+    #[instrument(skip(pool))]
+    pub async fn get_per_frame_evidence_type_weights(
+        pool: &PgPool,
+        frame_id: Uuid,
+    ) -> Result<Option<HashMap<String, f64>>, DbError> {
+        let row: Option<(Option<serde_json::Value>,)> =
+            sqlx::query_as("SELECT properties->'evidence_type_weights' FROM frames WHERE id = $1")
+                .bind(frame_id)
+                .fetch_optional(pool)
+                .await?;
+        let Some((Some(value),)) = row else {
+            return Ok(None);
+        };
+        let serde_json::Value::Object(obj) = value else {
+            warn!(
+                %frame_id,
+                "per-frame evidence_type_weights override is not a JSON object; ignoring"
+            );
+            return Ok(None);
+        };
+        let mut map: HashMap<String, f64> = HashMap::with_capacity(obj.len());
+        for (raw_key, raw_val) in obj {
+            let Some(w) = raw_val.as_f64() else {
+                warn!(
+                    %frame_id,
+                    key = %raw_key,
+                    "per-frame evidence_type_weights value is not numeric; dropping entry"
+                );
+                continue;
+            };
+            if !(0.0..=1.0).contains(&w) || !w.is_finite() {
+                warn!(
+                    %frame_id,
+                    key = %raw_key,
+                    value = %w,
+                    "per-frame evidence_type_weights value out of [0.0, 1.0]; dropping entry"
+                );
+                continue;
+            }
+            map.insert(raw_key.to_lowercase(), w);
+        }
+        if map.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(map))
+    }
+
+    /// Set a single per-frame evidence-type weight. Convenience wrapper
+    /// over `set_property` for the common single-key write path.
+    /// Phase 4 of issue #197.
+    ///
+    /// Reads the existing `evidence_type_weights` object (if any), merges
+    /// the new key, writes back. The key is NOT normalised on write —
+    /// readers normalise on read, so `"observation"` and `"OBSERVATION"`
+    /// in the JSONB resolve to the same effective entry but the JSONB
+    /// stores what the operator typed (an audit-trail consideration).
+    ///
+    /// Does NOT validate the evidence_type key against calibration;
+    /// operators may pre-register weights for evidence types not yet in
+    /// `calibration.toml`. Validation happens at read time via a warn-log
+    /// at the helper call-site (Q8 locked: loose validation).
+    ///
+    /// Does NOT validate the weight against `[0.0, 1.0]`; range-check
+    /// happens at read time in `get_per_frame_evidence_type_weights`,
+    /// dropping out-of-range entries with a warn-log (Q10 locked).
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` on actual DB failure.
+    #[instrument(skip(pool))]
+    pub async fn set_evidence_type_weight(
+        pool: &PgPool,
+        frame_id: Uuid,
+        evidence_type: &str,
+        weight: f64,
+    ) -> Result<(), DbError> {
+        // Read existing map (raw, NOT through the validating accessor — we
+        // want to preserve any operator-written entries verbatim during
+        // the merge, even ones the validator would drop on read).
+        let row: Option<(Option<serde_json::Value>,)> =
+            sqlx::query_as("SELECT properties->'evidence_type_weights' FROM frames WHERE id = $1")
+                .bind(frame_id)
+                .fetch_optional(pool)
+                .await?;
+        let mut obj = match row {
+            Some((Some(serde_json::Value::Object(map)),)) => map,
+            _ => serde_json::Map::new(),
+        };
+        obj.insert(evidence_type.to_string(), serde_json::Value::from(weight));
+        let merged = serde_json::Value::Object(obj);
+        Self::set_property(pool, frame_id, "evidence_type_weights", &merged).await
     }
 }
 

--- a/crates/epigraph-db/tests/frame_repository_properties.rs
+++ b/crates/epigraph-db/tests/frame_repository_properties.rs
@@ -1,0 +1,317 @@
+//! Repository round-trip tests for `FrameRepository`'s per-frame
+//! evidence-type weight accessors (Phase 4 of issue #197).
+//!
+//! Covers:
+//!   * `set_evidence_type_weight` / `get_per_frame_evidence_type_weights`
+//!     round-trip on canonical and aliased keys.
+//!   * Case normalisation on read (operator writes "Empirical", reader
+//!     sees "empirical").
+//!   * Malformed JSON value: object replaced with a string → Ok(None).
+//!   * Non-numeric weight in an otherwise-valid map: drops bad entry,
+//!     keeps valid ones.
+//!   * Out-of-range weight ([0.0, 1.0] clamp per Q10): dropped with
+//!     warn-log; if only entry, Ok(None).
+//!   * Missing `evidence_type_weights` key (other properties present):
+//!     Ok(None).
+//!   * Missing frame: Ok(None) (graceful, not error).
+//!
+//! All tests use `epigraph_db_repo_test` via `#[sqlx::test]`.
+
+use epigraph_db::FrameRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_frame(pool: &PgPool, name: &str) -> Uuid {
+    let row = FrameRepository::create(
+        pool,
+        name,
+        Some("phase4 test frame"),
+        &["TRUE".to_string(), "FALSE".to_string()],
+    )
+    .await
+    .expect("create frame");
+    row.id
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn roundtrip_canonical_key(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_canonical").await;
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "empirical", 0.5)
+        .await
+        .expect("set weight");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map)");
+    assert_eq!(map.len(), 1, "expected single entry, got {map:?}");
+    let w = map
+        .get("empirical")
+        .copied()
+        .expect("empirical key present");
+    assert!(
+        (w - 0.5).abs() < f64::EPSILON,
+        "expected empirical=0.5 round-trip, got {w}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn roundtrip_multiple_keys(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_multi").await;
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "empirical", 0.5)
+        .await
+        .expect("set empirical");
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "logical", 0.9)
+        .await
+        .expect("set logical");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map)");
+    assert_eq!(map.len(), 2, "expected 2 entries, got {map:?}");
+    assert!((map["empirical"] - 0.5).abs() < f64::EPSILON);
+    assert!((map["logical"] - 0.9).abs() < f64::EPSILON);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn case_normalised_on_read(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_case").await;
+    // Write with mixed case via raw set_property → JSONB stores
+    // "Empirical" literally.
+    FrameRepository::set_property(
+        &pool,
+        frame_id,
+        "evidence_type_weights",
+        &serde_json::json!({"Empirical": 0.7}),
+    )
+    .await
+    .expect("set property");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map)");
+    // Reader lowercases on parse — caller can probe with "empirical".
+    let w = map
+        .get("empirical")
+        .copied()
+        .expect("case-normalised key present");
+    assert!((w - 0.7).abs() < f64::EPSILON);
+    assert!(
+        !map.contains_key("Empirical"),
+        "mixed-case key must not survive lowercasing"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn malformed_value_returns_none(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_malformed").await;
+    // Operator wrote a string under the key instead of an object.
+    FrameRepository::set_property(
+        &pool,
+        frame_id,
+        "evidence_type_weights",
+        &serde_json::json!("not-an-object"),
+    )
+    .await
+    .expect("set property");
+
+    let result = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights");
+    assert!(
+        result.is_none(),
+        "non-object value must return Ok(None), got {result:?}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn non_numeric_entry_dropped_valid_kept(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_nonnum").await;
+    FrameRepository::set_property(
+        &pool,
+        frame_id,
+        "evidence_type_weights",
+        &serde_json::json!({"empirical": "string", "logical": 0.85}),
+    )
+    .await
+    .expect("set property");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map) — logical entry is valid");
+    assert_eq!(
+        map.len(),
+        1,
+        "expected only logical to survive, got {map:?}"
+    );
+    assert!((map["logical"] - 0.85).abs() < f64::EPSILON);
+    assert!(
+        !map.contains_key("empirical"),
+        "non-numeric empirical entry must be dropped"
+    );
+}
+
+/// Phase 4 Q10 locked decision: out-of-range values dropped with warn-log.
+/// 5.0 > 1.0 (the [0.0, 1.0] clamp); the dropped entry is the only one,
+/// so the accessor returns Ok(None).
+#[sqlx::test(migrations = "../../migrations")]
+async fn out_of_range_only_entry_returns_none(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_oor_only").await;
+    FrameRepository::set_property(
+        &pool,
+        frame_id,
+        "evidence_type_weights",
+        &serde_json::json!({"empirical": 5.0}),
+    )
+    .await
+    .expect("set property");
+
+    let result = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights");
+    assert!(
+        result.is_none(),
+        "out-of-range only entry → empty map → Ok(None), got {result:?}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn out_of_range_mixed_drops_bad_keeps_good(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_oor_mixed").await;
+    FrameRepository::set_property(
+        &pool,
+        frame_id,
+        "evidence_type_weights",
+        &serde_json::json!({
+            "empirical": 5.0,    // out of range, dropped
+            "logical": 0.85,     // valid, kept
+            "testimonial": -0.1, // negative, dropped
+        }),
+    )
+    .await
+    .expect("set property");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map) — logical kept");
+    assert_eq!(
+        map.len(),
+        1,
+        "expected only logical to survive, got {map:?}"
+    );
+    assert!((map["logical"] - 0.85).abs() < f64::EPSILON);
+}
+
+/// Phase 4 boundary values: 0.0 and 1.0 are both inclusive per Q10.
+#[sqlx::test(migrations = "../../migrations")]
+async fn boundary_values_zero_and_one_accepted(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_boundary").await;
+    FrameRepository::set_property(
+        &pool,
+        frame_id,
+        "evidence_type_weights",
+        &serde_json::json!({"empirical": 0.0, "logical": 1.0}),
+    )
+    .await
+    .expect("set property");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map)");
+    assert_eq!(
+        map.len(),
+        2,
+        "expected both boundary entries kept, got {map:?}"
+    );
+    assert!((map["empirical"] - 0.0).abs() < f64::EPSILON);
+    assert!((map["logical"] - 1.0).abs() < f64::EPSILON);
+}
+
+/// Other property keys are present but `evidence_type_weights` is
+/// absent → Ok(None). Phase 2's `intra_evidence_locality_factor` key
+/// must NOT leak into the Phase 4 accessor.
+#[sqlx::test(migrations = "../../migrations")]
+async fn missing_evidence_type_weights_key_returns_none(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_missing_key").await;
+    FrameRepository::set_property(
+        &pool,
+        frame_id,
+        "intra_evidence_locality_factor",
+        &serde_json::json!(0.5),
+    )
+    .await
+    .expect("set Phase-2 key only");
+
+    let result = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights");
+    assert!(
+        result.is_none(),
+        "Phase 2 key alone must not satisfy Phase 4 accessor, got {result:?}"
+    );
+}
+
+/// Querying a nonexistent frame_id returns Ok(None), not an error.
+#[sqlx::test(migrations = "../../migrations")]
+async fn missing_frame_returns_none(pool: PgPool) {
+    let result = FrameRepository::get_per_frame_evidence_type_weights(&pool, Uuid::new_v4())
+        .await
+        .expect("get weights on missing frame should not error");
+    assert!(
+        result.is_none(),
+        "missing frame must return Ok(None), got {result:?}"
+    );
+}
+
+/// `set_evidence_type_weight` is a read-modify-write merge. Setting a
+/// new key on top of an existing object preserves the existing entries.
+#[sqlx::test(migrations = "../../migrations")]
+async fn set_evidence_type_weight_merges_into_existing_map(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_merge").await;
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "empirical", 0.5)
+        .await
+        .expect("first write");
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "logical", 0.9)
+        .await
+        .expect("second write");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map)");
+    assert_eq!(
+        map.len(),
+        2,
+        "second write must preserve first entry, got {map:?}"
+    );
+    assert!((map["empirical"] - 0.5).abs() < f64::EPSILON);
+    assert!((map["logical"] - 0.9).abs() < f64::EPSILON);
+}
+
+/// `set_evidence_type_weight` on the same key twice overwrites.
+#[sqlx::test(migrations = "../../migrations")]
+async fn set_evidence_type_weight_overwrites_existing_key(pool: PgPool) {
+    let frame_id = seed_frame(&pool, "phase4_overwrite").await;
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "empirical", 0.5)
+        .await
+        .expect("first write");
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "empirical", 0.8)
+        .await
+        .expect("second write");
+
+    let map = FrameRepository::get_per_frame_evidence_type_weights(&pool, frame_id)
+        .await
+        .expect("get weights")
+        .expect("Some(map)");
+    assert_eq!(map.len(), 1, "single key after overwrite, got {map:?}");
+    assert!(
+        (map["empirical"] - 0.8).abs() < f64::EPSILON,
+        "second write must overwrite, got {}",
+        map["empirical"]
+    );
+}

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -333,6 +333,15 @@ pub async fn recompute_claim_belief_on_frame(
 /// (`frames.properties->>'intra_evidence_locality_factor'`) — flows
 /// through to combined BetP without rewriting any BBA row.
 ///
+/// Phase 4 of issue #197: extend the lookup chain with a per-frame
+/// evidence-type weight override map. Operators can set a per-frame
+/// `evidence_type_weights` JSONB property; when present and containing
+/// the BBA's lowercased `evidence_type`, the override wins over the
+/// global `[evidence_type_weights]` table. **Strict-key, no alias
+/// resolution at Tier 1** (Q9 locked decision in Phase 4 spec § 5):
+/// if the operator writes `{"observation": 1.0}`, that affects rows
+/// literally tagged `"observation"`, not also `"empirical"`.
+///
 /// # Inputs
 /// * `row` — the persisted BBA. The helper inspects
 ///   `row.evidence_type`, `row.locality_tag`, and (for the legacy
@@ -349,6 +358,10 @@ pub async fn recompute_claim_belief_on_frame(
 ///   `FrameRepository::get_intra_evidence_locality_factor`. Pre-loading
 ///   avoids a DB round-trip per row in a multi-BBA combine. `None`
 ///   means "no per-frame override; use the global calibration value".
+/// * `per_frame_evidence_weights` (Phase 4) — pre-loaded by the caller
+///   via `FrameRepository::get_per_frame_evidence_type_weights`. Map
+///   keys are already lowercased by the repo accessor. `None` means
+///   "no per-frame override; use the global calibration table".
 /// * `calibration` — pre-loaded `&CalibrationConfig`. The caller
 ///   resolves the load + fallback; the helper does not do I/O.
 ///
@@ -360,31 +373,29 @@ pub async fn recompute_claim_belief_on_frame(
 ///    return the stored value clamped. This is the pre-Phase-1a
 ///    legacy cohort (5202ded backfill populated `source_strength`
 ///    only, never `evidence_type`).
-/// 2. `evidence_type IS NOT NULL` AND
+/// 2. **Phase 4 Tier 1** — `evidence_type IS NOT NULL` AND
+///    `per_frame_evidence_weights.get(et.to_lowercase()) = Some(w)`
+///    → compose `w` with locality (same locality discount Tier 3
+///    applies), clamp to `[0.0, 1.0]`. Strict-key: no alias
+///    resolution against `calibration.evidence_type_aliases`.
+/// 3. `evidence_type IS NOT NULL` AND
 ///    `calibration.evidence_type_weight_present(et)` → look up the
 ///    calibrated weight, compose with locality:
 ///    * `locality_tag.starts_with("intra")` → `weight * intra_factor`
 ///      where `intra_factor` is the per-frame override (if any), else
 ///      the global calibration value.
 ///    * otherwise → `weight` (no discount).
-/// 3. `evidence_type IS NOT NULL` AND not calibrated AND
+/// 4. `evidence_type IS NOT NULL` AND not calibrated AND
 ///    `source_strength IS NOT NULL` → return the stored value clamped.
 ///    Path-1 sentinel from Phase 2 spec § 4: an `evidence_type` like
 ///    `"CORROBORATES"` that's neither a canonical key nor an alias
 ///    falls back to the write-time cache.
-/// 4. Both `evidence_type` and `source_strength` NULL → return `0.5`
+/// 5. Both `evidence_type` and `source_strength` NULL → return `0.5`
 ///    (the unknown-key calibration fallback).
-///
-/// # Phase 4 extension hook
-/// Phase 4 will widen the signature with a fourth parameter
-/// `per_frame_evidence_weights: Option<&HashMap<String, f64>>` for
-/// per-frame evidence-type weight overrides. See
-/// `docs/superpowers/specs/2026-05-28-per-frame-evidence-type-weights-spec.md`.
-/// The parameter is intentionally absent here so Phase 4 can introduce
-/// it without ambiguity.
 pub fn effective_source_strength(
     row: &MassFunctionRow,
     per_frame_intra_factor: Option<f64>,
+    per_frame_evidence_weights: Option<&HashMap<String, f64>>,
     calibration: &CalibrationConfig,
 ) -> f64 {
     // Step (1): legacy null-evidence_type cohort. The 5202ded backfill
@@ -396,14 +407,42 @@ pub fn effective_source_strength(
         if let Some(ss) = row.source_strength {
             return ss.clamp(0.0, 1.0);
         }
-        // Step (4): everything NULL → unknown-key 0.5 fallback.
+        // Step (5): everything NULL → unknown-key 0.5 fallback.
         return 0.5;
     }
 
     // SAFETY: just matched `Some` above.
     let evidence_type = row.evidence_type.as_deref().unwrap_or("");
 
-    // Step (2): evidence_type resolves to a calibrated weight (direct
+    // Helper closure: compose a base weight with the locality discount.
+    // Used by both Tier 1 (Phase 4 per-frame override) and Tier 2 (Phase
+    // 2 global calibration). Keeps the locality semantics identical
+    // across both tiers — an operator who writes `{"empirical": 0.5}`
+    // expects the same `intra` discount to apply on top of 0.5 as it
+    // would have applied to the global 1.0.
+    let compose_with_locality = |base: f64| -> f64 {
+        let intra_factor = per_frame_intra_factor
+            .unwrap_or(calibration.evidence_locality.intra_evidence_locality_factor);
+        let locality_factor = if row.locality_tag.starts_with("intra") {
+            intra_factor
+        } else {
+            1.0
+        };
+        (base * locality_factor).clamp(0.0, 1.0)
+    };
+
+    // Step (2) — Phase 4 Tier 1: per-frame override strict-key lookup.
+    // Map keys are already lowercased by the repo accessor; lowercase
+    // the BBA's evidence_type to match. NO alias resolution at this
+    // tier — see Q9 locked decision in Phase 4 spec § 5.
+    if let Some(map) = per_frame_evidence_weights {
+        let key = evidence_type.to_lowercase();
+        if let Some(&w) = map.get(&key) {
+            return compose_with_locality(w);
+        }
+    }
+
+    // Step (3): evidence_type resolves to a calibrated weight (direct
     // or via the alias table). Compose with locality. Any locality_tag
     // starting with "intra" — current values: 'intra_self_cite',
     // 'intra_methodological_overlap' (Phase 2 vocabulary expansion);
@@ -413,17 +452,10 @@ pub fn effective_source_strength(
     // helper) gets the un-discounted base weight.
     if calibration.evidence_type_weight_present(evidence_type) {
         let base = calibration.get_evidence_type_weight(evidence_type);
-        let intra_factor = per_frame_intra_factor
-            .unwrap_or(calibration.evidence_locality.intra_evidence_locality_factor);
-        let locality_factor = if row.locality_tag.starts_with("intra") {
-            intra_factor
-        } else {
-            1.0
-        };
-        return (base * locality_factor).clamp(0.0, 1.0);
+        return compose_with_locality(base);
     }
 
-    // Step (3): evidence_type was set but isn't a calibrated key (path
+    // Step (4): evidence_type was set but isn't a calibrated key (path
     // 1 sentinel from Phase 2 spec § 4). The legacy `source_strength`
     // cache preserves write-time semantics; without it we drop to the
     // 0.5 unknown-key fallback.
@@ -431,6 +463,48 @@ pub fn effective_source_strength(
         return ss.clamp(0.0, 1.0);
     }
     0.5
+}
+
+/// Phase 4 (issue #197) Q8: warn on per-frame evidence-type override
+/// keys that aren't in calibration's known vocabulary.
+///
+/// "Known vocabulary" = canonical key in `calibration.evidence_type_weights`
+/// ∪ alias in `calibration.evidence_type_aliases` ∪ a small allow-list of
+/// relationship-vocab strings the `auto_wire_ds_for_edge` write path may
+/// emit before they're added to `evidence_type_aliases`. Operators may
+/// legitimately register weights for future evidence types not yet in
+/// calibration.toml; this is a log signal for typos, not a hard reject.
+fn warn_on_unknown_evidence_type_keys(
+    frame_id: Uuid,
+    map: &HashMap<String, f64>,
+    calibration: &CalibrationConfig,
+) {
+    const RELATIONSHIP_VOCAB_ALLOWLIST: &[&str] = &[
+        "supports",
+        "corroborates",
+        "refutes",
+        "supersedes",
+        "derived_support",
+        "derived_refute",
+        "derived_supersession",
+    ];
+    for key in map.keys() {
+        // Map keys are already lowercased by the repo accessor; calibration
+        // accessors also lowercase internally. evidence_type_weight_present
+        // covers both canonical-key and alias resolution in one call.
+        if calibration.evidence_type_weight_present(key) {
+            continue;
+        }
+        if RELATIONSHIP_VOCAB_ALLOWLIST.contains(&key.as_str()) {
+            continue;
+        }
+        tracing::warn!(
+            %frame_id,
+            key = %key,
+            "per-frame evidence_type_weights override key is not in calibration vocabulary; \
+             possibly a typo (entry is still applied at Tier 1 strict-key)"
+        );
+    }
 }
 
 async fn recompute_combined_belief(
@@ -465,16 +539,50 @@ async fn recompute_combined_belief(
         .ok()
         .flatten();
 
+    // Phase 4 (issue #197): per-frame evidence-type weight override map.
+    // When set, its keyed entries win over the global calibration
+    // table at Tier 1 of `effective_source_strength`. Loaded once above
+    // the combine loop. On any DB error we fall through to `None`
+    // (silently no-ops at Tier 1) rather than failing the whole combine
+    // — recalibration overrides are operator-facing knobs, not
+    // load-bearing for the BetP write.
+    let per_frame_evidence_weights =
+        FrameRepository::get_per_frame_evidence_type_weights(pool, frame_id)
+            .await
+            .ok()
+            .flatten();
+
+    // Vocabulary warn-log (Q8 locked: loose validation at set_property,
+    // warn-log at read-site). Iterate the override map's keys and warn
+    // on any that don't resolve to a known evidence-type vocabulary
+    // entry: canonical calibration key, calibration alias, or one of
+    // the relationship-vocab strings the auto-wire write path emits.
+    // Surfaces operator typos in operational logs without blocking the
+    // write.
+    if let Some(ref map) = per_frame_evidence_weights {
+        warn_on_unknown_evidence_type_keys(frame_id, map, &calibration);
+    }
+
     let combined = if all_rows.len() == 1 {
         let r = &all_rows[0];
         let mf = parse_stored_bba(frame, &r.masses)?;
-        let reliability = effective_source_strength(r, per_frame_intra, &calibration);
+        let reliability = effective_source_strength(
+            r,
+            per_frame_intra,
+            per_frame_evidence_weights.as_ref(),
+            &calibration,
+        );
         combination::discount(&mf, reliability).map_err(|e| format!("discount: {e}"))?
     } else {
         let mut mass_fns = Vec::with_capacity(all_rows.len());
         for row in &all_rows {
             let mf = parse_stored_bba(frame, &row.masses)?;
-            let reliability = effective_source_strength(row, per_frame_intra, &calibration);
+            let reliability = effective_source_strength(
+                row,
+                per_frame_intra,
+                per_frame_evidence_weights.as_ref(),
+                &calibration,
+            );
             let d =
                 combination::discount(&mf, reliability).map_err(|e| format!("discount: {e}"))?;
             mass_fns.push(d);

--- a/crates/epigraph-engine/tests/effective_source_strength_unit.rs
+++ b/crates/epigraph-engine/tests/effective_source_strength_unit.rs
@@ -14,14 +14,18 @@
 //!     for relationships (`supports → derived_support`, etc.) so the
 //!     helper resolves a real weight via the alias chain.
 //!
-//! Phase 4 extension hook: the signature is intentionally (`row`,
-//! `per_frame_intra_factor`, `calibration`). Phase 4 will widen with a
-//! fourth parameter `per_frame_evidence_weights` per the Phase 4 spec.
+//! Phase 4 (issue #197) extension: the signature is
+//! `(row, per_frame_intra_factor, per_frame_evidence_weights, calibration)`.
+//! Per-frame evidence-type weight overrides win at Tier 1 strict-key
+//! when present; otherwise falls through to Phase 2 Tier 2 (global
+//! calibration with aliases) and Tier 3 (legacy source_strength cache).
+//! See `docs/superpowers/specs/2026-05-28-per-frame-evidence-type-weights-spec.md`.
 
 use chrono::Utc;
 use epigraph_db::MassFunctionRow;
 use epigraph_engine::calibration::CalibrationConfig;
 use epigraph_engine::edge_factor::effective_source_strength;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 // ── Fixtures ───────────────────────────────────────────────────────────────
@@ -72,7 +76,7 @@ fn empirical_intra_self_cite_applies_global_factor() {
     let r = row(Some("empirical"), "intra_self_cite", Some(1.0));
     // empirical = 1.0; intra factor 0.3 from calibration.toml → 0.3.
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         1.0 * 0.3,
         "empirical/intra_self_cite",
     );
@@ -84,7 +88,7 @@ fn empirical_intra_methodological_overlap_applies_global_factor() {
     // Documents Q3: any locality_tag starting with "intra" is intra.
     let r = row(Some("empirical"), "intra_methodological_overlap", Some(1.0));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         1.0 * 0.3,
         "empirical/intra_methodological_overlap",
     );
@@ -95,7 +99,7 @@ fn empirical_cross_no_discount() {
     let cfg = load_calibration();
     let r = row(Some("empirical"), "cross", Some(0.21));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         1.0,
         "empirical/cross (source_strength cache ignored at tier 2)",
     );
@@ -107,7 +111,7 @@ fn empirical_unknown_locality_no_discount() {
     // 'unknown' (and any non-"intra" string) → cross behaviour.
     let r = row(Some("empirical"), "unknown", Some(1.0));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         1.0,
         "empirical/unknown",
     );
@@ -119,7 +123,7 @@ fn derived_support_intra_self_cite() {
     // Phase 2: derived_support = 0.7 in calibration.toml.
     let r = row(Some("derived_support"), "intra_self_cite", Some(0.21));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.7 * 0.3,
         "derived_support/intra",
     );
@@ -130,7 +134,7 @@ fn derived_support_cross_no_discount() {
     let cfg = load_calibration();
     let r = row(Some("derived_support"), "cross", Some(0.7));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.7,
         "derived_support/cross",
     );
@@ -144,7 +148,7 @@ fn supports_relationship_resolves_via_alias() {
     let r = row(Some("supports"), "cross", None);
     // calibration.toml: supports → derived_support → 0.7.
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.7,
         "supports (via alias chain)",
     );
@@ -155,7 +159,7 @@ fn supports_relationship_intra_resolves_and_discounts() {
     let cfg = load_calibration();
     let r = row(Some("supports"), "intra_self_cite", None);
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.7 * 0.3,
         "supports/intra (via alias chain)",
     );
@@ -167,7 +171,7 @@ fn testimonial_intra_self_cite() {
     // testimonial = 0.6 in calibration.toml; intra factor 0.3 → 0.18.
     let r = row(Some("testimonial"), "intra_self_cite", None);
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.6 * 0.3,
         "testimonial/intra",
     );
@@ -183,14 +187,14 @@ fn per_frame_factor_override_recalibrates_without_db_write() {
 
     // Default factor (0.3 from calibration.toml).
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         1.0 * 0.3,
         "empirical/intra default factor",
     );
 
     // Per-frame override 0.5.
     approx(
-        effective_source_strength(&r, Some(0.5), &cfg),
+        effective_source_strength(&r, Some(0.5), None, &cfg),
         1.0 * 0.5,
         "empirical/intra per-frame factor 0.5",
     );
@@ -198,7 +202,7 @@ fn per_frame_factor_override_recalibrates_without_db_write() {
     // Per-frame override 0.9 (e.g. a textbook frame where intra-source
     // citation IS the assertion-grounding move).
     approx(
-        effective_source_strength(&r, Some(0.9), &cfg),
+        effective_source_strength(&r, Some(0.9), None, &cfg),
         1.0 * 0.9,
         "empirical/intra per-frame factor 0.9",
     );
@@ -212,7 +216,7 @@ fn null_evidence_type_with_source_strength_returns_stored() {
     // 5202ded backfill cohort: source_strength set, evidence_type NULL.
     let r = row(None, "unknown", Some(0.85));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.85,
         "null evidence_type, source_strength=0.85",
     );
@@ -227,7 +231,7 @@ fn null_evidence_type_with_source_strength_ignores_locality() {
     // null-evidence_type cohort.
     let r = row(None, "intra_self_cite", Some(0.85));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.85,
         "null evidence_type, intra locality — locality NOT re-applied",
     );
@@ -238,7 +242,7 @@ fn null_evidence_type_null_source_strength_falls_back_to_half() {
     let cfg = load_calibration();
     let r = row(None, "unknown", None);
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.5,
         "both null → 0.5 unknown-key fallback",
     );
@@ -253,7 +257,7 @@ fn unknown_evidence_type_with_source_strength_returns_cache() {
     // in `[evidence_type_weights]` nor in `[evidence_type_aliases]`.
     let r = row(Some("totally_unknown_key"), "intra_self_cite", Some(0.42));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.42,
         "unknown evidence_type → source_strength cache bridge",
     );
@@ -264,7 +268,7 @@ fn unknown_evidence_type_with_null_source_strength_falls_back_to_half() {
     let cfg = load_calibration();
     let r = row(Some("totally_unknown_key"), "intra_self_cite", None);
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.5,
         "unknown evidence_type, no cache → 0.5",
     );
@@ -280,7 +284,7 @@ fn output_is_clamped_to_unit_interval() {
     // sees an out-of-range reliability.
     let r = row(None, "unknown", Some(-0.1));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.0,
         "negative cached source_strength → clamped to 0.0",
     );
@@ -289,7 +293,7 @@ fn output_is_clamped_to_unit_interval() {
     // must catch it before `discount` panics.
     let r = row(None, "unknown", Some(1.5));
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         1.0,
         "above-unit cached source_strength → clamped to 1.0",
     );
@@ -307,7 +311,7 @@ fn fallback_config_preserves_pre_phase2_invariants() {
     let r = row(Some("empirical"), "intra_self_cite", Some(0.21));
     // empirical isn't in the empty map → step (3) cache returns 0.21.
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.21,
         "fallback config: empirical lookup misses, cache returns 0.21",
     );
@@ -315,8 +319,210 @@ fn fallback_config_preserves_pre_phase2_invariants() {
     // Without a cache value, fall through to 0.5.
     let r = row(Some("empirical"), "intra_self_cite", None);
     approx(
-        effective_source_strength(&r, None, &cfg),
+        effective_source_strength(&r, None, None, &cfg),
         0.5,
         "fallback config: empirical lookup misses, no cache → 0.5",
+    );
+}
+
+// ── Phase 4 (#197): per-frame evidence-type weight overrides ───────────────
+//
+// All cases below pass a non-None per-frame override map and exercise
+// the Tier 1 (strict-key) lookup. Map values must be in [0.0, 1.0]
+// (Q10 locked decision; repo accessor drops out-of-range entries at
+// read time, so the helper itself does no bounds enforcement at
+// construction here — but composed output is still clamped to [0,1]).
+
+fn pf_map(entries: &[(&str, f64)]) -> HashMap<String, f64> {
+    entries
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), *v))
+        .collect()
+}
+
+/// Tier 1 wins over global calibration when key matches the canonical
+/// `empirical` weight. Override 0.5 < global 1.0; composed with cross
+/// (no discount), result is 0.5.
+#[test]
+fn phase4_per_frame_override_matches_canonical_key() {
+    let cfg = load_calibration();
+    let r = row(Some("empirical"), "cross", Some(1.0));
+    let pf = pf_map(&[("empirical", 0.5)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.5,
+        "empirical/cross + per-frame{empirical: 0.5} → 0.5 (Tier 1)",
+    );
+}
+
+/// Tier 1 strict-key: override keyed on `observation` matches BBAs
+/// tagged literally `observation` (case-insensitive). Does NOT
+/// transitively apply to BBAs tagged the aliased canonical `empirical`.
+#[test]
+fn phase4_per_frame_override_matches_alias_key_literally() {
+    let cfg = load_calibration();
+    // calibration: observation → empirical → 1.0
+    // override: observation = 0.4
+    // row tagged "observation" → Tier 1 hit → 0.4 (cross locality, no discount)
+    let r = row(Some("observation"), "cross", None);
+    let pf = pf_map(&[("observation", 0.4)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.4,
+        "observation tag + per-frame{observation: 0.4} → 0.4 (Tier 1 strict-key)",
+    );
+}
+
+/// Tier 1 strict-key: override on canonical `empirical` does NOT
+/// reverse-alias to BBAs literally tagged `observation`. Documents
+/// the Phase 4 spec § 5 contract that aliases are NOT resolved at
+/// Tier 1.
+#[test]
+fn phase4_per_frame_override_strict_no_reverse_alias() {
+    let cfg = load_calibration();
+    // row tagged "observation"; per-frame map has only "empirical".
+    // Tier 1 misses; Tier 2 resolves observation → empirical → 1.0.
+    let r = row(Some("observation"), "cross", None);
+    let pf = pf_map(&[("empirical", 0.5)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        1.0,
+        "observation tag + per-frame{empirical: 0.5} → 1.0 (Tier 2; no reverse alias)",
+    );
+}
+
+/// Case-insensitive Tier 1 lookup: BBA tagged `Reference` (mixed
+/// case) matches per-frame `reference` (lowercase). Production has
+/// 104 `reference` and some mixed-case rows; the helper must
+/// normalize on lookup.
+#[test]
+fn phase4_per_frame_override_case_insensitive() {
+    let cfg = load_calibration();
+    let r = row(Some("Reference"), "cross", None);
+    // Per-frame map's keys are already lowercased by the repo
+    // accessor; the helper lowercases the BBA's evidence_type before
+    // probing the map.
+    let pf = pf_map(&[("reference", 0.6)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.6,
+        "Reference tag + per-frame{reference: 0.6} → 0.6 (case-insensitive Tier 1)",
+    );
+}
+
+/// Phase 4 side-benefit: an operator can patch the relationship
+/// vocabulary leak (e.g. `CORROBORATES` → calibration alias resolves
+/// it to `derived_support` but this test pins the case where the
+/// operator wants a frame-specific override for the relationship
+/// itself).
+#[test]
+fn phase4_per_frame_override_relationship_vocab_key() {
+    let cfg = load_calibration();
+    let r = row(Some("CORROBORATES"), "cross", None);
+    // Per-frame override on the lowercased relationship string —
+    // wins at Tier 1 strict-key.
+    let pf = pf_map(&[("corroborates", 0.65)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.65,
+        "CORROBORATES tag + per-frame{corroborates: 0.65} → 0.65 (Tier 1)",
+    );
+}
+
+/// Per-frame override present but does not contain BBA's evidence
+/// type; global calibration hits at Tier 2.
+#[test]
+fn phase4_per_frame_override_key_absent_global_hits() {
+    let cfg = load_calibration();
+    let r = row(Some("logical"), "cross", None);
+    // Map has empirical but not logical → Tier 1 miss; Tier 2 returns
+    // logical = 0.85.
+    let pf = pf_map(&[("empirical", 0.5)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.85,
+        "logical/cross + per-frame{empirical: 0.5} → 0.85 (Tier 2 fallthrough)",
+    );
+}
+
+/// Per-frame override present, key absent, global misses, but
+/// row.source_strength is set → Tier 3 cache bridge.
+#[test]
+fn phase4_per_frame_override_falls_through_to_source_strength_cache() {
+    let cfg = load_calibration();
+    // "totally_unknown_xyz" isn't in calibration or aliases; map
+    // doesn't include it; cache returns 0.21.
+    let r = row(Some("totally_unknown_xyz"), "intra_self_cite", Some(0.21));
+    let pf = pf_map(&[("empirical", 0.5)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.21,
+        "unknown evidence_type + per-frame{empirical: 0.5} + cache(0.21) → 0.21 (Tier 4)",
+    );
+}
+
+/// Phase 4 strict superset: when the per-frame map is `Some(empty
+/// HashMap)`, behavior is identical to `None`. The repo accessor
+/// returns `Ok(None)` on empty-after-parse, but defensive: the helper
+/// must handle `Some({})` gracefully.
+#[test]
+fn phase4_empty_map_is_strict_superset_of_none() {
+    let cfg = load_calibration();
+    let r = row(Some("empirical"), "intra_self_cite", Some(1.0));
+    let empty_map: HashMap<String, f64> = HashMap::new();
+
+    let with_none = effective_source_strength(&r, None, None, &cfg);
+    let with_empty = effective_source_strength(&r, None, Some(&empty_map), &cfg);
+    approx(
+        with_empty,
+        with_none,
+        "Some(empty HashMap) must be identical to None — Phase 4 is a strict superset",
+    );
+}
+
+/// Phase 4 is a no-op on the legacy null-`evidence_type` cohort
+/// (278 K of 279 K production rows). Tier 1 misses (no key to look
+/// up); Tier 2 (in the row-NULL case the helper short-circuits to
+/// the source_strength cache via step 1 of the fallback chain).
+#[test]
+fn phase4_null_evidence_type_is_unaffected() {
+    let cfg = load_calibration();
+    let r = row(None, "intra_self_cite", Some(0.85));
+    let pf = pf_map(&[("empirical", 0.5)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.85,
+        "null evidence_type + per-frame override → cache bridge (override is a no-op)",
+    );
+
+    // And without a cache value: 0.5 unknown-key fallback.
+    let r = row(None, "intra_self_cite", None);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.5,
+        "null evidence_type + per-frame override + no cache → 0.5",
+    );
+}
+
+/// Phase 4 + intra locality composition. The Tier 1 override is
+/// composed with the locality discount, identical to Tier 2.
+/// `empirical` override 0.5 + intra locality (global 0.3 default)
+/// → 0.5 * 0.3 = 0.15.
+#[test]
+fn phase4_per_frame_override_composes_with_locality() {
+    let cfg = load_calibration();
+    let r = row(Some("empirical"), "intra_self_cite", None);
+    let pf = pf_map(&[("empirical", 0.5)]);
+    approx(
+        effective_source_strength(&r, None, Some(&pf), &cfg),
+        0.5 * 0.3,
+        "empirical/intra + per-frame{empirical: 0.5} → 0.5 * 0.3 = 0.15",
+    );
+
+    // Per-frame intra factor 0.9 stacks on top of Tier 1 override 0.5.
+    approx(
+        effective_source_strength(&r, Some(0.9), Some(&pf), &cfg),
+        0.5 * 0.9,
+        "empirical/intra + per-frame{empirical: 0.5} + intra_factor 0.9 → 0.45",
     );
 }

--- a/crates/epigraph-engine/tests/intra_source_discount_regression.rs
+++ b/crates/epigraph-engine/tests/intra_source_discount_regression.rs
@@ -759,3 +759,177 @@ async fn per_frame_locality_factor_override_applied(pool: PgPool) {
          prev={nearly_undiscounted_betp}, new={deeply_discounted_betp}"
     );
 }
+
+// ── Phase 4 (#197): per-frame evidence-type weight override ────────────────
+
+/// **The key Phase 4 invariant**: a per-frame `evidence_type_weights`
+/// JSONB override flows through `recompute_claim_belief_binary` to
+/// combined BetP without any BBA rewrite. The override map is read
+/// at combine time via the new `effective_source_strength` Tier 1
+/// lookup. Without this assertion, Phase 4 ships green but the per-
+/// frame override is dead code at combine time.
+///
+/// Fixture key choice: this test exercises the same `auto_wire_ds_for_edge`
+/// write path as the Phase 2 regression. That write path resolves the
+/// `"supports"` relationship through `[evidence_type_aliases]` to the
+/// canonical SciFact key `"derived_support"` and stores THAT in
+/// `mass_functions.evidence_type` (see calibration.toml's alias section
+/// and the assertion at line ~292 of this file). So the Phase 4 override
+/// MUST be keyed on `"derived_support"`, not `"supports"` and not
+/// `"empirical"` — the BBAs aren't tagged either of those. This is the
+/// load-bearing detail the advisor flagged.
+///
+/// Q10 ([0.0, 1.0] clamp) constrains the upward-shift test: the global
+/// calibration `derived_support = 0.7`. An override `< 0.7` shifts BetP
+/// down, but an override `> 1.0` clamps to 1.0. We exercise a single
+/// down-shift + restore round-trip per the task's allowance ("if the
+/// upward case isn't possible under [0,1] clamp ... a single down-shift
+/// + restore round-trip is sufficient").
+#[sqlx::test(migrations = "../../migrations")]
+async fn per_frame_evidence_type_weight_override_applied(pool: PgPool) {
+    use epigraph_db::FrameRepository;
+
+    let agent = seed_agent(&pool, 0xD0_0001).await;
+    let target_doi = "10.phase4/evtw";
+    let paper = seed_paper(&pool, target_doi, "phase 4 evidence-type override").await;
+
+    // Target — start with NULL belief/plausibility so the only BBAs on
+    // the target come from the supporter wires.
+    let target_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current) \
+         VALUES ($1, $2, $3, $4, 0.5, true)",
+    )
+    .bind(target_id)
+    .bind("phase 4 evidence-type override target")
+    .bind(distinct_hash(0x60_0000))
+    .bind(agent)
+    .execute(&pool)
+    .await
+    .expect("seed target");
+    insert_edge(&pool, paper, target_id, "paper", "claim", "asserts").await;
+
+    // Seed two intra-source supporters, both citing the target's DOI.
+    // Each fires through `auto_wire_ds_for_edge("supports")` → BBA
+    // tagged `evidence_type = "derived_support"` (canonical), `locality_tag
+    // = "intra_self_cite"`.
+    for i in 0..2u32 {
+        let supporter = seed_claim_with_belief(
+            &pool,
+            agent,
+            &format!("phase 4 supporter {i}"),
+            0x61_0000 + i,
+            NEMS_BELIEF,
+            NEMS_BELIEF,
+            NEMS_BELIEF,
+        )
+        .await;
+        seed_doi_evidence(&pool, supporter, target_doi, 0x73_0000 + i).await;
+        let edge_id = insert_edge(&pool, supporter, target_id, "claim", "claim", "supports").await;
+        let outcome =
+            auto_wire_ds_for_edge(&pool, edge_id, agent, supporter, target_id, "supports")
+                .await
+                .expect("auto_wire");
+        assert_eq!(outcome, EdgeFactorOutcome::Wired);
+    }
+
+    // Sanity: 2 BBAs landed, all tagged with the canonical key.
+    let bba_count = count_target_bbas(&pool, target_id).await;
+    assert_eq!(
+        bba_count, 2,
+        "expected 2 BBAs on the target, got {bba_count}"
+    );
+    let canonical_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mass_functions \
+         WHERE claim_id = $1 AND evidence_type = 'derived_support'",
+    )
+    .bind(target_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count derived_support rows");
+    assert_eq!(
+        canonical_count, 2,
+        "expected both BBAs tagged 'derived_support' (auto-wire alias resolution), got {canonical_count}"
+    );
+
+    // Baseline BetP at calibration's global derived_support = 0.7.
+    let baseline_betp = read_betp(&pool, target_id)
+        .await
+        .expect("baseline BetP after supporter wires");
+    eprintln!(
+        "[per_frame_evidence_type_weight_override_applied] baseline BetP (global derived_support=0.7) = {baseline_betp}"
+    );
+
+    // ── Phase 4 Tier 1 down-shift: override derived_support to 0.1 ──
+    //
+    // 0.1 << 0.7 global → each supporter's reliability discount
+    // shrinks roughly 7x (composed with intra locality 0.3, the
+    // discount weight drops from 0.21 to 0.03), so each contributes
+    // far less mass to TRUE through the discount step, and combined
+    // BetP shifts downward.
+    //
+    // Why such a deep override: the BetP combine is non-linear, and
+    // a moderate override (e.g. 0.3) shifts BetP only ~0.03 in this
+    // 2-supporter fixture — within combination noise tolerance. The
+    // deep override produces a visibly-larger shift that survives the
+    // ≥0.02 threshold without false positives. Wider fixtures would
+    // amplify smaller overrides, but this 2-supporter shape is the
+    // simplest Phase 4 canary and matches the spec § 7 recipe.
+    let frame_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM frames WHERE name = $1")
+        .bind("binary_truth")
+        .fetch_one(&pool)
+        .await
+        .expect("binary_truth frame id");
+    FrameRepository::set_evidence_type_weight(&pool, frame_id, "derived_support", 0.1)
+        .await
+        .expect("set per-frame derived_support override");
+
+    // Recompute — the helper reads the override at combine time.
+    // **No BBA row rewrite** in between. This is the canary.
+    recompute_claim_belief_binary(&pool, target_id)
+        .await
+        .expect("recompute after per-frame evidence-type override");
+
+    let downshifted_betp = read_betp(&pool, target_id)
+        .await
+        .expect("BetP after override");
+    eprintln!(
+        "[per_frame_evidence_type_weight_override_applied] override 0.1 BetP = {downshifted_betp}"
+    );
+    // Threshold 0.02: combination noise from `combine_multiple`'s
+    // conflict-renormalisation is empirically << 1e-3 on a fixture
+    // this small with no random seeding. 0.02 is conservative
+    // headroom; observed shift is ~0.05+ with this override.
+    assert!(
+        downshifted_betp < baseline_betp - 0.02,
+        "per-frame override derived_support=0.1 (vs global 0.7) must shift BetP downward by ≥0.02: \
+         baseline={baseline_betp}, downshifted={downshifted_betp}"
+    );
+
+    // ── Round-trip: remove the override, BetP returns to baseline ──
+    //
+    // We remove the whole `evidence_type_weights` key — this exercises
+    // the "operator rolls back per-frame override" rollback path from
+    // Phase 4 spec § 9.6.
+    sqlx::query(
+        "UPDATE frames SET properties = properties - 'evidence_type_weights' WHERE id = $1",
+    )
+    .bind(frame_id)
+    .execute(&pool)
+    .await
+    .expect("remove evidence_type_weights key");
+    recompute_claim_belief_binary(&pool, target_id)
+        .await
+        .expect("recompute after override removal");
+
+    let restored_betp = read_betp(&pool, target_id)
+        .await
+        .expect("BetP after removal");
+    eprintln!("[per_frame_evidence_type_weight_override_applied] restored BetP = {restored_betp}");
+    assert!(
+        (restored_betp - baseline_betp).abs() < 1e-6,
+        "removing per-frame override must return BetP to baseline within float tolerance: \
+         baseline={baseline_betp}, restored={restored_betp}, delta={}",
+        (restored_betp - baseline_betp).abs()
+    );
+}

--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -319,12 +319,27 @@ pub async fn auto_wire_ds_update(
         .ok()
         .flatten();
 
+    // Phase 4 (issue #197): per-frame evidence-type weight override map.
+    // When set, its keyed entries win over the global calibration table
+    // at Tier 1 of `effective_source_strength`. Loaded once above the
+    // combine loop. On any DB error we fall through to `None`.
+    let per_frame_evidence_weights =
+        FrameRepository::get_per_frame_evidence_type_weights(pool, frame_id)
+            .await
+            .ok()
+            .flatten();
+
     let combined = if all_rows.len() <= 1 {
         // Single BBA — still apply discount
         let r = all_rows
             .first()
             .expect("len <= 1 with non-empty check: store_with_perspective wrote one");
-        let reliability = effective_source_strength(r, per_frame_intra, &calibration);
+        let reliability = effective_source_strength(
+            r,
+            per_frame_intra,
+            per_frame_evidence_weights.as_ref(),
+            &calibration,
+        );
         let mf = parse_stored_bba(&frame, &r.masses)?;
         combination::discount(&mf, reliability).map_err(|e| format!("discount: {e}"))?
     } else {
@@ -332,7 +347,12 @@ pub async fn auto_wire_ds_update(
         let mut mass_fns = Vec::with_capacity(all_rows.len());
         for row in &all_rows {
             let mf = parse_stored_bba(&frame, &row.masses)?;
-            let reliability = effective_source_strength(row, per_frame_intra, &calibration);
+            let reliability = effective_source_strength(
+                row,
+                per_frame_intra,
+                per_frame_evidence_weights.as_ref(),
+                &calibration,
+            );
             let discounted =
                 combination::discount(&mf, reliability).map_err(|e| format!("discount: {e}"))?;
             mass_fns.push(discounted);


### PR DESCRIPTION
## Summary

Phase 4 of issue #197. Extends `effective_source_strength` (the Phase 2 helper at `crates/epigraph-engine/src/edge_factor.rs`) with a per-frame evidence-type weight override map. Operators set per-frame weights via `frames.properties->>'evidence_type_weights'` (JSONB object); the helper's new **Tier 1 strict-key** lookup wins over global calibration when present.

**No schema migration** — leverages the JSONB property bag from migration 044 (shipped with #193's `intra_evidence_locality_factor` lever).

Spec: `docs/superpowers/specs/2026-05-28-per-frame-evidence-type-weights-spec.md`

## Locked Q&A decisions (override spec recommendations)

- **Q8 — Validation**: Loose. `set_property` stays a thin JSONB merge. Unrecognized keys logged at `recompute_combined_belief` via `warn_on_unknown_evidence_type_keys` (vocabulary = calibration's weights ∪ aliases ∪ a small relationship-vocab allow-list).
- **Q9 — Aliases at Tier 1**: Strict literal-match only. Operator writing `{"observation": 1.0}` affects rows tagged literally `observation`, NOT `empirical` (despite calibration's `observation → empirical` alias). Tier 2 still resolves aliases globally.
- **Q10 — Range**: **`[0.0, 1.0]` clamp** (deviates from spec's `[0.0, 2.0]` recommendation). Matches Shafer's reliability semantics (discount, not amplification). Out-of-range values dropped with `warn!`. Textbook frames wanting `reference > 1.0` are out of scope; widen later if a real use case emerges.
- **Q11 — JSON schema**: Hand-rolled validation. `cargo add --dry-run jsonschema` shows `jsonschema 0.46.5` ships with `reqwest`, `resolve-http`, `tls-aws-lc-rs` as defaults — too heavy a graph for a per-key parse. Repo accessor enforces: top-level object, numeric values in `[0.0, 1.0]`, keys lowercased on read, empty map after parse → `Ok(None)`.

## What changed

**Repository layer** (`crates/epigraph-db/src/repos/frame.rs`):
- `get_per_frame_evidence_type_weights(pool, frame_id) -> Result<Option<HashMap<String, f64>>, DbError>` — defensive parse-in-Rust, mirroring `get_intra_evidence_locality_factor`.
- `set_evidence_type_weight(pool, frame_id, evidence_type, weight)` — read-modify-write merge over `set_property`.

**Engine helper** (`crates/epigraph-engine/src/edge_factor.rs`):
- `effective_source_strength` widened from 3 to 4 parameters. Lookup chain is now strict 3-tier: Tier 1 per-frame override (strict-key, lowercased, composed with locality), Tier 2 global calibration (unchanged Phase 2 path), Tier 3 legacy `source_strength` cache (unchanged).
- Both combine call-sites (`recompute_combined_belief` in `edge_factor.rs` and the equivalent in `epigraph-mcp/src/tools/ds_auto.rs`) load the per-frame map once above the loop.

## Test plan

- [x] **`crates/epigraph-engine/tests/effective_source_strength_unit.rs`** — +10 Phase 4 unit cases (canonical match, alias literal match without reverse-alias, case-insensitive, relationship-vocab key, key-absent fallthrough, source_strength cache bridge, empty-map ≡ None, null evidence_type no-op, locality composition with override). All 27 tests pass.
- [x] **`crates/epigraph-engine/tests/intra_source_discount_regression.rs`** — +1 sqlx::test `per_frame_evidence_type_weight_override_applied`. Recipe: 2 supporters fired via `auto_wire_ds_for_edge("supports")`, override `{"derived_support": 0.1}`, recompute, assert BetP shifts down ≥ 0.02; remove override, recompute, assert BetP returns to baseline within 1e-6. **Override key is `derived_support`, not `empirical`** — the auto-wire write path resolves `supports → derived_support` via the alias table and stores the canonical key; an `empirical` override would never match the row. All 4 tests in this file pass.
- [x] **`crates/epigraph-db/tests/frame_repository_properties.rs`** (new) — +12 sqlx::test repo round-trip cases: canonical / multi-key / case-normalised / malformed-value / non-numeric-entry / out-of-range only / out-of-range mixed / boundary values 0.0 and 1.0 / missing key / missing frame / merge into existing map / overwrite key. All 12 tests pass.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy` clean on touched crates (pre-existing failures in `epigraph-tools` examples and `match_candidate_repo.rs` are unrelated to this PR — verified by running clippy on `origin/main` before changes).
- [x] `cargo test -p epigraph-db -p epigraph-engine -p epigraph-mcp` against `epigraph_db_repo_test` — all suites pass.
- [x] **No `sqlx::query!` macros added** — mirrors `get_intra_evidence_locality_factor`'s runtime `sqlx::query_as` pattern. `cargo sqlx prepare` not needed.

## Zero-behaviour-change on deploy day

Production has 0 frames carrying `properties ? 'evidence_type_weights'` (verified 2026-05-27). On deploy day every helper call falls through to Tier 2 (Phase 2 global calibration) — behavioural identity is by construction. Behavioural change only kicks in when an operator sets an override via `FrameRepository::set_evidence_type_weight` or direct psql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)