### PR TITLE
Dedup/recall hardening + quick wins (incl. a discovered recall prod bug)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Actions are pinned to a full commit SHA (not a floating tag) so a compromised
+# or force-pushed upstream tag cannot silently change what runs in CI. The
+# trailing comment records the version the SHA resolved to at pin time.
+# dtolnay/rust-toolchain selects the channel from the *ref name*; pinning by SHA
+# defeats that, so the channel stays explicit via the `toolchain` input below.
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -38,8 +43,8 @@ jobs:
       # reduces disk pressure.
       CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
     steps:
-      - uses: actions/checkout@v4.3.1
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           components: clippy, rustfmt
@@ -61,15 +66,18 @@ jobs:
             echo 'rustflags = ["-C", "link-arg=-fuse-ld=mold"]'
           } >> .cargo/config.toml
           mold --version
-      - uses: Swatinem/rust-cache@v2.8.1
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      # --locked: Cargo.lock is committed; enforce it so CI builds the exact
+      # locked dependency graph and fails loudly if the lock is stale rather
+      # than silently resolving newer versions.
       - name: Build
-        run: cargo build --workspace
+        run: cargo build --workspace --locked
       - name: Test (non-DB packages, parallel)
         # Packages without DB tests can run fully in parallel.
         # Crates with #[sqlx::test] integration tests (or live DB usage) are
         # excluded here and run sequentially below — concurrent test instances
         # race on _sqlx_migrations when applying migrations to the template DB.
-        run: cargo test --workspace
+        run: cargo test --workspace --locked
           --exclude epigraph-db
           --exclude epigraph-api
           --exclude epigraph-engine
@@ -80,20 +88,44 @@ jobs:
         # binaries race on _sqlx_migrations → "tuple concurrently updated".
         # --test-threads=1 serializes within the binary; running packages
         # sequentially prevents cross-binary races.
-        run: cargo test -p epigraph-db -- --test-threads=1
+        run: cargo test -p epigraph-db --locked -- --test-threads=1
       - name: Test (epigraph-api, serialized)
-        run: cargo test -p epigraph-api -- --test-threads=1
+        run: cargo test -p epigraph-api --locked -- --test-threads=1
       - name: Test (epigraph-engine, serialized)
-        run: cargo test -p epigraph-engine -- --test-threads=1
+        run: cargo test -p epigraph-engine --locked -- --test-threads=1
       - name: Test (epigraph-mcp, serialized)
         # claim_helper_tests adds a temporary CHECK constraint on `edges`
         # that would race with sibling tests under parallel execution.
-        run: cargo test -p epigraph-mcp -- --test-threads=1
+        run: cargo test -p epigraph-mcp --locked -- --test-threads=1
       - name: Test (epigraph-embeddings, serialized)
         # pgvector tests use #[sqlx::test] which races with parallel siblings
         # on _sqlx_migrations whenever a new migration is added.
-        run: cargo test -p epigraph-embeddings -- --test-threads=1
+        run: cargo test -p epigraph-embeddings --locked -- --test-threads=1
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --locked -- -D warnings
       - name: Format check
         run: cargo fmt --check
+
+  # Advisory, NOT a merge gate. cargo audit checks Cargo.lock against the
+  # RustSec DB fetched at run time, so a blocking gate would red-light every
+  # open PR the moment a new advisory lands on any transitive dependency —
+  # and Foreman auto-merges epigraph PRs, so unrelated red CI is actively
+  # harmful. continue-on-error keeps the result visible without blocking.
+  # The lockfile currently carries known advisories (bytes, rsa, rustls-webpki,
+  # sqlx, instant, …); flip this to a gate only once that backlog is triaged.
+  audit:
+    name: Security audit (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      # Installed from source rather than via a prebuilt-binary action so the
+      # trust surface stays the three actions pinned above — no extra upstream.
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Audit dependencies
+        run: cargo audit

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -2231,6 +2231,33 @@ impl ClaimRepository {
             .execute(&mut *tx)
             .await?;
 
+        // Migrate edges off the now-non-current duplicate onto the canonical
+        // claim, mirroring supersede()'s edge migration — otherwise edges to/from
+        // third claims dangle at a claim that no longer surfaces. Unlike supersede
+        // (which targets a freshly-minted claim with no pre-existing edges), the
+        // canonical here already exists, so guard against creating a
+        // canonical->canonical self-loop when an edge already linked dup and
+        // canonical. The 'supersedes' edges (dedup/lineage trail) are preserved.
+        sqlx::query(
+            "UPDATE edges SET target_id = $1 \
+             WHERE target_id = $2 AND target_type = 'claim' AND relationship != 'supersedes' \
+               AND NOT (source_type = 'claim' AND source_id = $1)",
+        )
+        .bind(canon_uuid)
+        .bind(dup_uuid)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "UPDATE edges SET source_id = $1 \
+             WHERE source_id = $2 AND source_type = 'claim' AND relationship != 'supersedes' \
+               AND NOT (target_type = 'claim' AND target_id = $1)",
+        )
+        .bind(canon_uuid)
+        .bind(dup_uuid)
+        .execute(&mut *tx)
+        .await?;
+
         tx.commit().await?;
         Ok(())
     }

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -490,6 +490,33 @@ impl ClaimRepository {
         query_embedding_pgvector: &str,
         limit: i64,
     ) -> Result<Vec<ClaimEmbeddingHit>, DbError> {
+        Self::search_by_embedding_scoped(pool, query_embedding_pgvector, limit, None, None).await
+    }
+
+    /// [`search_by_embedding_current`] with optional scope predicates pushed
+    /// into the query: `tags` requires label containment (`c.labels @> $tags`,
+    /// the claim must carry ALL given tags) and `agent_id` requires authorship.
+    /// A `None`/empty filter does not restrict (the `$n IS NULL OR …` idiom),
+    /// so the two compose with AND. Scoping at the DB keeps it correct and
+    /// index-friendly rather than over-fetching and filtering in Rust.
+    ///
+    /// # Errors
+    /// Returns [`DbError::QueryFailed`] on database errors.
+    #[instrument(skip(pool, query_embedding_pgvector))]
+    pub async fn search_by_embedding_scoped(
+        pool: &PgPool,
+        query_embedding_pgvector: &str,
+        limit: i64,
+        tags: Option<&[String]>,
+        agent_id: Option<Uuid>,
+    ) -> Result<Vec<ClaimEmbeddingHit>, DbError> {
+        // Empty tag slice scopes to nothing meaningful (`@> '{}'` is all rows);
+        // collapse it to None so the IS NULL branch short-circuits.
+        let tags_owned: Option<Vec<String>> = match tags {
+            Some(t) if !t.is_empty() => Some(t.to_vec()),
+            _ => None,
+        };
+
         let rows = sqlx::query_as::<_, ClaimEmbeddingHit>(
             r#"
             SELECT c.id AS claim_id,
@@ -497,12 +524,16 @@ impl ClaimRepository {
             FROM claims c
             WHERE c.embedding IS NOT NULL
               AND c.is_current
+              AND ($3::text[] IS NULL OR c.labels @> $3::text[])
+              AND ($4::uuid IS NULL OR c.agent_id = $4::uuid)
             ORDER BY c.embedding <=> $1::vector
             LIMIT $2
             "#,
         )
         .bind(query_embedding_pgvector)
         .bind(limit)
+        .bind(tags_owned)
+        .bind(agent_id)
         .fetch_all(pool)
         .await?;
 

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -470,6 +470,45 @@ impl ClaimRepository {
         Ok(q.fetch_all(pool).await?)
     }
 
+    /// Search **current** claims by embedding similarity across **all levels**.
+    ///
+    /// This is the search backing the simple `recall` MCP tool. Unlike
+    /// [`search_by_embedding`] — which is paper-paragraph-primary and
+    /// restricts to `(properties->>'level')::int = 2` — memorized claims have
+    /// no `level` property and store their vector on the 1536d
+    /// `claims.embedding` column. `recall` therefore needs a search with no
+    /// level restriction, limited to `is_current` so superseded/retired claims
+    /// are not resurfaced. (`recall` previously queried
+    /// `EvidenceRepository::search_by_embedding`, i.e. `evidence.embedding`,
+    /// which is unpopulated — so its semantic path returned nothing.)
+    ///
+    /// # Errors
+    /// Returns [`DbError::QueryFailed`] on database errors.
+    #[instrument(skip(pool, query_embedding_pgvector))]
+    pub async fn search_by_embedding_current(
+        pool: &PgPool,
+        query_embedding_pgvector: &str,
+        limit: i64,
+    ) -> Result<Vec<ClaimEmbeddingHit>, DbError> {
+        let rows = sqlx::query_as::<_, ClaimEmbeddingHit>(
+            r#"
+            SELECT c.id AS claim_id,
+                   1 - (c.embedding <=> $1::vector) AS similarity
+            FROM claims c
+            WHERE c.embedding IS NOT NULL
+              AND c.is_current
+            ORDER BY c.embedding <=> $1::vector
+            LIMIT $2
+            "#,
+        )
+        .bind(query_embedding_pgvector)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     /// Get all claims by an agent
     ///
     /// # Errors

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -473,9 +473,18 @@ impl MassFunctionRepository {
         Ok(rows)
     }
 
-    /// List distinct `claim_id`s that have at least one BBA, ordered by
-    /// `claim_id` for stable pagination. Used by bulk belief-recompute to
-    /// enumerate the rebuild population when no explicit target set is given.
+    /// List distinct `claim_id`s of **current** claims that have at least one
+    /// BBA, ordered by `claim_id` for stable pagination. Used by bulk
+    /// belief-recompute to enumerate the rebuild population when no explicit
+    /// target set is given.
+    ///
+    /// The `JOIN claims … WHERE c.is_current` matters because supersede /
+    /// mark_duplicate flip `is_current = false` but leave the claim's
+    /// `mass_functions` rows in place; without the filter the bulk path would
+    /// recompute beliefs on retired claims. This mirrors the sibling
+    /// labels-target path (`list_by_labels(.., current_only = true, ..)`).
+    /// `recompute_beliefs`' explicit `claim_ids` target bypasses this method,
+    /// so a caller can still deliberately recompute a non-current claim by id.
     #[instrument(skip(pool))]
     pub async fn list_claim_ids(
         pool: &PgPool,
@@ -484,9 +493,11 @@ impl MassFunctionRepository {
     ) -> Result<Vec<Uuid>, DbError> {
         let rows: Vec<Uuid> = sqlx::query_scalar(
             r#"
-            SELECT DISTINCT claim_id
-            FROM mass_functions
-            ORDER BY claim_id
+            SELECT DISTINCT mf.claim_id
+            FROM mass_functions mf
+            JOIN claims c ON c.id = mf.claim_id
+            WHERE c.is_current
+            ORDER BY mf.claim_id
             LIMIT $1 OFFSET $2
             "#,
         )
@@ -722,6 +733,59 @@ mod tests {
             .unwrap();
         assert_eq!(page1, expected[..2].to_vec());
         assert_eq!(page2, vec![expected[2]]);
+    }
+
+    /// `list_claim_ids` (the bulk belief-recompute enumeration) must EXCLUDE
+    /// non-current claims. supersede/mark_duplicate flip `is_current = false`
+    /// but deliberately leave the claim's `mass_functions` rows in place, so
+    /// without an is_current filter the bulk recompute path rebuilds beliefs
+    /// on retired claims — wasted work, and it diverges from the sibling
+    /// labels-target path which is already current-only.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn list_claim_ids_excludes_non_current_claims(pool: sqlx::PgPool) {
+        let agent = insert_agent(&pool, "lci-cur-a").await;
+        let suffix = Uuid::new_v4();
+        let frame_id = insert_frame(&pool, &format!("lci-cur-frame-{suffix}")).await;
+        let c_current = insert_claim(&pool, agent, &format!("lci-cur-1-{suffix}")).await;
+        let c_retired = insert_claim(&pool, agent, &format!("lci-cur-2-{suffix}")).await;
+
+        let masses = serde_json::json!({"0": 0.6, "0,1": 0.4});
+        for c in [c_current, c_retired] {
+            MassFunctionRepository::store(
+                &pool,
+                c,
+                frame_id,
+                Some(agent),
+                &masses,
+                None,
+                Some("test"),
+                "unknown",
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        // Retire one claim the way supersede/mark_duplicate do — flip
+        // is_current WITHOUT removing its BBAs.
+        sqlx::query("UPDATE claims SET is_current = false WHERE id = $1")
+            .bind(c_retired)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let ids = MassFunctionRepository::list_claim_ids(&pool, 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            ids,
+            vec![c_current],
+            "only the current claim's id is enumerated"
+        );
+        assert!(
+            !ids.contains(&c_retired),
+            "retired (is_current=false) claim must be excluded from bulk recompute"
+        );
     }
 
     /// Regression test for the NULL-perspective upsert bug fixed by

--- a/crates/epigraph-db/tests/claim_search_current.rs
+++ b/crates/epigraph-db/tests/claim_search_current.rs
@@ -1,0 +1,109 @@
+//! Integration tests for `ClaimRepository::search_by_embedding_current` and
+//! `search_by_embedding_scoped`.
+//!
+//! Context: the simple `recall` MCP tool used to search `evidence.embedding`,
+//! which is NULL for every memorized claim (memorize embeds `claims.embedding`).
+//! The existing `ClaimRepository::search_by_embedding` can't serve recall
+//! either — it restricts to `(properties->>'level')::int = 2` (paper
+//! paragraphs), excluding the level-`<none>` memorized claims. These tests pin
+//! the behavior of the new recall-facing search: current claims, ANY level,
+//! with optional tag/agent scope.
+//!
+//! Schema notes (mirrors `claim_search_by_embedding.rs`): `agents` row must
+//! exist before claims (FK); `content_hash` is NOT NULL and unique per agent.
+
+use epigraph_db::ClaimRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn build_query_vec() -> String {
+    let mut v = vec!["0.0"; 1536];
+    v[0] = "0.99";
+    format!("[{}]", v.join(","))
+}
+
+async fn seed_agent(pool: &PgPool, tag: &str) -> Uuid {
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(agent_id)
+        .bind(format!("{:0>2}", tag).repeat(32).chars().take(64).collect::<String>())
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    agent_id
+}
+
+fn distinct_hash(tag: u8) -> Vec<u8> {
+    let mut h = vec![0u8; 32];
+    h[0] = tag;
+    h
+}
+
+/// Insert a claim with control over level, is_current, labels and agent.
+/// `level = None` inserts an empty properties object (level `<none>`), the
+/// shape of a memorized claim.
+#[allow(clippy::too_many_arguments)]
+async fn seed_claim(
+    pool: &PgPool,
+    agent: Uuid,
+    hash_tag: u8,
+    level: Option<i32>,
+    is_current: bool,
+    labels: &[&str],
+    pgvec: &str,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    let props = match level {
+        Some(l) => format!(r#"{{"level": {l}}}"#),
+        None => "{}".to_string(),
+    };
+    let labels_vec: Vec<String> = labels.iter().map(|s| (*s).to_string()).collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding, is_current, labels) \
+         VALUES ($1, $2, $3, $4, 0.6, $5::jsonb, $6::vector, $7, $8)",
+    )
+    .bind(id)
+    .bind(format!("c-{id}"))
+    .bind(distinct_hash(hash_tag))
+    .bind(agent)
+    .bind(props)
+    .bind(pgvec)
+    .bind(is_current)
+    .bind(&labels_vec)
+    .execute(pool)
+    .await
+    .expect("insert claim");
+    id
+}
+
+/// The recall-facing search must return CURRENT claims of ANY level (including
+/// level-`<none>` memories) that have an embedding, and must EXCLUDE
+/// non-current claims — unlike the level-2-only `search_by_embedding`.
+#[sqlx::test(migrations = "../../migrations")]
+async fn search_current_returns_all_levels_excludes_non_current(pool: PgPool) {
+    let agent = seed_agent(&pool, "a1").await;
+    let pgvec = build_query_vec();
+
+    let mem = seed_claim(&pool, agent, 1, None, true, &[], &pgvec).await; // level <none>, current
+    let para = seed_claim(&pool, agent, 2, Some(2), true, &[], &pgvec).await; // level 2, current
+    let retired = seed_claim(&pool, agent, 3, None, false, &[], &pgvec).await; // current=false
+
+    let hits = ClaimRepository::search_by_embedding_current(&pool, &pgvec, 10)
+        .await
+        .expect("search_by_embedding_current");
+    let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
+
+    assert!(ids.contains(&mem), "memorized (level <none>) current claim must be returned");
+    assert!(ids.contains(&para), "level-2 current claim must be returned");
+    assert!(!ids.contains(&retired), "non-current claim must be excluded");
+
+    // Contrast: the existing level-2-only method would MISS the memory and the
+    // level<none> retired claim, returning only the level-2 paragraph. This is
+    // exactly why recall needs the new method.
+    let level2_only = ClaimRepository::search_by_embedding(&pool, &pgvec, 1536, 10, None)
+        .await
+        .expect("legacy search_by_embedding");
+    let l2_ids: Vec<Uuid> = level2_only.iter().map(|h| h.claim_id).collect();
+    assert!(!l2_ids.contains(&mem), "legacy method excludes the level <none> memory (the bug)");
+    assert!(l2_ids.contains(&para), "legacy method returns the level-2 paragraph");
+}

--- a/crates/epigraph-db/tests/claim_search_current.rs
+++ b/crates/epigraph-db/tests/claim_search_current.rs
@@ -26,7 +26,13 @@ async fn seed_agent(pool: &PgPool, tag: &str) -> Uuid {
     let agent_id = Uuid::new_v4();
     sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
         .bind(agent_id)
-        .bind(format!("{:0>2}", tag).repeat(32).chars().take(64).collect::<String>())
+        .bind(
+            format!("{:0>2}", tag)
+                .repeat(32)
+                .chars()
+                .take(64)
+                .collect::<String>(),
+        )
         .execute(pool)
         .await
         .expect("seed agent");
@@ -93,9 +99,18 @@ async fn search_current_returns_all_levels_excludes_non_current(pool: PgPool) {
         .expect("search_by_embedding_current");
     let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
 
-    assert!(ids.contains(&mem), "memorized (level <none>) current claim must be returned");
-    assert!(ids.contains(&para), "level-2 current claim must be returned");
-    assert!(!ids.contains(&retired), "non-current claim must be excluded");
+    assert!(
+        ids.contains(&mem),
+        "memorized (level <none>) current claim must be returned"
+    );
+    assert!(
+        ids.contains(&para),
+        "level-2 current claim must be returned"
+    );
+    assert!(
+        !ids.contains(&retired),
+        "non-current claim must be excluded"
+    );
 
     // Contrast: the existing level-2-only method would MISS the memory and the
     // level<none> retired claim, returning only the level-2 paragraph. This is
@@ -104,8 +119,14 @@ async fn search_current_returns_all_levels_excludes_non_current(pool: PgPool) {
         .await
         .expect("legacy search_by_embedding");
     let l2_ids: Vec<Uuid> = level2_only.iter().map(|h| h.claim_id).collect();
-    assert!(!l2_ids.contains(&mem), "legacy method excludes the level <none> memory (the bug)");
-    assert!(l2_ids.contains(&para), "legacy method returns the level-2 paragraph");
+    assert!(
+        !l2_ids.contains(&mem),
+        "legacy method excludes the level <none> memory (the bug)"
+    );
+    assert!(
+        l2_ids.contains(&para),
+        "legacy method returns the level-2 paragraph"
+    );
 }
 
 /// `search_by_embedding_scoped` pushes optional tag (label containment) and
@@ -130,7 +151,10 @@ async fn search_scoped_filters_by_tag_and_agent(pool: PgPool) {
         .await
         .expect("scoped none");
     let all_ids = ids(&all);
-    assert!([a_x, a_plain, b_x].iter().all(|c| all_ids.contains(c)), "no scope returns all");
+    assert!(
+        [a_x, a_plain, b_x].iter().all(|c| all_ids.contains(c)),
+        "no scope returns all"
+    );
 
     // Tag scope → only the two carrying topic-x, across agents.
     let tagged = ClaimRepository::search_by_embedding_scoped(
@@ -143,15 +167,25 @@ async fn search_scoped_filters_by_tag_and_agent(pool: PgPool) {
     .await
     .expect("scoped tag");
     let tagged_ids = ids(&tagged);
-    assert!(tagged_ids.contains(&a_x) && tagged_ids.contains(&b_x), "tag scope keeps topic-x claims");
-    assert!(!tagged_ids.contains(&a_plain), "tag scope drops the untagged claim");
+    assert!(
+        tagged_ids.contains(&a_x) && tagged_ids.contains(&b_x),
+        "tag scope keeps topic-x claims"
+    );
+    assert!(
+        !tagged_ids.contains(&a_plain),
+        "tag scope drops the untagged claim"
+    );
 
     // Agent scope → only agent_a's claims, regardless of tag.
-    let by_agent = ClaimRepository::search_by_embedding_scoped(&pool, &pgvec, 10, None, Some(agent_a))
-        .await
-        .expect("scoped agent");
+    let by_agent =
+        ClaimRepository::search_by_embedding_scoped(&pool, &pgvec, 10, None, Some(agent_a))
+            .await
+            .expect("scoped agent");
     let agent_ids = ids(&by_agent);
-    assert!(agent_ids.contains(&a_x) && agent_ids.contains(&a_plain), "agent scope keeps agent_a claims");
+    assert!(
+        agent_ids.contains(&a_x) && agent_ids.contains(&a_plain),
+        "agent scope keeps agent_a claims"
+    );
     assert!(!agent_ids.contains(&b_x), "agent scope drops agent_b claim");
 
     // Both → intersection: agent_a AND topic-x = only a_x.
@@ -164,5 +198,9 @@ async fn search_scoped_filters_by_tag_and_agent(pool: PgPool) {
     )
     .await
     .expect("scoped both");
-    assert_eq!(ids(&both), vec![a_x], "tag AND agent intersect to a single claim");
+    assert_eq!(
+        ids(&both),
+        vec![a_x],
+        "tag AND agent intersect to a single claim"
+    );
 }

--- a/crates/epigraph-db/tests/claim_search_current.rs
+++ b/crates/epigraph-db/tests/claim_search_current.rs
@@ -107,3 +107,62 @@ async fn search_current_returns_all_levels_excludes_non_current(pool: PgPool) {
     assert!(!l2_ids.contains(&mem), "legacy method excludes the level <none> memory (the bug)");
     assert!(l2_ids.contains(&para), "legacy method returns the level-2 paragraph");
 }
+
+/// `search_by_embedding_scoped` pushes optional tag (label containment) and
+/// agent predicates into the query. A None filter must not restrict; a Some
+/// filter must restrict, and the two combine (AND).
+#[sqlx::test(migrations = "../../migrations")]
+async fn search_scoped_filters_by_tag_and_agent(pool: PgPool) {
+    let agent_a = seed_agent(&pool, "a1").await;
+    let agent_b = seed_agent(&pool, "b2").await;
+    let pgvec = build_query_vec();
+
+    let a_x = seed_claim(&pool, agent_a, 1, None, true, &["topic-x"], &pgvec).await;
+    let a_plain = seed_claim(&pool, agent_a, 2, None, true, &[], &pgvec).await;
+    let b_x = seed_claim(&pool, agent_b, 3, None, true, &["topic-x"], &pgvec).await;
+
+    let ids = |hits: &[epigraph_db::ClaimEmbeddingHit]| -> Vec<Uuid> {
+        hits.iter().map(|h| h.claim_id).collect()
+    };
+
+    // No scope → all three.
+    let all = ClaimRepository::search_by_embedding_scoped(&pool, &pgvec, 10, None, None)
+        .await
+        .expect("scoped none");
+    let all_ids = ids(&all);
+    assert!([a_x, a_plain, b_x].iter().all(|c| all_ids.contains(c)), "no scope returns all");
+
+    // Tag scope → only the two carrying topic-x, across agents.
+    let tagged = ClaimRepository::search_by_embedding_scoped(
+        &pool,
+        &pgvec,
+        10,
+        Some(&["topic-x".to_string()]),
+        None,
+    )
+    .await
+    .expect("scoped tag");
+    let tagged_ids = ids(&tagged);
+    assert!(tagged_ids.contains(&a_x) && tagged_ids.contains(&b_x), "tag scope keeps topic-x claims");
+    assert!(!tagged_ids.contains(&a_plain), "tag scope drops the untagged claim");
+
+    // Agent scope → only agent_a's claims, regardless of tag.
+    let by_agent = ClaimRepository::search_by_embedding_scoped(&pool, &pgvec, 10, None, Some(agent_a))
+        .await
+        .expect("scoped agent");
+    let agent_ids = ids(&by_agent);
+    assert!(agent_ids.contains(&a_x) && agent_ids.contains(&a_plain), "agent scope keeps agent_a claims");
+    assert!(!agent_ids.contains(&b_x), "agent scope drops agent_b claim");
+
+    // Both → intersection: agent_a AND topic-x = only a_x.
+    let both = ClaimRepository::search_by_embedding_scoped(
+        &pool,
+        &pgvec,
+        10,
+        Some(&["topic-x".to_string()]),
+        Some(agent_a),
+    )
+    .await
+    .expect("scoped both");
+    assert_eq!(ids(&both), vec![a_x], "tag AND agent intersect to a single claim");
+}

--- a/crates/epigraph-db/tests/mark_duplicate_repo.rs
+++ b/crates/epigraph-db/tests/mark_duplicate_repo.rs
@@ -146,13 +146,33 @@ async fn mark_duplicate_migrates_edges_to_canonical(pool: PgPool) {
     .unwrap();
 
     // Incoming edge migrated: third -> dup became third -> canonical.
-    assert_eq!(edge_count(&pool, third, canonical).await, 1, "incoming edge not migrated");
-    assert_eq!(edge_count(&pool, third, dup).await, 0, "incoming edge left dangling at dup");
+    assert_eq!(
+        edge_count(&pool, third, canonical).await,
+        1,
+        "incoming edge not migrated"
+    );
+    assert_eq!(
+        edge_count(&pool, third, dup).await,
+        0,
+        "incoming edge left dangling at dup"
+    );
     // Outgoing edge migrated: dup -> third became canonical -> third.
-    assert_eq!(edge_count(&pool, canonical, third).await, 1, "outgoing edge not migrated");
-    assert_eq!(edge_count(&pool, dup, third).await, 0, "outgoing edge left dangling at dup");
+    assert_eq!(
+        edge_count(&pool, canonical, third).await,
+        1,
+        "outgoing edge not migrated"
+    );
+    assert_eq!(
+        edge_count(&pool, dup, third).await,
+        0,
+        "outgoing edge left dangling at dup"
+    );
     // Self-loop guard: the dup<->canonical edge must NOT become canonical->canonical.
-    assert_eq!(edge_count(&pool, canonical, canonical).await, 0, "created a self-loop");
+    assert_eq!(
+        edge_count(&pool, canonical, canonical).await,
+        0,
+        "created a self-loop"
+    );
 }
 
 #[sqlx::test(migrations = "../../migrations")]

--- a/crates/epigraph-db/tests/mark_duplicate_repo.rs
+++ b/crates/epigraph-db/tests/mark_duplicate_repo.rs
@@ -100,6 +100,61 @@ async fn mark_duplicate_rejects_self(pool: PgPool) {
     assert!(format!("{err:?}").contains("dup == canonical"), "{err:?}");
 }
 
+async fn seed_edge(pool: &PgPool, source: Uuid, target: Uuid, relationship: &str) {
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship, properties, created_at) \
+         VALUES (gen_random_uuid(), $1, 'claim', $2, 'claim', $3, '{}'::jsonb, NOW())",
+    )
+    .bind(source)
+    .bind(target)
+    .bind(relationship)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn edge_count(pool: &PgPool, source: Uuid, target: Uuid) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM edges WHERE source_id = $1 AND target_id = $2")
+        .bind(source)
+        .bind(target)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn mark_duplicate_migrates_edges_to_canonical(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let canonical = seed_claim(&pool, agent, "canonical").await;
+    let dup = seed_claim(&pool, agent, "duplicate").await;
+    let third = seed_claim(&pool, agent, "third").await;
+
+    // Incoming: a third claim supports the dup.
+    seed_edge(&pool, third, dup, "supports").await;
+    // Outgoing: the dup supports the third claim.
+    seed_edge(&pool, dup, third, "supports").await;
+    // Self-loop hazard: an edge already between dup and canonical. Redirecting its
+    // source to canonical would create a canonical->canonical self-loop.
+    seed_edge(&pool, dup, canonical, "related").await;
+
+    ClaimRepository::mark_duplicate(
+        &pool,
+        ClaimId::from_uuid(dup),
+        ClaimId::from_uuid(canonical),
+    )
+    .await
+    .unwrap();
+
+    // Incoming edge migrated: third -> dup became third -> canonical.
+    assert_eq!(edge_count(&pool, third, canonical).await, 1, "incoming edge not migrated");
+    assert_eq!(edge_count(&pool, third, dup).await, 0, "incoming edge left dangling at dup");
+    // Outgoing edge migrated: dup -> third became canonical -> third.
+    assert_eq!(edge_count(&pool, canonical, third).await, 1, "outgoing edge not migrated");
+    assert_eq!(edge_count(&pool, dup, third).await, 0, "outgoing edge left dangling at dup");
+    // Self-loop guard: the dup<->canonical edge must NOT become canonical->canonical.
+    assert_eq!(edge_count(&pool, canonical, canonical).await, 0, "created a self-loop");
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn mark_duplicate_rejects_missing_canonical(pool: PgPool) {
     let agent = seed_agent(&pool).await;

--- a/crates/epigraph-mcp/src/embed.rs
+++ b/crates/epigraph-mcp/src/embed.rs
@@ -95,12 +95,19 @@ impl McpEmbedder {
     }
 
     /// Search by embedding similarity. Returns (claim_id, similarity) pairs.
+    ///
+    /// Searches `claims.embedding` (where memorize/submit/ingest write claim
+    /// vectors) via `ClaimRepository::search_by_embedding_current`, restricted
+    /// to current claims of any level. This previously called
+    /// `EvidenceRepository::search_by_embedding` = `evidence.embedding`, which
+    /// is unpopulated, so the `recall` tool's semantic path always returned
+    /// empty.
     pub async fn search(&self, query: &str, limit: i64) -> Result<Vec<(uuid::Uuid, f64)>, String> {
         let embedding = self.generate(query).await?;
 
         let pgvec = format_pgvector(&embedding);
         let results =
-            epigraph_db::EvidenceRepository::search_by_embedding(&self.pool, &pgvec, limit)
+            epigraph_db::ClaimRepository::search_by_embedding_current(&self.pool, &pgvec, limit)
                 .await
                 .map_err(|e| e.to_string())?;
 

--- a/crates/epigraph-mcp/src/embed.rs
+++ b/crates/epigraph-mcp/src/embed.rs
@@ -94,22 +94,37 @@ impl McpEmbedder {
         }
     }
 
-    /// Search by embedding similarity. Returns (claim_id, similarity) pairs.
+    /// Search current claims by embedding similarity. Returns
+    /// (claim_id, similarity) pairs. Unscoped convenience wrapper over
+    /// [`search_scoped`](Self::search_scoped).
     ///
     /// Searches `claims.embedding` (where memorize/submit/ingest write claim
-    /// vectors) via `ClaimRepository::search_by_embedding_current`, restricted
-    /// to current claims of any level. This previously called
-    /// `EvidenceRepository::search_by_embedding` = `evidence.embedding`, which
-    /// is unpopulated, so the `recall` tool's semantic path always returned
-    /// empty.
+    /// vectors). This previously called `EvidenceRepository::search_by_embedding`
+    /// = `evidence.embedding`, which is unpopulated, so the `recall` tool's
+    /// semantic path always returned empty.
     pub async fn search(&self, query: &str, limit: i64) -> Result<Vec<(uuid::Uuid, f64)>, String> {
+        self.search_scoped(query, limit, None, None).await
+    }
+
+    /// Embedding search over current claims with optional scope pushed into
+    /// the query (see `ClaimRepository::search_by_embedding_scoped`): `tags`
+    /// requires label containment, `agent_id` requires authorship, `None` does
+    /// not restrict.
+    pub async fn search_scoped(
+        &self,
+        query: &str,
+        limit: i64,
+        tags: Option<&[String]>,
+        agent_id: Option<uuid::Uuid>,
+    ) -> Result<Vec<(uuid::Uuid, f64)>, String> {
         let embedding = self.generate(query).await?;
 
         let pgvec = format_pgvector(&embedding);
-        let results =
-            epigraph_db::ClaimRepository::search_by_embedding_current(&self.pool, &pgvec, limit)
-                .await
-                .map_err(|e| e.to_string())?;
+        let results = epigraph_db::ClaimRepository::search_by_embedding_scoped(
+            &self.pool, &pgvec, limit, tags, agent_id,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
 
         Ok(results
             .into_iter()

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -2,7 +2,7 @@
 
 use rmcp::model::*;
 
-use crate::errors::{internal_error, McpError};
+use crate::errors::{internal_error, invalid_params, McpError};
 use crate::server::EpiGraphMcpFull;
 use crate::tools::ds_auto;
 use crate::types::*;
@@ -132,15 +132,36 @@ pub async fn memorize(
     })
 }
 
+/// Parse the optional `agent_id` recall scope filter. A present-but-invalid
+/// UUID is an ERROR, never a silently dropped filter — silently ignoring it
+/// would widen recall to every agent (a scope bypass) while the caller
+/// believes the results are scoped. Blank/whitespace is treated as absent.
+fn parse_agent_filter(raw: Option<&str>) -> Result<Option<uuid::Uuid>, String> {
+    match raw.map(str::trim) {
+        None | Some("") => Ok(None),
+        Some(s) => uuid::Uuid::parse_str(s)
+            .map(Some)
+            .map_err(|e| format!("invalid agent_id {s:?}: {e}")),
+    }
+}
+
 pub async fn recall(
     server: &EpiGraphMcpFull,
     params: RecallParams,
 ) -> Result<CallToolResult, McpError> {
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
     let min_truth = params.min_truth.unwrap_or(0.3);
+    let agent_filter = parse_agent_filter(params.agent_id.as_deref()).map_err(invalid_params)?;
+    let tags = params.tags;
+    let tags_opt: Option<&[String]> = if tags.is_empty() { None } else { Some(&tags) };
+    let scoped = tags_opt.is_some() || agent_filter.is_some();
 
-    // Try semantic search first
-    let results = if let Ok(hits) = server.embedder.search(&params.query, limit).await {
+    // Try semantic search first, with any scope pushed into the query.
+    let results = if let Ok(hits) = server
+        .embedder
+        .search_scoped(&params.query, limit, tags_opt, agent_filter)
+        .await
+    {
         let mut results = Vec::new();
         for (claim_id, similarity) in hits {
             if let Ok(Some(claim)) =
@@ -158,8 +179,18 @@ pub async fn recall(
             }
         }
         results
+    } else if scoped {
+        // Degraded path: the embedder failed, so scoped semantic recall is
+        // unavailable. The text fallback (ILIKE over content) cannot enforce a
+        // tag scope — `Claim` carries no labels — so serving it would silently
+        // drop or bypass the requested scope. Return empty + warn rather than
+        // lie about what was searched.
+        tracing::warn!(
+            "recall: embedder unavailable; scoped recall (tags/agent_id) cannot be served by the unscoped text fallback — returning no results"
+        );
+        Vec::new()
     } else {
-        // Fallback to text search
+        // Fallback to unscoped text search (unchanged behaviour).
         let claims = ClaimRepository::list(&server.pool, limit, 0, Some(&params.query))
             .await
             .map_err(internal_error)?;
@@ -176,4 +207,30 @@ pub async fn recall(
     };
 
     success_json(&results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_agent_filter_none_or_blank_is_unscoped() {
+        assert_eq!(parse_agent_filter(None).unwrap(), None);
+        assert_eq!(parse_agent_filter(Some("")).unwrap(), None);
+        assert_eq!(parse_agent_filter(Some("   ")).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_agent_filter_accepts_valid_uuid() {
+        let u = uuid::Uuid::new_v4();
+        assert_eq!(parse_agent_filter(Some(&u.to_string())).unwrap(), Some(u));
+    }
+
+    #[test]
+    fn parse_agent_filter_rejects_bad_uuid_instead_of_silently_dropping() {
+        // A present-but-invalid agent_id MUST error. Silently returning None
+        // would widen recall to every agent while the caller believes the
+        // results are scoped — a scope bypass.
+        assert!(parse_agent_filter(Some("not-a-uuid")).is_err());
+    }
 }

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -162,6 +162,18 @@ pub struct RecallParams {
 
     #[schemars(description = "Maximum number of memories to return (default 10)")]
     pub limit: Option<i64>,
+
+    #[schemars(
+        description = "Restrict recall to claims carrying ALL these labels/tags (array containment). Default: no tag filter."
+    )]
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    #[schemars(
+        description = "Restrict recall to claims authored by this agent UUID. Default: any agent. An invalid UUID is rejected, not silently ignored."
+    )]
+    #[serde(default)]
+    pub agent_id: Option<String>,
 }
 
 // ── Ingestion ──


### PR DESCRIPTION
Hardening + quick wins from the 2026-06-01 Hermes-Agent comparison. All TDD'd, atomic commits.

## ⚠️ Headline: discovered prod bug — `recall`'s semantic search was dead
The simple `recall` MCP tool searched `EvidenceRepository::search_by_embedding` = `evidence.embedding`, which is **0-of-77,491 populated** in prod (`memorize` embeds the **claim**: `claims.embedding`, 426k/429k). The `WHERE e.embedding IS NOT NULL` clause therefore matched nothing, so recall's semantic path returned an **empty `Ok`** (no error → no text fallback) — it has been silently non-functional. This is the read side of the epistemic-compaction loop in `agent-runner` (the pre/post-compaction `recall(min_truth:0.3)` steps), so that loop's read-back was dead. The existing `ClaimRepository::search_by_embedding` couldn't be reused — it restricts to `level=2` paragraphs (~7.8k claims; ~0 memories, which are level `<none>`).

**`rdf.rs::search_triples` "Path B" shared the same dead `embedder.search` path and is now live too** — a beneficial behavior change worth calling out. (The `similar` trait method / epigraph-engine recall still uses evidence; deliberately left untouched.)

## Commits
- **`fix(db)` — exclude non-current claims from bulk belief-recompute** (`47f8b04`): `list_claim_ids` (the only `recompute_beliefs` bulk enumerator) JOINs claims + `WHERE c.is_current`. Verified safe: the labels-target path is already current-only, the explicit `claim_ids` target bypasses this method, and supersede/mark_duplicate leave BBAs in place (so the bug was real).
- **`fix(mcp)` — point recall at claims.embedding** (`391e175`): new `ClaimRepository::search_by_embedding_current` (claims, all levels, is_current); repointed `McpEmbedder::search`. Existing search methods untouched.
- **`feat(mcp)` — optional tag/agent scope on recall** (`6eeb50c`): `search_by_embedding_scoped` pushes tag (`@>`) + agent predicates into SQL; threaded through `RecallParams`. No silent scope failure — a bad `agent_id` → `invalid_params` (never an `.ok()`-swallowed bypass); embedder-down + scoped → empty + warn (the ILIKE fallback can't enforce a tag scope).
- **`chore(ci)` — SHA-pin actions, enforce --locked, advisory audit** (`674cc03`): see advisories note below.
- **`style(db)`** (`9588649`): rustfmt the new test fixtures.

## ⚠️ `cargo audit` surfaces 9 existing advisories
The new advisory (non-blocking) audit job reports 9 advisories on the current lockfile: `bytes` RUSTSEC-2026-0007, `rsa` RUSTSEC-2023-0071 (Marvin timing), `rustls-webpki` ×3, `sqlx` RUSTSEC-2024-0363, `instant` unmaintained, … — pre-existing transitive-dep debt, **separate remediation**. The job is advisory precisely so it doesn't false-block PRs (and Foreman auto-merges).

## Deferred
- **A3 (tool-description trimming)**: deliberately NOT done — trimming `#[tool(description=)]` prose risks regressing LLM tool-selection and there's no eval harness to verify a trim is safe. Net-negative for marginal token savings.

## Verification
Full `cargo test -p epigraph-db -p epigraph-mcp -- --test-threads=1`: **327 passed, 0 failed, 10 ignored / 66 binaries** (incl. `recall_with_context`, `find_workflow_fallback`, `embedder_writes_to_claims` — the shared-hot-path repoint broke nothing). clippy + fmt clean on touched code. Runtime queries → no `.sqlx` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)