### PR TITLE
fix(mcp): make --allow-unauthenticated-http actually allow tool calls (be2a3391)

### DIFF
--- a/crates/epigraph-mcp/src/auth.rs
+++ b/crates/epigraph-mcp/src/auth.rs
@@ -58,3 +58,41 @@ pub async fn bearer_auth_middleware(
             .into_response(),
     }
 }
+
+/// Build an [`AuthContext`] that holds every scope the tool registry knows
+/// about (derived from [`crate::scope_map::SCOPE_MAP`] so new scopes are
+/// covered automatically).
+///
+/// Used ONLY on the `--allow-unauthenticated-http` path. There, the operator
+/// has explicitly opted out of Bearer auth, so no real token is validated and
+/// no `AuthContext` would otherwise be attached — which makes the per-tool
+/// scope gate (`server::enforce_tool_scope`, applied to every HTTP call) reject
+/// *everything* with "no auth context", rendering the flag misleading (backlog
+/// bug `be2a3391`). Injecting this permissive context lets calls through, which
+/// is exactly what the operator asked for.
+pub fn unauthenticated_context() -> AuthContext {
+    let mut scopes: Vec<String> = crate::scope_map::SCOPE_MAP
+        .iter()
+        .map(|(_, scope)| (*scope).to_string())
+        .collect();
+    scopes.sort();
+    scopes.dedup();
+    AuthContext {
+        client_id: uuid::Uuid::nil(),
+        agent_id: None,
+        owner_id: None,
+        client_type: epigraph_auth::ClientType::Service,
+        scopes,
+        jti: uuid::Uuid::nil(),
+    }
+}
+
+/// Axum middleware for the `--allow-unauthenticated-http` listener: inject the
+/// permissive [`unauthenticated_context`] into every request so the downstream
+/// scope gate passes. Mirrors how [`bearer_auth_middleware`] inserts a
+/// *validated* `AuthContext`, minus the validation. Attach this ONLY when the
+/// operator passed `--allow-unauthenticated-http` (enforced in `main.rs`).
+pub async fn inject_unauthenticated_context(mut req: Request, next: Next) -> Response {
+    req.extensions_mut().insert(unauthenticated_context());
+    next.run(req).await
+}

--- a/crates/epigraph-mcp/src/main.rs
+++ b/crates/epigraph-mcp/src/main.rs
@@ -207,6 +207,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 state,
                 bearer_auth_middleware,
             ))
+        } else if cli.allow_unauthenticated_http {
+            // Operator opted out of Bearer auth (e.g. unix-socket listener
+            // behind filesystem perms). Inject a permissive AuthContext so the
+            // per-tool scope gate passes — without it every tool 403s on a
+            // missing auth context, making the flag misleading (bug be2a3391).
+            router.layer(axum::middleware::from_fn(
+                epigraph_mcp::auth::inject_unauthenticated_context,
+            ))
         } else {
             router
         };

--- a/crates/epigraph-mcp/tests/http_auth_test.rs
+++ b/crates/epigraph-mcp/tests/http_auth_test.rs
@@ -486,7 +486,12 @@ async fn unauthenticated_http_passes_scope_gate() {
     // bogus pool) — that's fine; we assert only that the failure is not
     // auth-shaped. Under the bug the body carried "no auth context" /
     // "requires scope 'claims:read'".
-    let auth_strings = ["Unauthorized", "Forbidden", "no auth context", "requires scope"];
+    let auth_strings = [
+        "Unauthorized",
+        "Forbidden",
+        "no auth context",
+        "requires scope",
+    ];
     for s in &auth_strings {
         assert!(
             !body.contains(s),

--- a/crates/epigraph-mcp/tests/http_auth_test.rs
+++ b/crates/epigraph-mcp/tests/http_auth_test.rs
@@ -407,3 +407,90 @@ async fn right_scope_passes_auth() {
         );
     }
 }
+
+// ─── Test 5: --allow-unauthenticated-http actually allows tool calls ───────
+// Backlog be2a3391: the flag started the HTTP listener but, because no
+// AuthContext was injected, the per-tool scope gate 403'd every call with
+// "no auth context" — so the listener accepted nothing. The fix injects a
+// permissive context (auth::inject_unauthenticated_context); this test boots
+// the router the way main.rs does for that flag and asserts a tool call is NOT
+// auth-rejected.
+
+/// MCP service wrapped in the permissive context-injection middleware
+/// (no bearer auth) — mirrors main.rs's `--allow-unauthenticated-http` branch.
+async fn boot_unauth_router() -> axum::Router {
+    use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+    use rmcp::transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService,
+    };
+
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(Duration::from_millis(100))
+        .connect_lazy("postgres://invalid:invalid@127.0.0.1:1/invalid")
+        .expect("connect_lazy never errors");
+    let signer = Arc::new(epigraph_crypto::AgentSigner::generate());
+    let embedder = Arc::new(epigraph_mcp::embed::McpEmbedder::new(pool.clone(), None));
+
+    let service = StreamableHttpService::new(
+        move || {
+            Ok(epigraph_mcp::EpiGraphMcpFull::new_shared(
+                pool.clone(),
+                signer.clone(),
+                embedder.clone(),
+                false,
+            ))
+        },
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default(),
+    );
+
+    axum::Router::new()
+        .nest_service("/mcp", service)
+        .layer(axum::middleware::from_fn(
+            epigraph_mcp::auth::inject_unauthenticated_context,
+        ))
+}
+
+async fn spawn_unauth_server() -> std::net::SocketAddr {
+    let router = boot_unauth_router().await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    addr
+}
+
+#[tokio::test]
+async fn unauthenticated_http_passes_scope_gate() {
+    let addr = spawn_unauth_server().await;
+    let url = format!("http://{addr}/mcp");
+    let c = client();
+
+    // No real token; the inject middleware supplies a permissive context. The
+    // handshake helper still sends a (now-ignored) Authorization header.
+    let session_id = mcp_handshake(&c, &url, "unused-no-bearer").await;
+
+    let (_status, body) = call_tool(
+        &c,
+        &url,
+        "unused-no-bearer",
+        &session_id,
+        "query_claims",
+        serde_json::json!({"query": "test"}),
+    )
+    .await;
+
+    // The scope gate must NOT reject. The call WILL fail at the DB layer (lazy
+    // bogus pool) — that's fine; we assert only that the failure is not
+    // auth-shaped. Under the bug the body carried "no auth context" /
+    // "requires scope 'claims:read'".
+    let auth_strings = ["Unauthorized", "Forbidden", "no auth context", "requires scope"];
+    for s in &auth_strings {
+        assert!(
+            !body.contains(s),
+            "--allow-unauthenticated-http must not auth-reject; found {s:?} in: {body}"
+        );
+    }
+}


### PR DESCRIPTION
## Bug (backlog `be2a3391`)
Starting the MCP HTTP listener with `--allow-unauthenticated-http` accepted the flag and bound the socket, but **every** `tools/call` was rejected with `Unauthorized: no auth context (Bearer token required)`. The flag advertises unauthenticated access yet allowed nothing.

## Root cause
In `main.rs`, the no-`--jwt-secret` path built the router with **no** middleware (`else { router }`), so no `AuthContext` was inserted. `server::enforce_tool_scope` (run on all HTTP calls) rejects when `auth` is `None`.

## Fix
- `auth::inject_unauthenticated_context` (crates/epigraph-mcp/src/auth.rs): axum middleware that injects a permissive `AuthContext` whose scopes are derived from `scope_map::SCOPE_MAP` (so future scopes are covered without edits). Mirrors `bearer_auth_middleware` minus validation.
- `main.rs` layers it on the `else if cli.allow_unauthenticated_http` branch. The `jwt XOR allow-unauth` startup gate is untouched; **authenticated deployments are unaffected**.

## Test
New `unauthenticated_http_passes_scope_gate` in `http_auth_test.rs` boots the inject router, completes the MCP handshake, and asserts a `query_claims` call is **not** auth-shaped (DB failure from the lazy test pool is fine). All 5 tests pass (4 pre-existing bearer/scope cases unchanged):

```
test result: ok. 5 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)