### PR TITLE
fix(matching): guard CORROBORATES edges against superseded/duplicate claims (5c7fc645)

### DIFF
--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -928,6 +928,31 @@ impl ClaimRepository {
         Ok(claims)
     }
 
+    /// Returns `true` iff **every** id in `ids` exists AND has
+    /// `is_current = true`.
+    ///
+    /// A missing id, a superseded claim (`is_current = false` via
+    /// [`Self::supersede`]), or a duplicate (via [`Self::mark_duplicate`])
+    /// all yield `false`. Used to guard structural-edge creation against
+    /// stale/duplicate endpoints — e.g. a CORROBORATES edge must not point at
+    /// a claim that has already been retired (backlog bug `5c7fc645`).
+    pub async fn are_all_current(pool: &PgPool, ids: &[uuid::Uuid]) -> Result<bool, DbError> {
+        if ids.is_empty() {
+            return Ok(true);
+        }
+        let live: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM claims \
+             WHERE id = ANY($1) AND COALESCE(is_current, true) = true",
+        )
+        .bind(ids)
+        .fetch_one(pool)
+        .await?;
+        // Distinct ids must each be present-and-current. A missing or
+        // non-current id lowers the count below the distinct cardinality.
+        let distinct: std::collections::HashSet<&uuid::Uuid> = ids.iter().collect();
+        Ok(live as usize == distinct.len())
+    }
+
     /// List claims that contain ALL of the specified labels.
     ///
     /// Uses the GIN index on `claims.labels` for efficient `@>` containment queries.

--- a/crates/epigraph-db/tests/are_all_current.rs
+++ b/crates/epigraph-db/tests/are_all_current.rs
@@ -1,0 +1,76 @@
+//! Regression test for backlog bug `5c7fc645`: `decide_match_candidate`
+//! wrote CORROBORATES edges without checking that both endpoints were still
+//! current, so a near-duplicate that had since been superseded/marked-duplicate
+//! could end up with a structural edge (e.g. a bidirectional support cycle on
+//! near-identical content).
+//!
+//! The fix routes the check through `ClaimRepository::are_all_current`, which
+//! this test pins: a superseded or missing endpoint must make the guard fail.
+
+use epigraph_db::ClaimRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn seed_claim(pool: &PgPool, agent_id: Uuid, is_current: bool, supersedes: Option<Uuid>) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current, supersedes) \
+         VALUES ($1, $2, $3, 0.6, $4, $5, $6)",
+    )
+    .bind(id)
+    .bind(format!("claim {id}"))
+    .bind(hash)
+    .bind(agent_id)
+    .bind(is_current)
+    .bind(supersedes)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn are_all_current_rejects_stale_or_missing(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let live_a = seed_claim(&pool, agent, true, None).await;
+    let live_b = seed_claim(&pool, agent, true, None).await;
+    // A superseded claim: is_current = false, pointing at live_a as its successor.
+    let superseded = seed_claim(&pool, agent, false, Some(live_a)).await;
+    let missing = Uuid::new_v4();
+
+    // Two live claims → guard passes (a CORROBORATES edge would be allowed).
+    assert!(ClaimRepository::are_all_current(&pool, &[live_a, live_b])
+        .await
+        .unwrap());
+
+    // Any superseded endpoint → guard fails (the bug scenario).
+    assert!(!ClaimRepository::are_all_current(&pool, &[live_a, superseded])
+        .await
+        .unwrap());
+
+    // A missing id → guard fails.
+    assert!(!ClaimRepository::are_all_current(&pool, &[live_a, missing])
+        .await
+        .unwrap());
+
+    // Empty set is vacuously true.
+    assert!(ClaimRepository::are_all_current(&pool, &[]).await.unwrap());
+}

--- a/crates/epigraph-db/tests/are_all_current.rs
+++ b/crates/epigraph-db/tests/are_all_current.rs
@@ -22,7 +22,12 @@ async fn seed_agent(pool: &PgPool) -> Uuid {
     id
 }
 
-async fn seed_claim(pool: &PgPool, agent_id: Uuid, is_current: bool, supersedes: Option<Uuid>) -> Uuid {
+async fn seed_claim(
+    pool: &PgPool,
+    agent_id: Uuid,
+    is_current: bool,
+    supersedes: Option<Uuid>,
+) -> Uuid {
     let id = Uuid::new_v4();
     let hash: Vec<u8> = id
         .as_bytes()
@@ -62,9 +67,11 @@ async fn are_all_current_rejects_stale_or_missing(pool: PgPool) {
         .unwrap());
 
     // Any superseded endpoint → guard fails (the bug scenario).
-    assert!(!ClaimRepository::are_all_current(&pool, &[live_a, superseded])
-        .await
-        .unwrap());
+    assert!(
+        !ClaimRepository::are_all_current(&pool, &[live_a, superseded])
+            .await
+            .unwrap()
+    );
 
     // A missing id → guard fails.
     assert!(!ClaimRepository::are_all_current(&pool, &[live_a, missing])

--- a/crates/epigraph-mcp/src/tools/matching.rs
+++ b/crates/epigraph-mcp/src/tools/matching.rs
@@ -21,7 +21,7 @@ use crate::errors::{internal_error, invalid_params, parse_uuid, McpError};
 use crate::server::EpiGraphMcpFull;
 use crate::types::*;
 
-use epigraph_db::MatchCandidateRepo;
+use epigraph_db::{ClaimRepository, MatchCandidateRepo};
 
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
@@ -139,6 +139,23 @@ pub async fn decide_match_candidate(
 
     match decision.as_str() {
         "promote" => {
+            // Guard: a CORROBORATES edge must connect two live claims. If
+            // either endpoint was superseded or marked duplicate (is_current =
+            // false) since the candidate was generated, promoting would create
+            // a structural inconsistency — an edge incident on a retired claim
+            // (backlog bug 5c7fc645). Refuse rather than write it.
+            if !ClaimRepository::are_all_current(&server.pool, &[row.claim_a, row.claim_b])
+                .await
+                .map_err(internal_error)?
+            {
+                return Err(invalid_params(format!(
+                    "cannot promote candidate {candidate_id}: a CORROBORATES edge requires both \
+                     claims to be current (is_current=true). One of {} / {} is superseded, a \
+                     duplicate, or missing.",
+                    row.claim_a, row.claim_b
+                )));
+            }
+
             repo.set_status(candidate_id, "promoted", Some(acting_agent))
                 .await
                 .map_err(internal_error)?;


### PR DESCRIPTION
## Bug (backlog `5c7fc645`)
`decide_match_candidate` could create a `CORROBORATES` edge incident on a claim that had already been superseded or marked-duplicate (`is_current = false`) — e.g. the reported near-duplicate pair forming a bidirectional support cycle.

## Root cause
The `"promote"` branch (crates/epigraph-mcp/src/tools/matching.rs) wrote the edge between `row.claim_a`/`row.claim_b` after only an existence/dup-edge check — never verifying the endpoints were still live.

## Fix
- New `ClaimRepository::are_all_current(pool, &[Uuid])` (crates/epigraph-db/src/repos/claim.rs) — `true` iff every id exists **and** is `is_current = true`. Keeps the SQL in the repo layer per repo conventions (the MCP tool already had inline SQL; no more added).
- `decide_match_candidate` calls it before promoting; a non-current/missing endpoint now returns `invalid_params` instead of writing the edge.

## Test
`crates/epigraph-db/tests/are_all_current.rs`: passes for two live claims, fails for a superseded endpoint, fails for a missing id, vacuously true for empty.

```
test are_all_current_rejects_stale_or_missing ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)