### PR TITLE
fix(query): filter query_claims truth range in SQL before LIMIT (5a55a48e)

### DIFF
--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -879,6 +879,55 @@ impl ClaimRepository {
         Ok(claims)
     }
 
+    /// List claims whose `truth_value` falls within `[min_truth, max_truth]`,
+    /// most-recent first. The range filter is applied in SQL **before**
+    /// `LIMIT`, so matching claims are reachable regardless of how recently
+    /// they were created.
+    ///
+    /// This exists because the obvious `list()` + post-query filter can only
+    /// ever inspect the first `limit` most-recent rows — a matching claim
+    /// outside that window is silently invisible (backlog bug `5a55a48e`:
+    /// `query_claims(max_truth=0.75)` returned empty while matching claims
+    /// existed).
+    pub async fn list_by_truth_range(
+        pool: &PgPool,
+        min_truth: f64,
+        max_truth: f64,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Claim>, DbError> {
+        let rows = sqlx::query_as::<_, ClaimRow>(
+            r#"
+            SELECT id, content, truth_value, agent_id, trace_id, created_at, updated_at
+            FROM claims
+            WHERE truth_value >= $1 AND truth_value <= $2
+            ORDER BY created_at DESC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(min_truth)
+        .bind(max_truth)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
+
+        let mut claims = Vec::with_capacity(rows.len());
+        for row in rows {
+            let truth_value = TruthValue::new(row.truth_value)?;
+            claims.push(claim_from_row(
+                row.id,
+                row.content,
+                row.agent_id,
+                row.trace_id,
+                truth_value,
+                row.created_at,
+                row.updated_at,
+            ));
+        }
+        Ok(claims)
+    }
+
     /// List claims that contain ALL of the specified labels.
     ///
     /// Uses the GIN index on `claims.labels` for efficient `@>` containment queries.

--- a/crates/epigraph-db/tests/list_by_truth_range.rs
+++ b/crates/epigraph-db/tests/list_by_truth_range.rs
@@ -1,0 +1,91 @@
+//! Regression test for backlog bug `5a55a48e`:
+//! `query_claims(min_truth=0, max_truth=0.75)` returned an empty list even
+//! though matching claims existed. Root cause: the MCP handler fetched the
+//! first `limit` rows (ordered `created_at DESC`) via `ClaimRepository::list`
+//! and applied the truth-value filter *in Rust, after* the `LIMIT`. A matching
+//! claim outside the most-recent `limit` rows was therefore invisible.
+//!
+//! `list_by_truth_range` filters in SQL *before* `LIMIT`, so a low-truth claim
+//! buried under many newer high-truth claims is still returned. This test pins
+//! exactly that scenario: it would fail under the old fetch-then-filter path.
+
+use epigraph_db::ClaimRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+/// Insert a claim with an explicit `truth_value` and `created_at`.
+async fn seed_claim(pool: &PgPool, agent_id: Uuid, truth: f64, created_at: &str) {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6::timestamptz)",
+    )
+    .bind(id)
+    .bind(format!("test claim {id}"))
+    .bind(hash)
+    .bind(truth)
+    .bind(agent_id)
+    .bind(created_at)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn truth_range_filter_finds_matches_outside_recent_window(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+
+    // 25 RECENT claims with high truth (0.95) — these crowd out the top-`limit`
+    // most-recent rows.
+    for i in 0..25 {
+        let ts = format!("2026-05-29T12:00:{:02}Z", i);
+        seed_claim(&pool, agent, 0.95, &ts).await;
+    }
+    // One OLD claim with low truth (0.50) — the only one in [0, 0.75], but it
+    // is the *oldest* row, so a fetch-recent-then-filter strategy never sees it.
+    seed_claim(&pool, agent, 0.50, "2026-01-01T00:00:00Z").await;
+
+    let results = ClaimRepository::list_by_truth_range(&pool, 0.0, 0.75, 20, 0)
+        .await
+        .unwrap();
+
+    // The low-truth claim must be returned despite being outside the 20 newest.
+    assert_eq!(
+        results.len(),
+        1,
+        "expected exactly the one claim in [0,0.75], got {}",
+        results.len()
+    );
+    let tv = results[0].truth_value.value();
+    assert!(
+        (0.0..=0.75).contains(&tv),
+        "returned claim truth {tv} outside requested range"
+    );
+
+    // And a high-truth query still excludes it.
+    let high = ClaimRepository::list_by_truth_range(&pool, 0.9, 1.0, 20, 0)
+        .await
+        .unwrap();
+    assert!(
+        high.iter().all(|c| c.truth_value.value() >= 0.9),
+        "high-range query leaked a sub-0.9 claim"
+    );
+}

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -250,21 +250,17 @@ pub async fn query_claims(
     params: QueryClaimsParams,
 ) -> Result<CallToolResult, McpError> {
     let limit = params.limit.unwrap_or(20).clamp(1, 100);
-
-    // Use list with search for now (min/max truth filtering done post-query)
-    let claims = ClaimRepository::list(&server.pool, limit, 0, None)
-        .await
-        .map_err(internal_error)?;
-
     let min = params.min_truth.unwrap_or(0.0);
     let max = params.max_truth.unwrap_or(1.0);
 
+    // Filter by truth range in SQL (before LIMIT) so matching claims outside
+    // the most-recent `limit` rows are still reachable (bug 5a55a48e).
+    let claims = ClaimRepository::list_by_truth_range(&server.pool, min, max, limit, 0)
+        .await
+        .map_err(internal_error)?;
+
     let results: Vec<ClaimResponse> = claims
         .into_iter()
-        .filter(|c| {
-            let tv = c.truth_value.value();
-            tv >= min && tv <= max
-        })
         .map(|c| ClaimResponse {
             id: c.id.as_uuid().to_string(),
             content: c.content.clone(),


### PR DESCRIPTION
## Bug (backlog `5a55a48e`)
`query_claims(min_truth=0, max_truth=0.75, limit=20)` returned `[]` despite claims with truth 0.44 existing.

## Root cause
`query_claims` (crates/epigraph-mcp/src/tools/claims.rs) called `ClaimRepository::list(limit, 0, None)` — which fetches the first `limit` rows ordered `created_at DESC` — then applied the `[min_truth, max_truth]` filter **in Rust, after the LIMIT**. Any matching claim outside the most-recent `limit` rows is invisible.

## Fix
- New `ClaimRepository::list_by_truth_range` (crates/epigraph-db/src/repos/claim.rs) applies the range in the SQL `WHERE` clause **before** `LIMIT`. Uses the runtime `query_as::<_, ClaimRow>` form (no `.sqlx` prepare needed) and reuses `claim_from_row` (signature unchanged, per repo conventions).
- `query_claims` now calls it and drops the post-query Rust filter.

## Test
`crates/epigraph-db/tests/list_by_truth_range.rs` seeds 25 recent high-truth (0.95) claims + 1 older low-truth (0.50) claim, then asserts `list_by_truth_range(0.0, 0.75, 20, 0)` returns the low-truth claim. This **fails** under the old fetch-recent-then-filter path and passes with the fix.

```
test truth_range_filter_finds_matches_outside_recent_window ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)