### PR TITLE
Workflow-evolution (GEPA) gate — decide layer

### DIFF
--- a/crates/epigraph-db/src/repos/behavioral_execution.rs
+++ b/crates/epigraph-db/src/repos/behavioral_execution.rs
@@ -180,6 +180,45 @@ impl BehavioralExecutionRepository {
         Ok(rate.unwrap_or(0.0))
     }
 
+    /// Fetch the most recent `limit` behavioral executions for a workflow,
+    /// newest first (by `created_at`).
+    ///
+    /// Projects every column EXCEPT `goal_embedding` (which has no
+    /// `sqlx::Decode` in this crate), matching [`BehavioralExecutionRow`]. This
+    /// is the raw-row getter the workflow-evolution (GEPA) proposer reads to
+    /// reflect on a workflow's recent runs — `step_beliefs` (per-step
+    /// `deviation_reason`), `tool_pattern`, `quality`, `success` — before
+    /// proposing a variant. The aggregate methods (`rolling_success_rate`,
+    /// `behavioral_affinity`) summarise; this returns the rows themselves.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn recent_executions(
+        pool: &PgPool,
+        workflow_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<BehavioralExecutionRow>, DbError> {
+        let rows = sqlx::query_as::<_, BehavioralExecutionRow>(
+            r#"
+            SELECT id, workflow_id, goal_text,
+                   success, step_beliefs, tool_pattern,
+                   quality, deviation_count, total_steps, created_at,
+                   step_claim_id
+            FROM behavioral_executions
+            WHERE workflow_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(workflow_id)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     /// Find workflows with high behavioral success for goals similar to the
     /// supplied embedding.
     ///
@@ -401,5 +440,82 @@ mod tests {
         .await
         .unwrap();
         assert!(count >= 1);
+    }
+
+    /// `recent_executions` returns a workflow's rows newest-first, honours the
+    /// limit, and is scoped to the requested workflow_id (the GEPA proposer
+    /// reads exactly this to reflect on a workflow's recent runs).
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn recent_executions_newest_first_scoped_and_limited(pool: sqlx::PgPool) {
+        let agent_id: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO agents (public_key, display_name) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(blake3::hash(b"re-agent").as_bytes().as_slice())
+        .bind("re-agent")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let mk_wf = |content: &'static str| {
+            let pool = pool.clone();
+            async move {
+                sqlx::query_scalar::<_, uuid::Uuid>(
+                    "INSERT INTO claims (content, content_hash, agent_id, truth_value) \
+                     VALUES ($1, $2, $3, 0.5) RETURNING id",
+                )
+                .bind(content)
+                .bind(blake3::hash(content.as_bytes()).as_bytes().as_slice())
+                .bind(agent_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+            }
+        };
+        let wf = mk_wf("wf-target").await;
+        let other = mk_wf("wf-other").await;
+
+        let base = chrono::Utc::now();
+        let mk_row = |wfid: uuid::Uuid, secs: i64, goal: &str| BehavioralExecutionRow {
+            id: uuid::Uuid::new_v4(),
+            workflow_id: wfid,
+            goal_text: goal.to_string(),
+            success: true,
+            step_beliefs: serde_json::json!({}),
+            tool_pattern: vec![],
+            quality: None,
+            deviation_count: 0,
+            total_steps: 1,
+            created_at: base + chrono::Duration::seconds(secs),
+            step_claim_id: None,
+        };
+        for (wfid, secs, goal) in [
+            (wf, 0, "oldest"),
+            (wf, 1, "mid"),
+            (wf, 2, "newest"),
+            (other, 5, "other-wf"),
+        ] {
+            BehavioralExecutionRepository::create(&pool, mk_row(wfid, secs, goal), None)
+                .await
+                .unwrap();
+        }
+
+        // Limit < count: newest two of the target workflow, DESC by created_at.
+        let recent = BehavioralExecutionRepository::recent_executions(&pool, wf, 2)
+            .await
+            .unwrap();
+        assert_eq!(recent.len(), 2, "limit honoured");
+        assert_eq!(recent[0].goal_text, "newest", "newest first");
+        assert_eq!(recent[1].goal_text, "mid");
+        assert!(
+            recent.iter().all(|r| r.workflow_id == wf),
+            "scoped to the requested workflow"
+        );
+
+        // Limit > count: all three target rows, never the other workflow's row.
+        let all = BehavioralExecutionRepository::recent_executions(&pool, wf, 100)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(all.iter().all(|r| r.workflow_id == wf));
     }
 }

--- a/crates/epigraph-db/src/repos/behavioral_execution.rs
+++ b/crates/epigraph-db/src/repos/behavioral_execution.rs
@@ -219,6 +219,42 @@ impl BehavioralExecutionRepository {
         Ok(rows)
     }
 
+    /// Count `(successes, total)` over a workflow's last `window` executions.
+    ///
+    /// Unlike `rolling_success_rate` (which returns only the rate), this keeps
+    /// the denominator — the Wilson promotion gate needs both the success count
+    /// and the sample size to compute a lower bound.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn success_stats(
+        pool: &PgPool,
+        workflow_id: Uuid,
+        window: i64,
+    ) -> Result<(i64, i64), DbError> {
+        let row: (i64, i64) = sqlx::query_as(
+            r#"
+            SELECT
+                COUNT(*) FILTER (WHERE success)::bigint AS successes,
+                COUNT(*)::bigint AS total
+            FROM (
+                SELECT success
+                FROM behavioral_executions
+                WHERE workflow_id = $1
+                ORDER BY created_at DESC
+                LIMIT $2
+            ) AS recent
+            "#,
+        )
+        .bind(workflow_id)
+        .bind(window)
+        .fetch_one(pool)
+        .await?;
+
+        Ok(row)
+    }
+
     /// Find workflows with high behavioral success for goals similar to the
     /// supplied embedding.
     ///
@@ -517,5 +553,71 @@ mod tests {
             .unwrap();
         assert_eq!(all.len(), 3);
         assert!(all.iter().all(|r| r.workflow_id == wf));
+    }
+
+    /// `success_stats` returns (successes, total) over the last `window`
+    /// executions of one workflow — the raw counts the Wilson promotion gate
+    /// needs (rolling_success_rate alone drops the denominator).
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn success_stats_counts_successes_and_total_over_window(pool: sqlx::PgPool) {
+        let agent_id: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO agents (public_key, display_name) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(blake3::hash(b"ss-agent").as_bytes().as_slice())
+        .bind("ss-agent")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let wf: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO claims (content, content_hash, agent_id, truth_value) \
+             VALUES ('ss-wf', sha256('ss-wf'::bytea), $1, 0.5) RETURNING id",
+        )
+        .bind(agent_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let base = chrono::Utc::now();
+        // 3 successes + 2 failures, staggered so the window cut is deterministic.
+        for (i, succ) in [false, false, true, true, true].iter().enumerate() {
+            BehavioralExecutionRepository::create(
+                &pool,
+                BehavioralExecutionRow {
+                    id: uuid::Uuid::new_v4(),
+                    workflow_id: wf,
+                    goal_text: "g".into(),
+                    success: *succ,
+                    step_beliefs: serde_json::json!({}),
+                    tool_pattern: vec![],
+                    quality: None,
+                    deviation_count: 0,
+                    total_steps: 1,
+                    created_at: base + chrono::Duration::seconds(i as i64),
+                    step_claim_id: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        // Whole history: 3 successes of 5.
+        let (succ, total) = BehavioralExecutionRepository::success_stats(&pool, wf, 100)
+            .await
+            .unwrap();
+        assert_eq!((succ, total), (3, 5));
+
+        // Window of the newest 3 (all successes): 3 of 3.
+        let (succ3, total3) = BehavioralExecutionRepository::success_stats(&pool, wf, 3)
+            .await
+            .unwrap();
+        assert_eq!((succ3, total3), (3, 3), "window restricts to newest N");
+
+        // Unknown workflow: empty.
+        let (z_s, z_t) =
+            BehavioralExecutionRepository::success_stats(&pool, uuid::Uuid::new_v4(), 100)
+                .await
+                .unwrap();
+        assert_eq!((z_s, z_t), (0, 0));
     }
 }

--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -360,6 +360,35 @@ impl WorkflowRepository {
         Ok(root.map(|(id,)| id).unwrap_or(workflow_id))
     }
 
+    /// The immediate parent of a workflow variant: the `target` of its outgoing
+    /// `variant_of`/`supersedes` edge (the workflow this one was derived from).
+    /// Returns `None` for a lineage root (no such outgoing edge). One hop only —
+    /// unlike [`find_lineage_root`], which walks to the ancestral root. Matches
+    /// that method's relationship set and claim→claim typing.
+    ///
+    /// The promotion gate compares a variant against its immediate parent; this
+    /// resolves which workflow that is.
+    pub async fn immediate_variant_parent(
+        pool: &PgPool,
+        workflow_id: Uuid,
+    ) -> Result<Option<Uuid>, sqlx::Error> {
+        let parent: Option<(Uuid,)> = sqlx::query_as(
+            r#"
+            SELECT e.target_id
+            FROM edges e
+            WHERE e.source_id = $1
+              AND e.relationship IN ('variant_of', 'supersedes')
+              AND e.source_type = 'claim' AND e.target_type = 'claim'
+            LIMIT 1
+            "#,
+        )
+        .bind(workflow_id)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(parent.map(|(id,)| id))
+    }
+
     /// For each `executes`-edge from the workflow root, walk supersedes/revises
     /// edges to the latest head claim. Mirrors the resolution logic that
     /// previously lived in `epigraph-mcp::tools::workflow_hierarchical::build_resolved_steps`.
@@ -777,6 +806,57 @@ mod tests {
         assert_eq!(row.1, 0);
         assert_eq!(row.2, "Deploy a canary release safely.");
         assert_eq!(row.3["tags"][0], "deploy");
+    }
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn immediate_variant_parent_returns_one_hop(pool: sqlx::PgPool) {
+        let agent: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO agents (public_key, display_name) VALUES ($1, 'ivp') RETURNING id",
+        )
+        .bind(blake3::hash(b"ivp-agent").as_bytes().as_slice())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let mk_claim = |content: &'static str| {
+            let pool = pool.clone();
+            async move {
+                sqlx::query_scalar::<_, uuid::Uuid>(
+                    "INSERT INTO claims (content, content_hash, agent_id, truth_value) \
+                     VALUES ($1, sha256($1::bytea), $2, 0.5) RETURNING id",
+                )
+                .bind(content)
+                .bind(agent)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+            }
+        };
+        let parent = mk_claim("ivp-parent").await;
+        let variant = mk_claim("ivp-variant").await;
+        sqlx::query(
+            "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+             VALUES (gen_random_uuid(), $1, 'claim', $2, 'claim', 'variant_of')",
+        )
+        .bind(variant)
+        .bind(parent)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The variant's one-hop parent is the variant_of target.
+        assert_eq!(
+            WorkflowRepository::immediate_variant_parent(&pool, variant)
+                .await
+                .unwrap(),
+            Some(parent)
+        );
+        // A lineage root has no outgoing variant_of/supersedes edge → None.
+        assert_eq!(
+            WorkflowRepository::immediate_variant_parent(&pool, parent)
+                .await
+                .unwrap(),
+            None
+        );
     }
 
     #[sqlx::test(migrations = "../../migrations")]

--- a/crates/epigraph-engine/src/lib.rs
+++ b/crates/epigraph-engine/src/lib.rs
@@ -57,6 +57,7 @@ pub mod theme_kmeans;
 pub mod uncertainty;
 pub mod unified_bp;
 pub mod voi;
+pub mod workflow_promotion;
 
 #[allow(deprecated)]
 pub use bayesian::BayesianUpdater;

--- a/crates/epigraph-engine/src/workflow_promotion.rs
+++ b/crates/epigraph-engine/src/workflow_promotion.rs
@@ -1,0 +1,226 @@
+//! Workflow-variant promotion gate (GEPA).
+//!
+//! Decides whether a proposed workflow *variant* is statistically good enough
+//! to be preferred over its lineage *parent*, based purely on behavioral
+//! execution outcomes (NOT claim `truth_value` — the hierarchical
+//! workflow-outcome path never updates it; the signal lives in
+//! `behavioral_executions`).
+//!
+//! A variant is promotable only when BOTH hold:
+//!  1. **Minimum sample** — it has at least `min_executions` of its OWN
+//!     executions (default 10). Below that, its success rate is noise.
+//!  2. **Beats the parent with confidence** — the Wilson score-interval LOWER
+//!     bound of the variant's success rate exceeds the parent's observed
+//!     success rate. Using the variant's lower bound (not its point estimate)
+//!     means we promote only when we're statistically confident the variant is
+//!     genuinely better, not lucky on a small sample.
+//!
+//! This is the autonomous statistical gate: a maintenance pass evaluates it and
+//! sets a `promotable` flag, keeping `find_workflow` read-only and cheap.
+
+use serde::Serialize;
+
+/// Tunables for the promotion gate.
+#[derive(Debug, Clone)]
+pub struct WorkflowPromotionConfig {
+    /// Minimum number of the variant's own executions before it is eligible.
+    pub min_executions: i64,
+    /// Wilson interval z-score (1.96 ≈ 95% one-sided-ish confidence).
+    pub z: f64,
+}
+
+impl Default for WorkflowPromotionConfig {
+    fn default() -> Self {
+        Self {
+            min_executions: 10,
+            z: 1.96,
+        }
+    }
+}
+
+/// Success counts for one workflow over a window of executions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkflowSampleStats {
+    pub successes: i64,
+    pub total: i64,
+}
+
+impl WorkflowSampleStats {
+    /// Observed success rate, or 0.0 when there are no executions.
+    #[must_use]
+    pub fn success_rate(&self) -> f64 {
+        if self.total <= 0 {
+            0.0
+        } else {
+            self.successes as f64 / self.total as f64
+        }
+    }
+}
+
+/// The gate's decision plus the figures behind it (for logging / the tool).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct WorkflowPromotionVerdict {
+    pub promotable: bool,
+    pub variant_lower_bound: f64,
+    pub parent_rate: f64,
+    pub variant_total: i64,
+    pub reason: String,
+}
+
+/// Wilson score-interval lower bound for `successes` of `total` Bernoulli
+/// trials at z-score `z`. Returns 0.0 for an empty sample. Clamped to `[0, 1]`.
+#[must_use]
+pub fn wilson_lower_bound(successes: i64, total: i64, z: f64) -> f64 {
+    if total <= 0 {
+        return 0.0;
+    }
+    let n = total as f64;
+    let p = (successes as f64 / n).clamp(0.0, 1.0);
+    let z2 = z * z;
+    let denom = 1.0 + z2 / n;
+    let center = p + z2 / (2.0 * n);
+    let margin = z * (p * (1.0 - p) / n + z2 / (4.0 * n * n)).sqrt();
+    ((center - margin) / denom).clamp(0.0, 1.0)
+}
+
+/// Evaluate whether `variant` should be promoted over a parent whose observed
+/// success rate is `parent_rate`.
+#[must_use]
+pub fn evaluate_workflow_promotion(
+    variant: &WorkflowSampleStats,
+    parent_rate: f64,
+    config: &WorkflowPromotionConfig,
+) -> WorkflowPromotionVerdict {
+    let variant_lower_bound = wilson_lower_bound(variant.successes, variant.total, config.z);
+
+    let (promotable, reason) = if variant.total < config.min_executions {
+        (
+            false,
+            format!(
+                "insufficient sample: {} executions < min {}",
+                variant.total, config.min_executions
+            ),
+        )
+    } else if variant_lower_bound > parent_rate {
+        (
+            true,
+            format!(
+                "variant Wilson lower bound {variant_lower_bound:.3} exceeds parent rate \
+                 {parent_rate:.3} over {} executions",
+                variant.total
+            ),
+        )
+    } else {
+        (
+            false,
+            format!(
+                "variant Wilson lower bound {variant_lower_bound:.3} does not exceed parent rate \
+                 {parent_rate:.3}"
+            ),
+        )
+    };
+
+    WorkflowPromotionVerdict {
+        promotable,
+        variant_lower_bound,
+        parent_rate,
+        variant_total: variant.total,
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64) {
+        assert!((a - b).abs() < 0.005, "expected ~{b}, got {a}");
+    }
+
+    #[test]
+    fn wilson_lower_bound_known_values() {
+        // 10/10 at z=1.96 → ~0.7225 (the classic "10 for 10" lower bound).
+        approx(wilson_lower_bound(10, 10, 1.96), 0.7225);
+        // 50/100 → ~0.4038.
+        approx(wilson_lower_bound(50, 100, 1.96), 0.4038);
+        // empty sample → 0.0.
+        approx(wilson_lower_bound(0, 0, 1.96), 0.0);
+        // lower bound is always below the point estimate for a finite sample.
+        assert!(wilson_lower_bound(60, 100, 1.96) < 0.6);
+    }
+
+    fn cfg() -> WorkflowPromotionConfig {
+        WorkflowPromotionConfig::default()
+    }
+
+    #[test]
+    fn rejects_below_min_sample_even_at_100pct() {
+        // 9/9 is a perfect record but below the min-10 sample → not promotable.
+        let v = WorkflowSampleStats {
+            successes: 9,
+            total: 9,
+        };
+        let verdict = evaluate_workflow_promotion(&v, 0.0, &cfg());
+        assert!(
+            !verdict.promotable,
+            "9 executions < min 10 must not promote"
+        );
+        assert!(verdict.reason.contains("sample") || verdict.reason.contains("executions"));
+    }
+
+    #[test]
+    fn promotes_when_lower_bound_beats_weak_parent() {
+        // 10/10 → lower bound ~0.72, beats a 0.5 parent.
+        let v = WorkflowSampleStats {
+            successes: 10,
+            total: 10,
+        };
+        let verdict = evaluate_workflow_promotion(&v, 0.5, &cfg());
+        assert!(
+            verdict.promotable,
+            "0.72 lower bound should beat a 0.5 parent"
+        );
+        approx(verdict.variant_lower_bound, 0.7225);
+    }
+
+    #[test]
+    fn does_not_promote_against_strong_parent() {
+        // Same 10/10 variant, but the parent already wins 0.8 of the time:
+        // 0.72 lower bound does NOT exceed 0.8 → stay conservative.
+        let v = WorkflowSampleStats {
+            successes: 10,
+            total: 10,
+        };
+        let verdict = evaluate_workflow_promotion(&v, 0.8, &cfg());
+        assert!(
+            !verdict.promotable,
+            "must not promote when lower bound < parent rate"
+        );
+    }
+
+    #[test]
+    fn marginal_case_60_of_100_barely_beats_half() {
+        // 60/100 lower bound ~0.502 just clears a 0.5 parent.
+        let v = WorkflowSampleStats {
+            successes: 60,
+            total: 100,
+        };
+        assert!(evaluate_workflow_promotion(&v, 0.5, &cfg()).promotable);
+        // 55/100 lower bound ~0.452 does NOT clear 0.5.
+        let v2 = WorkflowSampleStats {
+            successes: 55,
+            total: 100,
+        };
+        assert!(!evaluate_workflow_promotion(&v2, 0.5, &cfg()).promotable);
+    }
+
+    #[test]
+    fn min_executions_boundary_is_inclusive() {
+        // Exactly min_executions is eligible (>=, not >).
+        let v = WorkflowSampleStats {
+            successes: 10,
+            total: 10,
+        };
+        assert!(evaluate_workflow_promotion(&v, 0.0, &cfg()).promotable);
+    }
+}

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -37,6 +37,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("get_ownership", "claims:read"),
     ("get_perspective", "claims:read"),
     ("get_provenance", "claims:read"),
+    ("get_workflow_executions", "claims:read"),
     ("list_challenges", "claims:read"),
     ("list_events", "claims:read"),
     ("list_frames", "claims:read"),

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -27,6 +27,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("compare_methods", "claims:read"),
     ("embedding_neighborhood_density", "claims:read"),
     ("entity_neighborhood", "claims:read"),
+    ("evaluate_workflow_promotion", "claims:read"),
     ("find_cross_source_matches", "claims:read"),
     ("find_workflow", "claims:read"),
     ("find_workflow_hierarchical", "claims:read"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -443,7 +443,7 @@ impl EpiGraphMcpFull {
         tools::cdst_maintenance::recompute_beliefs(self, params).await
     }
 
-    // ── Workflows (5 tools) ──
+    // ── Workflows (6 tools) ──
 
     #[tool(
         description = "Store a new workflow with ordered steps and prerequisites. Returns a workflow_id from the hierarchical `workflows` table; use `report_workflow_outcome` with that returned id to record execution results."
@@ -462,6 +462,16 @@ impl EpiGraphMcpFull {
         Parameters(params): Parameters<FindWorkflowParams>,
     ) -> Result<CallToolResult, McpError> {
         tools::workflows::find_workflow(self, params).await
+    }
+
+    #[tool(
+        description = "List a workflow's most recent behavioral executions, newest first: per-run success, quality, tool_pattern, deviation_count and step_beliefs (per-step deviation_reason), plus a window success-rate. Read-only telemetry for analysing or evolving a workflow."
+    )]
+    async fn get_workflow_executions(
+        &self,
+        Parameters(params): Parameters<GetWorkflowExecutionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        tools::workflows::get_workflow_executions(self, params).await
     }
 
     #[tool(
@@ -950,7 +960,7 @@ impl EpiGraphMcpFull {
 impl ServerHandler for EpiGraphMcpFull {
     fn get_info(&self) -> ServerInfo {
         let mode = if self.read_only { "read-only" } else { "full" };
-        let tool_count = if self.read_only { 33 } else { 61 };
+        let tool_count = if self.read_only { 34 } else { 62 };
         ServerInfo {
             instructions: Some(format!(
                 "EpiGraph {mode} MCP server with {tool_count} epistemic tools."

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -443,7 +443,7 @@ impl EpiGraphMcpFull {
         tools::cdst_maintenance::recompute_beliefs(self, params).await
     }
 
-    // ── Workflows (6 tools) ──
+    // ── Workflows (7 tools) ──
 
     #[tool(
         description = "Store a new workflow with ordered steps and prerequisites. Returns a workflow_id from the hierarchical `workflows` table; use `report_workflow_outcome` with that returned id to record execution results."
@@ -472,6 +472,16 @@ impl EpiGraphMcpFull {
         Parameters(params): Parameters<GetWorkflowExecutionsParams>,
     ) -> Result<CallToolResult, McpError> {
         tools::workflows::get_workflow_executions(self, params).await
+    }
+
+    #[tool(
+        description = "Evaluate whether a workflow variant is statistically ready to be promoted over its immediate (variant_of) parent: the Wilson lower bound of the variant's behavioral success rate vs the parent's rate, over the same window, gated on a minimum sample. Read-only — returns a verdict, does not promote."
+    )]
+    async fn evaluate_workflow_promotion(
+        &self,
+        Parameters(params): Parameters<EvaluateWorkflowPromotionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        tools::workflows::evaluate_workflow_promotion(self, params).await
     }
 
     #[tool(
@@ -960,7 +970,7 @@ impl EpiGraphMcpFull {
 impl ServerHandler for EpiGraphMcpFull {
     fn get_info(&self) -> ServerInfo {
         let mode = if self.read_only { "read-only" } else { "full" };
-        let tool_count = if self.read_only { 34 } else { 62 };
+        let tool_count = if self.read_only { 35 } else { 63 };
         ServerInfo {
             instructions: Some(format!(
                 "EpiGraph {mode} MCP server with {tool_count} epistemic tools."

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -83,6 +83,71 @@ pub async fn get_workflow_executions(
     }))
 }
 
+/// Evaluate whether a workflow variant is statistically ready to be promoted
+/// over its immediate (`variant_of`) parent — the autonomous-statistical-gate
+/// verdict the workflow-evolution maintenance pass consumes. Resolves the
+/// parent, compares both sides over the SAME execution window with the Wilson
+/// lower-bound gate, and returns the verdict. READ-ONLY: it decides, it does
+/// not promote (applying a promotion is a separate, deliberate step).
+pub async fn evaluate_workflow_promotion(
+    server: &EpiGraphMcpFull,
+    params: EvaluateWorkflowPromotionParams,
+) -> Result<CallToolResult, McpError> {
+    use epigraph_engine::workflow_promotion::{
+        evaluate_workflow_promotion as gate, WorkflowPromotionConfig, WorkflowSampleStats,
+    };
+
+    let variant_id = parse_uuid(params.workflow_id.trim())?;
+    let window = params.window.unwrap_or(50).clamp(1, 500);
+
+    let Some(parent_id) = WorkflowRepository::immediate_variant_parent(&server.pool, variant_id)
+        .await
+        .map_err(|e| internal_error(e.to_string()))?
+    else {
+        return success_json(&serde_json::json!({
+            "workflow_id": variant_id,
+            "parent_id": serde_json::Value::Null,
+            "promotable": false,
+            "reason": "workflow has no variant_of/supersedes parent (it is a lineage root); nothing to promote over",
+        }));
+    };
+
+    // Same window on both sides — comparing across different windows would be
+    // apples to oranges.
+    let (v_succ, v_total) =
+        BehavioralExecutionRepository::success_stats(&server.pool, variant_id, window)
+            .await
+            .map_err(internal_error)?;
+    let (p_succ, p_total) =
+        BehavioralExecutionRepository::success_stats(&server.pool, parent_id, window)
+            .await
+            .map_err(internal_error)?;
+
+    let variant = WorkflowSampleStats {
+        successes: v_succ,
+        total: v_total,
+    };
+    let parent = WorkflowSampleStats {
+        successes: p_succ,
+        total: p_total,
+    };
+    let config = WorkflowPromotionConfig::default();
+    let verdict = gate(&variant, parent.success_rate(), &config);
+
+    success_json(&serde_json::json!({
+        "workflow_id": variant_id,
+        "parent_id": parent_id,
+        "window": window,
+        "min_executions": config.min_executions,
+        "variant": { "successes": v_succ, "total": v_total },
+        "parent": { "successes": p_succ, "total": p_total, "success_rate": parent.success_rate() },
+        "promotable": verdict.promotable,
+        "variant_lower_bound": verdict.variant_lower_bound,
+        "parent_rate": verdict.parent_rate,
+        "reason": verdict.reason,
+    }))
+}
+
 fn parse_workflow_content(content: &str) -> (String, Vec<String>, Vec<String>, Option<String>) {
     serde_json::from_str::<serde_json::Value>(content).map_or_else(
         |_| (content.to_string(), vec![], vec![], None),

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -34,6 +34,55 @@ fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpErro
     )]))
 }
 
+/// Read-only window into a workflow's recent behavioral executions, newest
+/// first: per-run `success`, `quality`, `tool_pattern`, `deviation_count`, and
+/// `step_beliefs` (per-step `deviation_reason`), plus a `window_success_rate`.
+/// This is the telemetry the workflow-evolution proposer reads before
+/// proposing a variant; an invalid `workflow_id` errors rather than returning
+/// an empty set (which would read as "no runs" and mislead the proposer).
+pub async fn get_workflow_executions(
+    server: &EpiGraphMcpFull,
+    params: GetWorkflowExecutionsParams,
+) -> Result<CallToolResult, McpError> {
+    let workflow_id = parse_uuid(params.workflow_id.trim())?;
+    let limit = params.limit.unwrap_or(20).clamp(1, 100);
+
+    let rows = BehavioralExecutionRepository::recent_executions(&server.pool, workflow_id, limit)
+        .await
+        .map_err(internal_error)?;
+
+    let returned = rows.len();
+    let successes = rows.iter().filter(|r| r.success).count();
+    let window_success_rate = if returned > 0 {
+        successes as f64 / returned as f64
+    } else {
+        0.0
+    };
+    let executions: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "id": r.id,
+                "goal_text": r.goal_text,
+                "success": r.success,
+                "quality": r.quality,
+                "deviation_count": r.deviation_count,
+                "total_steps": r.total_steps,
+                "tool_pattern": r.tool_pattern,
+                "step_beliefs": r.step_beliefs,
+                "created_at": r.created_at,
+            })
+        })
+        .collect();
+
+    success_json(&serde_json::json!({
+        "workflow_id": workflow_id,
+        "returned": returned,
+        "window_success_rate": window_success_rate,
+        "executions": executions,
+    }))
+}
+
 fn parse_workflow_content(content: &str) -> (String, Vec<String>, Vec<String>, Option<String>) {
     serde_json::from_str::<serde_json::Value>(content).map_or_else(
         |_| (content.to_string(), vec![], vec![], None),

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -293,6 +293,19 @@ pub struct GetWorkflowExecutionsParams {
     pub limit: Option<i64>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EvaluateWorkflowPromotionParams {
+    #[schemars(
+        description = "Workflow variant UUID to evaluate for promotion over its variant_of parent"
+    )]
+    pub workflow_id: String,
+
+    #[schemars(
+        description = "Execution window compared on each side, newest first (default 50, max 500)"
+    )]
+    pub window: Option<i64>,
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct StepExecution {
     #[schemars(description = "Zero-based index of the step in the workflow")]

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -282,6 +282,17 @@ pub struct FindWorkflowParams {
     pub limit: Option<i64>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetWorkflowExecutionsParams {
+    #[schemars(
+        description = "Workflow UUID (a `workflows` row id / lineage member) whose recent executions to fetch"
+    )]
+    pub workflow_id: String,
+
+    #[schemars(description = "Max executions to return, newest first (default 20, max 100)")]
+    pub limit: Option<i64>,
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct StepExecution {
     #[schemars(description = "Zero-based index of the step in the workflow")]

--- a/crates/epigraph-mcp/tests/evaluate_workflow_promotion.rs
+++ b/crates/epigraph-mcp/tests/evaluate_workflow_promotion.rs
@@ -1,0 +1,179 @@
+//! Behavioral test for the `evaluate_workflow_promotion` MCP tool — the
+//! read-only autonomous-statistical-gate verdict. Resolves a variant's parent
+//! via the variant_of edge, compares behavioral success over the same window
+//! with the Wilson lower-bound gate, and returns whether the variant is
+//! promotable WITHOUT acting on it.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_db::{BehavioralExecutionRepository, BehavioralExecutionRow};
+use epigraph_mcp::types::EvaluateWorkflowPromotionParams;
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use rmcp::model::RawContent;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0x2bu8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+fn result_json(out: rmcp::model::CallToolResult) -> serde_json::Value {
+    let first = out.content.first().cloned().expect("first content");
+    match first.raw {
+        RawContent::Text(t) => serde_json::from_str(&t.text).expect("result is JSON"),
+        other => panic!("expected text content, got {other:?}"),
+    }
+}
+
+async fn insert_agent(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels)
+         VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test'])
+         RETURNING id",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO claims (content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, sha256($1::bytea), 0.5, $2, true) RETURNING id",
+    )
+    .bind(content)
+    .bind(agent)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn seed_runs(pool: &PgPool, wf: Uuid, successes: usize, failures: usize) {
+    let base = chrono::Utc::now();
+    let mut i = 0i64;
+    for succ in std::iter::repeat(true)
+        .take(successes)
+        .chain(std::iter::repeat(false).take(failures))
+    {
+        BehavioralExecutionRepository::create(
+            pool,
+            BehavioralExecutionRow {
+                id: Uuid::new_v4(),
+                workflow_id: wf,
+                goal_text: "g".into(),
+                success: succ,
+                step_beliefs: serde_json::json!({}),
+                tool_pattern: vec![],
+                quality: None,
+                deviation_count: 0,
+                total_steps: 1,
+                created_at: base + chrono::Duration::seconds(i),
+                step_claim_id: None,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        i += 1;
+    }
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn promotes_confident_variant_over_weaker_parent(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "ewp-agent").await;
+    let parent = insert_claim(&pool, agent, "ewp-parent").await;
+    let variant = insert_claim(&pool, agent, "ewp-variant").await;
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES (gen_random_uuid(), $1, 'claim', $2, 'claim', 'variant_of')",
+    )
+    .bind(variant)
+    .bind(parent)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Parent: 5/10 (0.5). Variant: 12/12 (Wilson lower bound ~0.76 > 0.5).
+    seed_runs(&pool, parent, 5, 5).await;
+    seed_runs(&pool, variant, 12, 0).await;
+
+    let json = result_json(
+        tools::workflows::evaluate_workflow_promotion(
+            &server,
+            EvaluateWorkflowPromotionParams {
+                workflow_id: variant.to_string(),
+                window: Some(50),
+            },
+        )
+        .await
+        .expect("evaluate ok"),
+    );
+
+    assert_eq!(json["parent_id"], parent.to_string());
+    assert_eq!(
+        json["promotable"], true,
+        "confident variant promotes over 0.5 parent"
+    );
+    assert!(json["variant_lower_bound"].as_f64().unwrap() > 0.5);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn does_not_promote_small_sample_variant(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "ewp-agent2").await;
+    let parent = insert_claim(&pool, agent, "ewp-parent2").await;
+    let variant = insert_claim(&pool, agent, "ewp-variant2").await;
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES (gen_random_uuid(), $1, 'claim', $2, 'claim', 'variant_of')",
+    )
+    .bind(variant)
+    .bind(parent)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Variant is 3/3 — perfect but below the min-sample floor → not promotable.
+    seed_runs(&pool, parent, 1, 1).await;
+    seed_runs(&pool, variant, 3, 0).await;
+
+    let json = result_json(
+        tools::workflows::evaluate_workflow_promotion(
+            &server,
+            EvaluateWorkflowPromotionParams {
+                workflow_id: variant.to_string(),
+                window: None,
+            },
+        )
+        .await
+        .expect("evaluate ok"),
+    );
+    assert_eq!(
+        json["promotable"], false,
+        "3 executions is below the min sample"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn lineage_root_has_nothing_to_promote_over(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "ewp-agent3").await;
+    let root = insert_claim(&pool, agent, "ewp-root").await; // no variant_of edge
+
+    let json = result_json(
+        tools::workflows::evaluate_workflow_promotion(
+            &server,
+            EvaluateWorkflowPromotionParams {
+                workflow_id: root.to_string(),
+                window: None,
+            },
+        )
+        .await
+        .expect("evaluate ok"),
+    );
+    assert_eq!(json["promotable"], false);
+    assert!(json["parent_id"].is_null(), "a root has no parent");
+}

--- a/crates/epigraph-mcp/tests/get_workflow_executions.rs
+++ b/crates/epigraph-mcp/tests/get_workflow_executions.rs
@@ -1,0 +1,114 @@
+//! Behavioral test for the `get_workflow_executions` MCP tool — the read-only
+//! window into a workflow's recent behavioral executions that the workflow-
+//! evolution (GEPA) proposer consumes. Mirrors the server-construction harness
+//! in `recompute_beliefs_test.rs`.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_db::{BehavioralExecutionRepository, BehavioralExecutionRow};
+use epigraph_mcp::types::GetWorkflowExecutionsParams;
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use rmcp::model::RawContent;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0x2bu8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+fn result_json(out: rmcp::model::CallToolResult) -> serde_json::Value {
+    let first = out.content.first().cloned().expect("first content");
+    match first.raw {
+        RawContent::Text(t) => serde_json::from_str(&t.text).expect("result is JSON"),
+        other => panic!("expected text content, got {other:?}"),
+    }
+}
+
+async fn insert_agent(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels)
+         VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test'])
+         RETURNING id",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO claims (content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, sha256($1::bytea), 0.5, $2, true) RETURNING id",
+    )
+    .bind(content)
+    .bind(agent)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_workflow_executions_returns_recent_rows(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "gwe-agent").await;
+    let wf = insert_claim(&pool, agent, "gwe-workflow-root").await;
+
+    let base = chrono::Utc::now();
+    for (i, (succ, goal)) in [(true, "run-old"), (false, "run-new")].iter().enumerate() {
+        let row = BehavioralExecutionRow {
+            id: Uuid::new_v4(),
+            workflow_id: wf,
+            goal_text: (*goal).to_string(),
+            success: *succ,
+            step_beliefs: serde_json::json!({"deviation_reason": "none"}),
+            tool_pattern: vec!["bash".into()],
+            quality: Some(0.7),
+            deviation_count: 0,
+            total_steps: 2,
+            created_at: base + chrono::Duration::seconds(i as i64),
+            step_claim_id: None,
+        };
+        BehavioralExecutionRepository::create(&pool, row, None)
+            .await
+            .unwrap();
+    }
+
+    let out = tools::workflows::get_workflow_executions(
+        &server,
+        GetWorkflowExecutionsParams {
+            workflow_id: wf.to_string(),
+            limit: Some(10),
+        },
+    )
+    .await
+    .expect("get_workflow_executions ok");
+    let json = result_json(out);
+
+    assert_eq!(json["returned"], 2, "both executions returned");
+    let execs = json["executions"].as_array().expect("executions array");
+    assert_eq!(execs.len(), 2);
+    // Newest first: the second-inserted ("run-new") leads.
+    assert_eq!(execs[0]["goal_text"], "run-new");
+    assert_eq!(execs[0]["success"], false);
+    assert!(
+        execs[0]["step_beliefs"].is_object(),
+        "step_beliefs surfaced for reflection"
+    );
+
+    // A non-UUID workflow_id must be rejected, NOT silently return an empty set
+    // (that would be a confusing false negative for the proposer).
+    let bad = tools::workflows::get_workflow_executions(
+        &server,
+        GetWorkflowExecutionsParams {
+            workflow_id: "not-a-uuid".into(),
+            limit: None,
+        },
+    )
+    .await;
+    assert!(
+        bad.is_err(),
+        "invalid workflow_id must error, not return empty"
+    );
+}

--- a/docs/superpowers/plans/2026-06-01-workflow-evolution-gepa.md
+++ b/docs/superpowers/plans/2026-06-01-workflow-evolution-gepa.md
@@ -1,0 +1,101 @@
+# Workflow Evolution (GEPA) — Design & Status
+
+**Branch:** `feat/workflow-evolution-gepa`. Origin: the 2026-06-01 Hermes-Agent
+comparison (`~/hermes-epiclaw-lessons.md`, headlines #1/#2) — Hermes *designed*
+the "read traces → propose edit → gate it" reflective loop but never wired it;
+we have the richer signal (`behavioral_executions`) and consume it only for
+`find_workflow` ranking. This builds the proposer + gate.
+
+**User sign-off (2026-06-01):** the **autonomous statistical gate** — promote a
+variant on **behavioral `rolling_success_rate`** (NOT `truth_value`; the
+hierarchical workflow-outcome path never updates it), gated on **min-N ≥ 10** of
+the variant's own executions AND the variant's **Wilson lower bound beating the
+parent's rate**. Variants reuse the `variant_of` edge.
+
+---
+
+## What is built (the DECIDE layer — read-only, this branch)
+
+All TDD'd, committed:
+
+| Piece | Where | Commit |
+|-------|-------|--------|
+| `recent_executions(workflow_id, limit)` raw-row getter | `epigraph-db` behavioral_execution.rs | `f20ead6` |
+| `get_workflow_executions` MCP tool (claims:read) | `epigraph-mcp` | `5d27f54` |
+| Pure Wilson gate (`wilson_lower_bound`, `evaluate_workflow_promotion`) | `epigraph-engine` workflow_promotion.rs | `9f23329` |
+| `success_stats` + `immediate_variant_parent` DB queries | `epigraph-db` | `4346293` |
+| `evaluate_workflow_promotion` MCP tool (claims:read, read-only verdict) | `epigraph-mcp` | `4f6b57d` |
+
+These **decide**; they do not **act**. `evaluate_workflow_promotion` resolves a
+variant's immediate parent, compares both sides over the same window with the
+Wilson gate, and returns `{promotable, variant_lower_bound, parent_rate, …}` —
+safe to merge regardless of which apply-layer is later chosen.
+
+**Note (immediate parent vs lineage root):** the gate compares a variant against
+its *immediate* `variant_of` parent. Across many generations this can drift (a
+gen-3 variant is judged against gen-2, not the original root). Comparing to the
+lineage root (`find_lineage_root`) would avoid that but changes the semantics;
+deferred deliberately — not built.
+
+---
+
+## The PROPOSER (a scheduled Claude-CLI job — NOT committable Rust)
+
+The proposer is a prompt run by a `schedules.toml` Claude-CLI session under a
+`claims:write` token (Foreman credential-partition; **never** the Anthropic SDK
+— OAuth house rule). Its loop, all via existing MCP tools:
+
+1. Pick a workflow lineage with enough executions and a non-trivial failure rate.
+2. `get_workflow_executions(workflow_id)` → reflect on `step_beliefs`
+   (`deviation_reason`), `tool_pattern`, and per-run `success`/`quality`.
+3. Propose a variant via `improve_workflow_hierarchy` / `evolve_step` — these
+   already create the `variant_of` lineage edge. (No new edge type.)
+4. The variant accrues its own `behavioral_executions` as agents use it and call
+   `report_workflow_outcome`.
+5. (apply layer, below) once the variant has ≥ min-N runs,
+   `evaluate_workflow_promotion` says whether it has earned promotion.
+
+---
+
+## ⚠️ OPEN DECISION — the APPLY layer (prod-mutating; needs sign-off)
+
+`find_workflow` orders results by **semantic similarity**;
+`behavioral_success_rate` is a *returned field, not a sort key* (verified
+2026-06-01). So there is **no existing auto-promotion** — making a verdict
+actually change which workflow agents use is a deliberate new behavior. Three
+options, materially different blast radius:
+
+- **(A) Additive `promotable` flag, surfaced as metadata.** A maintenance pass
+  calls `evaluate_workflow_promotion` and stores the verdict (migration adding
+  `workflows.promotable`, or a claim label/property). `find_workflow` returns it
+  as a field so the calling agent prefers promoted variants. *Additive, smallest
+  blast radius; needs storage + a find_workflow field.* (Closest to the
+  sign-off's "maintenance pass sets a flag; find_workflow stays read-only".)
+- **(B) Deprecate the loser.** When a variant is promotable, the pass calls the
+  existing `deprecate_workflow` on the parent (truth → 0.05, already filtered by
+  `find_workflow`'s default `min_truth = 0.3`). *No migration, no find_workflow
+  change — but DESTRUCTIVE and not what the additive-flag sign-off implied.*
+- **(C) Re-rank `find_workflow` by the flag.** Biggest change; touches the hot
+  read path. Not recommended.
+
+**Recommendation: (A).** It matches the sign-off (additive flag, read-only
+find_workflow) and is reversible. **Not built — surfaced for an explicit
+decision, since it is the one hard-to-walk-back step (a job mutating prod
+workflow selection).**
+
+---
+
+## C-6 — the scheduled job (runtime artifact, NOT committed)
+
+A `[[schedule]]` entry in the deployed `/var/lib/epiclaw/data/schedules.toml`
+(runtime artifact; reload via `systemctl restart epiclaw`) drives the proposer +
+the chosen apply-layer pass. Documented here; the actual entry + prompt are
+authored at deploy time, like the existing `graph-integrity` / `system-health`
+jobs. Keep cadence conservative at first (e.g. daily) and log every proposal +
+verdict.
+
+## Remaining before the loop runs in prod
+1. **Sign off the apply layer (A/B/C above).**
+2. Build the chosen apply-layer maintenance pass (TDD).
+3. Author the `schedules.toml` proposer + apply entries (deploy-time).
+4. End-to-end dry run on a seeded lineage before enabling in prod.


### PR DESCRIPTION
The reflective "read traces → propose variant → gate it" loop from the 2026-06-01 Hermes-Agent comparison (headlines #1/#2). Hermes *designed* this loop but never wired it; we have the richer signal (`behavioral_executions`) and consumed it only for `find_workflow` ranking. This PR builds the **decide layer**. All TDD'd.

**Signed-off design:** autonomous statistical gate — promote a variant on behavioral `rolling_success_rate` (NOT `truth_value`; the hierarchical workflow-outcome path never updates it), gated on **min-N ≥ 10** of the variant's own executions AND the variant's **Wilson lower bound beating the parent's rate**. Variants reuse the `variant_of` edge.

## What this PR adds (read-only — decides, does not act)
- `BehavioralExecutionRepository::recent_executions` — raw-row getter (`f20ead6`)
- `get_workflow_executions` MCP tool — per-run success/quality/tool_pattern/step_beliefs telemetry (`5d27f54`)
- **Pure Wilson gate** in `epigraph-engine::workflow_promotion` — `wilson_lower_bound` + `evaluate_workflow_promotion`, 6 unit tests pinning the statistics (`9f23329`)
- `success_stats` (successes+total) + `immediate_variant_parent` (variant_of, one hop) DB queries (`4346293`)
- `evaluate_workflow_promotion` MCP tool — resolves the variant's parent, compares both sides over the **same** window with the gate, returns the verdict (`4f6b57d`)
- Design doc `docs/superpowers/plans/2026-06-01-workflow-evolution-gepa.md`

All new tools are `claims:read` and read-only; the scope-coverage test enforces the mapping. `evaluate_workflow_promotion` **decides but does not act**, so it's safe to merge regardless of the apply-layer choice below.

## ⚠️ OPEN DECISION — the apply layer (NOT in this PR)
`find_workflow` orders by **semantic similarity**; `behavioral_success_rate` is a returned field, not a sort key (verified). So there is **no existing auto-promotion** — making a verdict change which workflow agents use is a deliberate new, prod-mutating behavior. The fork (documented in the design doc):
- **(A)** additive `promotable` flag surfaced as metadata — *recommended, matches the sign-off, reversible; needs storage + a find_workflow field*
- **(B)** deprecate the loser (`deprecate_workflow`, truth→0.05) — *no migration but destructive*
- **(C)** re-rank find_workflow by the flag — *hot-path, not recommended*

Held for explicit sign-off; the proposer prompt + `schedules.toml` job are runtime artifacts (documented, not committed).

## Verification
Full `cargo test -p epigraph-engine -p epigraph-db -p epigraph-mcp -- --test-threads=1`: **824 passed, 0 failed, 14 ignored / 92 binaries**. Each new fn watched fail then pass; clippy + fmt clean; runtime queries → no `.sqlx` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)