### PR TITLE
docs(perspective): clarify source_reliability is replace-tier (can up-weight)

### DIFF
--- a/crates/epigraph-db/src/repos/perspective.rs
+++ b/crates/epigraph-db/src/repos/perspective.rs
@@ -54,10 +54,19 @@ impl PerspectiveRow {
     ///
     /// This is one half of the "frame function": it lets one observer
     /// down-weight, say, `testimonial` evidence to 0.4 while another trusts it
-    /// at 1.0, yielding different beliefs over the *same* evidence. The value
-    /// overrides the per-frame / global calibration evidence-type weight for the
-    /// querying perspective. Returns `None` when the key is absent (no override)
-    /// and silently skips any entry that is not a finite number in `[0, 1]`.
+    /// at 1.0, yielding different beliefs over the *same* evidence.
+    ///
+    /// The value **replaces** (does not scale) the per-frame / global
+    /// calibration evidence-type weight for the querying perspective — it is an
+    /// absolute reliability, so it can *up-weight* an evidence type above the
+    /// global default as well as down-weight it (e.g. a traditional-medicine
+    /// perspective setting `practitioner_interview → 0.9` against a global
+    /// default below that). This replace-tier semantics is what distinguishes
+    /// the frame function from a pure multiplicative discount, which could only
+    /// reduce the global weight. A perspective with no entry for a tag falls
+    /// through to the per-frame / global weight unchanged. Returns `None` when
+    /// the key is absent (no override) and silently skips any entry that is not
+    /// a finite number in `[0, 1]`.
     #[must_use]
     pub fn source_reliability(&self) -> Option<std::collections::HashMap<String, f64>> {
         self.reliability_map("source_reliability")


### PR DESCRIPTION
## What

Documentation-only clarification on `PerspectiveRow::source_reliability`.

PR #208 made per-perspective `source_reliability` an **absolute** evidence-type weight that *replaces* the per-frame/global calibration value (replace-tier), rather than a multiplicative discount on it. The existing docstring example only showed down-weighting (`testimonial → 0.4`) and didn't make explicit that the override can also **up-weight** an evidence type above the global default — which is the load-bearing reason replace-tier was chosen over a pure multiply (multiply can only reduce).

## Why

Context: while composing Phase 4 (per-frame `evidence_type_weights`) with #206 (per-perspective `source_reliability`), the replace-vs-multiply distinction was the one subtle correctness point. #208 chose replace-tier deliberately (it enables e.g. a traditional-medicine perspective trusting `practitioner_interview` above the global default — the radicle-demo use case). Making that explicit in the docstring prevents a future reader from assuming the old "α = 1.0 = identity, discount-only" framing from the original #206.

No behavior change. `cargo check -p epigraph-db` clean.

Resolves the doc-drift noted during #208 review.