### PR TITLE
fix(recall): read claims.embedding so flat recall() and find_workflow() return hits

### DIFF
--- a/crates/epigraph-db/Cargo.toml
+++ b/crates/epigraph-db/Cargo.toml
@@ -48,6 +48,10 @@ name = "claim_search_by_embedding"
 path = "tests/claim_search_by_embedding.rs"
 
 [[test]]
+name = "claim_search_claims_by_embedding"
+path = "tests/claim_search_claims_by_embedding.rs"
+
+[[test]]
 name = "match_candidate_migration"
 path = "tests/match_candidate_migration.rs"
 

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -470,6 +470,94 @@ impl ClaimRepository {
         Ok(q.fetch_all(pool).await?)
     }
 
+    /// Level-agnostic semantic search over `claims.embedding` (1536d) or
+    /// `claims.embedding_3072` (3072d) by cosine distance.
+    ///
+    /// Unlike [`ClaimRepository::search_by_embedding`], this method does NOT
+    /// filter on `(properties->>'level')::int = 2`. That paragraph-primary gate
+    /// is correct for `recall_with_context` (paper kNN), but it silently drops
+    /// every memorized claim (`memorize` writes no `level` property) and every
+    /// `workflow`-labeled claim, which is exactly why flat `recall` and
+    /// `find_workflow` returned empty against ~426k embedded claims (backlog
+    /// 1564bdaf): their read paths queried `evidence.embedding`, which has 0
+    /// populated rows, while the canonical write paths embed `claims.embedding`.
+    ///
+    /// Predicate mirrors `EvidenceRepository::search_by_embedding`'s
+    /// `COALESCE(c.is_current, true) = true` so superseded claims never surface.
+    /// `WHERE c.{column} IS NOT NULL ORDER BY c.{column} <=> $1::vector` matches
+    /// the full (non-level-partial) HNSW index `idx_claims_embedding_hnsw`
+    /// (migration 001) for the 1536d path.
+    ///
+    /// When `label_filter` is `Some(&labels)`, only claims whose `labels` array
+    /// overlaps (`&&`) the filter are returned — `find_workflow` passes
+    /// `&["workflow".to_string()]` so semantic hits match the ILIKE fallback's
+    /// scope before `enrich_workflow_result`. Pass `None` for unfiltered recall.
+    ///
+    /// Runtime `sqlx::query_as` (not the compile-checked `query!` macro) because
+    /// the column name and the optional label predicate are chosen at runtime —
+    /// the same precedent as `search_by_embedding`. Consequence: a SQL typo here
+    /// compiles but fails at runtime, so the integration test is load-bearing.
+    ///
+    /// # Errors
+    /// * [`DbError::InvalidData`] if `dim` is neither 1536 nor 3072.
+    /// * [`DbError::QueryFailed`] on database errors.
+    #[instrument(skip(pool, query_embedding_pgvector))]
+    pub async fn search_claims_by_embedding(
+        pool: &PgPool,
+        query_embedding_pgvector: &str,
+        dim: u32,
+        limit: i64,
+        label_filter: Option<&[String]>,
+    ) -> Result<Vec<ClaimEmbeddingHit>, DbError> {
+        let column = match dim {
+            1536 => "embedding",
+            3072 => "embedding_3072",
+            _ => {
+                return Err(DbError::InvalidData {
+                    reason: format!("unsupported centroid_dim: {dim} (must be 1536 or 3072)"),
+                });
+            }
+        };
+
+        // Two shapes: with / without the label-overlap predicate, to keep the
+        // no-filter path index-friendly and bind only what each shape uses.
+        let sql = if label_filter.is_some() {
+            format!(
+                r#"
+                SELECT c.id AS claim_id,
+                       1 - (c.{column} <=> $1::vector) AS similarity
+                FROM claims c
+                WHERE c.{column} IS NOT NULL
+                  AND COALESCE(c.is_current, true) = true
+                  AND c.labels && $3
+                ORDER BY c.{column} <=> $1::vector
+                LIMIT $2
+                "#
+            )
+        } else {
+            format!(
+                r#"
+                SELECT c.id AS claim_id,
+                       1 - (c.{column} <=> $1::vector) AS similarity
+                FROM claims c
+                WHERE c.{column} IS NOT NULL
+                  AND COALESCE(c.is_current, true) = true
+                ORDER BY c.{column} <=> $1::vector
+                LIMIT $2
+                "#
+            )
+        };
+
+        let mut q = sqlx::query_as::<_, ClaimEmbeddingHit>(&sql)
+            .bind(query_embedding_pgvector)
+            .bind(limit);
+        if let Some(labels) = label_filter {
+            q = q.bind(labels);
+        }
+
+        Ok(q.fetch_all(pool).await?)
+    }
+
     /// Get all claims by an agent
     ///
     /// # Errors

--- a/crates/epigraph-db/tests/claim_search_claims_by_embedding.rs
+++ b/crates/epigraph-db/tests/claim_search_claims_by_embedding.rs
@@ -72,9 +72,18 @@ async fn returns_level_less_and_non_level_2_claims(pool: PgPool) {
         .expect("search_claims_by_embedding");
     let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
 
-    assert!(ids.contains(&memorized), "level-less memorized claim must be returned");
-    assert!(ids.contains(&atom), "level=3 atom must be returned (no level gate)");
-    assert!(ids.contains(&para), "level=2 paragraph must still be returned");
+    assert!(
+        ids.contains(&memorized),
+        "level-less memorized claim must be returned"
+    );
+    assert!(
+        ids.contains(&atom),
+        "level=3 atom must be returned (no level gate)"
+    );
+    assert!(
+        ids.contains(&para),
+        "level=2 paragraph must still be returned"
+    );
 }
 
 /// label_filter=Some scopes results to the overlap set — find_workflow's
@@ -107,8 +116,14 @@ async fn label_filter_restricts_to_overlapping_labels(pool: PgPool) {
         .expect("search with label filter");
     let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
 
-    assert!(ids.contains(&wf), "workflow-labeled claim must be returned under filter");
-    assert!(!ids.contains(&other), "non-workflow claim must be excluded by label filter");
+    assert!(
+        ids.contains(&wf),
+        "workflow-labeled claim must be returned under filter"
+    );
+    assert!(
+        !ids.contains(&other),
+        "non-workflow claim must be excluded by label filter"
+    );
 }
 
 /// COALESCE(is_current, true) = true must exclude superseded claims, matching
@@ -140,8 +155,14 @@ async fn excludes_non_current_claims(pool: PgPool) {
         .expect("search");
     let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
 
-    assert!(ids.contains(&live), "is_current=true claim must be returned");
-    assert!(!ids.contains(&stale), "is_current=false claim must be excluded");
+    assert!(
+        ids.contains(&live),
+        "is_current=true claim must be returned"
+    );
+    assert!(
+        !ids.contains(&stale),
+        "is_current=false claim must be excluded"
+    );
 }
 
 /// Unsupported dim is an explicit InvalidData error, never a silent wrong-column query.

--- a/crates/epigraph-db/tests/claim_search_claims_by_embedding.rs
+++ b/crates/epigraph-db/tests/claim_search_claims_by_embedding.rs
@@ -1,0 +1,157 @@
+//! Integration tests for `ClaimRepository::search_claims_by_embedding`
+//! (backlog 1564bdaf). These assert the LEVEL-AGNOSTIC behavior that the
+//! pre-existing `search_by_embedding` (level=2-gated) does NOT provide — which
+//! is precisely the gap that made flat `recall`/`find_workflow` return empty.
+//!
+//! Seeding mirrors `claim_search_by_embedding.rs` (the established harness for
+//! this repo): a controlled `agents` row, distinct 32-byte content_hashes, and
+//! a 1536d query vector. Direct `sqlx::query` INSERTs here seed a THROWAWAY
+//! `#[sqlx::test]` database, not production — the no-raw-SQL invariant governs
+//! production claim writes (API/repo/MCP), not disposable test fixtures, and
+//! the sibling test file establishes this exact precedent.
+
+use epigraph_db::ClaimRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn build_query_vec() -> String {
+    let mut v = vec!["0.0"; 1536];
+    v[0] = "0.99";
+    format!("[{}]", v.join(","))
+}
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(agent_id)
+        .bind("bb".repeat(32))
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    agent_id
+}
+
+fn distinct_hash(tag: u8) -> Vec<u8> {
+    let mut h = vec![0u8; 32];
+    h[0] = tag;
+    h
+}
+
+/// CORE REGRESSION: a memorized claim (NO `level` property) and an atom
+/// (`level=3`) must BOTH be retrievable. The old `search_by_embedding` gates on
+/// `(properties->>'level')::int = 2` and would drop both — that gate is the
+/// root cause of the empty flat recall.
+#[sqlx::test(migrations = "../../migrations")]
+async fn returns_level_less_and_non_level_2_claims(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let pgvec = build_query_vec();
+
+    let memorized = Uuid::new_v4(); // properties = '{}' (no level), like memorize()
+    let atom = Uuid::new_v4(); // level = 3
+    let para = Uuid::new_v4(); // level = 2 (control: present under both methods)
+
+    // memorized: empty properties object — no 'level' key at all.
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding) \
+         VALUES ($1, $2, $3, $4, 0.9, '{}'::jsonb, $5::vector)",
+    )
+    .bind(memorized).bind("memorized claim").bind(distinct_hash(1))
+    .bind(agent).bind(&pgvec).execute(&pool).await.expect("insert memorized");
+
+    for (id, level, tag) in [(atom, 3, 2u8), (para, 2, 3u8)] {
+        sqlx::query(
+            "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding) \
+             VALUES ($1, $2, $3, $4, 0.9, jsonb_build_object('level', $5::int), $6::vector)",
+        )
+        .bind(id).bind(format!("c-{id}")).bind(distinct_hash(tag))
+        .bind(agent).bind(level).bind(&pgvec).execute(&pool).await.expect("insert leveled");
+    }
+
+    let hits = ClaimRepository::search_claims_by_embedding(&pool, &pgvec, 1536, 10, None)
+        .await
+        .expect("search_claims_by_embedding");
+    let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
+
+    assert!(ids.contains(&memorized), "level-less memorized claim must be returned");
+    assert!(ids.contains(&atom), "level=3 atom must be returned (no level gate)");
+    assert!(ids.contains(&para), "level=2 paragraph must still be returned");
+}
+
+/// label_filter=Some scopes results to the overlap set — find_workflow's
+/// semantic stage must see only `workflow`-labeled claims.
+#[sqlx::test(migrations = "../../migrations")]
+async fn label_filter_restricts_to_overlapping_labels(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let pgvec = build_query_vec();
+
+    let wf = Uuid::new_v4();
+    let other = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, labels, properties, embedding) \
+         VALUES ($1, $2, $3, $4, 0.9, ARRAY['workflow']::text[], '{}'::jsonb, $5::vector)",
+    )
+    .bind(wf).bind("a workflow").bind(distinct_hash(4))
+    .bind(agent).bind(&pgvec).execute(&pool).await.expect("insert workflow claim");
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, labels, properties, embedding) \
+         VALUES ($1, $2, $3, $4, 0.9, ARRAY['note']::text[], '{}'::jsonb, $5::vector)",
+    )
+    .bind(other).bind("a non-workflow note").bind(distinct_hash(5))
+    .bind(agent).bind(&pgvec).execute(&pool).await.expect("insert note claim");
+
+    let labels = ["workflow".to_string()];
+    let hits = ClaimRepository::search_claims_by_embedding(&pool, &pgvec, 1536, 10, Some(&labels))
+        .await
+        .expect("search with label filter");
+    let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
+
+    assert!(ids.contains(&wf), "workflow-labeled claim must be returned under filter");
+    assert!(!ids.contains(&other), "non-workflow claim must be excluded by label filter");
+}
+
+/// COALESCE(is_current, true) = true must exclude superseded claims, matching
+/// the evidence path's semantics callers rely on.
+#[sqlx::test(migrations = "../../migrations")]
+async fn excludes_non_current_claims(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let pgvec = build_query_vec();
+
+    let live = Uuid::new_v4();
+    let stale = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current, properties, embedding) \
+         VALUES ($1, $2, $3, $4, 0.9, true, '{}'::jsonb, $5::vector)",
+    )
+    .bind(live).bind("live claim").bind(distinct_hash(6))
+    .bind(agent).bind(&pgvec).execute(&pool).await.expect("insert live");
+
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current, properties, embedding) \
+         VALUES ($1, $2, $3, $4, 0.9, false, '{}'::jsonb, $5::vector)",
+    )
+    .bind(stale).bind("stale claim").bind(distinct_hash(7))
+    .bind(agent).bind(&pgvec).execute(&pool).await.expect("insert stale");
+
+    let hits = ClaimRepository::search_claims_by_embedding(&pool, &pgvec, 1536, 10, None)
+        .await
+        .expect("search");
+    let ids: Vec<Uuid> = hits.iter().map(|h| h.claim_id).collect();
+
+    assert!(ids.contains(&live), "is_current=true claim must be returned");
+    assert!(!ids.contains(&stale), "is_current=false claim must be excluded");
+}
+
+/// Unsupported dim is an explicit InvalidData error, never a silent wrong-column query.
+#[sqlx::test(migrations = "../../migrations")]
+async fn rejects_unsupported_dim(pool: PgPool) {
+    let pgvec = build_query_vec();
+    let result = ClaimRepository::search_claims_by_embedding(&pool, &pgvec, 2048, 5, None).await;
+    assert!(
+        matches!(result, Err(epigraph_db::DbError::InvalidData { .. })),
+        "expected InvalidData for unsupported dim, got {:?}",
+        result
+    );
+}

--- a/crates/epigraph-engine/src/recall.rs
+++ b/crates/epigraph-engine/src/recall.rs
@@ -14,7 +14,7 @@
 //! MCP behaviour.
 
 use epigraph_core::ClaimId;
-use epigraph_db::{ClaimRepository, EvidenceRepository, PgPool};
+use epigraph_db::{ClaimRepository, PgPool};
 use epigraph_embeddings::EmbeddingService;
 use thiserror::Error;
 
@@ -79,7 +79,11 @@ pub async fn recall(
     // Try semantic search first.
     let results = if let Ok(embedding) = embedder.generate_query(query).await {
         let pgvec = format_pgvector(&embedding);
-        match EvidenceRepository::search_by_embedding(pool, &pgvec, limit_i64).await {
+        // Read claims.embedding (populated) not evidence.embedding (empty); no
+        // label filter (library recall spans the whole corpus). dim comes from
+        // the injected embedder so a 3072d provider still routes correctly.
+        let dim = embedder.dimension() as u32;
+        match ClaimRepository::search_claims_by_embedding(pool, &pgvec, dim, limit_i64, None).await {
             Ok(hits) => {
                 let mut results = Vec::new();
                 for hit in hits {

--- a/crates/epigraph-engine/src/recall.rs
+++ b/crates/epigraph-engine/src/recall.rs
@@ -83,7 +83,8 @@ pub async fn recall(
         // label filter (library recall spans the whole corpus). dim comes from
         // the injected embedder so a 3072d provider still routes correctly.
         let dim = embedder.dimension() as u32;
-        match ClaimRepository::search_claims_by_embedding(pool, &pgvec, dim, limit_i64, None).await {
+        match ClaimRepository::search_claims_by_embedding(pool, &pgvec, dim, limit_i64, None).await
+        {
             Ok(hits) => {
                 let mut results = Vec::new();
                 for hit in hits {

--- a/crates/epigraph-mcp/src/embed.rs
+++ b/crates/epigraph-mcp/src/embed.rs
@@ -99,10 +99,14 @@ impl McpEmbedder {
         let embedding = self.generate(query).await?;
 
         let pgvec = format_pgvector(&embedding);
-        let results =
-            epigraph_db::EvidenceRepository::search_by_embedding(&self.pool, &pgvec, limit)
-                .await
-                .map_err(|e| e.to_string())?;
+        // McpEmbedder uses text-embedding-3-small (1536d). Read claims.embedding
+        // (426k populated) not evidence.embedding (0 populated). No label filter:
+        // flat recall spans the whole corpus, including level-less memorized claims.
+        let results = epigraph_db::ClaimRepository::search_claims_by_embedding(
+            &self.pool, &pgvec, 1536, limit, None,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
 
         Ok(results
             .into_iter()
@@ -176,7 +180,7 @@ impl EmbeddingService for McpEmbedder {
         Err(EmbeddingError::NotFound { claim_id })
     }
 
-    /// Find similar claims via `EvidenceRepository::search_by_embedding`.
+    /// Find similar claims via `ClaimRepository::search_claims_by_embedding`.
     ///
     /// Converts `f64` similarity from the DB row to `f32` for `SimilarClaim`.
     async fn similar(
@@ -186,10 +190,11 @@ impl EmbeddingService for McpEmbedder {
         min_similarity: f32,
     ) -> Result<Vec<SimilarClaim>, EmbeddingError> {
         let pgvec = format_pgvector(embedding);
-        let rows =
-            epigraph_db::EvidenceRepository::search_by_embedding(&self.pool, &pgvec, k as i64)
-                .await
-                .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))?;
+        let rows = epigraph_db::ClaimRepository::search_claims_by_embedding(
+            &self.pool, &pgvec, 1536, k as i64, None,
+        )
+        .await
+        .map_err(|e| EmbeddingError::DatabaseError(e.to_string()))?;
 
         Ok(rows
             .into_iter()

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -139,9 +139,14 @@ pub async fn recall(
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
     let min_truth = params.min_truth.unwrap_or(0.3);
 
-    // Try semantic search first
-    let results = if let Ok(hits) = server.embedder.search(&params.query, limit).await {
-        let mut results = Vec::new();
+    // Try semantic search first. The text fallback below fires whenever the
+    // assembled result set is empty — not only on embedder error — so an
+    // Ok(empty) from semantic search (the silent-empty failure mode that made
+    // recall dead against live data in backlog 1564bdaf) still degrades to
+    // text search instead of returning []. This also covers the case where
+    // every semantic hit was filtered out by min_truth.
+    let mut results: Vec<RecallResult> = Vec::new();
+    if let Ok(hits) = server.embedder.search(&params.query, limit).await {
         for (claim_id, similarity) in hits {
             if let Ok(Some(claim)) =
                 ClaimRepository::get_by_id(&server.pool, ClaimId::from_uuid(claim_id)).await
@@ -157,13 +162,14 @@ pub async fn recall(
                 }
             }
         }
-        results
-    } else {
-        // Fallback to text search
+    }
+
+    if results.is_empty() {
+        // Fallback to ILIKE text search over claim content.
         let claims = ClaimRepository::list(&server.pool, limit, 0, Some(&params.query))
             .await
             .map_err(internal_error)?;
-        claims
+        results = claims
             .into_iter()
             .filter(|c| c.truth_value.value() >= min_truth)
             .map(|c| RecallResult {
@@ -172,8 +178,8 @@ pub async fn recall(
                 truth_value: c.truth_value.value(),
                 similarity: 0.0,
             })
-            .collect()
-    };
+            .collect();
+    }
 
     success_json(&results)
 }

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -177,11 +177,21 @@ pub async fn find_workflow(
         }
     };
 
-    // Semantic search via evidence embeddings (only when embedding is available).
+    // Semantic search over claims.embedding (evidence.embedding is empty for
+    // workflows). Restrict to `workflow`-labeled claims so semantic neighbors
+    // match the ILIKE fallback's scope before enrich_workflow_result (which
+    // requires a workflow content blob). 1536d = McpEmbedder's model.
+    let workflow_labels = ["workflow".to_string()];
     let semantic_hits = if let Some(pgvec) = pgvec_opt.as_deref() {
-        epigraph_db::EvidenceRepository::search_by_embedding(&server.pool, pgvec, limit * 3)
-            .await
-            .map_err(internal_error)?
+        epigraph_db::ClaimRepository::search_claims_by_embedding(
+            &server.pool,
+            pgvec,
+            1536,
+            limit * 3,
+            Some(&workflow_labels),
+        )
+        .await
+        .map_err(internal_error)?
     } else {
         Vec::new()
     };


### PR DESCRIPTION
## Problem

Flat `recall` and `find_workflow` (MCP) return empty against ~429k claims. Root cause is an incomplete read/write column migration: `McpEmbedder::store` was migrated to write `claims.embedding` (with an explicit comment about the earlier evidence.embedding no-op), but the matching READ paths were left on `EvidenceRepository::search_by_embedding`, which queries `evidence.embedding`.

Empirical counts (read-only): `claims.embedding` populated on 426,214/429,194 rows (~99%); `evidence.embedding` populated on 0/77,455. None of the canonical write paths (memorize/submit_claim/ingest_document) populate evidence.embedding. So all three flat/semantic readers query an empty column and return zero hits. `recall_with_context` is unaffected — it already reads `claims.embedding` via `ClaimRepository::search_by_embedding`, but that method is hard-gated to `level=2`, which drops memorized (level-less) and workflow (label-driven) claims, so it is not a drop-in for flat recall / find_workflow.

## Fix

1. New `ClaimRepository::search_claims_by_embedding(pool, pgvec, dim, limit, label_filter)` — reads `claims.embedding`/`embedding_3072`, `COALESCE(is_current,true)=true`, NO level gate, optional `labels && $3`. Backed by the existing full HNSW index `idx_claims_embedding_hnsw` (migration 001).
2. Repoint the four read sites: `McpEmbedder::search` + `::similar`, `find_workflow`'s semantic stage (with `label=['workflow']`), and `epigraph_engine::recall::recall`.
3. Flat recall's text fallback now fires on empty results, not only on `Err` (kills the silent-Ok(empty) failure mode).

Deliberately does NOT start writing `evidence.embedding` (that would contradict the write-path migration and the CLAUDE.md embedding invariant).

## Known limitations
- find_workflow's semantic stage applies `labels && ['workflow']` (~144/429k rows). HNSW post-filtering can exhaust `ef_search` and under-return; the existing `results < half -> ILIKE` fallback backstops this, and legacy_flat workflow claims may predate embed-on-write and rely on ILIKE. This PR does not claim the semantic stage now fully serves workflows — it removes the empty-column dead end.

## Verifiability
- VERIFIED in this environment (Postgres NOT running here): `SQLX_OFFLINE=true cargo check --workspace` passes, and `cargo check -p epigraph-db -p epigraph-mcp -p epigraph-engine --tests` compiles the touched crates plus the new test file. All wiring compiles; `ClaimEmbeddingHit {claim_id, similarity}` matches every consuming loop; no new `.sqlx/` entry needed (runtime `query_as`, confirmed `git status .sqlx/` empty after build). `cargo clippy -D warnings` is CLEAN on the touched library code (all three crates, `--lib`) and on the new test target.
- Clippy CAVEAT: the full `cargo clippy --tests -- -D warnings` run fails on a pre-existing `clippy::incompatible_msrv` lint (`std::iter::repeat_n`) in UNRELATED epigraph-mcp test files (`query_claims_by_label.rs`, `resolve_backlog_item.rs`). This was confirmed present on clean `origin/main` (stash-verified) and is a toolchain/MSRV mismatch, NOT introduced by this PR. No untouched code was modified to silence it.
- NOT verified here: the new method's SQL is runtime-checked (`query_as`, not the `query!` macro), so `cargo check` does NOT validate it — correctness (the `labels && $3` array-overlap predicate, the level-agnostic/is_current behavior, column/bind order) is proven ONLY by `DATABASE_URL=postgres://epigraph:epigraph@localhost/epigraph_db_repo_test cargo test -p epigraph-db --test claim_search_claims_by_embedding` against a Postgres+pgvector DB (run on the dev VM). End-to-end MCP behavior (recall/find_workflow returning hits over the live 426k corpus) is deployment-time only and NOT runtime-verified in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
