### PR TITLE
feat(cli): add targeted document ingest command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "epigraph-ds",
  "epigraph-embeddings",
  "epigraph-engine",
+ "epigraph-ingest",
  "epigraph-interfaces",
  "epigraph-mcp",
  "futures",

--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -101,6 +101,11 @@ path = "src/bin/bootstrap_clients.rs"
 required-features = ["db"]
 
 [[bin]]
+name = "ingest-document"
+path = "src/bin/ingest_document.rs"
+required-features = ["db"]
+
+[[bin]]
 name = "backfill_factors"
 path = "src/bin/backfill_factors.rs"
 required-features = ["db"]
@@ -113,6 +118,7 @@ epigraph-embeddings = { workspace = true }
 epigraph-interfaces = { workspace = true }
 epigraph-ds = { workspace = true }
 epigraph-mcp = { workspace = true }
+epigraph-ingest = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 epigraph-db = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/epigraph-cli/src/bin/ingest_document.rs
+++ b/crates/epigraph-cli/src/bin/ingest_document.rs
@@ -1,0 +1,102 @@
+//! Operator CLI for the canonical hierarchical `ingest_document` pipeline.
+//!
+//! This is intentionally a thin wrapper around
+//! `epigraph_mcp::tools::ingestion::do_ingest_document`: it gives operators a
+//! per-invocation database target without forking the ingestion logic away from
+//! the MCP tool.
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context};
+use clap::Parser;
+use epigraph_crypto::AgentSigner;
+use epigraph_ingest::schema::DocumentExtraction;
+use epigraph_mcp::embed::McpEmbedder;
+use epigraph_mcp::tools::ingestion::do_ingest_document;
+use epigraph_mcp::EpiGraphMcpFull;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "ingest-document",
+    about = "Ingest a DocumentExtraction JSON into a target EpiGraph database"
+)]
+struct Cli {
+    /// PostgreSQL connection URL for the target graph.
+    #[arg(long, env = "DATABASE_URL", hide_env_values = true)]
+    database_url: String,
+
+    /// Path to a hierarchical DocumentExtraction JSON file.
+    #[arg(long)]
+    file: PathBuf,
+
+    /// Ed25519 secret key as 64 hex chars. If omitted, uses a deterministic
+    /// document-ingest-cli signer so repeated operator runs share attribution.
+    #[arg(long)]
+    agent_key: Option<String>,
+
+    /// OpenAI API key for embedding generation. If omitted, embeddings use the
+    /// MCP embedder's mock/no-provider behavior.
+    #[arg(long, env = "OPENAI_API_KEY", hide_env_values = true)]
+    openai_api_key: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "epigraph_cli=info,epigraph_mcp=info".parse().unwrap()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = Cli::parse();
+    run(cli).await
+}
+
+async fn run(cli: Cli) -> anyhow::Result<()> {
+    let data = tokio::fs::read_to_string(&cli.file)
+        .await
+        .with_context(|| format!("cannot read {}", cli.file.display()))?;
+    let extraction: DocumentExtraction =
+        serde_json::from_str(&data).context("invalid DocumentExtraction JSON")?;
+
+    let pool = epigraph_db::create_pool(&cli.database_url)
+        .await
+        .context("connect target database")?;
+    let signer = signer_from_cli(cli.agent_key.as_deref())?;
+    let embedder = McpEmbedder::new(pool.clone(), cli.openai_api_key);
+    let server = EpiGraphMcpFull::new(pool, signer, embedder, false);
+
+    let result = do_ingest_document(&server, &extraction)
+        .await
+        .map_err(|e| anyhow!("ingest_document failed: {}", e.message))?;
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.as_str())
+        .ok_or_else(|| anyhow!("ingest_document returned no text content"))?;
+
+    println!("{text}");
+    Ok(())
+}
+
+fn signer_from_cli(agent_key: Option<&str>) -> anyhow::Result<AgentSigner> {
+    if let Some(key_hex) = agent_key {
+        let bytes = (0..key_hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&key_hex[i..i + 2], 16))
+            .collect::<Result<Vec<u8>, _>>()
+            .context("invalid --agent-key hex")?;
+        let key: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| anyhow!("--agent-key must be exactly 32 bytes / 64 hex chars"))?;
+        return AgentSigner::from_bytes(&key).context("invalid --agent-key");
+    }
+
+    Ok(epigraph_crypto::did_key::keypair_from_name(
+        "document-ingest-cli",
+    ))
+}


### PR DESCRIPTION
## Summary
- Adds `epigraph-cli` binary `ingest-document` for operator-driven `DocumentExtraction` ingestion into an explicitly supplied `--database-url`.
- Reuses `epigraph_mcp::tools::ingestion::do_ingest_document` so the CLI stays on the canonical MCP ingest path.
- Supports `--agent-key` and optional `OPENAI_API_KEY`, with env values hidden from help output.

## Evidence
- Addresses #221: operators currently need a separately launched MCP server to target scratch/dev/demo graphs.

## Verification
- `cargo check -p epigraph-cli --bin ingest-document --features db`
- `cargo run -p epigraph-cli --bin ingest-document --features db -- --help`

Closes #221