### PR TITLE
refactor(db): route matcher edge writes through EdgeRepository::create_symmetric_if_absent

### DIFF
--- a/crates/epigraph-db/src/repos/edge.rs
+++ b/crates/epigraph-db/src/repos/edge.rs
@@ -1,6 +1,7 @@
 //! Edge repository for LPG-style relationships
 
 use crate::errors::DbError;
+use sqlx::types::Json;
 use sqlx::PgPool;
 use tracing::instrument;
 use uuid::Uuid;
@@ -170,6 +171,57 @@ impl EdgeRepository {
             },
             true,
         ))
+    }
+
+    /// Insert a `relationship` edge between `a` and `b` (both `claim`-typed),
+    /// skipping the insert when an edge with the same relationship already
+    /// connects the two in EITHER direction.
+    ///
+    /// This is the single home for the cross-source matcher's edge-write SQL:
+    /// the `Policy::write_edge` body in `epigraph-engine` and the
+    /// `decide_match_candidate` PROMOTE arm in `epigraph-mcp` both route
+    /// through it so the dedup form lives in one place. The existence check is
+    /// **bidirectional** — `(a,b)` and `(b,a)` with the same `relationship`
+    /// count as the same edge — because CORROBORATES is semantically symmetric
+    /// even though the row preserves the caller's `a,b` ordering (we do NOT
+    /// canonicalize).
+    ///
+    /// Returns `true` when a new row was inserted, `false` on a dedup hit.
+    ///
+    /// Single-statement `INSERT … SELECT … WHERE NOT EXISTS`; **not**
+    /// `ON CONFLICT` — migrations 017/018 dropped the unique triple index, so
+    /// there is no constraint to infer on. The matcher's `are_all_current`
+    /// guard stays at the MCP call site; this method is purely the write.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool, properties))]
+    pub async fn create_symmetric_if_absent(
+        pool: &PgPool,
+        a: Uuid,
+        b: Uuid,
+        relationship: &str,
+        properties: serde_json::Value,
+    ) -> Result<bool, DbError> {
+        let result = sqlx::query(
+            "INSERT INTO edges (source_id, source_type, target_id, target_type,
+                                relationship, properties)
+             SELECT $1, 'claim', $2, 'claim', $3, $4
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM edges
+                 WHERE ((source_id = $1 AND target_id = $2)
+                     OR (source_id = $2 AND target_id = $1))
+                   AND relationship = $3
+             )",
+        )
+        .bind(a)
+        .bind(b)
+        .bind(relationship)
+        .bind(Json(properties))
+        .execute(pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     /// Get edges by source entity

--- a/crates/epigraph-db/tests/edge_repo_tests.rs
+++ b/crates/epigraph-db/tests/edge_repo_tests.rs
@@ -90,3 +90,115 @@ async fn create_if_not_exists_distinguishes_by_relationship(pool: PgPool) {
         "different relationship → different edge"
     );
 }
+
+/// Count edges incident on either of two claims for a given relationship,
+/// in EITHER direction. The matcher treats CORROBORATES as symmetric, so this
+/// is the metric that proves bidirectional dedup.
+async fn incident_edge_count(pool: &PgPool, a: uuid::Uuid, b: uuid::Uuid, rel: &str) -> i64 {
+    let (count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges
+         WHERE relationship = $3
+           AND ((source_id = $1 AND target_id = $2)
+             OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(a)
+    .bind(b)
+    .bind(rel)
+    .fetch_one(pool)
+    .await
+    .expect("count edges");
+    count
+}
+
+/// LOAD-BEARING: `create_symmetric_if_absent` dedups in BOTH directions.
+///
+/// The forward call (A→B) inserts one CORROBORATES edge. The crucial assertion
+/// is the REVERSE call (B→A, same relationship): it must return `false` and
+/// must NOT add a second edge. A same-direction-only implementation would
+/// insert the reverse edge (returning `true`, count → 2); this is the only
+/// assertion that distinguishes symmetric dedup from a plain
+/// `(source,target,relationship)` check, so it is the heart of the refactor.
+#[sqlx::test(migrations = "../../migrations")]
+async fn reverse_direction_dedup_returns_false(pool: PgPool) {
+    let agent = make_agent(Some("sym"));
+    let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
+    let claim_a = make_claim(agent_row.id, "claim A for symmetric dedup", 0.5);
+    let claim_b = make_claim(agent_row.id, "claim B for symmetric dedup", 0.5);
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+
+    let props = serde_json::json!({"source": "cross_source_matcher", "score": 0.91});
+
+    // Forward A→B: first edge of this relationship → inserts.
+    let inserted = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+        .await
+        .expect("forward insert");
+    assert!(inserted, "first call must insert and return true");
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "CORROBORATES").await,
+        1,
+        "exactly one CORROBORATES edge after the forward call"
+    );
+
+    // Reverse B→A, same relationship: the symmetric existence check must see
+    // the existing (a→b) edge and SKIP. Returns false; count stays 1.
+    let inserted_reverse =
+        EdgeRepository::create_symmetric_if_absent(&pool, b, a, "CORROBORATES", props.clone())
+            .await
+            .expect("reverse call runs");
+    assert!(
+        !inserted_reverse,
+        "REVERSE-direction call must dedup (return false) — symmetric, not directional"
+    );
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "CORROBORATES").await,
+        1,
+        "reverse call must NOT add a second edge — count stays exactly 1"
+    );
+}
+
+/// Different relationships between the same pair are distinct edges — the
+/// dedup is scoped to `relationship`, not just the endpoints.
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) {
+    let agent = make_agent(Some("symrel"));
+    let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
+    let claim_a = make_claim(agent_row.id, "claim A for rel discrimination", 0.5);
+    let claim_b = make_claim(agent_row.id, "claim B for rel discrimination", 0.5);
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+
+    let props = serde_json::json!({"source": "cross_source_matcher"});
+
+    let first = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+        .await
+        .expect("corroborates insert");
+    assert!(first, "CORROBORATES must insert");
+
+    // A→B with a DIFFERENT relationship is a different edge → must insert.
+    let second = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
+        .await
+        .expect("contradicts insert");
+    assert!(second, "contradicts is a distinct relationship → must insert");
+
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "CORROBORATES").await,
+        1,
+        "one CORROBORATES edge"
+    );
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "contradicts").await,
+        1,
+        "one contradicts edge"
+    );
+    let total: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges
+         WHERE (source_id = $1 AND target_id = $2) OR (source_id = $2 AND target_id = $1)",
+    )
+    .bind(a)
+    .bind(b)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(total.0, 2, "two distinct edges total (one per relationship)");
+}

--- a/crates/epigraph-db/tests/edge_repo_tests.rs
+++ b/crates/epigraph-db/tests/edge_repo_tests.rs
@@ -124,15 +124,24 @@ async fn reverse_direction_dedup_returns_false(pool: PgPool) {
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
     let claim_a = make_claim(agent_row.id, "claim A for symmetric dedup", 0.5);
     let claim_b = make_claim(agent_row.id, "claim B for symmetric dedup", 0.5);
-    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
-    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a)
+        .await
+        .unwrap()
+        .id
+        .into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b)
+        .await
+        .unwrap()
+        .id
+        .into();
 
     let props = serde_json::json!({"source": "cross_source_matcher", "score": 0.91});
 
     // Forward A→B: first edge of this relationship → inserts.
-    let inserted = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
-        .await
-        .expect("forward insert");
+    let inserted =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+            .await
+            .expect("forward insert");
     assert!(inserted, "first call must insert and return true");
     assert_eq!(
         incident_edge_count(&pool, a, b, "CORROBORATES").await,
@@ -165,21 +174,34 @@ async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) 
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
     let claim_a = make_claim(agent_row.id, "claim A for rel discrimination", 0.5);
     let claim_b = make_claim(agent_row.id, "claim B for rel discrimination", 0.5);
-    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
-    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a)
+        .await
+        .unwrap()
+        .id
+        .into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b)
+        .await
+        .unwrap()
+        .id
+        .into();
 
     let props = serde_json::json!({"source": "cross_source_matcher"});
 
-    let first = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
-        .await
-        .expect("corroborates insert");
+    let first =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+            .await
+            .expect("corroborates insert");
     assert!(first, "CORROBORATES must insert");
 
     // A→B with a DIFFERENT relationship is a different edge → must insert.
-    let second = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
-        .await
-        .expect("contradicts insert");
-    assert!(second, "contradicts is a distinct relationship → must insert");
+    let second =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
+            .await
+            .expect("contradicts insert");
+    assert!(
+        second,
+        "contradicts is a distinct relationship → must insert"
+    );
 
     assert_eq!(
         incident_edge_count(&pool, a, b, "CORROBORATES").await,
@@ -200,5 +222,8 @@ async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) 
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(total.0, 2, "two distinct edges total (one per relationship)");
+    assert_eq!(
+        total.0, 2,
+        "two distinct edges total (one per relationship)"
+    );
 }

--- a/crates/epigraph-engine/src/matching/policy.rs
+++ b/crates/epigraph-engine/src/matching/policy.rs
@@ -9,7 +9,7 @@
 use crate::matching::scorer::MatchFeatures;
 use crate::matching::verifier::{map_relationship, Verdict};
 use epigraph_db::repos::match_candidate::MatchCandidateRepo;
-use sqlx::types::Json;
+use epigraph_db::EdgeRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -136,11 +136,12 @@ impl Policy {
         Ok(())
     }
 
-    /// Insert a claim→claim edge, skipping if the same (source, target,
-    /// relationship) triple already exists. The unique index
-    /// `idx_edges_unique_triple_non_authored` (migration 108) covers this for
-    /// CORROBORATES/contradicts; we still do an explicit existence check so
-    /// we don't depend on partial-index ON-CONFLICT inference quirks.
+    /// Insert a claim→claim edge, skipping if the same relationship already
+    /// connects the two claims in either direction. Delegates the dedup SQL to
+    /// [`EdgeRepository::create_symmetric_if_absent`] so the bidirectional
+    /// `WHERE NOT EXISTS` form lives in one place. Migrations 017/018 dropped
+    /// the unique triple index, so the explicit existence check (not
+    /// `ON CONFLICT`) is what prevents duplicates on re-run.
     async fn write_edge(
         &self,
         a: Uuid,
@@ -159,23 +160,7 @@ impl Policy {
             "verifier_rationale": v.map(|x| &x.rationale),
             "source":             "cross_source_matcher",
         });
-        sqlx::query(
-            "INSERT INTO edges (source_id, source_type, target_id, target_type,
-                                relationship, properties)
-             SELECT $1, 'claim', $2, 'claim', $3, $4
-             WHERE NOT EXISTS (
-                 SELECT 1 FROM edges
-                 WHERE ((source_id = $1 AND target_id = $2)
-                     OR (source_id = $2 AND target_id = $1))
-                   AND relationship = $3
-             )",
-        )
-        .bind(a)
-        .bind(b)
-        .bind(relationship)
-        .bind(Json(props))
-        .execute(&self.pool)
-        .await?;
+        EdgeRepository::create_symmetric_if_absent(&self.pool, a, b, relationship, props).await?;
         Ok(())
     }
 }

--- a/crates/epigraph-mcp/src/tools/matching.rs
+++ b/crates/epigraph-mcp/src/tools/matching.rs
@@ -15,13 +15,12 @@
 
 use rmcp::model::*;
 use serde::Serialize;
-use sqlx::types::Json;
 
 use crate::errors::{internal_error, invalid_params, parse_uuid, McpError};
 use crate::server::EpiGraphMcpFull;
 use crate::types::*;
 
-use epigraph_db::{ClaimRepository, MatchCandidateRepo};
+use epigraph_db::{ClaimRepository, EdgeRepository, MatchCandidateRepo};
 
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
@@ -161,9 +160,11 @@ pub async fn decide_match_candidate(
                 .map_err(internal_error)?;
 
             // Write CORROBORATES edge if it doesn't already exist (either
-            // direction). The unique-triple index was dropped in migration
-            // 109, so this explicit check is the only guard against
-            // duplicates from repeated `decide` calls.
+            // direction). The unique-triple index was dropped in migrations
+            // 017/018, so this explicit existence check — now centralized in
+            // `EdgeRepository::create_symmetric_if_absent` — is the only guard
+            // against duplicates from repeated `decide` calls. The
+            // are_all_current guard above stays here at the call site.
             let props = serde_json::json!({
                 "candidate_id":     candidate_id,
                 "score":            row.score,
@@ -172,21 +173,13 @@ pub async fn decide_match_candidate(
                 "decided_by":       acting_agent,
                 "source":           "cross_source_matcher",
             });
-            sqlx::query(
-                "INSERT INTO edges (source_id, source_type, target_id, target_type,
-                                     relationship, properties)
-                 SELECT $1, 'claim', $2, 'claim', 'CORROBORATES', $3
-                 WHERE NOT EXISTS (
-                     SELECT 1 FROM edges
-                     WHERE ((source_id = $1 AND target_id = $2)
-                         OR (source_id = $2 AND target_id = $1))
-                       AND relationship = 'CORROBORATES'
-                 )",
+            EdgeRepository::create_symmetric_if_absent(
+                &server.pool,
+                row.claim_a,
+                row.claim_b,
+                "CORROBORATES",
+                props,
             )
-            .bind(row.claim_a)
-            .bind(row.claim_b)
-            .bind(Json(props))
-            .execute(&server.pool)
             .await
             .map_err(internal_error)?;
         }

--- a/crates/epigraph-mcp/tests/matching_tools_smoke.rs
+++ b/crates/epigraph-mcp/tests/matching_tools_smoke.rs
@@ -36,6 +36,25 @@ async fn insert_claim(pool: &PgPool, agent: Uuid) -> Uuid {
     id
 }
 
+/// Insert a claim with `is_current = false` — a retired endpoint (superseded
+/// or marked-duplicate) that the `are_all_current` guard must refuse to
+/// promote an edge onto.
+async fn insert_retired_claim(pool: &PgPool, agent: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let content = format!("t19 retired {id}");
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, $2, sha256($2::bytea), 0.5, $3, false)",
+    )
+    .bind(id)
+    .bind(&content)
+    .bind(agent)
+    .execute(pool)
+    .await
+    .expect("retired claim");
+    id
+}
+
 async fn insert_agent(pool: &PgPool) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query(
@@ -280,5 +299,49 @@ async fn decide_match_candidate_rejected_in_read_only_mode(pool: PgPool) {
     assert!(
         format!("{err:?}").to_lowercase().contains("read-only"),
         "expected read-only refusal: {err:?}"
+    );
+}
+
+/// Guard survives the refactor: `are_all_current` lives at the MCP call site,
+/// NOT inside `EdgeRepository::create_symmetric_if_absent`. When one endpoint
+/// is `is_current = false`, promote must refuse and write NO edge. If a future
+/// edit folded the guard into the repo method (or dropped it), this catches it
+/// because the repo method has no notion of current-ness — backlog bug
+/// 5c7fc645 would re-open.
+#[sqlx::test(migrations = "../../migrations")]
+async fn decide_match_candidate_promote_blocked_when_endpoint_not_current(pool: PgPool) {
+    let server = build_server(pool.clone(), false).await; // write-enabled
+    let agent = insert_agent(&pool).await;
+    let live = insert_claim(&pool, agent).await;
+    let retired = insert_retired_claim(&pool, agent).await; // is_current = false
+    let cand = insert_candidate(&pool, live, retired, 0.97, "pending").await;
+
+    let err = tools::matching::decide_match_candidate(
+        &server,
+        DecideMatchCandidateParams {
+            candidate_id: cand.to_string(),
+            verdict: "promote".into(),
+        },
+    )
+    .await
+    .expect_err("promote must be refused when an endpoint is not current");
+    assert!(
+        format!("{err:?}").to_lowercase().contains("current"),
+        "refusal must cite the current-ness guard: {err:?}"
+    );
+
+    // The guard must short-circuit BEFORE any edge write.
+    let edge_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges WHERE relationship = 'CORROBORATES'
+         AND ((source_id = $1 AND target_id = $2) OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(live)
+    .bind(retired)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        edge_count.0, 0,
+        "no CORROBORATES edge may be written onto a retired claim"
     );
 }


### PR DESCRIPTION
## pure refactor — behavior-preserving

The cross-source matcher wrote graph edges via raw `INSERT INTO edges` at two sites — `Policy::write_edge` (engine) and the MCP `decide_match_candidate` promote arm — bypassing the repo layer (the repo's "all SQL lives in `crates/epigraph-db/src/repos/`" convention).

**Change:** add `EdgeRepository::create_symmetric_if_absent` (bidirectional `WHERE NOT EXISTS` on both `(a,b)`/`(b,a)`, **no** `ON CONFLICT` — migrations 017/018 dropped the unique triple index — plain `sqlx::query`, returns `rows_affected() > 0`) and route both call sites through it. The `are_all_current` guard **stays at the MCP call site** (not folded into the repo); ordering and props JSON preserved.

**Verification:** `edge_repo_tests` 4/4 (incl. `reverse_direction_dedup_returns_false`: the reverse B→A call returns `false` and the edge count stays 1 — the assertion that distinguishes symmetric dedup from a directional insert); `matching_tools_smoke` 7/7 (incl. promote-blocked-when-endpoint-not-current and read-only-mode).

**Base of the stack** — B1 and B2 stack on top. The matcher is **dormant in prod** (cross_source_sweep is not built/scheduled), so zero live-data risk. **Do not merge without human review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)