### PR TITLE
harden(A1): fail-closed JWT secret gate (epigraph-auth + api boot + mcp)

### DIFF
--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -107,6 +107,10 @@ pkcs1 = "0.7"  # PKCS#1 encoding for RSA fixtures
 toml = "0.8"  # provider config TOML parsing in tests
 
 [[test]]
+name = "boot_secret_gate_test"
+path = "tests/boot_secret_gate_test.rs"
+
+[[test]]
 name = "graph_routes_test"
 path = "tests/graph_routes_test.rs"
 

--- a/crates/epigraph-api/src/bin/server.rs
+++ b/crates/epigraph-api/src/bin/server.rs
@@ -155,6 +155,24 @@ async fn main() {
         }
     }
 
+    // Fail-closed JWT secret gate. Prod refuses to boot with an unset/dev
+    // secret; dev/CI opt out with EPIGRAPH_ALLOW_INSECURE_SECRET=1. The dev
+    // fallback in AppState::default_jwt_config is unchanged so the suite still
+    // compiles and runs.
+    let allow_insecure = std::env::var("EPIGRAPH_ALLOW_INSECURE_SECRET")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+    if !allow_insecure {
+        let secret = std::env::var("EPIGRAPH_JWT_SECRET").unwrap_or_default();
+        if let Err(reason) = epigraph_auth::assert_production_secret(secret.as_bytes()) {
+            eprintln!(
+                "FATAL: {reason}. Set a real EPIGRAPH_JWT_SECRET (>= 32 bytes, not the dev literal), \
+                 or set EPIGRAPH_ALLOW_INSECURE_SECRET=1 for local dev/CI."
+            );
+            std::process::exit(1);
+        }
+    }
+
     // Configure API settings.
     //
     // `require_signatures` enables a packet-signature gate on the write path

--- a/crates/epigraph-api/src/state.rs
+++ b/crates/epigraph-api/src/state.rs
@@ -451,8 +451,13 @@ impl AppState {
 
     /// Default JWT config from env var or dev fallback.
     fn default_jwt_config() -> Arc<crate::oauth::JwtConfig> {
-        let secret = std::env::var("EPIGRAPH_JWT_SECRET")
-            .unwrap_or_else(|_| "epigraph-dev-secret-change-in-production!!".to_string());
+        // NOTE: intentionally NOT fail-closed. This is called by test/builder
+        // constructors; the production gate lives in bin/server.rs::main behind
+        // EPIGRAPH_ALLOW_INSECURE_SECRET. See epigraph_auth::assert_production_secret.
+        let secret = std::env::var("EPIGRAPH_JWT_SECRET").unwrap_or_else(|_| {
+            String::from_utf8(epigraph_auth::DEV_JWT_SECRET.to_vec())
+                .expect("DEV_JWT_SECRET is valid UTF-8")
+        });
         Arc::new(crate::oauth::JwtConfig::from_secret(secret.as_bytes()))
     }
 

--- a/crates/epigraph-api/tests/boot_secret_gate_test.rs
+++ b/crates/epigraph-api/tests/boot_secret_gate_test.rs
@@ -1,0 +1,46 @@
+//! Boot-time secret gate: the server binary must refuse to start when
+//! EPIGRAPH_JWT_SECRET is unset/dev and EPIGRAPH_ALLOW_INSECURE_SECRET is not
+//! set, and must start when the opt-out is present. Drives the compiled
+//! `server` binary as a subprocess so it exercises the real `main`.
+
+use std::process::Command;
+
+fn server_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_server")
+}
+
+#[test]
+fn refuses_dev_secret_without_optout() {
+    let out = Command::new(server_bin())
+        .env_remove("EPIGRAPH_JWT_SECRET")
+        .env_remove("EPIGRAPH_ALLOW_INSECURE_SECRET")
+        .env("EPIGRAPH_PORT", "0")
+        .env("DATABASE_URL", "postgres://invalid:invalid@127.0.0.1:1/nope")
+        .output()
+        .expect("run server bin");
+    assert!(
+        !out.status.success(),
+        "server must exit non-zero with dev secret and no opt-out"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("EPIGRAPH_JWT_SECRET"),
+        "stderr must name the secret check; got: {stderr}"
+    );
+}
+
+#[test]
+fn optout_skips_secret_gate() {
+    let out = Command::new(server_bin())
+        .env_remove("EPIGRAPH_JWT_SECRET")
+        .env("EPIGRAPH_ALLOW_INSECURE_SECRET", "1")
+        .env("EPIGRAPH_PORT", "0")
+        .env("DATABASE_URL", "postgres://invalid:invalid@127.0.0.1:1/nope")
+        .output()
+        .expect("run server bin");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("EPIGRAPH_JWT_SECRET"),
+        "with the opt-out set the secret gate must be skipped; got: {stderr}"
+    );
+}

--- a/crates/epigraph-api/tests/boot_secret_gate_test.rs
+++ b/crates/epigraph-api/tests/boot_secret_gate_test.rs
@@ -15,7 +15,10 @@ fn refuses_dev_secret_without_optout() {
         .env_remove("EPIGRAPH_JWT_SECRET")
         .env_remove("EPIGRAPH_ALLOW_INSECURE_SECRET")
         .env("EPIGRAPH_PORT", "0")
-        .env("DATABASE_URL", "postgres://invalid:invalid@127.0.0.1:1/nope")
+        .env(
+            "DATABASE_URL",
+            "postgres://invalid:invalid@127.0.0.1:1/nope",
+        )
         .output()
         .expect("run server bin");
     assert!(
@@ -35,7 +38,10 @@ fn optout_skips_secret_gate() {
         .env_remove("EPIGRAPH_JWT_SECRET")
         .env("EPIGRAPH_ALLOW_INSECURE_SECRET", "1")
         .env("EPIGRAPH_PORT", "0")
-        .env("DATABASE_URL", "postgres://invalid:invalid@127.0.0.1:1/nope")
+        .env(
+            "DATABASE_URL",
+            "postgres://invalid:invalid@127.0.0.1:1/nope",
+        )
         .output()
         .expect("run server bin");
     let stderr = String::from_utf8_lossy(&out.stderr);

--- a/crates/epigraph-auth/src/lib.rs
+++ b/crates/epigraph-auth/src/lib.rs
@@ -16,6 +16,39 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// The committed development JWT secret. NEVER acceptable in production.
+/// Single source of truth — every consumer must reference this const, not a
+/// copy of the literal.
+pub const DEV_JWT_SECRET: &[u8] = b"epigraph-dev-secret-change-in-production!!";
+
+/// Minimum acceptable HMAC secret length, in bytes.
+pub const MIN_SECRET_LEN: usize = 32;
+
+/// Fail-closed production secret gate. Returns `Err(reason)` if the secret is
+/// empty, shorter than [`MIN_SECRET_LEN`] bytes, or equal to [`DEV_JWT_SECRET`].
+///
+/// Call this ONLY at binary boot, gated behind an opt-out env var for dev/CI.
+/// Do NOT call it inside `JwtConfig::from_secret` or any state/builder
+/// constructor — those are exercised by the test suite with the dev fallback.
+pub fn assert_production_secret(secret: &[u8]) -> Result<(), String> {
+    if secret.is_empty() {
+        return Err("EPIGRAPH_JWT_SECRET is empty".to_string());
+    }
+    if secret.len() < MIN_SECRET_LEN {
+        return Err(format!(
+            "EPIGRAPH_JWT_SECRET is {} bytes; minimum is {MIN_SECRET_LEN}",
+            secret.len()
+        ));
+    }
+    if secret == DEV_JWT_SECRET {
+        return Err(
+            "EPIGRAPH_JWT_SECRET is the committed dev literal; refusing to start in production"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct EpiGraphClaims {
     pub sub: Uuid,
@@ -205,5 +238,31 @@ mod tests {
         };
         assert!(check_scopes(&auth, &["claims:read"]).is_ok());
         assert!(check_scopes(&auth, &["claims:write"]).is_err());
+    }
+
+    #[test]
+    fn assert_production_secret_rejects_empty() {
+        assert!(assert_production_secret(b"").is_err());
+    }
+
+    #[test]
+    fn assert_production_secret_rejects_short() {
+        // 31 bytes — one below the 32-byte floor.
+        assert!(assert_production_secret(b"0123456789012345678901234567890").is_err());
+    }
+
+    #[test]
+    fn assert_production_secret_rejects_dev_literal() {
+        assert!(
+            assert_production_secret(DEV_JWT_SECRET).is_err(),
+            "the committed dev literal must never pass the production gate"
+        );
+    }
+
+    #[test]
+    fn assert_production_secret_accepts_real_secret() {
+        // 40 random-looking bytes, not the dev literal.
+        let secret = b"R7p2-Xq9_kL4vN8wErTy6uIoP1aSdFgHjKlZ0cVb";
+        assert!(assert_production_secret(secret).is_ok());
     }
 }

--- a/crates/epigraph-mcp/src/main.rs
+++ b/crates/epigraph-mcp/src/main.rs
@@ -102,14 +102,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // auth (e.g., a unix-socket listener behind filesystem permissions).
     if cli.listen.is_some() {
         match (cli.jwt_secret.as_deref(), cli.allow_unauthenticated_http) {
-            (Some(secret), false) if secret.len() < 32 => {
-                eprintln!(
-                    "ERROR: --jwt-secret must be at least 32 bytes (got {}).",
-                    secret.len()
-                );
-                std::process::exit(1);
+            (Some(secret), false) => {
+                if let Err(reason) = epigraph_auth::assert_production_secret(secret.as_bytes()) {
+                    eprintln!("ERROR: --jwt-secret rejected: {reason}");
+                    std::process::exit(1);
+                }
+                // authenticated path
             }
-            (Some(_), false) => {} // authenticated path
             (None, true) => {}     // operator-acknowledged unauthenticated path
             (Some(_), true) => {
                 eprintln!(

--- a/crates/epigraph-mcp/src/main.rs
+++ b/crates/epigraph-mcp/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 // authenticated path
             }
-            (None, true) => {}     // operator-acknowledged unauthenticated path
+            (None, true) => {} // operator-acknowledged unauthenticated path
             (Some(_), true) => {
                 eprintln!(
                     "ERROR: --jwt-secret and --allow-unauthenticated-http are mutually exclusive."

--- a/crates/epigraph-mcp/tests/jwt_secret_gate_test.rs
+++ b/crates/epigraph-mcp/tests/jwt_secret_gate_test.rs
@@ -1,0 +1,34 @@
+//! The --jwt-secret gate must reject the committed dev literal even though it
+//! is >= 32 bytes. Drives the compiled binary with --listen so the gate runs.
+
+use std::process::Command;
+
+fn mcp_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_epigraph-mcp-full")
+}
+
+#[test]
+fn rejects_dev_literal_jwt_secret() {
+    let out = Command::new(mcp_bin())
+        .args([
+            "--database-url",
+            "postgres://invalid:invalid@127.0.0.1:1/nope",
+            "--listen",
+            "127.0.0.1:0",
+            "--jwt-secret",
+            "epigraph-dev-secret-change-in-production!!",
+        ])
+        .output()
+        .expect("run mcp bin");
+    assert!(
+        !out.status.success(),
+        "mcp must reject the dev literal as a --jwt-secret"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.to_lowercase().contains("dev")
+            || stderr.contains("EPIGRAPH_JWT_SECRET")
+            || stderr.contains("--jwt-secret"),
+        "stderr must explain the dev-literal rejection; got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Problem
`EPIGRAPH_JWT_SECRET` silently falls back to a **committed dev literal** (`epigraph-api/src/state.rs`, byte-identical in episcience/epigraph-mcp/epigraph-internal). Same-secret-everywhere is by design for token portability — which is exactly why one unset/dev config forges tokens for every service (confirmed-critical, Track A §3 / A1).

## Change (3 commits, TDD)
- **`epigraph-auth`**: `assert_production_secret(&[u8])` (Err on empty / `<32` bytes / `== DEV_JWT_SECRET`) + `DEV_JWT_SECRET`/`MIN_SECRET_LEN` consts as the single source of truth. (`cc087d6`)
- **`epigraph-api`**: fail-closed gate at `bin/server.rs::main` (before any DB/port bind), prod refuses to boot on an unset/dev secret; dev/CI opt out with `EPIGRAPH_ALLOW_INSECURE_SECRET=1`. `state.rs::default_jwt_config` keeps the dev fallback (test/builder path) sourced from the shared const — no panic there. (`24426e3`)
- **`epigraph-mcp`**: `--jwt-secret` now rejects the dev literal (was a `<32`-bytes-only floor; the 42-byte literal slipped through). (`ca59f60`)

Subprocess tests prove the gate fires (and the opt-out skips it); the `epigraph-auth` unit tests cover the discriminating empty/`<32`/dev-literal cases.

## ⚠️ Deploy coordination (do NOT merge-and-restart blindly)
Rotating `EPIGRAPH_JWT_SECRET` to a real value invalidates **every live token at once** — restart ALL consumers together (epigraph-api, episcience, epigraph-mcp `--listen`, the gui sidecar, epiclaw-host stored sessions). See `epigraph-planning` INDEX §4. Until a real secret is set in prod env, set `EPIGRAPH_ALLOW_INSECURE_SECRET=1` to avoid a boot failure on the next restart.

## Scope
A1 only. A4 (HTTP route→scope coverage) and episcience/epigraph-internal centralization are later Track A tasks. Part of Wave 1 (criticals). Not auto-merged — review at will (epigraph-io convention: merge-commit, not squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)