### PR TITLE
feat(engine,mcp): CDST claim classification (supported / contradicted / not_enough_info)

### DIFF
--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -1894,6 +1894,26 @@ impl ClaimRepository {
         Ok(rows)
     }
 
+    /// Read a claim's cached CDST classification label (`supported` |
+    /// `contradicted` | `not_enough_info`), or `None` if unclassified or the
+    /// claim does not exist. Written by `recompute_combined_belief` via
+    /// `MassFunctionRepository::update_claim_classification`.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn get_classification(
+        pool: &PgPool,
+        claim_id: Uuid,
+    ) -> Result<Option<String>, DbError> {
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT classification FROM claims WHERE id = $1")
+                .bind(claim_id)
+                .fetch_optional(pool)
+                .await?;
+        Ok(row.and_then(|(c,)| c))
+    }
+
     /// Store an embedding vector on a claim.
     ///
     /// The embedding string must be a valid pgvector literal (e.g., "[0.1,0.2,...]").

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -342,6 +342,34 @@ impl MassFunctionRepository {
         Ok(())
     }
 
+    /// Write the CDST classification label for a claim.
+    ///
+    /// A verdict on the claim's *combined* belief (`supported` |
+    /// `contradicted` | `not_enough_info`), produced by
+    /// `epigraph_engine::classifier::classify` inside
+    /// `recompute_combined_belief`. Kept as a separate one-column UPDATE
+    /// rather than folded into [`Self::update_claim_belief`] because that
+    /// method has many callers and a param-ordering ratchet test; only the
+    /// combine cascade computes a classification, so only it calls this.
+    /// The extra UPDATE lands on the recompute (maintenance) path, not an
+    /// online read path.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn update_claim_classification(
+        pool: &PgPool,
+        claim_id: Uuid,
+        classification: &str,
+    ) -> Result<(), DbError> {
+        sqlx::query("UPDATE claims SET classification = $1, updated_at = NOW() WHERE id = $2")
+            .bind(classification)
+            .bind(claim_id)
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+
     /// Count mass functions for a claim-frame pair
     ///
     /// # Errors

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -709,6 +709,46 @@ async fn recompute_combined_belief(
     )
     .await
     .map_err(|e| format!("update_claim_belief: {e}"))?;
+
+    // CDST classification — a verdict on the COMBINED belief via the
+    // deterministic BetP 7-rule cascade. Defined only on the canonical binary
+    // {TRUE, FALSE} frame (supported = idx 0, contradicted = idx 1); other
+    // frames write the frame-agnostic belief scalars above but leave
+    // `claims.classification` untouched. Thresholds come from `calibration`
+    // (operator-tunable, same load as the discount path).
+    if frame.id == BINARY_FRAME_NAME {
+        let thresholds = &calibration.classifier_thresholds;
+        // theta = closed-world full-frame ignorance m({0,1}); the open-world
+        // missing mass is excluded (Smets TBM), matching the legacy
+        // `compute_betp` the cascade was calibrated against. `betp` (above) is
+        // pignistic(idx 0) = betp_supported.
+        let theta = combined.mass_of(&FocalElement::positive(BTreeSet::from([0_usize, 1_usize])));
+        let betp_unsup = measures::pignistic_probability(&combined, 1);
+        // has_opposing: does any single source BBA lean toward contradiction?
+        // Post-#197 a `refutes`/`contradicts` edge auto-wires a Negative-leaning
+        // BBA on the target, so edge-borne AND directly-submitted opposition both
+        // surface here as a per-BBA betp_unsup — this replaces (and subsumes) the
+        // legacy CONTRADICTS-edge query, which only saw edge-borne opposition.
+        let has_opposing = all_rows.iter().any(|row| {
+            parse_stored_bba(frame, &row.masses)
+                .map(|bba| {
+                    measures::pignistic_probability(&bba, 1) > thresholds.has_opposing_threshold
+                })
+                .unwrap_or(false)
+        });
+        let label = crate::classifier::classify(
+            conflict,
+            theta,
+            betp,
+            betp_unsup,
+            has_opposing,
+            thresholds,
+        );
+        MassFunctionRepository::update_claim_classification(pool, claim_id, &label.to_string())
+            .await
+            .map_err(|e| format!("update_claim_classification: {e}"))?;
+    }
+
     Ok(())
 }
 

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -294,17 +294,33 @@ pub async fn get_claim(
     let labels = ClaimRepository::get_labels(&server.pool, claim_id)
         .await
         .map_err(internal_error)?;
+    // Cached CDST classification ('supported' | 'contradicted' |
+    // 'not_enough_info' | null). Flattened onto the standard claim response so
+    // existing `ClaimResponse` consumers are unaffected.
+    let classification = ClaimRepository::get_classification(&server.pool, id)
+        .await
+        .map_err(internal_error)?;
 
-    success_json(&ClaimResponse {
-        id: claim.id.as_uuid().to_string(),
-        content: claim.content.clone(),
-        truth_value: claim.truth_value.value(),
-        agent_id: claim.agent_id.as_uuid().to_string(),
-        content_hash: ContentHasher::to_hex(&claim.content_hash),
-        created_at: claim.created_at.to_rfc3339(),
-        labels,
-        is_current: claim.is_current,
-        supersedes: claim.supersedes.map(|s| s.as_uuid().to_string()),
+    #[derive(serde::Serialize)]
+    struct GetClaimResponse {
+        #[serde(flatten)]
+        claim: ClaimResponse,
+        classification: Option<String>,
+    }
+
+    success_json(&GetClaimResponse {
+        claim: ClaimResponse {
+            id: claim.id.as_uuid().to_string(),
+            content: claim.content.clone(),
+            truth_value: claim.truth_value.value(),
+            agent_id: claim.agent_id.as_uuid().to_string(),
+            content_hash: ContentHasher::to_hex(&claim.content_hash),
+            created_at: claim.created_at.to_rfc3339(),
+            labels,
+            is_current: claim.is_current,
+            supersedes: claim.supersedes.map(|s| s.as_uuid().to_string()),
+        },
+        classification,
     })
 }
 

--- a/crates/epigraph-mcp/tests/classify_test.rs
+++ b/crates/epigraph-mcp/tests/classify_test.rs
@@ -1,0 +1,153 @@
+//! Behavioral tests for CDST classification: recompute_combined_belief (driven
+//! here via the recompute_beliefs MCP tool) writes claims.classification, and
+//! get_claim surfaces it.
+//!
+//! Setup uses `auto_wire_ds_update` to stock real binary-frame BBAs; note that
+//! path does NOT itself classify (only the recompute cascade does), so we then
+//! call recompute_beliefs and assert the label.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_db::ClaimRepository;
+use epigraph_mcp::types::{GetClaimParams, RecomputeBeliefsParams};
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use rmcp::model::RawContent;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0x3cu8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+async fn insert_agent(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels)
+         VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test'])
+         RETURNING id",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO claims (content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, sha256($1::bytea), 0.5, $2, true) RETURNING id",
+    )
+    .bind(content)
+    .bind(agent)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn wire(pool: &PgPool, claim: Uuid, agent: Uuid, confidence: f64, supports: bool) {
+    tools::ds_auto::auto_wire_ds_update(pool, claim, agent, confidence, 1.0, supports, None, None)
+        .await
+        .expect("auto_wire_ds_update");
+}
+
+/// Recompute classifies the claim and `get_classification` reads it back.
+async fn recompute_and_label(
+    server: &EpiGraphMcpFull,
+    pool: &PgPool,
+    claim: Uuid,
+) -> Option<String> {
+    tools::cdst_maintenance::recompute_beliefs(
+        server,
+        RecomputeBeliefsParams {
+            claim_ids: Some(vec![claim.to_string()]),
+            labels: None,
+            limit: None,
+            offset: None,
+        },
+    )
+    .await
+    .expect("recompute_beliefs");
+    ClaimRepository::get_classification(pool, claim)
+        .await
+        .expect("get_classification")
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn strong_support_classifies_supported(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "classify-sup").await;
+    let claim = insert_claim(&pool, agent, &format!("classify-sup-{}", Uuid::new_v4())).await;
+    wire(&pool, claim, agent, 0.9, true).await;
+
+    assert_eq!(
+        recompute_and_label(&server, &pool, claim).await.as_deref(),
+        Some("supported")
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn strong_opposition_classifies_contradicted(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "classify-con").await;
+    let claim = insert_claim(&pool, agent, &format!("classify-con-{}", Uuid::new_v4())).await;
+    // A strong FALSE-leaning BBA → betp_unsup dominates → contradicted.
+    wire(&pool, claim, agent, 0.9, false).await;
+
+    assert_eq!(
+        recompute_and_label(&server, &pool, claim).await.as_deref(),
+        Some("contradicted")
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn high_ignorance_classifies_not_enough_info(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "classify-nei").await;
+    let claim = insert_claim(&pool, agent, &format!("classify-nei-{}", Uuid::new_v4())).await;
+    // A single very-low-confidence BBA leaves most mass on Θ (theta > nei
+    // threshold) with no conflict → not_enough_info.
+    wire(&pool, claim, agent, 0.05, true).await;
+
+    assert_eq!(
+        recompute_and_label(&server, &pool, claim).await.as_deref(),
+        Some("not_enough_info")
+    );
+}
+
+/// A claim with no BBAs is never classified (recompute returns early), and the
+/// label stays NULL.
+#[sqlx::test(migrations = "../../migrations")]
+async fn no_bba_leaves_classification_null(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "classify-null").await;
+    let claim = insert_claim(&pool, agent, &format!("classify-null-{}", Uuid::new_v4())).await;
+
+    assert_eq!(recompute_and_label(&server, &pool, claim).await, None);
+}
+
+/// get_claim surfaces the cached classification on the flattened response.
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_claim_exposes_classification(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "classify-getclaim").await;
+    let claim = insert_claim(&pool, agent, &format!("classify-gc-{}", Uuid::new_v4())).await;
+    wire(&pool, claim, agent, 0.9, true).await;
+    let _ = recompute_and_label(&server, &pool, claim).await;
+
+    let out = tools::claims::get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: claim.to_string(),
+        },
+    )
+    .await
+    .expect("get_claim");
+    let text = match out.content.first().cloned().expect("content").raw {
+        RawContent::Text(t) => t.text,
+        other => panic!("expected text, got {other:?}"),
+    };
+    let j: serde_json::Value = serde_json::from_str(&text).expect("json");
+    assert_eq!(j["classification"], "supported");
+    // Flatten preserves the base ClaimResponse fields.
+    assert_eq!(j["id"], claim.to_string());
+}

--- a/migrations/047_claims_classification.sql
+++ b/migrations/047_claims_classification.sql
@@ -1,0 +1,16 @@
+-- CDST claim classification: 'supported' | 'contradicted' | 'not_enough_info'.
+-- NULL = unclassified (no BBAs yet, or not recomputed since this column was added).
+--
+-- Computed by the deterministic BetP 7-rule cascade
+-- (epigraph_engine::classifier::classify) inside recompute_combined_belief —
+-- a verdict on the claim's *combined* belief, parallel to the cached
+-- pignistic_prob. Populated / refreshed in bulk via the `recompute_beliefs`
+-- MCP tool (recompute_beliefs → recompute_claim_belief_on_frame →
+-- recompute_combined_belief).
+--
+-- Replaces the deprecated EpigraphV2 scripts/classify_mass_functions.py, which
+-- stored the label in claims.properties->>'cdst_label' (no current Rust reader).
+ALTER TABLE claims ADD COLUMN classification TEXT;
+
+-- Partial index: the common query is "show me contradicted / NEI claims".
+CREATE INDEX idx_claims_classification ON claims (classification) WHERE classification IS NOT NULL;


### PR DESCRIPTION
## What

Turns the **orphaned** `classifier::classify` (the ported deterministic BetP 7-rule cascade, previously reachable only from unit tests) into a first-class, persisted claim verdict — the in-engine replacement for the removed `scripts/classify_mass_functions.py`.

- **Migration 047** — `claims.classification TEXT` (+ partial index for "show me contradicted/NEI claims"). Classification is a verdict on a claim's **combined** belief, parallel to the cached `pignistic_prob` → it lives on `claims.*` (frame-agnostic), **not** `mass_functions` (which holds individual source BBAs). The legacy script stored it in `claims.properties->>'cdst_label'` (verified: no current Rust reader).
- **`recompute_combined_belief`** computes and writes it, **binary-frame only** (`supported`=idx 0, `contradicted`=idx 1; other frames write belief scalars but leave classification untouched).
- Because **`recompute_beliefs` (#210)** routes through `recompute_combined_belief`, it now **bulk-classifies** — the canonical "classify everything" path. Run it after ingest / calibration edits.
- **`get_claim`** surfaces the label via a flattened response (no churn to the shared `ClaimResponse`).

## Input derivation (anchored to the validated legacy `compute_betp`)

- `theta` = closed-world full-frame ignorance `m({0,1})`; the open-world *missing* mass is **excluded** (Smets TBM), matching the `compute_betp` the cascade's thresholds were calibrated against.
- `betp_sup`/`betp_unsup` = the system's `pignistic_probability` on idx 0/1 (same measure that writes `claims.pignistic_prob`).
- `has_opposing` = any **source BBA** with `betp_unsup > has_opposing_threshold`. Post-#197 a `refutes`/`contradicts` edge auto-wires a Negative-leaning BBA on the target, so this per-BBA check **subsumes** the legacy `CONTRADICTS`-edge query (it sees edge-borne *and* directly-submitted opposition). It only affects Rule 1, which is gated on `conflict_k >= ct`, so uncertain-but-supporting BBAs can't false-trigger a contradiction.
- Thresholds come from `calibration.classifier_thresholds` (operator-tunable, same load as the discount path).

## Two deliberate decisions (flagging, since they differ from the original framing)

1. **`claims.classification`, not `mass_functions.classification`** — classification is per-claim (a verdict on the combined belief), as the legacy per-claim `cdst_label` confirms. A dedicated queryable column.
2. **Separate `update_claim_classification` write**, not folded into `update_claim_belief` — the latter has 8 callers and a param-order ratchet test; only the combine cascade classifies, so only it writes. The extra one-column UPDATE lands on the recompute (maintenance) path, never an online read.

## Scope

Closes the **classify** third of backlog `22aa93ca` (rebuild shipped in #210; parent-mass *propagate* is reframed as a separate design item — it needs typed argument structure, not `decomposes_to` rollup). A `query_claims_by_classification` tool is an easy follow-up, intentionally not bundled here.

## Tests

5 behavioral (`classify_test.rs`): strong support → `supported`; strong opposition → `contradicted`; very-low-confidence → `not_enough_info`; no BBAs → NULL; `get_claim` exposes the label. Plus no regression in `recompute_beliefs_test` / `source_strength_tests`. clippy + fmt clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)