### PR TITLE
feat(decomposition): build query_undecomposed_claims + decompose primitives for the dead decomposition-cycle schedule

### DIFF
--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -81,6 +81,11 @@ path = "src/bin/reembed.rs"
 required-features = ["db"]
 
 [[bin]]
+name = "decompose_claims"
+path = "src/bin/decompose_claims.rs"
+required-features = ["db"]
+
+[[bin]]
 name = "embed_backfill"
 path = "src/bin/embed_backfill.rs"
 required-features = ["db"]

--- a/crates/epigraph-cli/src/bin/decompose_claims.rs
+++ b/crates/epigraph-cli/src/bin/decompose_claims.rs
@@ -1,0 +1,125 @@
+//! `decompose_claims` — split standalone compound claims into atomic
+//! propositions + wire parent -decomposes_to-> atom edges.
+//!
+//! The decompose primitive the dead `decomposition-cycle` schedule needs.
+//! Enumerates via `ClaimRepository::list_undecomposed`, decomposes each batch
+//! through the prepaid Claude path (`create_llm_client("epigraph")`, which
+//! prefers CLAUDE_CODE_OAUTH_TOKEN — NEVER the Anthropic-SDK pay-per-token
+//! variant the V2 `_api.py`/`_openai.py` scripts used), parses with
+//! `epigraph_cli::decompose::parse_batch_response`, and persists atoms through
+//! the canonical API claim path so embedding + DS auto-wire + signing happen
+//! on write.
+//!
+//! Required: DATABASE_URL, EPIGRAPH_API (e.g. http://127.0.0.1:8080),
+//! EPIGRAPH_TOKEN (bearer for the API), and CLAUDE_CODE_OAUTH_TOKEN.
+//! Use `--provider mock` for a dry compile/smoke without credentials.
+
+use clap::Parser;
+use epigraph_cli::decompose::{build_batch_prompt, parse_batch_response, persist_decomposition};
+use epigraph_db::ClaimRepository;
+
+#[derive(Parser)]
+#[command(name = "decompose_claims", about = "Decompose undecomposed compound claims into atoms")]
+struct Cli {
+    /// Max claims to process this run.
+    #[arg(long, default_value_t = 200)]
+    limit: i64,
+    /// Claims per LLM call.
+    #[arg(long, default_value_t = 10)]
+    batch_size: usize,
+    /// LLM provider selector for create_llm_client ("epigraph" auto, or "mock").
+    #[arg(long, default_value = "epigraph")]
+    provider: String,
+    /// Parse/enumerate only — do not call the LLM or write anything.
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    let pool = epigraph_cli::db_connect().await?;
+
+    let claims = ClaimRepository::list_undecomposed(&pool, cli.limit, 0).await?;
+    eprintln!("found {} undecomposed claims", claims.len());
+    if cli.dry_run || claims.is_empty() {
+        for c in &claims {
+            println!("{}\t{}", c.id.as_uuid(), c.content);
+        }
+        return Ok(());
+    }
+
+    // Prepaid Claude path. create_llm_client("epigraph") returns the first
+    // active provider (Anthropic-from-env, OAuth-preferred); "mock" for smoke.
+    let llm = epigraph_cli::enrichment::llm_client::create_llm_client(&cli.provider)?;
+    let embedder = epigraph_cli::embedding_service();
+
+    // API submit closure — canonical claim create (embed + DS + sign on write).
+    let api_base = std::env::var("EPIGRAPH_API")
+        .unwrap_or_else(|_| "http://127.0.0.1:8080".to_string());
+    let token = std::env::var("EPIGRAPH_TOKEN").unwrap_or_default();
+    let http = reqwest::Client::new();
+
+    let mut total_atoms = 0usize;
+    let mut total_edges = 0usize;
+    for chunk in claims.chunks(cli.batch_size) {
+        let indexed: Vec<(usize, &str)> = chunk
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (i, c.content.as_str()))
+            .collect();
+        let prompt = build_batch_prompt(&indexed);
+        // SCAFFOLD BOUNDARY: this network call cannot run in the CI box.
+        let raw = match llm.complete_json(&prompt).await {
+            Ok(v) => v.to_string(),
+            Err(e) => {
+                eprintln!("  LLM call failed for batch: {e}; skipping");
+                continue;
+            }
+        };
+        let parsed = parse_batch_response(&raw);
+        for (local_idx, decomp) in parsed {
+            let Some(parent) = chunk.get(local_idx) else { continue; };
+            let parent_id = parent.id.as_uuid();
+            let http = http.clone();
+            let api_base = api_base.clone();
+            let token = token.clone();
+            let outcome = persist_decomposition(
+                &pool,
+                parent_id,
+                &decomp,
+                embedder.clone(),
+                move |atom_text, generality| {
+                    let http = http.clone();
+                    let api_base = api_base.clone();
+                    let token = token.clone();
+                    async move {
+                        // Canonical create via API: signing + DS + embed-on-write.
+                        let resp = http
+                            .post(format!("{api_base}/api/v1/claims"))
+                            .bearer_auth(&token)
+                            .json(&serde_json::json!({
+                                "content": atom_text,
+                                "methodology": "inductive_generalization",
+                                "evidence_type": "logical",
+                                "confidence": 0.5,
+                                "labels": ["atom", format!("generality:{generality}")],
+                            }))
+                            .send()
+                            .await?;
+                        let v: serde_json::Value = resp.error_for_status()?.json().await?;
+                        let id = v.get("id").or_else(|| v.get("claim_id"))
+                            .and_then(|x| x.as_str())
+                            .ok_or("API create returned no claim id")?;
+                        Ok(uuid::Uuid::parse_str(id)?)
+                    }
+                },
+            )
+            .await?;
+            total_atoms += outcome.atom_claim_ids.len();
+            total_edges += outcome.edges_created;
+        }
+    }
+    eprintln!("decompose complete: {total_atoms} atoms, {total_edges} decomposes_to edges");
+    Ok(())
+}

--- a/crates/epigraph-cli/src/bin/decompose_claims.rs
+++ b/crates/epigraph-cli/src/bin/decompose_claims.rs
@@ -19,7 +19,10 @@ use epigraph_cli::decompose::{build_batch_prompt, parse_batch_response, persist_
 use epigraph_db::ClaimRepository;
 
 #[derive(Parser)]
-#[command(name = "decompose_claims", about = "Decompose undecomposed compound claims into atoms")]
+#[command(
+    name = "decompose_claims",
+    about = "Decompose undecomposed compound claims into atoms"
+)]
 struct Cli {
     /// Max claims to process this run.
     #[arg(long, default_value_t = 200)]
@@ -55,8 +58,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let embedder = epigraph_cli::embedding_service();
 
     // API submit closure — canonical claim create (embed + DS + sign on write).
-    let api_base = std::env::var("EPIGRAPH_API")
-        .unwrap_or_else(|_| "http://127.0.0.1:8080".to_string());
+    let api_base =
+        std::env::var("EPIGRAPH_API").unwrap_or_else(|_| "http://127.0.0.1:8080".to_string());
     let token = std::env::var("EPIGRAPH_TOKEN").unwrap_or_default();
     let http = reqwest::Client::new();
 
@@ -79,7 +82,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         let parsed = parse_batch_response(&raw);
         for (local_idx, decomp) in parsed {
-            let Some(parent) = chunk.get(local_idx) else { continue; };
+            let Some(parent) = chunk.get(local_idx) else {
+                continue;
+            };
             let parent_id = parent.id.as_uuid();
             let http = http.clone();
             let api_base = api_base.clone();
@@ -108,7 +113,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .send()
                             .await?;
                         let v: serde_json::Value = resp.error_for_status()?.json().await?;
-                        let id = v.get("id").or_else(|| v.get("claim_id"))
+                        let id = v
+                            .get("id")
+                            .or_else(|| v.get("claim_id"))
                             .and_then(|x| x.as_str())
                             .ok_or("API create returned no claim id")?;
                         Ok(uuid::Uuid::parse_str(id)?)

--- a/crates/epigraph-cli/src/decompose.rs
+++ b/crates/epigraph-cli/src/decompose.rs
@@ -242,7 +242,10 @@ mod tests {
         let raw = r#"{"0": {"atoms": ["X is Y", "X causes Z"], "generality": [0, 1]}}"#;
         let out = parse_batch_response(raw);
         let d = out.get(&0).expect("index 0 parsed");
-        assert_eq!(d.atoms, vec!["X is Y".to_string(), "X causes Z".to_string()]);
+        assert_eq!(
+            d.atoms,
+            vec!["X is Y".to_string(), "X causes Z".to_string()]
+        );
         assert_eq!(d.generality, vec![0, 1]);
     }
 
@@ -250,7 +253,10 @@ mod tests {
     fn recovers_json_from_markdown_fence_with_prose() {
         let raw = "Here you go:\n```json\n{\"2\": {\"atoms\": [\"A\", \"B\"], \"generality\": [1, 2]}}\n```\nDone.";
         let out = parse_batch_response(raw);
-        assert!(out.contains_key(&2), "must recover the fenced object despite surrounding prose");
+        assert!(
+            out.contains_key(&2),
+            "must recover the fenced object despite surrounding prose"
+        );
         assert_eq!(out.get(&2).unwrap().atoms.len(), 2);
     }
 
@@ -267,14 +273,22 @@ mod tests {
         let d = parse_batch_response(raw);
         let entry = d.get(&0).unwrap();
         assert_eq!(entry.atoms.len(), 2);
-        assert_eq!(entry.generality, vec![-1, -1], "bare array has no generality => all -1");
+        assert_eq!(
+            entry.generality,
+            vec![-1, -1],
+            "bare array has no generality => all -1"
+        );
     }
 
     #[test]
     fn generality_length_mismatch_falls_back_to_unknown() {
         let raw = r#"{"0": {"atoms": ["a", "b"], "generality": [0]}}"#;
         let d = parse_batch_response(raw).remove(&0).unwrap();
-        assert_eq!(d.generality, vec![-1, -1], "mismatched generality length must be discarded, not zip-truncated");
+        assert_eq!(
+            d.generality,
+            vec![-1, -1],
+            "mismatched generality length must be discarded, not zip-truncated"
+        );
     }
 
     #[test]
@@ -289,6 +303,10 @@ mod tests {
     fn out_of_range_generality_clamped_to_unknown() {
         let raw = r#"{"0": {"atoms": ["a", "b", "c"], "generality": [0, 7, -3]}}"#;
         let d = parse_batch_response(raw).remove(&0).unwrap();
-        assert_eq!(d.generality, vec![0, -1, -1], "only 0/1/2 are valid tiers; others -> -1");
+        assert_eq!(
+            d.generality,
+            vec![0, -1, -1],
+            "only 0/1/2 are valid tiers; others -> -1"
+        );
     }
 }

--- a/crates/epigraph-cli/src/decompose.rs
+++ b/crates/epigraph-cli/src/decompose.rs
@@ -1,0 +1,294 @@
+//! Compound-claim -> atomic-proposition decomposition core.
+//!
+//! A hardened port of the deterministic logic of V2
+//! `scripts/decompose_claims_claude.py` (the Claude-CLI variant — the
+//! `_api.py`/`_openai.py` SDK variants are REJECTED per
+//! feedback_claude_cli_oauth: LLM calls go through the prepaid Claude path,
+//! never the Anthropic SDK with a pay-per-token key). The actual model call
+//! is made by the `decompose_claims` binary via
+//! `epigraph_cli::enrichment::llm_client::create_llm_client` (which prefers
+//! `CLAUDE_CODE_OAUTH_TOKEN`); this module owns the prompt, the response
+//! parser, and the graph-write side so both are unit/integration testable
+//! without a network round-trip.
+//!
+//! "Hardened" because the parser adds three robustness behaviors NOT present
+//! in V2 `_parse_batch_response`: (1) a generality array whose length does not
+//! match the atoms array is discarded (all `-1`) rather than zip-truncated;
+//! (2) out-of-range generality values are sanitized to `-1` instead of passed
+//! through; (3) an entry whose `atoms` array contains a non-string element is
+//! dropped entirely rather than coerced — so a malformed entry never
+//! fabricates a decomposition. The unit tests below pin all three.
+
+use serde_json::Value;
+
+/// The batch decomposition prompt. `{claims}` is replaced with a newline-
+/// delimited `[idx] statement` list. Ported (semantics) from V2
+/// `DECOMPOSE_BATCH_PROMPT`.
+pub const DECOMPOSE_BATCH_PROMPT: &str = r#"You are an epistemic claim decomposer. Given a set of numbered claims, break each into atomic propositions — each expressing exactly ONE subject-predicate-object relationship that can be independently true or false.
+
+Rules:
+- Each atomic claim must be a complete, self-contained sentence
+- Resolve pronouns and references (replace \"it\", \"they\", \"this\" with the actual referent)
+- Preserve specific numbers, names, and quantitative details exactly
+- Do NOT add information not present in the original
+- Do NOT include opinions or interpretations
+- If a claim is already atomic, return it unchanged as a single item
+- Separate definitional claims (\"X is Y\") from consequential claims (\"X leads to Y\")
+
+Return ONLY a JSON object mapping each claim index to an object with \"atoms\" (array of atomic strings) and \"generality\" (array of integers, one per atom: 0=foundational/definitional, 1=intermediate/contextual, 2=specialized/applied).
+
+Example output: {\"0\": {\"atoms\": [\"X is defined as Y\", \"X leads to Z\"], \"generality\": [0, 1]}, \"1\": {\"atoms\": [\"Company A uses X\"], \"generality\": [2]}}
+
+Claims:
+{claims}"#;
+
+/// One claim's decomposition: atoms plus a generality tier per atom
+/// (0=foundational, 1=intermediate, 2=specialized, -1=unknown).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Decomposition {
+    pub atoms: Vec<String>,
+    pub generality: Vec<i64>,
+}
+
+/// Build the batch prompt body for a slice of `(local_index, statement)`.
+pub fn build_batch_prompt(claims: &[(usize, &str)]) -> String {
+    let body = claims
+        .iter()
+        .map(|(idx, stmt)| format!("[{idx}] {stmt}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    DECOMPOSE_BATCH_PROMPT.replace("{claims}", &body)
+}
+
+/// Parse a batch decomposition response into `local_index -> Decomposition`.
+///
+/// Hardened port of V2 `_parse_batch_response`: tolerant to a JSON object, a
+/// markdown ```json fence, leading/trailing prose, integer-or-string keys, and
+/// a bare atoms array (no generality). Invalid/empty atom lists for a key are
+/// dropped (NOT defaulted to a single atom) so a malformed entry never
+/// fabricates a decomposition. Generality is sanitized to the {-1,0,1,2} set
+/// and length-matched to atoms (mismatch -> all -1). The length-mismatch,
+/// out-of-range, and non-string-drop behaviors are intentional additions over
+/// V2 (see module doc; pinned by the tests below).
+pub fn parse_batch_response(raw: &str) -> std::collections::BTreeMap<usize, Decomposition> {
+    let mut out = std::collections::BTreeMap::new();
+
+    // Strip a markdown code fence if present (```json ... ``` or ``` ... ```).
+    let text = strip_code_fence(raw);
+    // Slice to the outermost {...}.
+    let (start, end) = match (text.find('{'), text.rfind('}')) {
+        (Some(s), Some(e)) if e > s => (s, e + 1),
+        _ => return out,
+    };
+    let parsed: Value = match serde_json::from_str(&text[start..end]) {
+        Ok(v) => v,
+        Err(_) => return out,
+    };
+    let Some(obj) = parsed.as_object() else {
+        return out;
+    };
+
+    for (key, val) in obj {
+        let Ok(idx) = key.parse::<usize>() else {
+            continue;
+        };
+        // Accept {"atoms":[...], "generality":[...]} OR a bare [..] array.
+        let (atoms_val, gen_val) = match val {
+            Value::Object(m) => (m.get("atoms").cloned(), m.get("generality").cloned()),
+            Value::Array(_) => (Some(val.clone()), None),
+            _ => continue,
+        };
+        let Some(Value::Array(atoms_arr)) = atoms_val else {
+            continue;
+        };
+        let atoms: Vec<String> = atoms_arr
+            .iter()
+            .filter_map(|a| a.as_str().map(str::to_string))
+            .collect();
+        // Drop entries whose atoms aren't all strings, or are empty.
+        if atoms.is_empty() || atoms.len() != atoms_arr.len() {
+            continue;
+        }
+        let generality = match gen_val {
+            Some(Value::Array(g)) if g.len() == atoms.len() => g
+                .iter()
+                // Only 0/1/2 are valid generality tiers; anything else
+                // (out-of-range int, non-int) sanitizes to -1 (unknown).
+                .map(|v| v.as_i64().filter(|n| (0..=2).contains(n)).unwrap_or(-1))
+                .collect(),
+            _ => vec![-1; atoms.len()],
+        };
+        out.insert(idx, Decomposition { atoms, generality });
+    }
+    out
+}
+
+fn strip_code_fence(raw: &str) -> String {
+    let t = raw.trim();
+    if let Some(start) = t.find("```") {
+        let after = &t[start + 3..];
+        let after = after.strip_prefix("json").unwrap_or(after);
+        if let Some(end) = after.find("```") {
+            return after[..end].trim().to_string();
+        }
+    }
+    t.to_string()
+}
+
+#[cfg(feature = "db")]
+pub use db_writes::{persist_decomposition, PersistOutcome};
+
+#[cfg(feature = "db")]
+mod db_writes {
+    use super::Decomposition;
+    use epigraph_db::{ClaimRepository, EdgeRepository};
+    use sqlx::PgPool;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    /// What `persist_decomposition` did, for reporting/tests.
+    pub struct PersistOutcome {
+        pub atom_claim_ids: Vec<Uuid>,
+        pub edges_created: usize,
+        pub skipped_singletons: usize,
+    }
+
+    /// Persist one compound claim's atoms as child claims and wire
+    /// `parent -decomposes_to-> atom` edges.
+    ///
+    /// Direction is parent (source) -> child (target), matching
+    /// `epigraph_ingest::common::edges::decomposes_edge` and
+    /// `MCP link_hierarchical`. Idempotent on the edge triple via
+    /// `EdgeRepository::create_if_not_exists`.
+    ///
+    /// Atom claims are written through `submit_via` — a closure the caller
+    /// supplies that goes through the CANONICAL claim-create path so signing,
+    /// provenance, DS auto-wire and embed-on-write are preserved. In the
+    /// binary this closure POSTs to the local API `/api/v1/claims` (or calls
+    /// the in-process submit helper); in tests it is a fake that inserts a
+    /// minimal claim row, letting us verify the edge/label wiring WITHOUT an
+    /// LLM or an embedder.
+    ///
+    /// Single-atom decompositions are SKIPPED (a claim that decomposes to
+    /// exactly itself is already atomic — writing a self-equivalent child +
+    /// edge would pollute the graph and is what `is_current`-atoms look like).
+    pub async fn persist_decomposition<F, Fut>(
+        pool: &PgPool,
+        parent_id: Uuid,
+        decomp: &Decomposition,
+        embedder: Option<Arc<dyn epigraph_embeddings::EmbeddingService>>,
+        submit_via: F,
+    ) -> Result<PersistOutcome, Box<dyn std::error::Error>>
+    where
+        F: Fn(String, i64) -> Fut,
+        Fut: std::future::Future<Output = Result<Uuid, Box<dyn std::error::Error>>>,
+    {
+        // Already atomic: nothing to decompose.
+        if decomp.atoms.len() <= 1 {
+            return Ok(PersistOutcome {
+                atom_claim_ids: vec![],
+                edges_created: 0,
+                skipped_singletons: 1,
+            });
+        }
+        // Guard: parent must still be current (never wire onto a retired claim).
+        if !ClaimRepository::are_all_current(pool, &[parent_id]).await? {
+            return Err(format!("parent claim {parent_id} is not current").into());
+        }
+        let mut atom_ids = Vec::with_capacity(decomp.atoms.len());
+        let mut edges = 0usize;
+        for (i, atom) in decomp.atoms.iter().enumerate() {
+            let gen = decomp.generality.get(i).copied().unwrap_or(-1);
+            let atom_id = submit_via(atom.clone(), gen).await?;
+            // Best-effort embed-on-write when the caller passes a live embedder
+            // and the submit path did not already embed (API path embeds; the
+            // direct-insert test fake does not).
+            if let Some(ref e) = embedder {
+                if let Ok(vec) = e.generate(atom).await {
+                    let _ = e.store(atom_id, &vec).await;
+                }
+            }
+            let (_row, was_created) = EdgeRepository::create_if_not_exists(
+                pool,
+                parent_id,
+                "claim",
+                atom_id,
+                "claim",
+                "decomposes_to",
+                Some(serde_json::json!({"generality": gen, "via": "decompose_claims"})),
+                None,
+                None,
+            )
+            .await?;
+            if was_created {
+                edges += 1;
+            }
+            atom_ids.push(atom_id);
+        }
+        Ok(PersistOutcome {
+            atom_claim_ids: atom_ids,
+            edges_created: edges,
+            skipped_singletons: 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_object_with_atoms_and_generality() {
+        let raw = r#"{"0": {"atoms": ["X is Y", "X causes Z"], "generality": [0, 1]}}"#;
+        let out = parse_batch_response(raw);
+        let d = out.get(&0).expect("index 0 parsed");
+        assert_eq!(d.atoms, vec!["X is Y".to_string(), "X causes Z".to_string()]);
+        assert_eq!(d.generality, vec![0, 1]);
+    }
+
+    #[test]
+    fn recovers_json_from_markdown_fence_with_prose() {
+        let raw = "Here you go:\n```json\n{\"2\": {\"atoms\": [\"A\", \"B\"], \"generality\": [1, 2]}}\n```\nDone.";
+        let out = parse_batch_response(raw);
+        assert!(out.contains_key(&2), "must recover the fenced object despite surrounding prose");
+        assert_eq!(out.get(&2).unwrap().atoms.len(), 2);
+    }
+
+    #[test]
+    fn malformed_json_yields_empty_not_panic() {
+        assert!(parse_batch_response("not json at all").is_empty());
+        assert!(parse_batch_response("{ broken").is_empty());
+        assert!(parse_batch_response("").is_empty());
+    }
+
+    #[test]
+    fn bare_array_form_defaults_generality_to_unknown() {
+        let raw = r#"{"0": ["only atom", "second atom"]}"#;
+        let d = parse_batch_response(raw);
+        let entry = d.get(&0).unwrap();
+        assert_eq!(entry.atoms.len(), 2);
+        assert_eq!(entry.generality, vec![-1, -1], "bare array has no generality => all -1");
+    }
+
+    #[test]
+    fn generality_length_mismatch_falls_back_to_unknown() {
+        let raw = r#"{"0": {"atoms": ["a", "b"], "generality": [0]}}"#;
+        let d = parse_batch_response(raw).remove(&0).unwrap();
+        assert_eq!(d.generality, vec![-1, -1], "mismatched generality length must be discarded, not zip-truncated");
+    }
+
+    #[test]
+    fn entry_with_non_string_atoms_is_dropped_not_coerced() {
+        let raw = r#"{"0": {"atoms": ["valid", 42], "generality": [0, 1]}, "1": {"atoms": ["good"], "generality": [0]}}"#;
+        let out = parse_batch_response(raw);
+        assert!(!out.contains_key(&0), "an atoms array with a non-string element must be dropped entirely (no fabricated decomposition)");
+        assert!(out.contains_key(&1), "the valid sibling entry survives");
+    }
+
+    #[test]
+    fn out_of_range_generality_clamped_to_unknown() {
+        let raw = r#"{"0": {"atoms": ["a", "b", "c"], "generality": [0, 7, -3]}}"#;
+        let d = parse_batch_response(raw).remove(&0).unwrap();
+        assert_eq!(d.generality, vec![0, -1, -1], "only 0/1/2 are valid tiers; others -> -1");
+    }
+}

--- a/crates/epigraph-cli/src/lib.rs
+++ b/crates/epigraph-cli/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod bootstrap;
 #[cfg(feature = "db")]
 pub mod bridge;
+pub mod decompose;
 pub mod enrichment;
 #[cfg(feature = "genai")]
 pub mod matching_client;

--- a/crates/epigraph-cli/tests/persist_decomposition_test.rs
+++ b/crates/epigraph-cli/tests/persist_decomposition_test.rs
@@ -12,12 +12,22 @@ use uuid::Uuid;
 async fn seed_agent(pool: &PgPool) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2,'hex'))")
-        .bind(id).bind("bb".repeat(32)).execute(pool).await.unwrap();
+        .bind(id)
+        .bind("bb".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
     id
 }
 async fn insert_min_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
     let id = Uuid::new_v4();
-    let hash: Vec<u8> = id.as_bytes().iter().copied().chain(std::iter::repeat_n(0,16)).take(32).collect();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
     sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current) VALUES ($1,$2,$3,0.5,$4,true)")
         .bind(id).bind(content).bind(hash).bind(agent).execute(pool).await.unwrap();
     id
@@ -26,21 +36,28 @@ async fn insert_min_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
 #[sqlx::test(migrations = "../../migrations")]
 async fn persists_atoms_and_wires_parent_to_child_edges(pool: PgPool) {
     let agent = seed_agent(&pool).await;
-    let parent = insert_min_claim(&pool, agent, "compound: gravity bends light and time dilates near mass").await;
+    let parent = insert_min_claim(
+        &pool,
+        agent,
+        "compound: gravity bends light and time dilates near mass",
+    )
+    .await;
 
     let decomp = Decomposition {
-        atoms: vec!["Gravity bends light".to_string(), "Time dilates near mass".to_string()],
+        atoms: vec![
+            "Gravity bends light".to_string(),
+            "Time dilates near mass".to_string(),
+        ],
         generality: vec![0, 1],
     };
     let pool_c = pool.clone();
-    let outcome = persist_decomposition(
-        &pool, parent, &decomp, None,
-        move |atom_text, _gen| {
-            let pool_c = pool_c.clone();
-            let agent = agent;
-            async move { Ok(insert_min_claim(&pool_c, agent, &atom_text).await) }
-        },
-    ).await.unwrap();
+    let outcome = persist_decomposition(&pool, parent, &decomp, None, move |atom_text, _gen| {
+        let pool_c = pool_c.clone();
+        let agent = agent;
+        async move { Ok(insert_min_claim(&pool_c, agent, &atom_text).await) }
+    })
+    .await
+    .unwrap();
 
     assert_eq!(outcome.atom_claim_ids.len(), 2);
     assert_eq!(outcome.edges_created, 2);
@@ -54,18 +71,28 @@ async fn persists_atoms_and_wires_parent_to_child_edges(pool: PgPool) {
         let cnt: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'")
             .bind(parent).bind(atom_id).fetch_one(&pool).await.unwrap();
-        assert_eq!(cnt, 1, "parent must be the SOURCE of decomposes_to and atom the TARGET");
+        assert_eq!(
+            cnt, 1,
+            "parent must be the SOURCE of decomposes_to and atom the TARGET"
+        );
         // No reversed edge.
         let rev: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'")
             .bind(atom_id).bind(parent).fetch_one(&pool).await.unwrap();
-        assert_eq!(rev, 0, "edge direction must be parent->child, never child->parent");
+        assert_eq!(
+            rev, 0,
+            "edge direction must be parent->child, never child->parent"
+        );
         // Generality recorded on the edge property — checked per-target so the
         // assertion is independent of edges.id ordering.
         let gen: serde_json::Value = sqlx::query_scalar(
             "SELECT properties->'generality' FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'")
             .bind(parent).bind(atom_id).fetch_one(&pool).await.unwrap();
-        assert_eq!(gen, serde_json::json!(expected_gen), "generality tier must be recorded on the matching edge");
+        assert_eq!(
+            gen,
+            serde_json::json!(expected_gen),
+            "generality tier must be recorded on the matching edge"
+        );
     }
 }
 
@@ -73,16 +100,31 @@ async fn persists_atoms_and_wires_parent_to_child_edges(pool: PgPool) {
 async fn single_atom_decomposition_is_skipped(pool: PgPool) {
     let agent = seed_agent(&pool).await;
     let parent = insert_min_claim(&pool, agent, "already atomic single proposition here").await;
-    let decomp = Decomposition { atoms: vec!["already atomic single proposition here".to_string()], generality: vec![0] };
+    let decomp = Decomposition {
+        atoms: vec!["already atomic single proposition here".to_string()],
+        generality: vec![0],
+    };
     let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let calls_c = calls.clone();
     let outcome = persist_decomposition(&pool, parent, &decomp, None, move |_t, _g| {
         calls_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         async move { Ok(Uuid::new_v4()) }
-    }).await.unwrap();
+    })
+    .await
+    .unwrap();
     assert_eq!(outcome.skipped_singletons, 1);
     assert_eq!(outcome.edges_created, 0);
-    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0, "single-atom decomposition must not submit or wire anything");
-    let cnt: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship='decomposes_to'").bind(parent).fetch_one(&pool).await.unwrap();
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "single-atom decomposition must not submit or wire anything"
+    );
+    let cnt: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship='decomposes_to'",
+    )
+    .bind(parent)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
     assert_eq!(cnt, 0);
 }

--- a/crates/epigraph-cli/tests/persist_decomposition_test.rs
+++ b/crates/epigraph-cli/tests/persist_decomposition_test.rs
@@ -1,0 +1,88 @@
+//! Integration test for `epigraph_cli::decompose::persist_decomposition`
+//! (item 46aee550). Uses an INJECTED submit closure that direct-inserts a
+//! minimal claim row, so we verify the parent->child decomposes_to wiring +
+//! generality property + single-atom skip WITHOUT an LLM or an embedder.
+//! Requires the `db` feature: run with `--features db`.
+#![cfg(feature = "db")]
+
+use epigraph_cli::decompose::{persist_decomposition, Decomposition};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2,'hex'))")
+        .bind(id).bind("bb".repeat(32)).execute(pool).await.unwrap();
+    id
+}
+async fn insert_min_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id.as_bytes().iter().copied().chain(std::iter::repeat_n(0,16)).take(32).collect();
+    sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current) VALUES ($1,$2,$3,0.5,$4,true)")
+        .bind(id).bind(content).bind(hash).bind(agent).execute(pool).await.unwrap();
+    id
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn persists_atoms_and_wires_parent_to_child_edges(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let parent = insert_min_claim(&pool, agent, "compound: gravity bends light and time dilates near mass").await;
+
+    let decomp = Decomposition {
+        atoms: vec!["Gravity bends light".to_string(), "Time dilates near mass".to_string()],
+        generality: vec![0, 1],
+    };
+    let pool_c = pool.clone();
+    let outcome = persist_decomposition(
+        &pool, parent, &decomp, None,
+        move |atom_text, _gen| {
+            let pool_c = pool_c.clone();
+            let agent = agent;
+            async move { Ok(insert_min_claim(&pool_c, agent, &atom_text).await) }
+        },
+    ).await.unwrap();
+
+    assert_eq!(outcome.atom_claim_ids.len(), 2);
+    assert_eq!(outcome.edges_created, 2);
+    assert_eq!(outcome.skipped_singletons, 0);
+
+    // Direction: parent is SOURCE, atom is TARGET. Assert via SQL on edges.
+    // Also assert generality per-target (NOT positionally via `ORDER BY id`,
+    // which is gen_random_uuid -> random): atom ids come back in atom order,
+    // so zip each with its expected generality and check that specific edge.
+    for (atom_id, expected_gen) in outcome.atom_claim_ids.iter().zip([0i64, 1]) {
+        let cnt: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'")
+            .bind(parent).bind(atom_id).fetch_one(&pool).await.unwrap();
+        assert_eq!(cnt, 1, "parent must be the SOURCE of decomposes_to and atom the TARGET");
+        // No reversed edge.
+        let rev: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'")
+            .bind(atom_id).bind(parent).fetch_one(&pool).await.unwrap();
+        assert_eq!(rev, 0, "edge direction must be parent->child, never child->parent");
+        // Generality recorded on the edge property — checked per-target so the
+        // assertion is independent of edges.id ordering.
+        let gen: serde_json::Value = sqlx::query_scalar(
+            "SELECT properties->'generality' FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'decomposes_to'")
+            .bind(parent).bind(atom_id).fetch_one(&pool).await.unwrap();
+        assert_eq!(gen, serde_json::json!(expected_gen), "generality tier must be recorded on the matching edge");
+    }
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn single_atom_decomposition_is_skipped(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let parent = insert_min_claim(&pool, agent, "already atomic single proposition here").await;
+    let decomp = Decomposition { atoms: vec!["already atomic single proposition here".to_string()], generality: vec![0] };
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let calls_c = calls.clone();
+    let outcome = persist_decomposition(&pool, parent, &decomp, None, move |_t, _g| {
+        calls_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        async move { Ok(Uuid::new_v4()) }
+    }).await.unwrap();
+    assert_eq!(outcome.skipped_singletons, 1);
+    assert_eq!(outcome.edges_created, 0);
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0, "single-atom decomposition must not submit or wire anything");
+    let cnt: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM edges WHERE source_id = $1 AND relationship='decomposes_to'").bind(parent).fetch_one(&pool).await.unwrap();
+    assert_eq!(cnt, 0);
+}

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -1042,6 +1042,91 @@ impl ClaimRepository {
         Ok(out)
     }
 
+    /// List claims that have NEVER been touched by decomposition: claims that
+    /// are neither the source (parent) nor the target (child) of any
+    /// `decomposes_to` edge.
+    ///
+    /// `decomposes_to` is parent -> child (source = compound/parent, target =
+    /// atom/child) — see `epigraph_ingest::common::edges::decomposes_edge`
+    /// ("Build a decomposes_to edge between two claim nodes ... for parent ->
+    /// child relationships"). A leaf atom therefore has only an *incoming*
+    /// decomposes_to edge, so an outgoing-only predicate would wrongly
+    /// re-select every atom for re-decomposition. We exclude BOTH directions —
+    /// matching V2 `scripts/export_decomposition_input.py`'s
+    /// `NOT EXISTS (... source_id = c.id ...) AND NOT EXISTS (... target_id =
+    /// c.id ...)` predicate — so only standalone claims created via
+    /// non-hierarchical paths (`memorize`, `submit_claim`, workflow outputs,
+    /// legacy imports) are returned.
+    ///
+    /// Excludes host-telemetry claims (the `telemetry` label OR a
+    /// `properties->>'event'` marker) per the repo embedding policy — these
+    /// are container/task lifecycle noise with no decomposable propositional
+    /// content, and replace V2's brittle `content LIKE 'Agent sent message%'`
+    /// skip-patterns. Also drops trivially short content (`length > 10`), the
+    /// one filter ported verbatim from V2.
+    ///
+    /// Ordered `created_at ASC` (oldest first) so a bounded batch makes
+    /// monotonic progress through the backlog across scheduled runs.
+    pub async fn list_undecomposed(
+        pool: &PgPool,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Claim>, DbError> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            id: Uuid,
+            content: String,
+            truth_value: f64,
+            agent_id: Uuid,
+            trace_id: Option<Uuid>,
+            created_at: chrono::DateTime<chrono::Utc>,
+            updated_at: chrono::DateTime<chrono::Utc>,
+        }
+
+        let limit = limit.clamp(1, 1000);
+        let offset = offset.max(0);
+        let rows = sqlx::query_as::<_, Row>(
+            r#"
+            SELECT c.id, c.content, c.truth_value, c.agent_id, c.trace_id,
+                   c.created_at, c.updated_at
+            FROM claims c
+            WHERE COALESCE(c.is_current, true) = true
+              AND length(c.content) > 10
+              AND NOT ('telemetry' = ANY(c.labels))
+              AND (c.properties ->> 'event') IS NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM edges e
+                  WHERE e.source_id = c.id AND e.relationship = 'decomposes_to'
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM edges e
+                  WHERE e.target_id = c.id AND e.relationship = 'decomposes_to'
+              )
+            ORDER BY c.created_at ASC
+            LIMIT $1 OFFSET $2
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
+
+        let mut claims = Vec::with_capacity(rows.len());
+        for row in rows {
+            let truth_value = TruthValue::new(row.truth_value)?;
+            claims.push(claim_from_row(
+                row.id,
+                row.content,
+                row.agent_id,
+                row.trace_id,
+                truth_value,
+                row.created_at,
+                row.updated_at,
+            ));
+        }
+        Ok(claims)
+    }
+
     /// Search workflow-tagged claims by content text match.
     ///
     /// Used by find_workflow MCP tool as a fallback when semantic search via

--- a/crates/epigraph-db/tests/list_undecomposed.rs
+++ b/crates/epigraph-db/tests/list_undecomposed.rs
@@ -12,13 +12,29 @@ use uuid::Uuid;
 async fn seed_agent(pool: &PgPool) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2,'hex'))")
-        .bind(id).bind("aa".repeat(32)).execute(pool).await.unwrap();
+        .bind(id)
+        .bind("aa".repeat(32))
+        .execute(pool)
+        .await
+        .unwrap();
     id
 }
 
-async fn seed_claim(pool: &PgPool, agent: Uuid, content: &str, labels: &[&str], props: serde_json::Value) -> Uuid {
+async fn seed_claim(
+    pool: &PgPool,
+    agent: Uuid,
+    content: &str,
+    labels: &[&str],
+    props: serde_json::Value,
+) -> Uuid {
     let id = Uuid::new_v4();
-    let hash: Vec<u8> = id.as_bytes().iter().copied().chain(std::iter::repeat_n(0,16)).take(32).collect();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
     sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id, labels, is_current, properties) VALUES ($1,$2,$3,0.5,$4,$5,true,$6)")
         .bind(id).bind(content).bind(hash).bind(agent)
         .bind(labels.iter().map(|s| s.to_string()).collect::<Vec<_>>())
@@ -31,23 +47,81 @@ async fn seed_claim(pool: &PgPool, agent: Uuid, content: &str, labels: &[&str], 
 async fn list_undecomposed_excludes_both_edge_directions_and_noise(pool: PgPool) {
     let agent = seed_agent(&pool).await;
 
-    let parent = seed_claim(&pool, agent, "a compound claim that was already decomposed", &[], serde_json::json!({})).await;
-    let child = seed_claim(&pool, agent, "an atom child of the compound claim above", &[], serde_json::json!({})).await;
-    EdgeRepository::create_if_not_exists(&pool, parent, "claim", child, "claim", "decomposes_to", None, None, None).await.unwrap();
+    let parent = seed_claim(
+        &pool,
+        agent,
+        "a compound claim that was already decomposed",
+        &[],
+        serde_json::json!({}),
+    )
+    .await;
+    let child = seed_claim(
+        &pool,
+        agent,
+        "an atom child of the compound claim above",
+        &[],
+        serde_json::json!({}),
+    )
+    .await;
+    EdgeRepository::create_if_not_exists(
+        &pool,
+        parent,
+        "claim",
+        child,
+        "claim",
+        "decomposes_to",
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
-    let standalone = seed_claim(&pool, agent, "a standalone compound claim never decomposed at all", &[], serde_json::json!({})).await;
-    let telemetry = seed_claim(&pool, agent, "Agent sent message to container epiclaw worker", &["telemetry"], serde_json::json!({"event": "agent_output"})).await;
+    let standalone = seed_claim(
+        &pool,
+        agent,
+        "a standalone compound claim never decomposed at all",
+        &[],
+        serde_json::json!({}),
+    )
+    .await;
+    let telemetry = seed_claim(
+        &pool,
+        agent,
+        "Agent sent message to container epiclaw worker",
+        &["telemetry"],
+        serde_json::json!({"event": "agent_output"}),
+    )
+    .await;
     let short = seed_claim(&pool, agent, "tiny", &[], serde_json::json!({})).await;
 
-    let rows = ClaimRepository::list_undecomposed(&pool, 50, 0).await.unwrap();
+    let rows = ClaimRepository::list_undecomposed(&pool, 50, 0)
+        .await
+        .unwrap();
     let ids: std::collections::HashSet<Uuid> = rows.iter().map(|c| c.id.as_uuid()).collect();
 
-    assert!(ids.contains(&standalone), "standalone claim (no decomposes_to edge either direction) must be returned");
-    assert!(!ids.contains(&parent), "parent of a decomposes_to edge (outgoing) must be excluded");
+    assert!(
+        ids.contains(&standalone),
+        "standalone claim (no decomposes_to edge either direction) must be returned"
+    );
+    assert!(
+        !ids.contains(&parent),
+        "parent of a decomposes_to edge (outgoing) must be excluded"
+    );
     assert!(!ids.contains(&child), "child of a decomposes_to edge (incoming) must be excluded — outgoing-only predicate would wrongly include this atom");
-    assert!(!ids.contains(&telemetry), "telemetry claim must be excluded");
-    assert!(!ids.contains(&short), "too-short (<=10 char) content must be excluded");
-    assert_eq!(rows.len(), 1, "exactly the one standalone claim is undecomposed");
+    assert!(
+        !ids.contains(&telemetry),
+        "telemetry claim must be excluded"
+    );
+    assert!(
+        !ids.contains(&short),
+        "too-short (<=10 char) content must be excluded"
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly the one standalone claim is undecomposed"
+    );
     let _ = ClaimId::from_uuid(standalone);
 }
 
@@ -56,13 +130,26 @@ async fn list_undecomposed_orders_oldest_first_and_pages(pool: PgPool) {
     let agent = seed_agent(&pool).await;
     let mut seeded = Vec::new();
     for i in 0..3 {
-        seeded.push(seed_claim(&pool, agent, &format!("standalone undecomposed claim number {i}"), &[], serde_json::json!({})).await);
+        seeded.push(
+            seed_claim(
+                &pool,
+                agent,
+                &format!("standalone undecomposed claim number {i}"),
+                &[],
+                serde_json::json!({}),
+            )
+            .await,
+        );
     }
     // created_at ASC => insertion order.
-    let page1 = ClaimRepository::list_undecomposed(&pool, 2, 0).await.unwrap();
+    let page1 = ClaimRepository::list_undecomposed(&pool, 2, 0)
+        .await
+        .unwrap();
     assert_eq!(page1.len(), 2);
     assert_eq!(page1[0].id.as_uuid(), seeded[0], "oldest first");
-    let page2 = ClaimRepository::list_undecomposed(&pool, 2, 2).await.unwrap();
+    let page2 = ClaimRepository::list_undecomposed(&pool, 2, 2)
+        .await
+        .unwrap();
     assert_eq!(page2.len(), 1);
     assert_eq!(page2[0].id.as_uuid(), seeded[2]);
 }

--- a/crates/epigraph-db/tests/list_undecomposed.rs
+++ b/crates/epigraph-db/tests/list_undecomposed.rs
@@ -1,0 +1,68 @@
+//! Integration tests for `ClaimRepository::list_undecomposed` — the
+//! 'never touched by decomposition' predicate (item 46aee550). Seeds the
+//! cross-product of edge states (outgoing-only, incoming-only, none) plus the
+//! two exclusion classes (telemetry, too-short) so a regression in ANY arm
+//! of the WHERE clause surfaces here.
+
+use epigraph_core::ClaimId;
+use epigraph_db::{ClaimRepository, EdgeRepository};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2,'hex'))")
+        .bind(id).bind("aa".repeat(32)).execute(pool).await.unwrap();
+    id
+}
+
+async fn seed_claim(pool: &PgPool, agent: Uuid, content: &str, labels: &[&str], props: serde_json::Value) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id.as_bytes().iter().copied().chain(std::iter::repeat_n(0,16)).take(32).collect();
+    sqlx::query("INSERT INTO claims (id, content, content_hash, truth_value, agent_id, labels, is_current, properties) VALUES ($1,$2,$3,0.5,$4,$5,true,$6)")
+        .bind(id).bind(content).bind(hash).bind(agent)
+        .bind(labels.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+        .bind(props)
+        .execute(pool).await.unwrap();
+    id
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn list_undecomposed_excludes_both_edge_directions_and_noise(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+
+    let parent = seed_claim(&pool, agent, "a compound claim that was already decomposed", &[], serde_json::json!({})).await;
+    let child = seed_claim(&pool, agent, "an atom child of the compound claim above", &[], serde_json::json!({})).await;
+    EdgeRepository::create_if_not_exists(&pool, parent, "claim", child, "claim", "decomposes_to", None, None, None).await.unwrap();
+
+    let standalone = seed_claim(&pool, agent, "a standalone compound claim never decomposed at all", &[], serde_json::json!({})).await;
+    let telemetry = seed_claim(&pool, agent, "Agent sent message to container epiclaw worker", &["telemetry"], serde_json::json!({"event": "agent_output"})).await;
+    let short = seed_claim(&pool, agent, "tiny", &[], serde_json::json!({})).await;
+
+    let rows = ClaimRepository::list_undecomposed(&pool, 50, 0).await.unwrap();
+    let ids: std::collections::HashSet<Uuid> = rows.iter().map(|c| c.id.as_uuid()).collect();
+
+    assert!(ids.contains(&standalone), "standalone claim (no decomposes_to edge either direction) must be returned");
+    assert!(!ids.contains(&parent), "parent of a decomposes_to edge (outgoing) must be excluded");
+    assert!(!ids.contains(&child), "child of a decomposes_to edge (incoming) must be excluded — outgoing-only predicate would wrongly include this atom");
+    assert!(!ids.contains(&telemetry), "telemetry claim must be excluded");
+    assert!(!ids.contains(&short), "too-short (<=10 char) content must be excluded");
+    assert_eq!(rows.len(), 1, "exactly the one standalone claim is undecomposed");
+    let _ = ClaimId::from_uuid(standalone);
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn list_undecomposed_orders_oldest_first_and_pages(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let mut seeded = Vec::new();
+    for i in 0..3 {
+        seeded.push(seed_claim(&pool, agent, &format!("standalone undecomposed claim number {i}"), &[], serde_json::json!({})).await);
+    }
+    // created_at ASC => insertion order.
+    let page1 = ClaimRepository::list_undecomposed(&pool, 2, 0).await.unwrap();
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1[0].id.as_uuid(), seeded[0], "oldest first");
+    let page2 = ClaimRepository::list_undecomposed(&pool, 2, 2).await.unwrap();
+    assert_eq!(page2.len(), 1);
+    assert_eq!(page2[0].id.as_uuid(), seeded[2]);
+}

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -49,6 +49,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("query_claims_by_methodology", "claims:read"),
     ("query_paper", "claims:read"),
     ("query_triples", "claims:read"),
+    ("query_undecomposed_claims", "claims:read"),
     ("recall", "claims:read"),
     ("recall_with_context", "claims:read"),
     ("scoped_belief", "claims:read"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -184,7 +184,7 @@ impl EpiGraphMcpFull {
         }
     }
 
-    // ── Claims (5 tools) ──
+    // ── Claims (11 tools) ──
 
     #[tool(
         description = "Submit an epistemic claim with evidence. The full evidence text is preserved for human audit. Supports all evidence types (empirical 1.0x, statistical 0.9x, logical 0.85x, testimonial 0.6x). Prefer this over memorize when you have a source or data to cite."
@@ -205,6 +205,16 @@ impl EpiGraphMcpFull {
         Parameters(params): Parameters<QueryClaimsParams>,
     ) -> Result<CallToolResult, McpError> {
         tools::claims::query_claims(self, params).await
+    }
+
+    #[tool(
+        description = "List claims that have NEVER been decomposed — claims that are neither parent (source) nor child (target) of any decomposes_to edge. These are standalone claims from non-hierarchical paths (memorize, submit_claim, legacy imports). Excludes host-telemetry claims and content <=10 chars. Ordered oldest-first. Step 1 of the 'Process undecomposed claims through decomposition pipeline' workflow; feed the returned claim_ids to the decompose_claims CLI."
+    )]
+    async fn query_undecomposed_claims(
+        &self,
+        Parameters(params): Parameters<crate::types::QueryUndecomposedClaimsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        tools::claims::query_undecomposed_claims(self, params).await
     }
 
     #[tool(

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -646,3 +646,32 @@ pub async fn patch_claim(
         "after_trace": diff.after_trace,
     }))
 }
+
+pub async fn query_undecomposed_claims(
+    server: &EpiGraphMcpFull,
+    params: crate::types::QueryUndecomposedClaimsParams,
+) -> Result<CallToolResult, McpError> {
+    let limit = params.limit.unwrap_or(50).clamp(1, 1000);
+    let offset = params.offset.unwrap_or(0).max(0);
+
+    let claims = ClaimRepository::list_undecomposed(&server.pool, limit, offset)
+        .await
+        .map_err(internal_error)?;
+
+    let results: Vec<ClaimResponse> = claims
+        .into_iter()
+        .map(|c| ClaimResponse {
+            id: c.id.as_uuid().to_string(),
+            content: c.content.clone(),
+            truth_value: c.truth_value.value(),
+            agent_id: c.agent_id.as_uuid().to_string(),
+            content_hash: ContentHasher::to_hex(&c.content_hash),
+            created_at: c.created_at.to_rfc3339(),
+            labels: Vec::new(),
+            is_current: true,
+            supersedes: None,
+        })
+        .collect();
+
+    success_json(&results)
+}

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -89,6 +89,20 @@ pub struct QueryClaimsParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct QueryUndecomposedClaimsParams {
+    #[schemars(
+        description = "Maximum number of undecomposed claims to return (default 50, max 1000). Claims are ordered created_at ASC (oldest first) so scheduled runs make monotonic progress."
+    )]
+    pub limit: Option<i64>,
+
+    #[schemars(
+        description = "Skip the first N matching claims (default 0). Combine with limit to page through the backlog."
+    )]
+    #[serde(default)]
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetClaimParams {
     #[schemars(description = "The UUID of the claim to retrieve")]
     pub claim_id: String,


### PR DESCRIPTION
## What

Resurrects the deployed epiclaw `decomposition-cycle` scheduled task (cron `0 0 23 * * 5`, in the deployed epiclaw-release config — not the current epiclaw-host repo, which uses a DB-backed scheduler) by building the two genuinely net-new primitives its prompt needs, mirroring the tier2-enrichment / cdst-backfill resolution pattern (real primitives + a graph-registered workflow on top):

1. **`ClaimRepository::list_undecomposed`** (epigraph-db) — selects claims that are neither parent (source) nor child (target) of any `decomposes_to` edge, excluding host-telemetry and trivially-short claims. Surfaced as the read-only MCP tool **`query_undecomposed_claims`**.
2. **`decompose` core + `decompose_claims` CLI** (epigraph-cli) — a hardened port of the deterministic logic of V2 `decompose_claims_claude.py` (prompt + tolerant response parser) plus `persist_decomposition`, which writes atoms through the canonical claim-create path (embed + DS + sign on write) and wires `parent -decomposes_to-> atom` edges. The model call goes through `create_llm_client("epigraph")` (prefers `CLAUDE_CODE_OAUTH_TOKEN`, the prepaid path). The V2 `_api.py`/`_openai.py` SDK variants are REJECTED per `feedback_claude_cli_oauth`.

## Why this is build+wire, not retire (the fork)

`decomposes_to` is actively consumed: `clusters/build-from-bridges` runs Louvain over `decomposes_to` (migration 028) and `recall_with_context` reconstructs paragraphs from it — atoms missing the edge degrade clustering and recall. The task is in the LIVE deployed schedule, and `find_workflow("Process undecomposed claims through decomposition pipeline")` returns `[]` today (confirmed live during authoring), so the schedule is dead with nothing to resolve. Resolution is build the primitives + register the workflow.

**Alternative (surfaced to owner):** if the team decides non-hierarchical claim sources (`memorize`, `submit_claim`, legacy imports) should simply not exist — i.e. all ingestion routed through hierarchical extraction — then the correct fix is to RETIRE the `decomposition-cycle` schedule entry instead. That is an epiclaw-release / epiclaw-host change, out of scope for this epigraph PR. This PR takes the build+wire branch; flag if you prefer retire.

## Direction correctness

The seed said 'lacking *outgoing* decomposes_to'. That is wrong for the predicate: `decomposes_to` is parent→child (verified: `epigraph_ingest::common::edges::decomposes_edge`), so leaf atoms have only an *incoming* edge — an outgoing-only filter would re-select every atom for re-decomposition. We exclude BOTH directions (matching V2 `export_decomposition_input.py`). A regression test pins this exact distinction.

## Scope boundaries / follow-ups

- **Workflow registration is a POST-MERGE deploy step** (see Verifiability), not in this PR, because `store_workflow` embeds steps inline and the referenced tools must exist first.
- **Schedule prompt fix** (point step-1 at the now-registered workflow) is an epiclaw-release / epiclaw-host change, separate item.
- The binary's POST /api/v1/claims request/response field names must be reconciled against `routes/claims.rs::create_claim` before first live run.

## Verifiability

**VERIFIED (cargo-test, ephemeral Postgres via sqlx::test, no API keys):** the `list_undecomposed` predicate (both-direction exclusion, telemetry/short filtering, oldest-first paging); the response parser (7 adversarial cases — fences, prose, malformed, bare array, mismatched/out-of-range generality, non-string atoms); `persist_decomposition` edge wiring (parent→child direction with explicit no-reversed-edge assertion, generality property asserted per-target so it is independent of edges.id ordering, single-atom skip) via an injected submit fake. The `decompose_claims --dry-run` enumeration path was run live against the test DB. Compiles + clippy `-D warnings` clean across the touched `--lib` and new `--test`/`--bin` targets. No DB migration; no `cargo sqlx prepare` needed (runtime `query_as`).

**NOT verified in this harness (compiles-only scaffold):** the live `claude` LLM call in `decompose_claims` (no OAuth token / no network in CI), the HTTP claim-create contract in the binary (request/response field names must be reconciled against `routes/claims.rs::create_claim`), and the MCP tool over a live transport. A read-only `find_workflow(...)` was run live and returned `[]` (evidence only). The post-merge `store_workflow` registration is a deploy step, not runtime-verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
