### PR TITLE
feat: evidence_type tagging + config-based two-tier per-perspective reliability

### DIFF
--- a/.claude/skills/extract-claims/SKILL.md
+++ b/.claude/skills/extract-claims/SKILL.md
@@ -164,6 +164,45 @@ Assemble all stages into a single `DocumentExtraction` JSON structure:
 | `confidence` | 0.0–1.0; based on evidence quality and source clarity |
 | `generality` | 0 (specific fact), 1 (general principle), 2 (specialized theory) |
 | `resolved` | Boolean; true if all pronouns are explicit, entities named |
+| `evidence_type` | **Pick exactly ONE from the closed set below.** Tags the kind of support behind the claim; drives Dempster–Shafer reliability weighting. |
+
+### `evidence_type` — pick one from this closed set
+
+Choose the single value that best describes *how* the claim is supported. Set
+it per paragraph (atoms inherit it). Anything outside this set is dropped, so
+do **not** invent values:
+
+| Value | Use when the support is… |
+|-------|--------------------------|
+| `empirical` | direct observation, measurement, or experiment |
+| `statistical` | aggregate/quantitative analysis over a sample |
+| `regulatory` | a binding rule, statute, standard, or formal approval |
+| `logical` | a derivation or argument made within the text |
+| `testimonial` | attributed expert testimony or a sourced statement |
+| `circumstantial` | indirect or inferred support |
+| `conversational` | informal/anecdotal report (e.g. a transcript remark) |
+
+When unsure between two, prefer the stronger (higher in this table); if none
+fit, omit the field rather than guessing.
+
+Set it on the **paragraph** object the ingester actually reads (sibling of
+`compound`, `atoms`, `methodology`); atoms inherit it:
+
+```json
+{
+  "compound": "Two empirical observations support the thesis.",
+  "supporting_text": "Measured directly in two assays.",
+  "atoms": ["Observation one ...", "Observation two ..."],
+  "confidence": 0.8,
+  "methodology": "extraction",
+  "evidence_type": "empirical"
+}
+```
+
+> NOTE: the large illustrative JSON earlier in this doc predates the current
+> ingest schema (`source`/`compound`/string-atoms with per-paragraph
+> `evidence_type`). Follow the paragraph snippet above and the field table —
+> not the older block — for the shape `ingest_document` parses.
 
 ## Submission via `ingest_document`
 

--- a/crates/epigraph-db/src/repos/perspective.rs
+++ b/crates/epigraph-db/src/repos/perspective.rs
@@ -19,31 +19,22 @@ pub struct PerspectiveRow {
     pub frame_ids: Option<Vec<Uuid>>,
     pub extraction_method: Option<String>,
     pub confidence_calibration: Option<f64>,
-    /// Free-form jsonb. The frame-function feature reads
-    /// `properties->'source_reliability'` — a map of evidence-type tag →
-    /// reliability α ∈ [0,1] — to discount a shared evidence corpus from this
-    /// perspective's viewpoint. See [`PerspectiveRow::source_reliability`].
+    /// Free-form jsonb. The frame-function feature reads two reliability maps
+    /// from it — `properties->'source_reliability'` (evidence-type tag → α) and
+    /// `properties->'locality_reliability'` (locality_tag → factor) — to
+    /// re-weight a shared evidence corpus from this perspective's viewpoint.
+    /// See [`PerspectiveRow::source_reliability`] and
+    /// [`PerspectiveRow::locality_reliability`].
     pub properties: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
 }
 
 impl PerspectiveRow {
-    /// Per-perspective source-reliability map: evidence-type tag → α ∈ [0,1],
-    /// read from `properties->'source_reliability'`.
-    ///
-    /// This is the "frame function": it lets one observer down-weight, say,
-    /// `practitioner_interview` evidence to 0.4 while another trusts it at 1.0,
-    /// yielding different beliefs over the *same* evidence. Returns `None` when
-    /// the key is absent (the perspective falls back to legacy own-BBA scoping)
-    /// and silently skips any entry whose value is not a finite number in
-    /// `[0, 1]`.
-    #[must_use]
-    pub fn source_reliability(&self) -> Option<std::collections::HashMap<String, f64>> {
-        let obj = self
-            .properties
-            .as_ref()?
-            .get("source_reliability")?
-            .as_object()?;
+    /// Read a `properties.<key>` object as a `tag → factor` map, keeping only
+    /// entries whose value is a finite number in `[0, 1]`. Returns `None` when
+    /// the key is absent or yields no valid entries.
+    fn reliability_map(&self, key: &str) -> Option<std::collections::HashMap<String, f64>> {
+        let obj = self.properties.as_ref()?.get(key)?.as_object()?;
         let map: std::collections::HashMap<String, f64> = obj
             .iter()
             .filter_map(|(k, v)| {
@@ -56,6 +47,32 @@ impl PerspectiveRow {
         } else {
             Some(map)
         }
+    }
+
+    /// Per-perspective source-reliability map: evidence-type tag → α ∈ [0,1],
+    /// read from `properties->'source_reliability'`.
+    ///
+    /// This is one half of the "frame function": it lets one observer
+    /// down-weight, say, `testimonial` evidence to 0.4 while another trusts it
+    /// at 1.0, yielding different beliefs over the *same* evidence. The value
+    /// overrides the per-frame / global calibration evidence-type weight for the
+    /// querying perspective. Returns `None` when the key is absent (no override)
+    /// and silently skips any entry that is not a finite number in `[0, 1]`.
+    #[must_use]
+    pub fn source_reliability(&self) -> Option<std::collections::HashMap<String, f64>> {
+        self.reliability_map("source_reliability")
+    }
+
+    /// Per-perspective locality-reliability map: `mass_functions.locality_tag`
+    /// → factor ∈ [0,1], read from `properties->'locality_reliability'`.
+    ///
+    /// The other half of the frame function: it lets an observer set its own
+    /// trust in each evidence-locality pathway (e.g. `intra_self_cite` →
+    /// 0.2, `cross` → 1.0), overriding the per-frame / global intra-locality
+    /// factor. Same validation as [`Self::source_reliability`].
+    #[must_use]
+    pub fn locality_reliability(&self) -> Option<std::collections::HashMap<String, f64>> {
+        self.reliability_map("locality_reliability")
     }
 }
 
@@ -102,40 +119,63 @@ impl PerspectiveRepository {
         Ok(row)
     }
 
-    /// Set this perspective's source-reliability map (the frame function),
-    /// merging it into `properties` under the `source_reliability` key without
-    /// disturbing other `properties` entries.
-    ///
-    /// `reliability` maps an evidence-type tag (matching `mass_functions.
-    /// evidence_type`) to α ∈ [0,1]. Pass an empty map to clear the override
-    /// (the perspective then falls back to legacy own-BBA scoping).
-    ///
-    /// # Errors
-    /// Returns `DbError::QueryFailed` if the database query fails.
-    #[instrument(skip(pool, reliability))]
-    pub async fn set_source_reliability(
+    /// Merge a `tag → factor` map into `properties.<field>` without disturbing
+    /// other `properties` entries. The path element is parameterised (bound as
+    /// `text[]`), so callers supply a static field name — no SQL injection.
+    #[instrument(skip(pool, map))]
+    async fn set_reliability_map(
         pool: &PgPool,
         id: Uuid,
-        reliability: &std::collections::HashMap<String, f64>,
+        field: &str,
+        map: &std::collections::HashMap<String, f64>,
     ) -> Result<(), DbError> {
-        let value = serde_json::to_value(reliability).unwrap_or(serde_json::Value::Null);
+        let value = serde_json::to_value(map).unwrap_or(serde_json::Value::Null);
         sqlx::query(
             r#"
             UPDATE perspectives
             SET properties = jsonb_set(
                 COALESCE(properties, '{}'::jsonb),
-                '{source_reliability}',
-                $2::jsonb,
+                ARRAY[$2]::text[],
+                $3::jsonb,
                 true
             )
             WHERE id = $1
             "#,
         )
         .bind(id)
+        .bind(field)
         .bind(value)
         .execute(pool)
         .await?;
         Ok(())
+    }
+
+    /// Set this perspective's source-reliability map (evidence-type tag → α ∈
+    /// [0,1]), merging into `properties.source_reliability`. Empty map clears
+    /// the override.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    pub async fn set_source_reliability(
+        pool: &PgPool,
+        id: Uuid,
+        reliability: &std::collections::HashMap<String, f64>,
+    ) -> Result<(), DbError> {
+        Self::set_reliability_map(pool, id, "source_reliability", reliability).await
+    }
+
+    /// Set this perspective's locality-reliability map (`locality_tag` → factor
+    /// ∈ [0,1]), merging into `properties.locality_reliability`. Empty map
+    /// clears the override.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    pub async fn set_locality_reliability(
+        pool: &PgPool,
+        id: Uuid,
+        reliability: &std::collections::HashMap<String, f64>,
+    ) -> Result<(), DbError> {
+        Self::set_reliability_map(pool, id, "locality_reliability", reliability).await
     }
 
     /// Ensure a synthetic "evidence_grounded" perspective row exists with the
@@ -322,6 +362,25 @@ mod tests {
         let map = row.source_reliability().expect("map present");
         assert!((map["western_clinical"] - 0.95).abs() < f64::EPSILON);
         assert!((map["practitioner_interview"] - 0.4).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn locality_reliability_parses_independently_of_source() {
+        let row = make_row(Some(serde_json::json!({
+            "source_reliability": { "empirical": 0.9 },
+            "locality_reliability": { "intra_self_cite": 0.2, "cross": 1.0, "bad": 2.0 }
+        })));
+        let loc = row.locality_reliability().expect("locality map present");
+        assert!((loc["intra_self_cite"] - 0.2).abs() < f64::EPSILON);
+        assert!((loc["cross"] - 1.0).abs() < f64::EPSILON);
+        assert!(!loc.contains_key("bad"), "out-of-range factor dropped");
+        // The two maps are independent.
+        assert!(row.source_reliability().unwrap().contains_key("empirical"));
+        // Absent locality_reliability → None even when source_reliability is set.
+        let only_source = make_row(Some(
+            serde_json::json!({ "source_reliability": { "empirical": 0.9 } }),
+        ));
+        assert!(only_source.locality_reliability().is_none());
     }
 
     #[test]

--- a/crates/epigraph-engine/src/belief_query.rs
+++ b/crates/epigraph-engine/src/belief_query.rs
@@ -13,11 +13,13 @@ use epigraph_db::{
     ClaimRepository, FrameRepository, MassFunctionRepository, MassFunctionRow,
     PerspectiveRepository, PgPool,
 };
-use epigraph_ds::{
-    combination::{self, CombinationMethod},
-    FocalElement, FrameOfDiscernment, MassFunction,
-};
+use epigraph_ds::{combination, FocalElement, FrameOfDiscernment, MassFunction};
 use thiserror::Error;
+
+use crate::calibration::CalibrationConfig;
+use crate::edge_factor::{
+    effective_source_strength, effective_source_strength_with_perspective, PerspectiveReliability,
+};
 use uuid::Uuid;
 
 /// Errors from the library-level `get_belief` function.
@@ -131,23 +133,13 @@ pub async fn get_belief(
             return Ok(BeliefInterval::empty_frame(frame.hypothesis_count()));
         }
 
-        let mut mass_fns: Vec<MassFunction> = Vec::with_capacity(all_bbas.len());
-        for row in &all_bbas {
-            let mf = MassFunction::from_json_masses(frame.clone(), &row.masses)
-                .map_err(BeliefQueryError::ParseMasses)?;
-            mass_fns.push(mf);
-        }
-
-        let combined = if mass_fns.len() == 1 {
-            mass_fns.into_iter().next().expect("checked len == 1")
-        } else {
-            let mut result = mass_fns[0].clone();
-            for mf in &mass_fns[1..] {
-                result = combination::redistribute(&result, mf, CombinationMethod::Dempster, None)
-                    .map_err(BeliefQueryError::Ds)?;
-            }
-            result
-        };
+        // Discount each BBA by its calibrated reliability (evidence-type weight
+        // × locality, via `effective_source_strength`) before combining, so the
+        // framed read agrees with the cached `claims.pignistic_prob` that the
+        // recompute path writes. `perspective = None` → global calibration.
+        let combined = recompute_framed_belief(pool, frame_id, &frame, &all_bbas, None)
+            .await?
+            .expect("all_bbas is non-empty so combination yields Some");
 
         let target = FocalElement::positive(BTreeSet::from([hypothesis_index]));
         let bel = epigraph_ds::measures::belief(&combined, &target);
@@ -176,13 +168,15 @@ pub async fn get_belief(
 /// Compute a **perspective-scoped** belief on demand — the "frame function".
 ///
 /// This is `get_belief`'s framed path re-weighted from one observer's
-/// viewpoint: every stored BBA on `(claim, frame)` is Shafer-discounted by the
-/// perspective's reliability for that BBA's `evidence_type` tag before
-/// combination. Because it recomputes from the labelled BBAs, it works
-/// regardless of how the evidence was ingested — there is no cache to populate
-/// and no dependency on a particular write path. A perspective with no
-/// `source_reliability` map (or an absent perspective) discounts nothing, so it
-/// reproduces the global `get_belief` value.
+/// viewpoint: every stored BBA on `(claim, frame)` is Shafer-discounted by its
+/// reliability *for this perspective* before combination, where the perspective
+/// may override both the evidence-type weight (`source_reliability`) and the
+/// locality factor (`locality_reliability`) on top of the per-frame / global
+/// calibration tiers. Because it recomputes from the labelled BBAs, it works
+/// regardless of how the evidence was ingested — no cache, no write-path
+/// dependency. A perspective with neither map (or an absent perspective)
+/// expresses no opinion, so the result reduces exactly to the global
+/// `get_belief`.
 ///
 /// # Errors
 /// `FrameNotFound` if `frame_id` is absent; `ParseMasses`/`Ds` on malformed or
@@ -206,13 +200,19 @@ pub async fn get_perspective_belief(
         return Ok(BeliefInterval::empty_frame(frame.hypothesis_count()));
     }
 
-    // The perspective's source-reliability map; None when the perspective is
-    // absent or declares no map → no discount → equals the global belief.
-    let reliability = PerspectiveRepository::get_by_id(pool, perspective_id)
+    // The perspective's frame-function config: source-reliability (evidence
+    // type) + locality-reliability (pathway). Absent/empty → no opinion → the
+    // computation reduces to the global `get_belief`.
+    let perspective = PerspectiveRepository::get_by_id(pool, perspective_id)
         .await?
-        .and_then(|p| p.source_reliability());
+        .map(|p| PerspectiveReliability {
+            source_reliability: p.source_reliability().unwrap_or_default(),
+            locality_reliability: p.locality_reliability().unwrap_or_default(),
+        })
+        .unwrap_or_default();
 
-    let combined = combine_perspective_masses(&all_bbas, reliability.as_ref(), &frame)?
+    let combined = recompute_framed_belief(pool, frame_id, &frame, &all_bbas, Some(&perspective))
+        .await?
         .expect("all_bbas is non-empty so combination yields Some");
 
     let target = FocalElement::positive(BTreeSet::from([hypothesis_index]));
@@ -227,154 +227,77 @@ pub async fn get_perspective_belief(
     })
 }
 
-/// Discount each BBA by `reliability[evidence_type]` (α = 1.0 when the tag is
-/// `None` or unmapped) and Dempster-combine, mirroring `get_belief`'s framed
-/// combination. Returns `Ok(None)` only when `rows` is empty.
+/// Recompute the combined mass function for a framed claim, discounting each
+/// stored BBA by its effective reliability before Dempster combination.
 ///
-/// Pure given its inputs (no DB), so the frame-function math is unit-testable
-/// without seeding a claim/frame.
-pub fn combine_perspective_masses(
-    rows: &[MassFunctionRow],
-    reliability: Option<&std::collections::HashMap<String, f64>>,
+/// Reliability is resolved through `effective_source_strength`'s tier chain
+/// (per-frame override → global calibration → stored `source_strength`), with
+/// locality applied. When `perspective` is `Some`, the perspective's
+/// frame-function overrides sit at the top of that chain for both the
+/// evidence-type weight and the locality factor. This is the single path both
+/// `get_belief` (perspective = `None`) and `get_perspective_belief` use, so a
+/// no-opinion perspective reproduces the global belief exactly, and both agree
+/// with the cached `claims.pignistic_prob`.
+///
+/// Calibration and the per-frame overrides are loaded once. Per-frame loads are
+/// best-effort: a DB error there falls back to global calibration rather than
+/// failing the read. Returns `Ok(None)` only when `rows` is empty.
+async fn recompute_framed_belief(
+    pool: &PgPool,
+    frame_id: Uuid,
     frame: &FrameOfDiscernment,
+    rows: &[MassFunctionRow],
+    perspective: Option<&PerspectiveReliability>,
 ) -> Result<Option<MassFunction>, BeliefQueryError> {
+    if rows.is_empty() {
+        return Ok(None);
+    }
+
+    let calibration = CalibrationConfig::from_workspace_root()
+        .unwrap_or_else(|_| CalibrationConfig::default_for_phase2_fallback());
+    let per_frame_intra = FrameRepository::get_intra_evidence_locality_factor(pool, frame_id)
+        .await
+        .ok()
+        .flatten();
+    let per_frame_weights = FrameRepository::get_per_frame_evidence_type_weights(pool, frame_id)
+        .await
+        .ok()
+        .flatten();
+
     let mut mass_fns: Vec<MassFunction> = Vec::with_capacity(rows.len());
     for row in rows {
         let mf = MassFunction::from_json_masses(frame.clone(), &row.masses)
             .map_err(BeliefQueryError::ParseMasses)?;
-        let alpha = reliability
-            .and_then(|m| row.evidence_type.as_deref().and_then(|t| m.get(t)))
-            .copied()
-            .unwrap_or(1.0);
-        mass_fns.push(combination::discount(&mf, alpha)?);
+        let alpha = match perspective {
+            Some(p) => effective_source_strength_with_perspective(
+                row,
+                per_frame_intra,
+                per_frame_weights.as_ref(),
+                &calibration,
+                p,
+            ),
+            None => effective_source_strength(
+                row,
+                per_frame_intra,
+                per_frame_weights.as_ref(),
+                &calibration,
+            ),
+        };
+        mass_fns.push(combination::discount(&mf, alpha).map_err(BeliefQueryError::Ds)?);
     }
 
-    if mass_fns.is_empty() {
-        return Ok(None);
-    }
-    let combined = if mass_fns.len() == 1 {
-        mass_fns.into_iter().next().expect("checked len == 1")
-    } else {
-        let mut result = mass_fns[0].clone();
-        for mf in &mass_fns[1..] {
-            result = combination::redistribute(&result, mf, CombinationMethod::Dempster, None)?;
-        }
-        result
-    };
+    // Combine via the SAME adaptive rule the recompute/write path uses
+    // (`combine_multiple`: canonical sort + per-step Dempster/Conjunctive/
+    // Yager/Inagaki selection by conflict). Matching it — not a plain Dempster
+    // fold — is what makes this compute-on-read result reproduce the recompute
+    // path's combination for the same discounted BBAs.
+    let (combined, _reports) =
+        combination::combine_multiple(&mass_fns, 0.9).map_err(BeliefQueryError::Ds)?;
     Ok(Some(combined))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use epigraph_ds::measures;
-    use std::collections::{BTreeMap, HashMap};
-
-    fn binary() -> FrameOfDiscernment {
-        FrameOfDiscernment::new("binary", vec!["H0".to_string(), "H1".to_string()]).unwrap()
-    }
-
-    /// A supporting BBA: `mass` on TRUE (H0), the rest on Θ, tagged `evidence_type`.
-    fn row(frame: &FrameOfDiscernment, evidence_type: Option<&str>, mass: f64) -> MassFunctionRow {
-        let mut bba = BTreeMap::new();
-        bba.insert(FocalElement::positive(BTreeSet::from([0])), mass);
-        bba.insert(FocalElement::theta(frame), 1.0 - mass);
-        let mf = MassFunction::new(frame.clone(), bba).unwrap();
-        MassFunctionRow {
-            id: Uuid::new_v4(),
-            claim_id: Uuid::new_v4(),
-            frame_id: Uuid::new_v4(),
-            source_agent_id: None,
-            perspective_id: None,
-            masses: mf.masses_to_json(),
-            conflict_k: None,
-            combination_method: Some("auto_wire".to_string()),
-            source_strength: Some(1.0),
-            evidence_type: evidence_type.map(str::to_string),
-            locality_tag: "unknown".to_string(),
-            evidence_id: None,
-            created_at: chrono::Utc::now(),
-        }
-    }
-
-    fn bel_h0(frame: &FrameOfDiscernment, mf: &MassFunction) -> f64 {
-        let _ = frame;
-        measures::belief(mf, &FocalElement::positive(BTreeSet::from([0])))
-    }
-
-    #[test]
-    fn divergent_beliefs_from_same_evidence() {
-        // Same two BBAs (a clinical result + an interview), two observers who
-        // trust the interview differently → different belief in H0.
-        let frame = binary();
-        let rows = [
-            row(&frame, Some("western_clinical"), 0.6),
-            row(&frame, Some("practitioner_interview"), 0.7),
-        ];
-        let skeptic = HashMap::from([
-            ("western_clinical".to_string(), 1.0),
-            ("practitioner_interview".to_string(), 0.3),
-        ]);
-        let believer = HashMap::from([
-            ("western_clinical".to_string(), 1.0),
-            ("practitioner_interview".to_string(), 1.0),
-        ]);
-
-        let s = combine_perspective_masses(&rows, Some(&skeptic), &frame)
-            .unwrap()
-            .unwrap();
-        let b = combine_perspective_masses(&rows, Some(&believer), &frame)
-            .unwrap()
-            .unwrap();
-        let (sb, bb) = (bel_h0(&frame, &s), bel_h0(&frame, &b));
-        assert!(
-            sb < bb,
-            "skeptic {sb} should believe less than believer {bb}"
-        );
-        assert!(sb > 0.0 && bb < 1.0);
-    }
-
-    #[test]
-    fn neutral_perspective_reproduces_global() {
-        // An all-α=1.0 believer and the no-map (global) case must combine
-        // identically — neutral observer == global belief.
-        let frame = binary();
-        let rows = [
-            row(&frame, Some("western_clinical"), 0.6),
-            row(&frame, Some("practitioner_interview"), 0.7),
-        ];
-        let believer = HashMap::from([
-            ("western_clinical".to_string(), 1.0),
-            ("practitioner_interview".to_string(), 1.0),
-        ]);
-        let with_map = combine_perspective_masses(&rows, Some(&believer), &frame)
-            .unwrap()
-            .unwrap();
-        let no_map = combine_perspective_masses(&rows, None, &frame)
-            .unwrap()
-            .unwrap();
-        assert!((bel_h0(&frame, &with_map) - bel_h0(&frame, &no_map)).abs() < 1e-12);
-    }
-
-    #[test]
-    fn untagged_evidence_is_not_discounted() {
-        // A BBA with no evidence_type passes through at α=1.0 even when the
-        // perspective has a (non-matching) map — you can't down-weight what you
-        // can't identify.
-        let frame = binary();
-        let tagged = [row(&frame, None, 0.8)];
-        let map = HashMap::from([("practitioner_interview".to_string(), 0.1)]);
-        let out = combine_perspective_masses(&tagged, Some(&map), &frame)
-            .unwrap()
-            .unwrap();
-        assert!((bel_h0(&frame, &out) - 0.8).abs() < 1e-12);
-    }
-
-    #[test]
-    fn empty_rows_yield_none() {
-        let frame = binary();
-        assert!(combine_perspective_masses(&[], None, &frame)
-            .unwrap()
-            .is_none());
-    }
-}
+// The frame-function reliability composition (perspective × per-frame ×
+// calibration, at both the evidence-type and locality tiers) is unit-tested at
+// its source in `edge_factor::tests` (effective_source_strength_with_perspective).
+// The full DB chain — get_perspective_belief vs get_belief over stored BBAs —
+// is covered by the `perspective_frame_function` sqlx integration test.

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -465,6 +465,105 @@ pub fn effective_source_strength(
     0.5
 }
 
+/// A querying perspective's reliability overrides — the "frame function"
+/// config. Both maps are keyed lowercase and override, respectively, the
+/// evidence-type base weight and the locality factor for that observer. Empty
+/// maps mean "no opinion" (fall through to per-frame / global calibration).
+#[derive(Debug, Clone, Default)]
+pub struct PerspectiveReliability {
+    /// `evidence_type` → base reliability weight ∈ [0,1].
+    pub source_reliability: HashMap<String, f64>,
+    /// `locality_tag` → locality factor ∈ [0,1].
+    pub locality_reliability: HashMap<String, f64>,
+}
+
+impl PerspectiveReliability {
+    /// `true` when neither map has any entry — the perspective expresses no
+    /// reliability opinion and is treated identically to the global
+    /// (no-perspective) computation.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.source_reliability.is_empty() && self.locality_reliability.is_empty()
+    }
+}
+
+/// Per-BBA reliability for a **specific querying perspective** — the same tier
+/// chain as [`effective_source_strength`] with the perspective inserted as the
+/// highest-priority tier at *both* the evidence-type weight and the locality
+/// factor.
+///
+/// Resolution per BBA:
+/// - **base weight** = `perspective.source_reliability[evidence_type]`
+///   → per-frame override → global calibration weight → stored `source_strength`
+///   → 0.5.
+/// - **locality factor** = `perspective.locality_reliability[locality_tag]`
+///   → (per-frame ∨ global intra factor, applied when the tag is `intra*`)
+///   → 1.0.
+/// - result = `base × locality`, clamped.
+///
+/// When the perspective has no override touching this BBA (no matching
+/// evidence-type key *and* no matching locality key), the result is exactly
+/// [`effective_source_strength`] — so a no-opinion perspective reproduces the
+/// global belief. Nothing is hardwired: every weight comes from config
+/// (perspective JSONB → frame properties → `calibration.toml`).
+#[must_use]
+pub fn effective_source_strength_with_perspective(
+    row: &MassFunctionRow,
+    per_frame_intra_factor: Option<f64>,
+    per_frame_evidence_weights: Option<&HashMap<String, f64>>,
+    calibration: &CalibrationConfig,
+    perspective: &PerspectiveReliability,
+) -> f64 {
+    let etype = row.evidence_type.as_deref().map(str::to_lowercase);
+    let locality_key = row.locality_tag.to_lowercase();
+
+    let persp_base = etype
+        .as_ref()
+        .and_then(|t| perspective.source_reliability.get(t))
+        .copied();
+    let persp_locality = perspective.locality_reliability.get(&locality_key).copied();
+
+    // No override touches this BBA → identical to the global computation.
+    if persp_base.is_none() && persp_locality.is_none() {
+        return effective_source_strength(
+            row,
+            per_frame_intra_factor,
+            per_frame_evidence_weights,
+            calibration,
+        );
+    }
+
+    // Base evidence-type weight: perspective → per-frame → calibration →
+    // stored source_strength → 0.5.
+    let base = persp_base
+        .or_else(|| {
+            etype
+                .as_ref()
+                .and_then(|t| per_frame_evidence_weights.and_then(|m| m.get(t)).copied())
+        })
+        .or_else(|| {
+            etype
+                .as_ref()
+                .filter(|t| calibration.evidence_type_weight_present(t))
+                .map(|t| calibration.get_evidence_type_weight(t))
+        })
+        .or(row.source_strength)
+        .unwrap_or(0.5);
+
+    // Locality factor: perspective → legacy intra logic (per-frame ∨ global
+    // intra factor when the tag is intra*, else 1.0).
+    let locality = persp_locality.unwrap_or_else(|| {
+        if locality_key.starts_with("intra") {
+            per_frame_intra_factor
+                .unwrap_or(calibration.evidence_locality.intra_evidence_locality_factor)
+        } else {
+            1.0
+        }
+    });
+
+    (base * locality).clamp(0.0, 1.0)
+}
+
 /// Phase 4 (issue #197) Q8: warn on per-frame evidence-type override
 /// keys that aren't in calibration's known vocabulary.
 ///

--- a/crates/epigraph-engine/tests/effective_source_strength_unit.rs
+++ b/crates/epigraph-engine/tests/effective_source_strength_unit.rs
@@ -526,3 +526,122 @@ fn phase4_per_frame_override_composes_with_locality() {
         "empirical/intra + per-frame{empirical: 0.5} + intra_factor 0.9 → 0.45",
     );
 }
+
+// ── Perspective overrides (frame function): effective_source_strength_with_perspective ──
+//
+// The querying perspective sits at the TOP of both tier chains (evidence-type
+// weight and locality factor). A perspective with no matching key reduces to
+// the global computation.
+
+use epigraph_engine::edge_factor::{
+    effective_source_strength_with_perspective, PerspectiveReliability,
+};
+
+fn perspective(source: &[(&str, f64)], locality: &[(&str, f64)]) -> PerspectiveReliability {
+    PerspectiveReliability {
+        source_reliability: source.iter().map(|(k, v)| ((*k).to_string(), *v)).collect(),
+        locality_reliability: locality
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), *v))
+            .collect(),
+    }
+}
+
+#[test]
+fn perspective_evidence_weight_overrides_calibration() {
+    let cfg = load_calibration();
+    let r = row(Some("empirical"), "unknown", Some(1.0));
+    // Global: empirical 1.0 × locality(unknown→1.0) = 1.0.
+    approx(
+        effective_source_strength(&r, None, None, &cfg),
+        1.0,
+        "global empirical",
+    );
+    // Perspective downweights empirical to 0.5 → 0.5 × 1.0.
+    let p = perspective(&[("empirical", 0.5)], &[]);
+    approx(
+        effective_source_strength_with_perspective(&r, None, None, &cfg, &p),
+        0.5,
+        "perspective empirical 0.5",
+    );
+}
+
+#[test]
+fn perspective_locality_overrides_intra_factor() {
+    let cfg = load_calibration();
+    let r = row(Some("empirical"), "intra_self_cite", Some(1.0));
+    // Global: empirical 1.0 × intra 0.3 = 0.3.
+    approx(
+        effective_source_strength(&r, None, None, &cfg),
+        0.3,
+        "global intra",
+    );
+    // Perspective trusts intra_self_cite more (0.8) → 1.0 × 0.8.
+    let p = perspective(&[], &[("intra_self_cite", 0.8)]);
+    approx(
+        effective_source_strength_with_perspective(&r, None, None, &cfg, &p),
+        0.8,
+        "perspective locality 0.8",
+    );
+}
+
+#[test]
+fn perspective_composes_evidence_and_locality() {
+    let cfg = load_calibration();
+    let r = row(Some("testimonial"), "intra_self_cite", Some(1.0));
+    // Both tiers overridden: base 0.5 × locality 0.5 = 0.25.
+    let p = perspective(&[("testimonial", 0.5)], &[("intra_self_cite", 0.5)]);
+    approx(
+        effective_source_strength_with_perspective(&r, None, None, &cfg, &p),
+        0.25,
+        "0.5 × 0.5",
+    );
+}
+
+#[test]
+fn perspective_without_matching_key_equals_global() {
+    let cfg = load_calibration();
+    let r = row(Some("empirical"), "unknown", Some(1.0));
+    // Perspective has opinions, but none touch this BBA → identical to global.
+    let p = perspective(&[("statistical", 0.1)], &[("cross", 0.2)]);
+    approx(
+        effective_source_strength_with_perspective(&r, None, None, &cfg, &p),
+        effective_source_strength(&r, None, None, &cfg),
+        "non-matching perspective == global",
+    );
+    // Empty perspective is likewise a no-op.
+    let empty = PerspectiveReliability::default();
+    assert!(empty.is_empty());
+    approx(
+        effective_source_strength_with_perspective(&r, None, None, &cfg, &empty),
+        effective_source_strength(&r, None, None, &cfg),
+        "empty perspective == global",
+    );
+}
+
+#[test]
+fn perspective_locality_applies_to_untagged_evidence() {
+    let cfg = load_calibration();
+    // No evidence_type → base falls to stored source_strength (0.6). A
+    // perspective locality opinion still applies on top.
+    let r = row(None, "intra_self_cite", Some(0.6));
+    // Global leaves untyped rows at the stored source_strength (no locality).
+    approx(
+        effective_source_strength(&r, None, None, &cfg),
+        0.6,
+        "global untyped",
+    );
+    let p = perspective(&[], &[("intra_self_cite", 0.5)]);
+    approx(
+        effective_source_strength_with_perspective(&r, None, None, &cfg, &p),
+        0.6 * 0.5,
+        "untyped base 0.6 × perspective locality 0.5",
+    );
+    // With no relevant override, untyped row still equals global.
+    let unrelated = perspective(&[("empirical", 0.1)], &[("cross", 0.2)]);
+    approx(
+        effective_source_strength_with_perspective(&r, None, None, &cfg, &unrelated),
+        0.6,
+        "untyped, no matching override → global 0.6",
+    );
+}

--- a/crates/epigraph-engine/tests/perspective_frame_function.rs
+++ b/crates/epigraph-engine/tests/perspective_frame_function.rs
@@ -246,3 +246,119 @@ async fn unmapped_perspective_equals_global(pool: PgPool) {
         .expect("global belief");
     assert!((scoped.belief - global.belief).abs() < 1e-9);
 }
+
+/// The locality tier is config-driven and per-perspective overridable: an
+/// observer can trust an intra-source pathway that the global calibration
+/// discounts (and vice-versa), changing the belief over identical evidence.
+#[sqlx::test(migrations = "../../migrations")]
+async fn perspective_locality_reliability_overrides_global(pool: PgPool) {
+    let agent = insert_agent(&pool).await;
+    let claim_id = insert_claim(&pool, agent).await;
+    let frame_row =
+        FrameRepository::create(&pool, "ff_loc", None, &["H0".to_string(), "H1".to_string()])
+            .await
+            .expect("frame");
+    let frame =
+        FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
+
+    // One empirical BBA from an intra-source pathway: mass 0.8 on H0.
+    let mut bba = std::collections::BTreeMap::new();
+    bba.insert(
+        FocalElement::positive(std::collections::BTreeSet::from([0])),
+        0.8,
+    );
+    bba.insert(FocalElement::theta(&frame), 0.2);
+    let mf = MassFunction::new(frame.clone(), bba).unwrap();
+    MassFunctionRepository::store_with_perspective(
+        &pool,
+        claim_id,
+        frame_row.id,
+        Some(agent),
+        None,
+        &mf.masses_to_json(),
+        None,
+        Some("discount"),
+        Some(1.0),
+        Some("empirical"),
+        "intra_self_cite", // intra pathway → globally discounted
+        None,
+    )
+    .await
+    .expect("store bba");
+
+    // Global: empirical(1.0) × intra factor(0.3) discounts the belief.
+    let global = epigraph_engine::belief_query::get_belief(&pool, claim_id, Some(frame_row.id))
+        .await
+        .expect("global belief");
+
+    // Observer who fully trusts intra_self_cite → no intra discount → higher belief.
+    let truster = PerspectiveRepository::create(
+        &pool,
+        "intra-truster",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("truster");
+    PerspectiveRepository::set_locality_reliability(
+        &pool,
+        truster.id,
+        &HashMap::from([("intra_self_cite".to_string(), 1.0)]),
+    )
+    .await
+    .expect("set locality");
+    let trusted = epigraph_engine::belief_query::get_perspective_belief(
+        &pool,
+        claim_id,
+        frame_row.id,
+        truster.id,
+    )
+    .await
+    .expect("trusted belief");
+
+    // Observer who distrusts intra_self_cite harder than the global factor.
+    let skeptic = PerspectiveRepository::create(
+        &pool,
+        "intra-skeptic",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("skeptic");
+    PerspectiveRepository::set_locality_reliability(
+        &pool,
+        skeptic.id,
+        &HashMap::from([("intra_self_cite".to_string(), 0.1)]),
+    )
+    .await
+    .expect("set locality");
+    let skeptical = epigraph_engine::belief_query::get_perspective_belief(
+        &pool,
+        claim_id,
+        frame_row.id,
+        skeptic.id,
+    )
+    .await
+    .expect("skeptical belief");
+
+    assert!(
+        trusted.belief > global.belief,
+        "intra-truster ({}) should exceed global ({})",
+        trusted.belief,
+        global.belief
+    );
+    assert!(
+        skeptical.belief < global.belief,
+        "intra-skeptic ({}) should fall below global ({})",
+        skeptical.belief,
+        global.belief
+    );
+}

--- a/crates/epigraph-ingest/src/common/evidence_type.rs
+++ b/crates/epigraph-ingest/src/common/evidence_type.rs
@@ -1,0 +1,82 @@
+//! Canonical evidence-type vocabulary for extraction.
+//!
+//! The extracting LLM tags each paragraph/atom with an `evidence_type` chosen
+//! from [`EVIDENCE_TYPES`]. That tag lands on the BBA's
+//! `mass_functions.evidence_type`, where two consumers key on it:
+//!
+//! - **Global belief** — `effective_source_strength` resolves the tag to a
+//!   reliability weight via `calibration.toml`'s `[evidence_type_weights]`
+//!   (issue #197 Phase 2). An unrecognised tag falls through to the 0.5
+//!   unknown-key default, silently flattening the calibration — so we
+//!   normalise to the canonical set at plan-build time and drop anything else.
+//! - **Per-perspective belief** — the frame function (`get_perspective_belief`)
+//!   discounts each BBA by the querying perspective's reliability for its tag.
+//!
+//! These keys are therefore a **subset of the calibration `evidence_type_weights`
+//! keys**; `evidence_type_set_is_calibration_subset` (in epigraph-mcp tests)
+//! guards that invariant against drift between this list and `calibration.toml`.
+
+/// Canonical evidence types the extractor may assign. Mirrors the canonical
+/// keys in `calibration.toml` `[evidence_type_weights]`.
+///
+/// - `regulatory` — a binding rule, statute, standard, or approval.
+/// - `empirical` — direct observation/measurement/experiment.
+/// - `statistical` — aggregate/quantitative analysis over a sample.
+/// - `logical` — derivation or assertion argued within the text.
+/// - `testimonial` — explicit attributed testimony or expert statement.
+/// - `circumstantial` — indirect/inferred support.
+/// - `conversational` — informal/anecdotal report (e.g. transcript remark).
+pub const EVIDENCE_TYPES: &[&str] = &[
+    "regulatory",
+    "empirical",
+    "statistical",
+    "logical",
+    "testimonial",
+    "circumstantial",
+    "conversational",
+];
+
+/// Normalise an extractor-supplied evidence-type tag to a canonical key.
+///
+/// Case-insensitive and whitespace-trimming. Returns `Some(canonical)` only for
+/// a value in [`EVIDENCE_TYPES`]; any other value (including `None` or an
+/// unrecognised string) returns `None`, so the BBA is stored untagged rather
+/// than with a tag that would hit the 0.5 unknown-key fallback. Dropping an
+/// unmappable tag is deliberate: an untagged BBA cleanly inherits its stored
+/// `source_strength` (global) and α = 1.0 (per-perspective).
+#[must_use]
+pub fn normalize_evidence_type(raw: Option<&str>) -> Option<String> {
+    let key = raw?.trim().to_lowercase();
+    EVIDENCE_TYPES
+        .iter()
+        .find(|&&t| t == key)
+        .map(|&t| t.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_canonical_case_insensitively() {
+        assert_eq!(
+            normalize_evidence_type(Some("empirical")).as_deref(),
+            Some("empirical")
+        );
+        assert_eq!(
+            normalize_evidence_type(Some("  Statistical ")).as_deref(),
+            Some("statistical")
+        );
+        assert_eq!(
+            normalize_evidence_type(Some("TESTIMONIAL")).as_deref(),
+            Some("testimonial")
+        );
+    }
+
+    #[test]
+    fn drops_unknown_and_none() {
+        assert_eq!(normalize_evidence_type(Some("western_clinical")), None);
+        assert_eq!(normalize_evidence_type(Some("")), None);
+        assert_eq!(normalize_evidence_type(None), None);
+    }
+}

--- a/crates/epigraph-ingest/src/common/mod.rs
+++ b/crates/epigraph-ingest/src/common/mod.rs
@@ -3,6 +3,7 @@
 //! and workflow-specific schemas wrap them in `document::` and `workflow::`.
 
 pub mod edges;
+pub mod evidence_type;
 pub mod ids;
 pub mod paths;
 pub mod plan;

--- a/crates/epigraph-ingest/src/document/builder.rs
+++ b/crates/epigraph-ingest/src/document/builder.rs
@@ -110,6 +110,13 @@ pub fn build_ingest_plan(extraction: &DocumentExtraction) -> IngestPlan {
             path_index.insert(para_path.clone(), para_id);
 
             let enrichment = enrichment_from_paragraph(paragraph);
+            // Normalise once per paragraph to a canonical calibration key (or
+            // None); the atoms below inherit the same tag. Keeps unrecognised
+            // extractor values off the BBA, where they'd hit the 0.5
+            // unknown-evidence-type fallback.
+            let para_evidence_type = crate::common::evidence_type::normalize_evidence_type(
+                paragraph.evidence_type.as_deref(),
+            );
 
             claims.push(PlannedClaim {
                 id: para_id,
@@ -124,7 +131,7 @@ pub fn build_ingest_plan(extraction: &DocumentExtraction) -> IngestPlan {
                 content_hash: para_hash,
                 confidence: paragraph.confidence,
                 methodology: paragraph.methodology.clone(),
-                evidence_type: paragraph.evidence_type.clone(),
+                evidence_type: para_evidence_type.clone(),
                 supporting_text: Some(paragraph.supporting_text.clone()),
                 enrichment: enrichment.clone(),
             });
@@ -156,7 +163,7 @@ pub fn build_ingest_plan(extraction: &DocumentExtraction) -> IngestPlan {
                     content_hash: atom_hash,
                     confidence: paragraph.confidence,
                     methodology: paragraph.methodology.clone(),
-                    evidence_type: paragraph.evidence_type.clone(),
+                    evidence_type: para_evidence_type.clone(),
                     supporting_text: Some(paragraph.supporting_text.clone()),
                     enrichment: enrichment.clone(),
                 });

--- a/crates/epigraph-ingest/src/document/schema.rs
+++ b/crates/epigraph-ingest/src/document/schema.rs
@@ -75,6 +75,11 @@ pub struct Paragraph {
     pub confidence: f64,
     #[serde(default)]
     pub methodology: Option<String>,
+    /// Evidence type for this paragraph and its atoms. The extractor picks ONE
+    /// canonical value from [`crate::common::evidence_type::EVIDENCE_TYPES`]
+    /// (regulatory, empirical, statistical, logical, testimonial,
+    /// circumstantial, conversational). Normalised at plan-build time; any
+    /// unrecognised value is dropped to `None`.
     #[serde(default)]
     pub evidence_type: Option<String>,
     #[serde(default)]

--- a/crates/epigraph-ingest/tests/integration.rs
+++ b/crates/epigraph-ingest/tests/integration.rs
@@ -1,6 +1,45 @@
 use epigraph_ingest::builder::build_ingest_plan;
 use epigraph_ingest::schema::DocumentExtraction;
 
+/// Paragraph `evidence_type` is normalised to a canonical key and inherited by
+/// its atoms; an unrecognised value is dropped to `None` so it never reaches
+/// the BBA as an unknown tag.
+#[test]
+fn evidence_type_normalized_and_inherited_by_atoms() {
+    let json = r#"{
+      "source": { "title": "T" },
+      "sections": [{
+        "title": "S",
+        "paragraphs": [
+          { "compound": "c1", "evidence_type": "Empirical", "atoms": ["a1", "a2"] },
+          { "compound": "c2", "evidence_type": "made_up_type", "atoms": ["a3"] },
+          { "compound": "c3", "atoms": ["a4"] }
+        ]
+      }]
+    }"#;
+    let extraction: DocumentExtraction = serde_json::from_str(json).unwrap();
+    let plan = build_ingest_plan(&extraction);
+
+    let etype = |content: &str| {
+        plan.claims
+            .iter()
+            .find(|c| c.content == content)
+            .unwrap()
+            .evidence_type
+            .clone()
+    };
+
+    // Canonical (case-insensitive) value propagates to the paragraph and atoms.
+    assert_eq!(etype("c1").as_deref(), Some("empirical"));
+    assert_eq!(etype("a1").as_deref(), Some("empirical"));
+    assert_eq!(etype("a2").as_deref(), Some("empirical"));
+    // Unrecognised value is dropped.
+    assert_eq!(etype("c2"), None);
+    assert_eq!(etype("a3"), None);
+    // Absent value stays None.
+    assert_eq!(etype("a4"), None);
+}
+
 #[test]
 fn test_full_extraction_from_fixture() {
     let json = include_str!("fixtures/sample_hierarchical.json");

--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -49,6 +49,11 @@ pub struct BatchDsEntry {
     pub claim_id: Uuid,
     pub confidence: f64,
     pub weight: f64,
+    /// Canonical evidence-type tag from the extraction plan, stored on the BBA
+    /// so `effective_source_strength` (global) and the frame function
+    /// (per-perspective) can key reliability on it. `None` → untagged BBA
+    /// (falls back to the stored `source_strength` / α = 1.0).
+    pub evidence_type: Option<String>,
 }
 
 /// Canonical binary frame name.
@@ -441,10 +446,10 @@ async fn wire_single_batch_entry(
         &masses_json,
         None,
         Some("auto_wire"),
-        Some(entry.weight), // source_strength = evidence-type reliability
-        None,               // evidence_type (not threaded through batch yet)
-        "unknown",          // batch ds_auto path; no per-entry locality (issue #197)
-        None,               // batch path predates per-claim evidence rows (issue #197 Phase 3)
+        Some(entry.weight), // source_strength = methodology weight (legacy fallback when evidence_type is None)
+        entry.evidence_type.as_deref(), // evidence_type → effective_source_strength / frame function
+        "unknown",                      // batch ds_auto path; no per-entry locality (issue #197)
+        None, // batch path predates per-claim evidence rows (issue #197 Phase 3)
     )
     .await
     .map_err(|e| format!("store BBA: {e}"))?;

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -331,6 +331,7 @@ pub async fn do_ingest_document(
                 claim_id: persisted_id,
                 confidence,
                 weight,
+                evidence_type: planned.evidence_type.clone(),
             });
         }
 

--- a/crates/epigraph-mcp/tests/evidence_type_vocab.rs
+++ b/crates/epigraph-mcp/tests/evidence_type_vocab.rs
@@ -1,0 +1,27 @@
+//! Guard: the extraction evidence-type vocabulary must stay a subset of the
+//! calibration `[evidence_type_weights]` keys.
+//!
+//! `effective_source_strength` and the per-perspective frame function both
+//! resolve a BBA's `evidence_type` through `calibration.toml`; a tag outside
+//! the calibrated vocabulary silently hits the 0.5 unknown-key fallback. The
+//! ingest crate hardcodes its set (it has no calibration dependency), so this
+//! test — in a crate that depends on both — is what stops the two from
+//! drifting apart.
+
+use epigraph_engine::calibration::CalibrationConfig;
+use epigraph_ingest::common::evidence_type::EVIDENCE_TYPES;
+
+#[test]
+fn extraction_vocabulary_is_a_calibration_subset() {
+    let calibration =
+        CalibrationConfig::from_workspace_root().expect("load workspace calibration.toml");
+
+    for &etype in EVIDENCE_TYPES {
+        assert!(
+            calibration.evidence_type_weight_present(etype),
+            "evidence type {etype:?} is in EVIDENCE_TYPES but missing from \
+             calibration.toml [evidence_type_weights] — it would hit the 0.5 \
+             unknown-key fallback. Add it to calibration or remove it from the set."
+        );
+    }
+}

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -443,6 +443,71 @@ async fn ingest_document_handles_compound_equals_atom(pool: sqlx::PgPool) {
     );
 }
 
+#[sqlx::test(migrations = "../../migrations")]
+async fn ingest_tags_bbas_with_normalized_evidence_type(pool: sqlx::PgPool) {
+    let server = make_server(pool.clone());
+
+    // Two atoms under a paragraph tagged (mixed-case) "Empirical" → their BBAs
+    // must carry the normalized canonical tag; nothing should carry the raw
+    // pre-normalization string.
+    let extraction_json = serde_json::json!({
+        "source": {
+            "title": "evidence-type-wiring",
+            "doi": "test/evidence-type-wiring",
+            "source_type": "Paper",
+            "authors": [{"name": "test", "affiliations": [], "roles": ["author"]}],
+            "metadata": {}
+        },
+        "thesis": "Evidence-type tags reach the BBA.",
+        "thesis_derivation": "TopDown",
+        "sections": [{
+            "title": "Body",
+            "summary": "One paragraph, two atoms, tagged Empirical.",
+            "paragraphs": [{
+                "compound": "Two empirical observations support the thesis.",
+                "supporting_text": "Measured directly in two assays.",
+                "atoms": [
+                    "Observation one holds under standard conditions",
+                    "Observation two replicates observation one"
+                ],
+                "generality": [0, 0],
+                "confidence": 0.8,
+                "methodology": "extraction",
+                "evidence_type": "Empirical"
+            }]
+        }],
+        "relationships": []
+    });
+    let extraction: epigraph_ingest::schema::DocumentExtraction =
+        serde_json::from_value(extraction_json).expect("fixture parses");
+
+    do_ingest_document(&server, &extraction)
+        .await
+        .expect("ingest succeeds");
+
+    // Atom BBAs carry the normalized canonical tag.
+    let empirical_bbas: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM mass_functions WHERE evidence_type = 'empirical'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        empirical_bbas >= 2,
+        "expected >=2 atom BBAs tagged 'empirical', found {empirical_bbas}"
+    );
+
+    // The raw (un-normalized) value never reaches the column.
+    let raw_case: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM mass_functions WHERE evidence_type = 'Empirical'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        raw_case, 0,
+        "raw 'Empirical' should have been normalized to lowercase"
+    );
+}
+
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
     let content = result.content.first().expect("at least one content block");
     content.as_text().expect("text content").text.clone()


### PR DESCRIPTION
Two coupled changes on the `#197`/`#206` evidence-reliability line. Originally just the ingest tagging (commit 1); extended per review to compose both belief read paths through one config-based reliability chain (commit 2), accommodating backlog `7b934e58` (partial), `3d5fdb05`, and `00b02ca9`.

## Commit 1 — tag document BBAs with a normalized `evidence_type`

`ingest_document` built BBAs with `evidence_type = NULL`, so document-ingested claims couldn't participate in evidence-type-keyed reliability. Now:
- **epigraph-ingest** `common::evidence_type`: canonical `EVIDENCE_TYPES` (the `calibration.toml` keys) + `normalize_evidence_type` (case-insensitive; unknown → `None`). `build_ingest_plan` normalizes each paragraph's tag and propagates it to atoms.
- **epigraph-mcp**: `BatchDsEntry` carries `evidence_type`; threaded to `store_with_perspective` (was hardcoded `None`).
- **extract-claims SKILL.md**: documents the closed set, with a parser-shaped snippet.
- Guard test: `EVIDENCE_TYPES ⊆ calibration` keys. Verified against real extractions (`logical/empirical/testimonial/statistical` — all in-set).

## Commit 2 — config-based two-tier reliability, per-perspective overridable

Per maintainer direction ("compose both paths; both config-based — evidence *and* locality; don't hardwire either"):

- **framed `get_belief`** now discounts each BBA by `effective_source_strength` (evidence-type weight × locality) and combines via the same adaptive `combine_multiple` the recompute/write path uses — so compute-on-read reproduces the recompute path (`auto_wire_ds_update`) instead of a raw, undiscounted Dempster fold. (Closes the discount-half of `3d5fdb05`.)
- **`get_perspective_belief`** routes through the same shared helper with the querying perspective as the **top tier at both** the evidence-type weight (`source_reliability`) and the locality factor (`locality_reliability`). Implements `00b02ca9`'s `frame override × locality × perspective` chain. A no-opinion perspective reduces *by construction* to global `get_belief`.
- New `effective_source_strength_with_perspective(.., &PerspectiveReliability)`: perspective overrides → per-frame → global calibration, at both tiers; no matching key ⇒ identical to `effective_source_strength` (global helper + callers unchanged).
- **epigraph-db**: `PerspectiveRow::locality_reliability()` + `set_locality_reliability` (parameterized `jsonb_set`), sharing a helper with `source_reliability`. Locality is now config-based and per-observer-overridable, not hardwired.

### Decisions (from maintainer)
- **JSONB substrate kept** — the `980e31bb` join-table redesign is deferred.
- **Legacy backfill** of ~278k NULL `mass_functions.evidence_type` rows (`7b934e58`) stays a separate data migration; this PR is go-forward + read-path only.

### Caveats / follow-ups
- **Ingest/recompute asymmetry (pre-existing):** initial ingest writes the cached `pignistic_prob` *without* `effective_source_strength`, so exact equality with the cached column holds for recompute-touched claims, not ingest-initial ones. Out of scope.
- **Perf:** `get_belief` (hot path) now loads+parses `calibration.toml` from disk + 2 per-frame reads per call, matching the recompute path's per-call pattern. Worth a follow-up to cache the calibration load (kept per-call so operator tuning still applies).
- Workflow ingest (`workflow/builder.rs`) still emits `evidence_type = None` — separate.

## Tests
- Unit: `normalize_evidence_type`; `build_ingest_plan` propagation; `EVIDENCE_TYPES ⊆ calibration` guard; 5× `effective_source_strength_with_perspective` (evidence override, locality override, composition, no-match==global, untagged+locality); `locality_reliability` accessor.
- Integration (`#[sqlx::test]`): ingested `"Empirical"` → `mass_functions.evidence_type='empirical'`; perspective divergence over identical evidence; **intra-truster > global > intra-skeptic** via locality override.
- Full `epigraph-mcp` suite (35 groups) green after the global `get_belief` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)