### PR TITLE
Workflow-evolution (GEPA) — apply layer (additive promotable flag)

### DIFF
--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -233,6 +233,59 @@ impl ClaimRepository {
         Ok(())
     }
 
+    /// Read a claim's workflow-promotion flag
+    /// (`properties->'promotion'->>'promotable'`). `None` when the claim was
+    /// never evaluated (or does not exist); `Some(bool)` otherwise. Used by
+    /// `find_workflow` to surface whether a variant has been promoted.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn promotion_flag(pool: &PgPool, claim_id: ClaimId) -> Result<Option<bool>, DbError> {
+        let id: Uuid = claim_id.into();
+        let flag: Option<Option<bool>> = sqlx::query_scalar(
+            "SELECT (properties->'promotion'->>'promotable')::bool FROM claims WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
+        Ok(flag.flatten())
+    }
+
+    /// Shallow-merge `patch` into the claim's `properties` JSONB (`||`),
+    /// preserving keys not present in `patch` and overwriting those that are.
+    /// Unlike [`set_properties`] (which replaces the whole object), this is for
+    /// incrementally attaching/refreshing a sub-object — e.g. the workflow
+    /// promotion verdict — without clobbering hierarchy metadata like `level`.
+    ///
+    /// # Errors
+    /// Returns `DbError::NotFound` if no claim has `claim_id`;
+    /// `DbError::QueryFailed` on other database errors.
+    #[instrument(skip(pool, patch))]
+    pub async fn merge_properties(
+        pool: &PgPool,
+        claim_id: ClaimId,
+        patch: &serde_json::Value,
+    ) -> Result<(), DbError> {
+        let id: Uuid = claim_id.into();
+        let result = sqlx::query(
+            "UPDATE claims SET properties = COALESCE(properties, '{}'::jsonb) || $2, \
+             updated_at = NOW() WHERE id = $1",
+        )
+        .bind(id)
+        .bind(patch)
+        .execute(pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(DbError::NotFound {
+                entity: "Claim".to_string(),
+                id,
+            });
+        }
+        Ok(())
+    }
+
     /// Create a new claim within an existing transaction (LEGACY — implicit content-hash dedup)
     ///
     /// Same as `create()` but accepts a `&mut PgConnection` for transactional use.
@@ -2404,6 +2457,76 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(row.0, props);
+    }
+
+    /// `merge_properties` shallow-merges a patch into `properties`, preserving
+    /// untouched keys and OVERWRITING the patched key on a repeat call. This is
+    /// what makes the workflow-promotion flag bidirectional: re-running the
+    /// pass with promotable=false replaces a prior promotable=true rather than
+    /// leaving a stale mark, while sibling keys (e.g. `level`) survive.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn merge_properties_preserves_siblings_and_overwrites_target(pool: sqlx::PgPool) {
+        let (agent_id, agent_pk): (Uuid, Vec<u8>) = sqlx::query_as(
+            "INSERT INTO agents (public_key, display_name, agent_type, labels)
+             VALUES (sha256(gen_random_uuid()::text::bytea), 'merge-props-test', 'system', ARRAY['test'])
+             RETURNING id, public_key",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let mut public_key = [0u8; 32];
+        public_key.copy_from_slice(&agent_pk);
+        let claim = Claim::new(
+            "Test claim for merge".to_string(),
+            AgentId::from_uuid(agent_id),
+            public_key,
+            TruthValue::clamped(0.5),
+        );
+        let persisted = ClaimRepository::create(&pool, &claim).await.unwrap();
+        ClaimRepository::set_properties(&pool, persisted.id, serde_json::json!({"level": 2}))
+            .await
+            .unwrap();
+
+        // Merge a promotion verdict — `level` must survive.
+        ClaimRepository::merge_properties(
+            &pool,
+            persisted.id,
+            &serde_json::json!({"promotion": {"promotable": true, "lower_bound": 0.72}}),
+        )
+        .await
+        .unwrap();
+        let row: (serde_json::Value,) =
+            sqlx::query_as("SELECT properties FROM claims WHERE id = $1")
+                .bind(Uuid::from(persisted.id))
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0["level"], 2, "sibling key preserved");
+        assert_eq!(row.0["promotion"]["promotable"], true);
+
+        // Re-merge with promotable=false (a demotion) — overwrites the promotion
+        // sub-object, `level` still preserved.
+        ClaimRepository::merge_properties(
+            &pool,
+            persisted.id,
+            &serde_json::json!({"promotion": {"promotable": false}}),
+        )
+        .await
+        .unwrap();
+        let row2: (serde_json::Value,) =
+            sqlx::query_as("SELECT properties FROM claims WHERE id = $1")
+                .bind(Uuid::from(persisted.id))
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            row2.0["level"], 2,
+            "sibling key still preserved after re-merge"
+        );
+        assert_eq!(
+            row2.0["promotion"]["promotable"], false,
+            "promotion sub-object overwritten — bidirectional, no stale mark"
+        );
     }
 
     #[sqlx::test(migrations = "../../migrations")]

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -76,6 +76,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("link_hierarchical", "claims:write"),
     ("memorize", "claims:write"),
     ("patch_claim", "claims:write"),
+    ("refresh_workflow_promotion", "claims:write"),
     ("publish_event", "claims:write"),
     ("recompute_beliefs", "claims:write"),
     ("reconcile_sheaf", "claims:write"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -443,7 +443,7 @@ impl EpiGraphMcpFull {
         tools::cdst_maintenance::recompute_beliefs(self, params).await
     }
 
-    // ── Workflows (7 tools) ──
+    // ── Workflows (8 tools) ──
 
     #[tool(
         description = "Store a new workflow with ordered steps and prerequisites. Returns a workflow_id from the hierarchical `workflows` table; use `report_workflow_outcome` with that returned id to record execution results."
@@ -482,6 +482,17 @@ impl EpiGraphMcpFull {
         Parameters(params): Parameters<EvaluateWorkflowPromotionParams>,
     ) -> Result<CallToolResult, McpError> {
         tools::workflows::evaluate_workflow_promotion(self, params).await
+    }
+
+    #[tool(
+        description = "Re-evaluate a workflow variant's promotion verdict and write it to the variant's properties.promotion, overwriting any prior value (so a regressed variant is demoted, not left stale). The apply layer of the workflow-evolution gate; the maintenance pass calls this per candidate variant. Write."
+    )]
+    async fn refresh_workflow_promotion(
+        &self,
+        Parameters(params): Parameters<EvaluateWorkflowPromotionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::workflows::refresh_workflow_promotion(self, params).await
     }
 
     #[tool(
@@ -970,7 +981,7 @@ impl EpiGraphMcpFull {
 impl ServerHandler for EpiGraphMcpFull {
     fn get_info(&self) -> ServerInfo {
         let mode = if self.read_only { "read-only" } else { "full" };
-        let tool_count = if self.read_only { 35 } else { 63 };
+        let tool_count = if self.read_only { 35 } else { 64 };
         ServerInfo {
             instructions: Some(format!(
                 "EpiGraph {mode} MCP server with {tool_count} epistemic tools."

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -7,7 +7,7 @@ use crate::server::EpiGraphMcpFull;
 use crate::tools::ds_auto;
 use crate::types::*;
 
-use epigraph_core::{AgentId, Claim, Evidence, EvidenceType, TruthValue};
+use epigraph_core::{AgentId, Claim, ClaimId, Evidence, EvidenceType, TruthValue};
 use epigraph_crypto::ContentHasher;
 use epigraph_db::{
     BehavioralExecutionRepository, ClaimRepository, EdgeRepository, EvidenceRepository,
@@ -93,54 +93,164 @@ pub async fn evaluate_workflow_promotion(
     server: &EpiGraphMcpFull,
     params: EvaluateWorkflowPromotionParams,
 ) -> Result<CallToolResult, McpError> {
+    let variant_id = parse_uuid(params.workflow_id.trim())?;
+    let window = params.window.unwrap_or(50).clamp(1, 500);
+    let assessment = assess_workflow_promotion(server, variant_id, window).await?;
+    success_json(&assessment.to_json())
+}
+
+/// One workflow variant's promotion assessment: its parent (if any), both
+/// sides' counts over the same window, and the gate verdict. Shared by the
+/// read-only `evaluate_workflow_promotion` tool and the write-side
+/// `refresh_workflow_promotion` pass so both compute the verdict identically.
+struct PromotionAssessment {
+    variant_id: uuid::Uuid,
+    parent_id: Option<uuid::Uuid>,
+    window: i64,
+    min_executions: i64,
+    variant: (i64, i64),
+    parent: (i64, i64),
+    /// `None` exactly when the workflow has no parent (a lineage root).
+    verdict: Option<epigraph_engine::workflow_promotion::WorkflowPromotionVerdict>,
+}
+
+impl PromotionAssessment {
+    fn parent_rate(&self) -> f64 {
+        let (s, t) = self.parent;
+        if t <= 0 {
+            0.0
+        } else {
+            s as f64 / t as f64
+        }
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        match &self.verdict {
+            None => serde_json::json!({
+                "workflow_id": self.variant_id,
+                "parent_id": serde_json::Value::Null,
+                "promotable": false,
+                "reason": "workflow has no variant_of/supersedes parent (it is a lineage root); nothing to promote over",
+            }),
+            Some(v) => serde_json::json!({
+                "workflow_id": self.variant_id,
+                "parent_id": self.parent_id,
+                "window": self.window,
+                "min_executions": self.min_executions,
+                "variant": { "successes": self.variant.0, "total": self.variant.1 },
+                "parent": { "successes": self.parent.0, "total": self.parent.1, "success_rate": self.parent_rate() },
+                "promotable": v.promotable,
+                "variant_lower_bound": v.variant_lower_bound,
+                "parent_rate": v.parent_rate,
+                "reason": v.reason,
+            }),
+        }
+    }
+}
+
+/// Resolve the variant's immediate parent, pull both sides' (successes, total)
+/// over the SAME window (mixing windows would be apples-to-oranges), and apply
+/// the Wilson gate. A lineage root yields `verdict: None`.
+async fn assess_workflow_promotion(
+    server: &EpiGraphMcpFull,
+    variant_id: uuid::Uuid,
+    window: i64,
+) -> Result<PromotionAssessment, McpError> {
     use epigraph_engine::workflow_promotion::{
         evaluate_workflow_promotion as gate, WorkflowPromotionConfig, WorkflowSampleStats,
     };
+    let config = WorkflowPromotionConfig::default();
 
+    let parent_id = WorkflowRepository::immediate_variant_parent(&server.pool, variant_id)
+        .await
+        .map_err(|e| internal_error(e.to_string()))?;
+
+    let variant = BehavioralExecutionRepository::success_stats(&server.pool, variant_id, window)
+        .await
+        .map_err(internal_error)?;
+
+    let (parent, verdict) = match parent_id {
+        None => ((0, 0), None),
+        Some(pid) => {
+            let parent = BehavioralExecutionRepository::success_stats(&server.pool, pid, window)
+                .await
+                .map_err(internal_error)?;
+            let parent_rate = if parent.1 <= 0 {
+                0.0
+            } else {
+                parent.0 as f64 / parent.1 as f64
+            };
+            let v = gate(
+                &WorkflowSampleStats {
+                    successes: variant.0,
+                    total: variant.1,
+                },
+                parent_rate,
+                &config,
+            );
+            (parent, Some(v))
+        }
+    };
+
+    Ok(PromotionAssessment {
+        variant_id,
+        parent_id,
+        window,
+        min_executions: config.min_executions,
+        variant,
+        parent,
+        verdict,
+    })
+}
+
+/// Apply layer (additive promotable flag). Re-evaluate a workflow variant's
+/// promotion verdict and write it to the variant claim's
+/// `properties.promotion`, OVERWRITING any prior value. This is bidirectional
+/// by construction: a variant that has regressed below threshold gets
+/// `promotable: false` on the next run rather than keeping a stale `true`. A
+/// lineage root (no parent) is left untouched. The maintenance pass / scheduled
+/// job calls this per candidate variant; `find_workflow` surfaces the flag.
+pub async fn refresh_workflow_promotion(
+    server: &EpiGraphMcpFull,
+    params: EvaluateWorkflowPromotionParams,
+) -> Result<CallToolResult, McpError> {
     let variant_id = parse_uuid(params.workflow_id.trim())?;
     let window = params.window.unwrap_or(50).clamp(1, 500);
+    let assessment = assess_workflow_promotion(server, variant_id, window).await?;
 
-    let Some(parent_id) = WorkflowRepository::immediate_variant_parent(&server.pool, variant_id)
-        .await
-        .map_err(|e| internal_error(e.to_string()))?
-    else {
+    let Some(verdict) = &assessment.verdict else {
         return success_json(&serde_json::json!({
             "workflow_id": variant_id,
-            "parent_id": serde_json::Value::Null,
-            "promotable": false,
-            "reason": "workflow has no variant_of/supersedes parent (it is a lineage root); nothing to promote over",
+            "refreshed": false,
+            "reason": "lineage root (no variant_of parent); nothing to promote over",
         }));
     };
 
-    // Same window on both sides — comparing across different windows would be
-    // apples to oranges.
-    let (v_succ, v_total) =
-        BehavioralExecutionRepository::success_stats(&server.pool, variant_id, window)
-            .await
-            .map_err(internal_error)?;
-    let (p_succ, p_total) =
-        BehavioralExecutionRepository::success_stats(&server.pool, parent_id, window)
-            .await
-            .map_err(internal_error)?;
-
-    let variant = WorkflowSampleStats {
-        successes: v_succ,
-        total: v_total,
-    };
-    let parent = WorkflowSampleStats {
-        successes: p_succ,
-        total: p_total,
-    };
-    let config = WorkflowPromotionConfig::default();
-    let verdict = gate(&variant, parent.success_rate(), &config);
+    // Overwrite properties.promotion with the CURRENT verdict (provenance for
+    // audit + demotion). Overwriting — not a write-once set — is what keeps the
+    // flag honest as more executions accrue.
+    let promotion = serde_json::json!({
+        "promotion": {
+            "promotable": verdict.promotable,
+            "lower_bound": verdict.variant_lower_bound,
+            "parent_rate": verdict.parent_rate,
+            "parent_id": assessment.parent_id,
+            "n": assessment.variant.1,
+            "evaluated_at": chrono::Utc::now().to_rfc3339(),
+        }
+    });
+    ClaimRepository::merge_properties(
+        &server.pool,
+        epigraph_core::ClaimId::from_uuid(variant_id),
+        &promotion,
+    )
+    .await
+    .map_err(internal_error)?;
 
     success_json(&serde_json::json!({
         "workflow_id": variant_id,
-        "parent_id": parent_id,
-        "window": window,
-        "min_executions": config.min_executions,
-        "variant": { "successes": v_succ, "total": v_total },
-        "parent": { "successes": p_succ, "total": p_total, "success_rate": parent.success_rate() },
+        "parent_id": assessment.parent_id,
+        "refreshed": true,
         "promotable": verdict.promotable,
         "variant_lower_bound": verdict.variant_lower_bound,
         "parent_rate": verdict.parent_rate,
@@ -470,6 +580,12 @@ async fn enrich_workflow_result(
         None
     };
 
+    // Promotion flag set by the refresh_workflow_promotion maintenance pass.
+    // Advisory metadata; best-effort (a lookup failure must not drop the result).
+    let promotable = ClaimRepository::promotion_flag(pool, ClaimId::from_uuid(workflow_id))
+        .await
+        .unwrap_or(None);
+
     Some(FindWorkflowResult {
         workflow_id: workflow_id.to_string(),
         goal,
@@ -483,6 +599,7 @@ async fn enrich_workflow_result(
         behavioral_affinity,
         behavioral_success_rate,
         behavioral_execution_count,
+        promotable,
     })
 }
 

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -814,6 +814,12 @@ pub struct FindWorkflowResult {
     pub behavioral_success_rate: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub behavioral_execution_count: Option<i64>,
+    /// Set by the workflow-promotion maintenance pass (`refresh_workflow_promotion`)
+    /// from the variant's `properties.promotion.promotable`. `Some(true)` means
+    /// the gate found this variant statistically better than its parent; absent
+    /// when never evaluated. Advisory — callers may prefer promoted variants.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub promotable: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/epigraph-mcp/tests/refresh_workflow_promotion.rs
+++ b/crates/epigraph-mcp/tests/refresh_workflow_promotion.rs
@@ -1,0 +1,180 @@
+//! Behavioral test for the `refresh_workflow_promotion` apply-layer tool.
+//!
+//! The critical property is BIDIRECTIONALITY: the promotable flag is computed
+//! over a window, so a variant promoted today can regress tomorrow. The pass
+//! must overwrite the verdict each run — never leave a stale `promotable:true`.
+
+use epigraph_core::ClaimId;
+use epigraph_crypto::AgentSigner;
+use epigraph_db::{BehavioralExecutionRepository, BehavioralExecutionRow, ClaimRepository};
+use epigraph_mcp::types::EvaluateWorkflowPromotionParams;
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use rmcp::model::RawContent;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0x2bu8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+fn result_json(out: rmcp::model::CallToolResult) -> serde_json::Value {
+    let first = out.content.first().cloned().expect("first content");
+    match first.raw {
+        RawContent::Text(t) => serde_json::from_str(&t.text).expect("result is JSON"),
+        other => panic!("expected text content, got {other:?}"),
+    }
+}
+
+async fn insert_agent(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels)
+         VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test'])
+         RETURNING id",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO claims (content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, sha256($1::bytea), 0.5, $2, true) RETURNING id",
+    )
+    .bind(content)
+    .bind(agent)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn seed_runs(pool: &PgPool, wf: Uuid, successes: usize, failures: usize) {
+    let base = chrono::Utc::now();
+    let mut i = 0i64;
+    for succ in std::iter::repeat(true)
+        .take(successes)
+        .chain(std::iter::repeat(false).take(failures))
+    {
+        BehavioralExecutionRepository::create(
+            pool,
+            BehavioralExecutionRow {
+                id: Uuid::new_v4(),
+                workflow_id: wf,
+                goal_text: "g".into(),
+                success: succ,
+                step_beliefs: serde_json::json!({}),
+                tool_pattern: vec![],
+                quality: None,
+                deviation_count: 0,
+                total_steps: 1,
+                created_at: base + chrono::Duration::milliseconds(i),
+                step_claim_id: None,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        i += 1;
+    }
+}
+
+async fn link_variant(pool: &PgPool, variant: Uuid, parent: Uuid) {
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES (gen_random_uuid(), $1, 'claim', $2, 'claim', 'variant_of')",
+    )
+    .bind(variant)
+    .bind(parent)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn refresh_sets_then_clears_promotable(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "rwp-agent").await;
+    let parent = insert_claim(&pool, agent, "rwp-parent").await;
+    let variant = insert_claim(&pool, agent, "rwp-variant").await;
+    link_variant(&pool, variant, parent).await;
+
+    // Phase 1: variant 12/12 over a 0.5 parent → promotable. Flag written true.
+    seed_runs(&pool, parent, 5, 5).await;
+    seed_runs(&pool, variant, 12, 0).await;
+    let j1 = result_json(
+        tools::workflows::refresh_workflow_promotion(
+            &server,
+            EvaluateWorkflowPromotionParams {
+                workflow_id: variant.to_string(),
+                window: Some(50),
+            },
+        )
+        .await
+        .expect("refresh ok"),
+    );
+    assert_eq!(j1["refreshed"], true);
+    assert_eq!(j1["promotable"], true);
+    assert_eq!(
+        ClaimRepository::promotion_flag(&pool, ClaimId::from_uuid(variant))
+            .await
+            .unwrap(),
+        Some(true),
+        "promotable flag persisted to properties"
+    );
+
+    // Phase 2: the variant regresses (20 failures → 12/32 = 0.375 < parent 0.5).
+    // A second refresh must OVERWRITE the verdict to false — not leave a stale true.
+    seed_runs(&pool, variant, 0, 20).await;
+    let j2 = result_json(
+        tools::workflows::refresh_workflow_promotion(
+            &server,
+            EvaluateWorkflowPromotionParams {
+                workflow_id: variant.to_string(),
+                window: Some(50),
+            },
+        )
+        .await
+        .expect("refresh ok"),
+    );
+    assert_eq!(
+        j2["promotable"], false,
+        "regressed variant is demoted on re-run"
+    );
+    assert_eq!(
+        ClaimRepository::promotion_flag(&pool, ClaimId::from_uuid(variant))
+            .await
+            .unwrap(),
+        Some(false),
+        "flag cleared to false (bidirectional) — no stale promotable mark"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn refresh_skips_lineage_root(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "rwp-agent2").await;
+    let root = insert_claim(&pool, agent, "rwp-root").await; // no variant_of edge
+
+    let j = result_json(
+        tools::workflows::refresh_workflow_promotion(
+            &server,
+            EvaluateWorkflowPromotionParams {
+                workflow_id: root.to_string(),
+                window: None,
+            },
+        )
+        .await
+        .expect("refresh ok"),
+    );
+    assert_eq!(j["refreshed"], false, "a lineage root is left untouched");
+    assert_eq!(
+        ClaimRepository::promotion_flag(&pool, ClaimId::from_uuid(root))
+            .await
+            .unwrap(),
+        None,
+        "no promotion flag written for a root"
+    );
+}

--- a/docs/superpowers/plans/2026-06-01-workflow-evolution-gepa.md
+++ b/docs/superpowers/plans/2026-06-01-workflow-evolution-gepa.md
@@ -57,7 +57,16 @@ The proposer is a prompt run by a `schedules.toml` Claude-CLI session under a
 
 ---
 
-## ⚠️ OPEN DECISION — the APPLY layer (prod-mutating; needs sign-off)
+## APPLY layer — option (A) chosen and BUILT (stacked branch `feat/workflow-promotion-apply`)
+
+User chose **(A) additive promotable flag** (2026-06-01). Built + TDD'd, stacked on the decide-layer branch:
+- `ClaimRepository::merge_properties` + `promotion_flag` (db) — store/read the verdict on `properties.promotion`.
+- `refresh_workflow_promotion` MCP tool (`claims:write`) — re-evaluates a variant and writes the verdict to `properties.promotion`, **overwriting every run** (bidirectional: a regressed variant is demoted, not left stale; `evaluated_at` makes staleness auditable). A lineage root is left untouched.
+- `find_workflow` surfaces `promotable` (advisory field; still ranks by similarity).
+
+The maintenance pass calls `refresh_workflow_promotion` per candidate variant; `find_workflow` callers see `promotable: true` and may prefer those variants. Reversible. Storage is a claim **property** (not a `workflows` column — variants are claims; not a label — a property carries the full verdict provenance for audit + demotion).
+
+### (historical) the fork that was decided
 
 `find_workflow` orders results by **semantic similarity**;
 `behavioral_success_rate` is a *returned field, not a sort key* (verified
@@ -95,7 +104,7 @@ jobs. Keep cadence conservative at first (e.g. daily) and log every proposal +
 verdict.
 
 ## Remaining before the loop runs in prod
-1. **Sign off the apply layer (A/B/C above).**
-2. Build the chosen apply-layer maintenance pass (TDD).
+1. ~~Sign off the apply layer~~ — done (A).
+2. ~~Build the apply-layer maintenance pass~~ — done (`refresh_workflow_promotion`, TDD).
 3. Author the `schedules.toml` proposer + apply entries (deploy-time).
 4. End-to-end dry run on a seeded lineage before enabling in prod.


### PR DESCRIPTION
**Stacked on #229** (`feat/workflow-evolution-gepa`) — it uses the decide-layer's `evaluate`/`success_stats`/`immediate_variant_parent`/engine gate, which don't exist on `main` yet. **Base will retarget to `main` after #229 merges.** Review #229 first.

The apply layer the decide-layer's verdict feeds. You signed off **option A — additive promotable flag** (over deprecate-loser / re-rank). All TDD'd.

## What this adds
- `ClaimRepository::merge_properties` + `promotion_flag` (`62dbfe5`) — store/read the verdict on the variant claim's `properties.promotion`. Storage is a claim **property** (variants are claims, not `workflows` rows → not a column; a property carries the full verdict provenance for audit + demotion → not a status label).
- `refresh_workflow_promotion` MCP tool (`claims:write`, `9430150`) — re-evaluates a variant via the shared `assess_workflow_promotion` helper and writes the verdict to `properties.promotion`, **overwriting every run**. A lineage root is left untouched.
- `find_workflow` now surfaces `promotable` as an advisory field (it still ranks by similarity; the flag does not re-rank the hot path).

## The correctness crux: bidirectionality
`promotable` is computed over a window, so a variant promoted today can regress. The pass **overwrites** the verdict each run rather than write-once, so a regressed variant is **demoted**, not left with a stale `promotable: true` (`evaluated_at` makes staleness auditable). Test `refresh_sets_then_clears_promotable` promotes a 12/12 variant over a 0.5 parent, then feeds it 20 failures (12/32 = 0.375) and asserts the flag flips to `false` on the next pass.

## Not in this PR (runtime artifacts)
The `schedules.toml` proposer + the maintenance job that calls `refresh_workflow_promotion` per candidate variant are authored at deploy time (like `graph-integrity`), plus an end-to-end dry run. The per-workflow refresh primitive + bulk-enumeration approach are documented in `docs/superpowers/plans/2026-06-01-workflow-evolution-gepa.md`.

## Verification
Full `cargo test -p epigraph-engine -p epigraph-db -p epigraph-mcp -- --test-threads=1`: **827 passed, 0 failed, 14 ignored / 93 binaries**. Bidirectional promote→demote + root-skip + merge/overwrite all covered; the refactored decide-layer tests still pass; scope-coverage enforces `refresh_workflow_promotion` → `claims:write`. clippy + fmt clean; runtime queries → no `.sqlx` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)