### PR TITLE
fix(api): re-assert POST /claims dedup (409) at app layer (c11c1295)

### DIFF
--- a/crates/epigraph-api/src/routes/claims.rs
+++ b/crates/epigraph-api/src/routes/claims.rs
@@ -454,8 +454,10 @@ pub async fn create_claim(
         // brick API boot on the existing duplicates.)
         let content_hash = epigraph_crypto::ContentHasher::hash(claim.content.as_bytes());
         let agent_uuid: Uuid = claim.agent_id.into();
-        let dup_conflict = || ApiError::Conflict {
+        let dup_conflict = || {
+            ApiError::Conflict {
             reason: "claim already exists for this (content_hash, agent_id); use if_not_exists=true to retrieve it".to_string(),
+        }
         };
         if ClaimRepository::find_by_content_hash_and_agent(
             &mut tx,

--- a/crates/epigraph-api/src/routes/claims.rs
+++ b/crates/epigraph-api/src/routes/claims.rs
@@ -444,17 +444,35 @@ pub async fn create_claim(
     let (created_claim, was_created) = if request.if_not_exists {
         ClaimRepository::create_or_get(&mut tx, &claim).await?
     } else {
+        // The (content_hash, agent_id) UNIQUE constraint that create_strict's
+        // 409-on-duplicate contract relied on was dropped (migration 107), so
+        // create_strict now silently INSERTs duplicates — 20+ identical claims
+        // accumulated this way (bug c11c1295). Re-assert the contract at the app
+        // layer: refuse a duplicate up front with the same 409 the constraint
+        // would have produced. (Restoring the DB constraint requires de-duping
+        // existing rows first and is a separate migration; adding it here would
+        // brick API boot on the existing duplicates.)
+        let content_hash = epigraph_crypto::ContentHasher::hash(claim.content.as_bytes());
+        let agent_uuid: Uuid = claim.agent_id.into();
+        let dup_conflict = || ApiError::Conflict {
+            reason: "claim already exists for this (content_hash, agent_id); use if_not_exists=true to retrieve it".to_string(),
+        };
+        if ClaimRepository::find_by_content_hash_and_agent(
+            &mut tx,
+            content_hash.as_slice(),
+            agent_uuid,
+        )
+        .await?
+        .is_some()
+        {
+            return Err(dup_conflict());
+        }
         match ClaimRepository::create_strict(&mut tx, &claim).await {
             Ok(c) => (c, true),
-            Err(epigraph_db::DbError::DuplicateKey { .. }) => {
-                // Post-107: the (content_hash, agent_id) UNIQUE constraint fired.
-                // Surface as 409 Conflict so callers can distinguish "already
-                // exists for this agent" from a generic 400. Pre-107 this branch
-                // is unreachable because the constraint does not exist.
-                return Err(ApiError::Conflict {
-                    reason: "claim already exists for this (content_hash, agent_id); use if_not_exists=true to retrieve it".to_string(),
-                });
-            }
+            // Belt-and-suspenders: if the UNIQUE constraint is ever restored, or
+            // a concurrent writer wins the race between the check above and this
+            // INSERT, still surface 409 rather than a generic 500.
+            Err(epigraph_db::DbError::DuplicateKey { .. }) => return Err(dup_conflict()),
             Err(e) => return Err(e.into()),
         }
     };

--- a/crates/epigraph-api/tests/post_claims_dedup_409.rs
+++ b/crates/epigraph-api/tests/post_claims_dedup_409.rs
@@ -69,5 +69,8 @@ async fn duplicate_create_strict_returns_409() {
             .fetch_one(&pool)
             .await
             .unwrap();
-    assert_eq!(count, 1, "exactly one claim row should exist, found {count}");
+    assert_eq!(
+        count, 1,
+        "exactly one claim row should exist, found {count}"
+    );
 }

--- a/crates/epigraph-api/tests/post_claims_dedup_409.rs
+++ b/crates/epigraph-api/tests/post_claims_dedup_409.rs
@@ -1,0 +1,73 @@
+#![cfg(feature = "db")]
+//! Regression test for backlog bug `c11c1295`: POST /api/v1/claims with the
+//! default `if_not_exists=false` silently inserted duplicate
+//! `(content_hash, agent_id)` rows (20+ identical refuted claims accumulated
+//! this way) because the UNIQUE constraint create_strict relied on for its
+//! documented "409 on duplicate" contract was dropped in migration 107.
+//!
+//! The fix re-asserts that contract at the app layer. A second identical create
+//! must now return 409 Conflict instead of inserting a duplicate.
+
+use sqlx::postgres::PgPoolOptions;
+mod common;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn duplicate_create_strict_returns_409() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let agent = common::seed_system_agent(&pool).await;
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+    let (token, _) = common::test_bearer_token_with_seeded_client(&pool, &["claims:write"]).await;
+
+    // Unique content per run so the test is independent of prior DB state.
+    let content = format!("c11c1295 dedup regression {}", uuid::Uuid::new_v4());
+    let body = serde_json::json!({ "content": content, "agent_id": agent });
+    let client = reqwest::Client::new();
+    let endpoint = format!("http://{addr}/api/v1/claims");
+
+    // First create (if_not_exists omitted → defaults false) succeeds.
+    let r1 = client
+        .post(&endpoint)
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let s1 = r1.status();
+    assert!(
+        s1.is_success(),
+        "first create should succeed; got {s1} body={}",
+        r1.text().await.unwrap_or_default()
+    );
+
+    // Second identical create must be refused with 409 — NOT a silent duplicate.
+    let r2 = client
+        .post(&endpoint)
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let s2 = r2.status();
+    assert_eq!(
+        s2,
+        409,
+        "duplicate create must return 409 Conflict; got {s2} body={}",
+        r2.text().await.unwrap_or_default()
+    );
+
+    // And exactly one row exists for this (content, agent) — no duplicate landed.
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM claims WHERE content = $1 AND agent_id = $2")
+            .bind(&content)
+            .bind(agent)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 1, "exactly one claim row should exist, found {count}");
+}


### PR DESCRIPTION
## Bug (backlog `c11c1295`)
`POST /api/v1/claims` with the default `if_not_exists=false` silently inserted duplicate `(content_hash, agent_id)` rows — 20+ identical refuted claims accumulated this way.

## Root cause
`create_strict`'s documented contract is "409 Conflict on duplicate `(content_hash, agent_id)`", which **relied on a DB UNIQUE constraint dropped in migration 107**. Without it, `create_strict` just INSERTs, and the handler's `DuplicateKey` arm is unreachable.

## Fix (code-only — no migration)
Before `create_strict`, the handler now looks up the existing `(content_hash, agent_id)` (via the same `ClaimRepository::find_by_content_hash_and_agent` that `create_or_get` uses) and returns the documented **409 Conflict** if found. The `DuplicateKey` arm is kept as a belt-and-suspenders guard for a future constraint-restore / concurrent-writer race.

**Deliberately NOT in this PR:** restoring the `UNIQUE(content_hash, agent_id)` constraint. That migration would **fail at API boot** against the existing duplicate rows — it needs a de-dup pass first, tracked as a separate follow-up. (We just cleared a migration-drift boot hazard; not introducing another.)

## Test
`crates/epigraph-api/tests/post_claims_dedup_409.rs`: posts the same claim twice (default `if_not_exists`), asserts the second is `409` and exactly one row exists.

```
test duplicate_create_strict_returns_409 ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)