### PR TITLE
feat(mcp): recompute_beliefs — bulk CDST cache-refresh tool

### DIFF
--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -414,6 +414,61 @@ impl MassFunctionRepository {
 
         Ok(rows)
     }
+
+    /// List every distinct `frame_id` a claim carries BBAs on, paired with the
+    /// frame's name and **ordered by frame name**.
+    ///
+    /// The `claims.{belief, plausibility, pignistic_prob, ...}` columns are
+    /// frame-agnostic scalars (last-writer-wins), so callers that recompute a
+    /// claim across all its frames must process them in a deterministic order
+    /// for two runs to converge to the same cached value. Frame-name order is
+    /// that canonical order — it matches the `epigraph-recompute-belief`
+    /// operator binary.
+    #[instrument(skip(pool))]
+    pub async fn list_frames_for_claim(
+        pool: &PgPool,
+        claim_id: Uuid,
+    ) -> Result<Vec<(Uuid, String)>, DbError> {
+        let rows: Vec<(Uuid, String)> = sqlx::query_as(
+            r#"
+            SELECT DISTINCT mf.frame_id, f.name
+            FROM mass_functions mf
+            JOIN frames f ON f.id = mf.frame_id
+            WHERE mf.claim_id = $1
+            ORDER BY f.name
+            "#,
+        )
+        .bind(claim_id)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// List distinct `claim_id`s that have at least one BBA, ordered by
+    /// `claim_id` for stable pagination. Used by bulk belief-recompute to
+    /// enumerate the rebuild population when no explicit target set is given.
+    #[instrument(skip(pool))]
+    pub async fn list_claim_ids(
+        pool: &PgPool,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Uuid>, DbError> {
+        let rows: Vec<Uuid> = sqlx::query_scalar(
+            r#"
+            SELECT DISTINCT claim_id
+            FROM mass_functions
+            ORDER BY claim_id
+            LIMIT $1 OFFSET $2
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows)
+    }
 }
 
 #[cfg(test)]
@@ -478,6 +533,167 @@ mod tests {
         assert_eq!(all.len(), 2);
         assert!(all.iter().any(|r| r.claim_id == claim1_id));
         assert!(all.iter().any(|r| r.claim_id == claim2_id));
+    }
+
+    // Helper: insert a fresh system agent and return its id.
+    #[cfg(test)]
+    async fn insert_agent(pool: &PgPool, name: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels)
+             VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test'])
+             RETURNING id",
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[cfg(test)]
+    async fn insert_frame(pool: &PgPool, name: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO frames (name, hypotheses) VALUES ($1, '{\"supported\",\"contradicted\"}') RETURNING id",
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[cfg(test)]
+    async fn insert_claim(pool: &PgPool, agent_id: Uuid, content: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO claims (content, content_hash, truth_value, agent_id) VALUES ($1, sha256($1::bytea), 0.5, $2) RETURNING id",
+        )
+        .bind(content)
+        .bind(agent_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// `list_frames_for_claim` must (a) return each frame ONCE even when the
+    /// claim has multiple BBAs on it (DISTINCT), and (b) order by frame NAME,
+    /// not by insertion order / frame id — the ordering the recompute cascade
+    /// relies on for deterministic last-writer convergence.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn list_frames_for_claim_is_distinct_and_name_ordered(pool: sqlx::PgPool) {
+        let agent_a = insert_agent(&pool, "frames-for-claim-a").await;
+        let agent_b = insert_agent(&pool, "frames-for-claim-b").await;
+        // Insert the alphabetically-LATER frame FIRST, so insertion order is
+        // the reverse of name order — a name-blind query would fail the assert.
+        let suffix = Uuid::new_v4();
+        let frame_z = insert_frame(&pool, &format!("zzz-{suffix}")).await;
+        let frame_a = insert_frame(&pool, &format!("aaa-{suffix}")).await;
+        let claim_id = insert_claim(&pool, agent_a, &format!("ffc-{suffix}")).await;
+
+        let masses = serde_json::json!({"0": 0.6, "0,1": 0.4});
+        // Two BBAs (distinct agents) on frame_z → must still collapse to one frame entry.
+        for ag in [agent_a, agent_b] {
+            MassFunctionRepository::store(
+                &pool,
+                claim_id,
+                frame_z,
+                Some(ag),
+                &masses,
+                None,
+                Some("test"),
+                "unknown",
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        MassFunctionRepository::store(
+            &pool,
+            claim_id,
+            frame_a,
+            Some(agent_a),
+            &masses,
+            None,
+            Some("test"),
+            "unknown",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let frames = MassFunctionRepository::list_frames_for_claim(&pool, claim_id)
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 2, "two distinct frames despite 3 BBAs");
+        assert_eq!(frames[0].0, frame_a, "name-ordered: aaa frame first");
+        assert_eq!(frames[1].0, frame_z, "name-ordered: zzz frame last");
+    }
+
+    /// `list_claim_ids` must return DISTINCT claim ids (a claim with multiple
+    /// BBAs appears once), ordered ascending, and page correctly via limit/offset.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn list_claim_ids_is_distinct_and_paged(pool: sqlx::PgPool) {
+        let agent_a = insert_agent(&pool, "lci-a").await;
+        let agent_b = insert_agent(&pool, "lci-b").await;
+        let suffix = Uuid::new_v4();
+        let frame_id = insert_frame(&pool, &format!("lci-frame-{suffix}")).await;
+        let c1 = insert_claim(&pool, agent_a, &format!("lci-1-{suffix}")).await;
+        let c2 = insert_claim(&pool, agent_a, &format!("lci-2-{suffix}")).await;
+        let c3 = insert_claim(&pool, agent_a, &format!("lci-3-{suffix}")).await;
+
+        let masses = serde_json::json!({"0": 0.6, "0,1": 0.4});
+        // c1 gets TWO BBAs (distinct agents) — must appear ONCE in the result.
+        for ag in [agent_a, agent_b] {
+            MassFunctionRepository::store(
+                &pool,
+                c1,
+                frame_id,
+                Some(ag),
+                &masses,
+                None,
+                Some("test"),
+                "unknown",
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        for c in [c2, c3] {
+            MassFunctionRepository::store(
+                &pool,
+                c,
+                frame_id,
+                Some(agent_a),
+                &masses,
+                None,
+                Some("test"),
+                "unknown",
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        // Ephemeral sqlx::test DB → only our 3 distinct claims have BBAs.
+        let all = MassFunctionRepository::list_claim_ids(&pool, 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            all.len(),
+            3,
+            "3 distinct claim ids despite c1 having 2 BBAs"
+        );
+
+        let mut expected = vec![c1, c2, c3];
+        expected.sort();
+        assert_eq!(all, expected, "ascending claim_id order");
+
+        // Paging: page 1 (limit 2) + page 2 (offset 2) partition the set, disjoint.
+        let page1 = MassFunctionRepository::list_claim_ids(&pool, 2, 0)
+            .await
+            .unwrap();
+        let page2 = MassFunctionRepository::list_claim_ids(&pool, 2, 2)
+            .await
+            .unwrap();
+        assert_eq!(page1, expected[..2].to_vec());
+        assert_eq!(page2, vec![expected[2]]);
     }
 
     /// Regression test for the NULL-perspective upsert bug fixed by

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -75,6 +75,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("memorize", "claims:write"),
     ("patch_claim", "claims:write"),
     ("publish_event", "claims:write"),
+    ("recompute_beliefs", "claims:write"),
     ("reconcile_sheaf", "claims:write"),
     ("report_hierarchical_outcome", "claims:write"),
     ("report_workflow_outcome", "claims:write"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -432,6 +432,17 @@ impl EpiGraphMcpFull {
         tools::paper_queries::query_claims_by_label(self, params).await
     }
 
+    #[tool(
+        description = "Recompute cached claim beliefs (Bel/Pl/BetP/conflict) from current mass_functions state, per-frame, in deterministic frame-name order. The in-server sibling of the epigraph-recompute-belief CLI. Target by `claim_ids` (explicit), `labels` (e.g. a paper's claim set), or neither (bulk over all claims with BBAs, bounded by `limit`). Use after ingest or after editing calibration.toml / per-frame overrides so the cached scalars catch up to the combine path."
+    )]
+    async fn recompute_beliefs(
+        &self,
+        Parameters(params): Parameters<RecomputeBeliefsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::cdst_maintenance::recompute_beliefs(self, params).await
+    }
+
     // ── Workflows (5 tools) ──
 
     #[tool(
@@ -928,7 +939,7 @@ impl EpiGraphMcpFull {
 impl ServerHandler for EpiGraphMcpFull {
     fn get_info(&self) -> ServerInfo {
         let mode = if self.read_only { "read-only" } else { "full" };
-        let tool_count = if self.read_only { 33 } else { 60 };
+        let tool_count = if self.read_only { 33 } else { 61 };
         ServerInfo {
             instructions: Some(format!(
                 "EpiGraph {mode} MCP server with {tool_count} epistemic tools."

--- a/crates/epigraph-mcp/src/tools/cdst_maintenance.rs
+++ b/crates/epigraph-mcp/src/tools/cdst_maintenance.rs
@@ -1,0 +1,152 @@
+//! CDST maintenance tools.
+//!
+//! [`recompute_beliefs`] is the in-server, queryable sibling of the
+//! `epigraph-recompute-belief` operator binary: it refreshes the cached
+//! `claims.{belief, plausibility, pignistic_prob, conflict_k, missing_mass}`
+//! scalars from current `mass_functions` state, per-frame, in deterministic
+//! frame-name order.
+//!
+//! Why it exists: several write paths populate or discount BBAs without
+//! refreshing the cached belief — e.g. initial `ingest_document` writes the
+//! cache from the raw built BBA (no `effective_source_strength` discount,
+//! backlog 50ea636e), and operator edits to `calibration.toml` /
+//! per-frame overrides change combined belief only on the next recompute.
+//! This tool re-runs the canonical `recompute_claim_belief_on_frame` cascade
+//! so the cache catches up, targeted (`claim_ids` / `labels`) or in bulk.
+
+#![allow(clippy::wildcard_imports)]
+
+use rmcp::model::*;
+use uuid::Uuid;
+
+use crate::errors::{internal_error, invalid_params, McpError};
+use crate::server::EpiGraphMcpFull;
+use crate::types::RecomputeBeliefsParams;
+
+use epigraph_db::{ClaimRepository, MassFunctionRepository};
+
+fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(value).map_err(internal_error)?,
+    )]))
+}
+
+#[derive(serde::Serialize)]
+struct RecomputeError {
+    claim_id: String,
+    frame_id: String,
+    error: String,
+}
+
+#[derive(serde::Serialize)]
+struct RecomputeBeliefsResult {
+    /// How the target claim set was selected: `claim_ids` | `labels` | `all_with_bbas`.
+    target: &'static str,
+    /// Number of candidate claims considered.
+    claims_considered: usize,
+    /// Claims that had at least one (claim, frame) belief recomputed.
+    claims_recomputed: usize,
+    /// Candidate claims that carried no BBAs, so nothing was recomputed.
+    claims_skipped_no_bba: usize,
+    /// Total (claim, frame) belief writes performed.
+    frame_writes: usize,
+    /// Per-(claim, frame) errors; recompute continues past failures.
+    errors: Vec<RecomputeError>,
+    /// True when the bulk enumeration hit `limit` and more claims remain
+    /// (page with `offset` or use the `epigraph-recompute-belief` CLI).
+    truncated: bool,
+}
+
+/// Bulk-recompute cached claim beliefs from current `mass_functions` state.
+///
+/// Target precedence: `claim_ids` (explicit) > `labels` (current claims with
+/// all labels) > bulk enumeration of every claim that has a BBA. Each target
+/// claim is recomputed on **every frame it carries BBAs on**, in frame-name
+/// order, so the frame-agnostic cached scalars converge deterministically.
+pub async fn recompute_beliefs(
+    server: &EpiGraphMcpFull,
+    params: RecomputeBeliefsParams,
+) -> Result<CallToolResult, McpError> {
+    let pool = &server.pool;
+    let limit = params.limit.unwrap_or(500).clamp(1, 2000);
+    let offset = params.offset.unwrap_or(0).max(0);
+
+    let claim_ids_param = params.claim_ids.unwrap_or_default();
+    let labels_param = params.labels.unwrap_or_default();
+
+    let (target, claim_ids, truncated): (&'static str, Vec<Uuid>, bool) =
+        if !claim_ids_param.is_empty() {
+            let mut ids = Vec::with_capacity(claim_ids_param.len());
+            for s in &claim_ids_param {
+                ids.push(
+                    Uuid::parse_str(s.trim())
+                        .map_err(|e| invalid_params(format!("invalid claim_id {s:?}: {e}")))?,
+                );
+            }
+            ("claim_ids", ids, false)
+        } else if !labels_param.is_empty() {
+            let rows =
+                ClaimRepository::list_by_labels(pool, &labels_param, &[], true, 0.0, limit, offset)
+                    .await
+                    .map_err(internal_error)?;
+            let truncated = rows.len() as i64 == limit;
+            let ids: Vec<Uuid> = rows.into_iter().map(|(c, _)| c.id.into()).collect();
+            ("labels", ids, truncated)
+        } else {
+            // Fetch limit+1 to detect truncation, then trim back to limit.
+            let mut ids = MassFunctionRepository::list_claim_ids(pool, limit + 1, offset)
+                .await
+                .map_err(internal_error)?;
+            let truncated = ids.len() as i64 > limit;
+            ids.truncate(limit as usize);
+            ("all_with_bbas", ids, truncated)
+        };
+
+    let claims_considered = claim_ids.len();
+    let mut claims_recomputed = 0usize;
+    let mut claims_skipped_no_bba = 0usize;
+    let mut frame_writes = 0usize;
+    let mut errors: Vec<RecomputeError> = Vec::new();
+
+    for claim_id in claim_ids {
+        let frames = MassFunctionRepository::list_frames_for_claim(pool, claim_id)
+            .await
+            .map_err(internal_error)?;
+        if frames.is_empty() {
+            claims_skipped_no_bba += 1;
+            continue;
+        }
+        let mut wrote_any = false;
+        for (frame_id, _name) in frames {
+            match epigraph_engine::edge_factor::recompute_claim_belief_on_frame(
+                pool, claim_id, frame_id,
+            )
+            .await
+            {
+                Ok(true) => {
+                    frame_writes += 1;
+                    wrote_any = true;
+                }
+                Ok(false) => {}
+                Err(e) => errors.push(RecomputeError {
+                    claim_id: claim_id.to_string(),
+                    frame_id: frame_id.to_string(),
+                    error: e,
+                }),
+            }
+        }
+        if wrote_any {
+            claims_recomputed += 1;
+        }
+    }
+
+    success_json(&RecomputeBeliefsResult {
+        target,
+        claims_considered,
+        claims_recomputed,
+        claims_skipped_no_bba,
+        frame_writes,
+        errors,
+        truncated,
+    })
+}

--- a/crates/epigraph-mcp/src/tools/cdst_maintenance.rs
+++ b/crates/epigraph-mcp/src/tools/cdst_maintenance.rs
@@ -74,33 +74,37 @@ pub async fn recompute_beliefs(
     let claim_ids_param = params.claim_ids.unwrap_or_default();
     let labels_param = params.labels.unwrap_or_default();
 
-    let (target, claim_ids, truncated): (&'static str, Vec<Uuid>, bool) =
-        if !claim_ids_param.is_empty() {
-            let mut ids = Vec::with_capacity(claim_ids_param.len());
-            for s in &claim_ids_param {
-                ids.push(
-                    Uuid::parse_str(s.trim())
-                        .map_err(|e| invalid_params(format!("invalid claim_id {s:?}: {e}")))?,
-                );
-            }
-            ("claim_ids", ids, false)
-        } else if !labels_param.is_empty() {
-            let rows =
-                ClaimRepository::list_by_labels(pool, &labels_param, &[], true, 0.0, limit, offset)
-                    .await
-                    .map_err(internal_error)?;
-            let truncated = rows.len() as i64 == limit;
-            let ids: Vec<Uuid> = rows.into_iter().map(|(c, _)| c.id.into()).collect();
-            ("labels", ids, truncated)
-        } else {
-            // Fetch limit+1 to detect truncation, then trim back to limit.
-            let mut ids = MassFunctionRepository::list_claim_ids(pool, limit + 1, offset)
+    let (target, claim_ids, truncated): (&'static str, Vec<Uuid>, bool) = if !claim_ids_param
+        .is_empty()
+    {
+        let mut ids = Vec::with_capacity(claim_ids_param.len());
+        for s in &claim_ids_param {
+            ids.push(
+                Uuid::parse_str(s.trim())
+                    .map_err(|e| invalid_params(format!("invalid claim_id {s:?}: {e}")))?,
+            );
+        }
+        ("claim_ids", ids, false)
+    } else if !labels_param.is_empty() {
+        // Fetch limit+1 to distinguish "exactly limit, none remain" from
+        // "limit reached, more remain" (same trick as the bulk path).
+        let mut rows =
+            ClaimRepository::list_by_labels(pool, &labels_param, &[], true, 0.0, limit + 1, offset)
                 .await
                 .map_err(internal_error)?;
-            let truncated = ids.len() as i64 > limit;
-            ids.truncate(limit as usize);
-            ("all_with_bbas", ids, truncated)
-        };
+        let truncated = rows.len() as i64 > limit;
+        rows.truncate(limit as usize);
+        let ids: Vec<Uuid> = rows.into_iter().map(|(c, _)| c.id.into()).collect();
+        ("labels", ids, truncated)
+    } else {
+        // Fetch limit+1 to detect truncation, then trim back to limit.
+        let mut ids = MassFunctionRepository::list_claim_ids(pool, limit + 1, offset)
+            .await
+            .map_err(internal_error)?;
+        let truncated = ids.len() as i64 > limit;
+        ids.truncate(limit as usize);
+        ("all_with_bbas", ids, truncated)
+    };
 
     let claims_considered = claim_ids.len();
     let mut claims_recomputed = 0usize;

--- a/crates/epigraph-mcp/src/tools/mod.rs
+++ b/crates/epigraph-mcp/src/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod alternative_sets;
 pub mod batch;
+pub mod cdst_maintenance;
 pub mod challenges;
 pub mod claims;
 pub mod ds;

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -1416,3 +1416,29 @@ pub struct DecideMatchCandidateParams {
     #[schemars(description = "Decision: 'promote' (writes CORROBORATES edge) or 'reject'")]
     pub verdict: String,
 }
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RecomputeBeliefsParams {
+    #[schemars(
+        description = "Explicit claim UUIDs to recompute. Highest-priority target selector — when present and non-empty, `labels` and the bulk enumeration are ignored."
+    )]
+    #[serde(default)]
+    pub claim_ids: Option<Vec<String>>,
+
+    #[schemars(
+        description = "Recompute every current claim carrying ALL of these labels (e.g. a paper's claim set). Used only when `claim_ids` is absent/empty."
+    )]
+    #[serde(default)]
+    pub labels: Option<Vec<String>>,
+
+    #[schemars(
+        description = "Cap on the number of claims processed (default 500, max 2000). For the bulk path (no claim_ids/labels) this bounds the DISTINCT-claim enumeration and the response reports `truncated=true` when more remain — page with repeated calls or use the `epigraph-recompute-belief` CLI for full-DB rebuilds."
+    )]
+    pub limit: Option<i64>,
+
+    #[schemars(
+        description = "Offset into the bulk DISTINCT-claim enumeration for pagination (default 0). Ignored when `claim_ids` or `labels` is given."
+    )]
+    #[serde(default)]
+    pub offset: Option<i64>,
+}

--- a/crates/epigraph-mcp/tests/recompute_beliefs_test.rs
+++ b/crates/epigraph-mcp/tests/recompute_beliefs_test.rs
@@ -52,6 +52,19 @@ async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
     .unwrap()
 }
 
+async fn insert_claim_with_label(pool: &PgPool, agent: Uuid, content: &str, label: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO claims (content, content_hash, truth_value, agent_id, is_current, labels)
+         VALUES ($1, sha256($1::bytea), 0.5, $2, true, ARRAY[$3]) RETURNING id",
+    )
+    .bind(content)
+    .bind(agent)
+    .bind(label)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
 /// Give `claim_id` a real binary-frame BBA + cached belief.
 async fn wire_bba(pool: &PgPool, claim_id: Uuid, agent_id: Uuid) {
     tools::ds_auto::auto_wire_ds_update(
@@ -200,4 +213,60 @@ async fn recompute_bulk_truncates_at_limit(pool: PgPool) {
     let j2 = result_json(out2);
     assert_eq!(j2["claims_considered"], 1);
     assert_eq!(j2["truncated"], false, "no claims remain after offset 1");
+}
+
+/// The labels path must report `truncated` honestly: true when more labeled
+/// claims remain past `limit`, and — critically — false when exactly `limit`
+/// claims exist and none remain (the bug the limit+1 fetch fixes).
+#[sqlx::test(migrations = "../../migrations")]
+async fn recompute_labels_truncation_is_exact(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "recompute-lbl").await;
+    let label = format!("rb-lbl-{}", Uuid::new_v4());
+    for i in 0..2 {
+        let c = insert_claim_with_label(
+            &pool,
+            agent,
+            &format!("recompute-lbl-{i}-{}", Uuid::new_v4()),
+            &label,
+        )
+        .await;
+        wire_bba(&pool, c, agent).await;
+    }
+
+    // limit=1 over 2 labeled claims → one remains → truncated.
+    let out = tools::cdst_maintenance::recompute_beliefs(
+        &server,
+        RecomputeBeliefsParams {
+            claim_ids: None,
+            labels: Some(vec![label.clone()]),
+            limit: Some(1),
+            offset: None,
+        },
+    )
+    .await
+    .expect("recompute_beliefs labels limit=1");
+    let j = result_json(out);
+    assert_eq!(j["target"], "labels");
+    assert_eq!(j["claims_considered"], 1);
+    assert_eq!(j["truncated"], true);
+
+    // limit=2 over exactly 2 labeled claims → none remain → NOT truncated.
+    let out2 = tools::cdst_maintenance::recompute_beliefs(
+        &server,
+        RecomputeBeliefsParams {
+            claim_ids: None,
+            labels: Some(vec![label]),
+            limit: Some(2),
+            offset: None,
+        },
+    )
+    .await
+    .expect("recompute_beliefs labels limit=2");
+    let j2 = result_json(out2);
+    assert_eq!(j2["claims_considered"], 2);
+    assert_eq!(
+        j2["truncated"], false,
+        "exactly limit claims, none remain — must not false-positive"
+    );
 }

--- a/crates/epigraph-mcp/tests/recompute_beliefs_test.rs
+++ b/crates/epigraph-mcp/tests/recompute_beliefs_test.rs
@@ -1,0 +1,203 @@
+//! Behavioral tests for the `recompute_beliefs` CDST-maintenance tool.
+//!
+//! Setup mirrors `source_strength_tests.rs`: `auto_wire_ds_update` writes a
+//! real BBA on the canonical `binary_truth` frame and seeds the cached
+//! `claims.pignistic_prob`. We then corrupt the cache and assert the tool
+//! restores it (the 50ea636e ingest-initial-asymmetry use case), plus check
+//! the target-selection, truncation, and no-BBA-skip reporting.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_mcp::types::RecomputeBeliefsParams;
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use rmcp::model::RawContent;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0x2bu8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+fn result_json(out: rmcp::model::CallToolResult) -> serde_json::Value {
+    let first = out.content.first().cloned().expect("first content");
+    let text = match first.raw {
+        RawContent::Text(t) => t.text,
+        other => panic!("expected text content, got {other:?}"),
+    };
+    serde_json::from_str(&text).expect("result is JSON")
+}
+
+async fn insert_agent(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels)
+         VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test'])
+         RETURNING id",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO claims (content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, sha256($1::bytea), 0.5, $2, true) RETURNING id",
+    )
+    .bind(content)
+    .bind(agent)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+/// Give `claim_id` a real binary-frame BBA + cached belief.
+async fn wire_bba(pool: &PgPool, claim_id: Uuid, agent_id: Uuid) {
+    tools::ds_auto::auto_wire_ds_update(
+        pool,
+        claim_id,
+        agent_id,
+        0.9,  // confidence
+        1.0,  // weight
+        true, // supports
+        Some("empirical"),
+        None, // evidence_id
+    )
+    .await
+    .expect("auto_wire_ds_update");
+}
+
+async fn pignistic(pool: &PgPool, claim_id: Uuid) -> f64 {
+    sqlx::query_scalar::<_, f64>("SELECT pignistic_prob FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// Targeting by `claim_ids` restores a deliberately-corrupted cache to the
+/// correct combine result and reports accurate counts.
+#[sqlx::test(migrations = "../../migrations")]
+async fn recompute_claim_ids_restores_stale_cache(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "recompute-stale").await;
+    let claim = insert_claim(&pool, agent, &format!("recompute-stale-{}", Uuid::new_v4())).await;
+    wire_bba(&pool, claim, agent).await;
+
+    let correct = pignistic(&pool, claim).await;
+    // Corrupt the cache to a value the combine path would never produce here.
+    sqlx::query("UPDATE claims SET pignistic_prob = 0.123 WHERE id = $1")
+        .bind(claim)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!((pignistic(&pool, claim).await - 0.123).abs() < 1e-9);
+
+    let out = tools::cdst_maintenance::recompute_beliefs(
+        &server,
+        RecomputeBeliefsParams {
+            claim_ids: Some(vec![claim.to_string()]),
+            labels: None,
+            limit: None,
+            offset: None,
+        },
+    )
+    .await
+    .expect("recompute_beliefs");
+
+    let j = result_json(out);
+    assert_eq!(j["target"], "claim_ids");
+    assert_eq!(j["claims_considered"], 1);
+    assert_eq!(j["claims_recomputed"], 1);
+    assert_eq!(j["claims_skipped_no_bba"], 0);
+    assert!(j["frame_writes"].as_u64().unwrap() >= 1);
+    assert_eq!(j["truncated"], false);
+    assert!(j["errors"].as_array().unwrap().is_empty());
+
+    // Cache is back to the correct combine result, not the corrupted value.
+    let restored = pignistic(&pool, claim).await;
+    assert!(
+        (restored - correct).abs() < 1e-9,
+        "expected restored {correct}, got {restored}"
+    );
+    assert!((restored - 0.123).abs() > 1e-6, "still corrupted");
+}
+
+/// A claim with no BBAs is counted as skipped, not recomputed, and is not an error.
+#[sqlx::test(migrations = "../../migrations")]
+async fn recompute_skips_claim_without_bbas(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "recompute-nobba").await;
+    let bare = insert_claim(&pool, agent, &format!("recompute-nobba-{}", Uuid::new_v4())).await;
+
+    let out = tools::cdst_maintenance::recompute_beliefs(
+        &server,
+        RecomputeBeliefsParams {
+            claim_ids: Some(vec![bare.to_string()]),
+            labels: None,
+            limit: None,
+            offset: None,
+        },
+    )
+    .await
+    .expect("recompute_beliefs");
+
+    let j = result_json(out);
+    assert_eq!(j["claims_considered"], 1);
+    assert_eq!(j["claims_recomputed"], 0);
+    assert_eq!(j["claims_skipped_no_bba"], 1);
+    assert_eq!(j["frame_writes"], 0);
+    assert!(j["errors"].as_array().unwrap().is_empty());
+}
+
+/// The bulk path (no claim_ids/labels) enumerates claims-with-BBAs and sets
+/// `truncated=true` when `limit` is smaller than the population.
+#[sqlx::test(migrations = "../../migrations")]
+async fn recompute_bulk_truncates_at_limit(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "recompute-bulk").await;
+    // Two claims with BBAs; ephemeral DB so the bulk population is exactly 2.
+    for i in 0..2 {
+        let c = insert_claim(
+            &pool,
+            agent,
+            &format!("recompute-bulk-{i}-{}", Uuid::new_v4()),
+        )
+        .await;
+        wire_bba(&pool, c, agent).await;
+    }
+
+    let out = tools::cdst_maintenance::recompute_beliefs(
+        &server,
+        RecomputeBeliefsParams {
+            claim_ids: None,
+            labels: None,
+            limit: Some(1),
+            offset: None,
+        },
+    )
+    .await
+    .expect("recompute_beliefs");
+
+    let j = result_json(out);
+    assert_eq!(j["target"], "all_with_bbas");
+    assert_eq!(j["claims_considered"], 1, "limit=1 caps the batch");
+    assert_eq!(j["truncated"], true, "more claims remain past limit");
+
+    // Page 2 picks up the remaining claim and is not truncated.
+    let out2 = tools::cdst_maintenance::recompute_beliefs(
+        &server,
+        RecomputeBeliefsParams {
+            claim_ids: None,
+            labels: None,
+            limit: Some(1),
+            offset: Some(1),
+        },
+    )
+    .await
+    .expect("recompute_beliefs page 2");
+    let j2 = result_json(out2);
+    assert_eq!(j2["claims_considered"], 1);
+    assert_eq!(j2["truncated"], false, "no claims remain after offset 1");
+}


### PR DESCRIPTION
## What

Adds `recompute_beliefs`, an MCP tool that refreshes the cached `claims.{belief, plausibility, pignistic_prob, conflict_k, missing_mass}` scalars from current `mass_functions` state — the in-server, queryable sibling of the existing `epigraph-recompute-belief` operator CLI.

Each target claim is recomputed on **every frame it carries BBAs on**, in **frame-name order** (the frame-agnostic cached scalars are last-writer-wins, so deterministic ordering makes repeated runs converge — matching the CLI).

**Target precedence:** `claim_ids` (explicit) → `labels` (current claims with all labels) → bulk enumeration of every claim with a BBA (bounded by `limit`, default 500 / max 2000, reports `truncated=true` and is pageable via `offset` — no silent cap).

## Why (Group C investigation)

From a backlog assessment of the CDST-maintenance gap:

- **Closes the `rebuild_all_mass_functions` portion of `22aa93ca`** — the legacy bulk-rebuild script was removed; the engine logic (`recompute_claim_belief_on_frame`) existed but had no MCP/bulk entry point. This exposes it.
- **Remediation lever for `50ea636e`** — initial `ingest_document` caches belief from the raw built BBA *without* the `effective_source_strength` discount, so a freshly-ingested claim's cache disagrees with its compute-on-read belief until first recombine. `recompute_beliefs` re-runs the canonical cascade so the cache catches up (e.g. `recompute_beliefs(labels: ["<paper>"])` post-ingest). Also applies after `calibration.toml` / per-frame override edits.

Scope deliberately limited to the one tool with no design fork. The remaining `22aa93ca` pieces (parent-mass propagation, exposing the orphaned `classifier::classify`) and the decomposition-query item (`3426242c`/`46aee550`) involve schema/semantics decisions and are left for separate, discussed work.

## Changes

- **epigraph-db** — `MassFunctionRepository::list_frames_for_claim` (DISTINCT, name-ordered) + `list_claim_ids` (DISTINCT, paged). Runtime `sqlx` (no `.sqlx` regeneration).
- **epigraph-mcp** — `tools::cdst_maintenance::recompute_beliefs` + `RecomputeBeliefsParams`; registered as a `claims:write` tool (`reject_if_read_only` + `SCOPE_MAP` entry; tool-count bumped).

## Tests

- Repo: DISTINCT-collapse, frame **name**-ordering (not insertion order), limit/offset paging.
- MCP behavioral: corrupted cache → `recompute_beliefs(claim_ids)` restores it to the exact combine result; claim with no BBAs → counted `skipped_no_bba` (not an error); bulk path sets `truncated=true` at `limit` and pages correctly.

All green locally: 2 repo + 3 MCP tests, clippy clean, `cargo fmt --check` clean, scope-map coverage test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)