### PR TITLE
feat(perspective): source-reliability write endpoint (HTTP + MCP)

### DIFF
--- a/crates/epigraph-api/src/routes/mod.rs
+++ b/crates/epigraph-api/src/routes/mod.rs
@@ -280,6 +280,10 @@ pub fn create_router(state: AppState) -> Router {
             "/api/v1/perspectives",
             post(perspective::create_perspective),
         )
+        .route(
+            "/api/v1/perspectives/:id/source-reliability",
+            put(perspective::set_source_reliability),
+        )
         .route("/api/v1/communities", post(community::create_community))
         .route(
             "/api/v1/communities/:id/members",
@@ -917,6 +921,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/v1/perspectives",
             post(perspective::create_perspective),
+        )
+        .route(
+            "/api/v1/perspectives/:id/source-reliability",
+            put(perspective::set_source_reliability),
         )
         .route("/api/v1/communities", post(community::create_community))
         .route(

--- a/crates/epigraph-api/src/routes/perspective.rs
+++ b/crates/epigraph-api/src/routes/perspective.rs
@@ -53,6 +53,27 @@ fn default_confidence_calibration() -> f64 {
     0.5
 }
 
+/// Request to set a perspective's source-reliability map — the frame-function lens:
+/// evidence-type tag → α ∈ [0,1]. An empty map clears the override. Read at query
+/// time by `epigraph_engine::belief_query::get_perspective_belief`.
+#[derive(Debug, Deserialize)]
+pub struct SetSourceReliabilityRequest {
+    pub source_reliability: std::collections::HashMap<String, f64>,
+}
+
+/// Reject any reliability weight outside [0, 1] (or NaN) before it reaches the DB.
+fn validate_reliability(map: &std::collections::HashMap<String, f64>) -> Result<(), ApiError> {
+    for (tag, &alpha) in map {
+        if alpha.is_nan() || !(0.0..=1.0).contains(&alpha) {
+            return Err(ApiError::ValidationError {
+                field: format!("source_reliability.{tag}"),
+                reason: "reliability weight must be in [0, 1]".to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Response for a perspective
 #[derive(Debug, Serialize)]
 pub struct PerspectiveResponse {
@@ -136,6 +157,26 @@ pub async fn create_perspective(
     }
 
     Ok((StatusCode::CREATED, Json(perspective_to_response(row))))
+}
+
+/// Set a perspective's source-reliability map (the frame-function lens). Merges into
+/// `properties.source_reliability`; an empty map clears the override.
+///
+/// `PUT /api/v1/perspectives/:id/source-reliability`
+#[cfg(feature = "db")]
+pub async fn set_source_reliability(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(request): Json<SetSourceReliabilityRequest>,
+) -> Result<StatusCode, ApiError> {
+    validate_reliability(&request.source_reliability)?;
+    epigraph_db::PerspectiveRepository::set_source_reliability(
+        &state.db_pool,
+        id,
+        &request.source_reliability,
+    )
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// List all perspectives
@@ -243,6 +284,15 @@ pub async fn create_perspective(
 }
 
 #[cfg(not(feature = "db"))]
+pub async fn set_source_reliability(
+    Path(_id): Path<Uuid>,
+    Json(request): Json<SetSourceReliabilityRequest>,
+) -> Result<StatusCode, ApiError> {
+    validate_reliability(&request.source_reliability)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(not(feature = "db"))]
 pub async fn list_perspectives(
     Query(_params): Query<ListPerspectivesQuery>,
 ) -> Result<Json<Vec<PerspectiveResponse>>, ApiError> {
@@ -288,5 +338,38 @@ mod tests {
         let q: ListPerspectivesQuery = serde_json::from_str("{}").unwrap();
         assert_eq!(q.limit, 50);
         assert_eq!(q.offset, 0);
+    }
+
+    #[test]
+    fn set_source_reliability_request_parses() {
+        let req: SetSourceReliabilityRequest = serde_json::from_str(
+            r#"{"source_reliability":{"western_clinical":0.9,"ayurvedic_classical":0.15}}"#,
+        )
+        .unwrap();
+        assert_eq!(req.source_reliability.len(), 2);
+        assert!((req.source_reliability["western_clinical"] - 0.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn validate_reliability_rejects_out_of_range() {
+        let bad = std::collections::HashMap::from([("western_clinical".to_string(), 1.5)]);
+        match validate_reliability(&bad) {
+            Err(ApiError::ValidationError { field, .. }) => {
+                assert_eq!(field, "source_reliability.western_clinical");
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_reliability_accepts_in_range_and_empty() {
+        // Empty map is valid — it clears the override.
+        assert!(validate_reliability(&std::collections::HashMap::new()).is_ok());
+        let ok = std::collections::HashMap::from([
+            ("a".to_string(), 0.0),
+            ("b".to_string(), 1.0),
+            ("c".to_string(), 0.42),
+        ]);
+        assert!(validate_reliability(&ok).is_ok());
     }
 }

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -80,6 +80,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("report_hierarchical_outcome", "claims:write"),
     ("report_workflow_outcome", "claims:write"),
     ("resolve_backlog_item", "claims:write"),
+    ("set_source_reliability", "claims:write"),
     ("stage_claims", "claims:write"),
     ("store_workflow", "claims:write"),
     ("submit_claim", "claims:write"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -670,6 +670,17 @@ impl EpiGraphMcpFull {
         tools::perspectives::create_perspective(self, params).await
     }
 
+    #[tool(
+        description = "Set a perspective's source-reliability map (evidence-type tag -> alpha in [0,1]) — the frame-function lens read by scoped_belief / get_perspective_belief, so two observers weight the same evidence differently. An empty map clears the override."
+    )]
+    async fn set_source_reliability(
+        &self,
+        Parameters(params): Parameters<SetSourceReliabilityParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::perspectives::set_source_reliability(self, params).await
+    }
+
     #[tool(description = "List all perspectives with optional limit.")]
     async fn list_perspectives(
         &self,

--- a/crates/epigraph-mcp/src/tools/perspectives.rs
+++ b/crates/epigraph-mcp/src/tools/perspectives.rs
@@ -88,6 +88,30 @@ pub async fn create_perspective(
     }))
 }
 
+/// Set a perspective's source-reliability map (the frame-function lens): evidence-type
+/// tag -> alpha in [0,1], merged into `properties.source_reliability`. Empty map clears it.
+pub async fn set_source_reliability(
+    server: &EpiGraphMcpFull,
+    params: SetSourceReliabilityParams,
+) -> Result<CallToolResult, McpError> {
+    let id = parse_uuid(&params.perspective_id)?;
+    for (tag, &alpha) in &params.source_reliability {
+        if alpha.is_nan() || !(0.0..=1.0).contains(&alpha) {
+            return Err(invalid_params(format!(
+                "reliability for '{tag}' must be in [0, 1]"
+            )));
+        }
+    }
+    PerspectiveRepository::set_source_reliability(&server.pool, id, &params.source_reliability)
+        .await
+        .map_err(internal_error)?;
+    success_json(&serde_json::json!({
+        "perspective_id": id.to_string(),
+        "source_reliability": params.source_reliability,
+        "status": "set",
+    }))
+}
+
 /// List all perspectives with optional pagination.
 pub async fn list_perspectives(
     server: &EpiGraphMcpFull,

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -1264,6 +1264,17 @@ pub struct CreatePerspectiveParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetSourceReliabilityParams {
+    #[schemars(description = "UUID of the perspective whose source-reliability lens to set")]
+    pub perspective_id: String,
+
+    #[schemars(
+        description = "Map of evidence-type tag -> reliability alpha in [0,1] (e.g. {\"western_clinical\":0.95,\"ayurvedic_classical\":0.15}). This is the frame-function lens read by scoped_belief. An empty map clears the override."
+    )]
+    pub source_reliability: std::collections::HashMap<String, f64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListPerspectivesParams {
     #[schemars(description = "Maximum number of perspectives to return (default 20)")]
     pub limit: Option<i64>,


### PR DESCRIPTION
## Summary

Exposes the per-perspective frame-function lens — `perspectives.properties.source_reliability` (evidence_type tag → α ∈ [0,1]) — through the sanctioned API. Until now only the `PerspectiveRepository::set_source_reliability` repo fn could set it, so API/MCP/frontend clients could create a perspective and submit evidence but **couldn't give it a distinct opinion** — its belief collapsed to the global `get_belief`. Frames scope belief propagation; this map is the observer lens read by `get_perspective_belief` / `scoped_belief`.

## Changes

- **HTTP** `PUT /api/v1/perspectives/:id/source-reliability` — `SetSourceReliabilityRequest { source_reliability }`; validates α ∈ [0,1], returns `204`, empty map clears the override. Registered in both router blocks (db + non-db handler variants).
- **MCP** `set_source_reliability` tool (`SetSourceReliabilityParams`) — same validation, `reject_if_read_only`-gated.
- Both are thin wrappers over the existing `PerspectiveRepository::set_source_reliability` repo fn — **no new SQL**, so no `cargo sqlx prepare` needed.
- Tests: request parse + range validation (rejects out-of-range on the right field; accepts in-range/empty).

## Verification

- `cargo check -p epigraph-api -p epigraph-mcp` (default `db` features) — clean.
- `cargo test -p epigraph-api --lib perspective` — 5/5 pass.

## Notes

- The `--no-default-features` (no-db) build has pre-existing, unrelated errors on `main` (`EpiGraphEvent` undeclared, etc.); the default `db` build — the one that ships — is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)