### PR TITLE
fix(engine): stage cross-source candidates as pending for human review when not auto-promoting

### DIFF
--- a/crates/epigraph-db/src/repos/edge.rs
+++ b/crates/epigraph-db/src/repos/edge.rs
@@ -1,6 +1,7 @@
 //! Edge repository for LPG-style relationships
 
 use crate::errors::DbError;
+use sqlx::types::Json;
 use sqlx::PgPool;
 use tracing::instrument;
 use uuid::Uuid;
@@ -170,6 +171,57 @@ impl EdgeRepository {
             },
             true,
         ))
+    }
+
+    /// Insert a `relationship` edge between `a` and `b` (both `claim`-typed),
+    /// skipping the insert when an edge with the same relationship already
+    /// connects the two in EITHER direction.
+    ///
+    /// This is the single home for the cross-source matcher's edge-write SQL:
+    /// the `Policy::write_edge` body in `epigraph-engine` and the
+    /// `decide_match_candidate` PROMOTE arm in `epigraph-mcp` both route
+    /// through it so the dedup form lives in one place. The existence check is
+    /// **bidirectional** — `(a,b)` and `(b,a)` with the same `relationship`
+    /// count as the same edge — because CORROBORATES is semantically symmetric
+    /// even though the row preserves the caller's `a,b` ordering (we do NOT
+    /// canonicalize).
+    ///
+    /// Returns `true` when a new row was inserted, `false` on a dedup hit.
+    ///
+    /// Single-statement `INSERT … SELECT … WHERE NOT EXISTS`; **not**
+    /// `ON CONFLICT` — migrations 017/018 dropped the unique triple index, so
+    /// there is no constraint to infer on. The matcher's `are_all_current`
+    /// guard stays at the MCP call site; this method is purely the write.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool, properties))]
+    pub async fn create_symmetric_if_absent(
+        pool: &PgPool,
+        a: Uuid,
+        b: Uuid,
+        relationship: &str,
+        properties: serde_json::Value,
+    ) -> Result<bool, DbError> {
+        let result = sqlx::query(
+            "INSERT INTO edges (source_id, source_type, target_id, target_type,
+                                relationship, properties)
+             SELECT $1, 'claim', $2, 'claim', $3, $4
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM edges
+                 WHERE ((source_id = $1 AND target_id = $2)
+                     OR (source_id = $2 AND target_id = $1))
+                   AND relationship = $3
+             )",
+        )
+        .bind(a)
+        .bind(b)
+        .bind(relationship)
+        .bind(Json(properties))
+        .execute(pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     /// Get edges by source entity

--- a/crates/epigraph-db/tests/edge_repo_tests.rs
+++ b/crates/epigraph-db/tests/edge_repo_tests.rs
@@ -90,3 +90,115 @@ async fn create_if_not_exists_distinguishes_by_relationship(pool: PgPool) {
         "different relationship → different edge"
     );
 }
+
+/// Count edges incident on either of two claims for a given relationship,
+/// in EITHER direction. The matcher treats CORROBORATES as symmetric, so this
+/// is the metric that proves bidirectional dedup.
+async fn incident_edge_count(pool: &PgPool, a: uuid::Uuid, b: uuid::Uuid, rel: &str) -> i64 {
+    let (count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges
+         WHERE relationship = $3
+           AND ((source_id = $1 AND target_id = $2)
+             OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(a)
+    .bind(b)
+    .bind(rel)
+    .fetch_one(pool)
+    .await
+    .expect("count edges");
+    count
+}
+
+/// LOAD-BEARING: `create_symmetric_if_absent` dedups in BOTH directions.
+///
+/// The forward call (A→B) inserts one CORROBORATES edge. The crucial assertion
+/// is the REVERSE call (B→A, same relationship): it must return `false` and
+/// must NOT add a second edge. A same-direction-only implementation would
+/// insert the reverse edge (returning `true`, count → 2); this is the only
+/// assertion that distinguishes symmetric dedup from a plain
+/// `(source,target,relationship)` check, so it is the heart of the refactor.
+#[sqlx::test(migrations = "../../migrations")]
+async fn reverse_direction_dedup_returns_false(pool: PgPool) {
+    let agent = make_agent(Some("sym"));
+    let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
+    let claim_a = make_claim(agent_row.id, "claim A for symmetric dedup", 0.5);
+    let claim_b = make_claim(agent_row.id, "claim B for symmetric dedup", 0.5);
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+
+    let props = serde_json::json!({"source": "cross_source_matcher", "score": 0.91});
+
+    // Forward A→B: first edge of this relationship → inserts.
+    let inserted = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+        .await
+        .expect("forward insert");
+    assert!(inserted, "first call must insert and return true");
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "CORROBORATES").await,
+        1,
+        "exactly one CORROBORATES edge after the forward call"
+    );
+
+    // Reverse B→A, same relationship: the symmetric existence check must see
+    // the existing (a→b) edge and SKIP. Returns false; count stays 1.
+    let inserted_reverse =
+        EdgeRepository::create_symmetric_if_absent(&pool, b, a, "CORROBORATES", props.clone())
+            .await
+            .expect("reverse call runs");
+    assert!(
+        !inserted_reverse,
+        "REVERSE-direction call must dedup (return false) — symmetric, not directional"
+    );
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "CORROBORATES").await,
+        1,
+        "reverse call must NOT add a second edge — count stays exactly 1"
+    );
+}
+
+/// Different relationships between the same pair are distinct edges — the
+/// dedup is scoped to `relationship`, not just the endpoints.
+#[sqlx::test(migrations = "../../migrations")]
+async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) {
+    let agent = make_agent(Some("symrel"));
+    let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
+    let claim_a = make_claim(agent_row.id, "claim A for rel discrimination", 0.5);
+    let claim_b = make_claim(agent_row.id, "claim B for rel discrimination", 0.5);
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+
+    let props = serde_json::json!({"source": "cross_source_matcher"});
+
+    let first = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+        .await
+        .expect("corroborates insert");
+    assert!(first, "CORROBORATES must insert");
+
+    // A→B with a DIFFERENT relationship is a different edge → must insert.
+    let second = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
+        .await
+        .expect("contradicts insert");
+    assert!(second, "contradicts is a distinct relationship → must insert");
+
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "CORROBORATES").await,
+        1,
+        "one CORROBORATES edge"
+    );
+    assert_eq!(
+        incident_edge_count(&pool, a, b, "contradicts").await,
+        1,
+        "one contradicts edge"
+    );
+    let total: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges
+         WHERE (source_id = $1 AND target_id = $2) OR (source_id = $2 AND target_id = $1)",
+    )
+    .bind(a)
+    .bind(b)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(total.0, 2, "two distinct edges total (one per relationship)");
+}

--- a/crates/epigraph-db/tests/edge_repo_tests.rs
+++ b/crates/epigraph-db/tests/edge_repo_tests.rs
@@ -124,15 +124,24 @@ async fn reverse_direction_dedup_returns_false(pool: PgPool) {
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
     let claim_a = make_claim(agent_row.id, "claim A for symmetric dedup", 0.5);
     let claim_b = make_claim(agent_row.id, "claim B for symmetric dedup", 0.5);
-    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
-    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a)
+        .await
+        .unwrap()
+        .id
+        .into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b)
+        .await
+        .unwrap()
+        .id
+        .into();
 
     let props = serde_json::json!({"source": "cross_source_matcher", "score": 0.91});
 
     // Forward A→B: first edge of this relationship → inserts.
-    let inserted = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
-        .await
-        .expect("forward insert");
+    let inserted =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+            .await
+            .expect("forward insert");
     assert!(inserted, "first call must insert and return true");
     assert_eq!(
         incident_edge_count(&pool, a, b, "CORROBORATES").await,
@@ -165,21 +174,34 @@ async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) 
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
     let claim_a = make_claim(agent_row.id, "claim A for rel discrimination", 0.5);
     let claim_b = make_claim(agent_row.id, "claim B for rel discrimination", 0.5);
-    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
-    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a)
+        .await
+        .unwrap()
+        .id
+        .into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b)
+        .await
+        .unwrap()
+        .id
+        .into();
 
     let props = serde_json::json!({"source": "cross_source_matcher"});
 
-    let first = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
-        .await
-        .expect("corroborates insert");
+    let first =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+            .await
+            .expect("corroborates insert");
     assert!(first, "CORROBORATES must insert");
 
     // A→B with a DIFFERENT relationship is a different edge → must insert.
-    let second = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
-        .await
-        .expect("contradicts insert");
-    assert!(second, "contradicts is a distinct relationship → must insert");
+    let second =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
+            .await
+            .expect("contradicts insert");
+    assert!(
+        second,
+        "contradicts is a distinct relationship → must insert"
+    );
 
     assert_eq!(
         incident_edge_count(&pool, a, b, "CORROBORATES").await,
@@ -200,5 +222,8 @@ async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) 
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(total.0, 2, "two distinct edges total (one per relationship)");
+    assert_eq!(
+        total.0, 2,
+        "two distinct edges total (one per relationship)"
+    );
 }

--- a/crates/epigraph-engine/src/matching/pipeline.rs
+++ b/crates/epigraph-engine/src/matching/pipeline.rs
@@ -28,6 +28,8 @@ pub struct RunReport {
     pub run_id: Uuid,
     pub scanned_pairs: usize,
     pub promoted: usize,
+    /// Candidates staged as `pending` for human review (`auto_promote=false`).
+    pub staged: usize,
     pub mid_band: usize,
     pub rejected: usize,
 }
@@ -115,10 +117,21 @@ pub async fn run_pipeline(pool: &PgPool, inputs: RunInputs) -> anyhow::Result<Ru
         }
     }
 
+    // When not auto-promoting, every AutoPromote/WriteContradicts decision
+    // above actually STAGED a `pending` candidate for human review (Policy
+    // wrote `status='pending'` under the same `auto_promote` flag), so report
+    // it honestly as `staged` rather than `promoted`.
+    let (promoted, staged) = if inputs.auto_promote {
+        (promoted, 0usize)
+    } else {
+        (0usize, promoted)
+    };
+
     Ok(RunReport {
         run_id,
         scanned_pairs: pairs.len(),
         promoted,
+        staged,
         mid_band,
         rejected,
     })

--- a/crates/epigraph-engine/src/matching/policy.rs
+++ b/crates/epigraph-engine/src/matching/policy.rs
@@ -61,7 +61,11 @@ impl Policy {
         // queue (`decide_match_candidate`, `MatchCandidateRepo::list_pending`,
         // the API `pending[]` array) had no producer at all, so the whole
         // human-review surface was dead in normal operation.
-        let promote_status = if self.auto_promote { "promoted" } else { "pending" };
+        let promote_status = if self.auto_promote {
+            "promoted"
+        } else {
+            "pending"
+        };
 
         match action {
             PolicyAction::AutoPromote => {

--- a/crates/epigraph-engine/src/matching/policy.rs
+++ b/crates/epigraph-engine/src/matching/policy.rs
@@ -54,6 +54,15 @@ impl Policy {
         // doesn't accept these as args yet; we patch them in below.
         let features_json = serde_json::to_value(f)?;
 
+        // `auto_promote` gates BOTH the edge write (below) AND whether the
+        // candidate is committed (`promoted`) or staged for human review
+        // (`pending`). Before this, `auto_promote=false` left the row as
+        // `promoted` with no edge — a half-state — and the `pending` review
+        // queue (`decide_match_candidate`, `MatchCandidateRepo::list_pending`,
+        // the API `pending[]` array) had no producer at all, so the whole
+        // human-review surface was dead in normal operation.
+        let promote_status = if self.auto_promote { "promoted" } else { "pending" };
+
         match action {
             PolicyAction::AutoPromote => {
                 let id = self
@@ -63,7 +72,7 @@ impl Policy {
                         hi,
                         f.score,
                         features_json,
-                        "promoted",
+                        promote_status,
                         Some(self.run_id),
                     )
                     .await?;
@@ -83,7 +92,7 @@ impl Policy {
                         hi,
                         f.score,
                         features_json,
-                        "promoted",
+                        promote_status,
                         Some(self.run_id),
                     )
                     .await?;

--- a/crates/epigraph-engine/src/matching/policy.rs
+++ b/crates/epigraph-engine/src/matching/policy.rs
@@ -9,7 +9,7 @@
 use crate::matching::scorer::MatchFeatures;
 use crate::matching::verifier::{map_relationship, Verdict};
 use epigraph_db::repos::match_candidate::MatchCandidateRepo;
-use sqlx::types::Json;
+use epigraph_db::EdgeRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -136,11 +136,12 @@ impl Policy {
         Ok(())
     }
 
-    /// Insert a claim→claim edge, skipping if the same (source, target,
-    /// relationship) triple already exists. The unique index
-    /// `idx_edges_unique_triple_non_authored` (migration 108) covers this for
-    /// CORROBORATES/contradicts; we still do an explicit existence check so
-    /// we don't depend on partial-index ON-CONFLICT inference quirks.
+    /// Insert a claim→claim edge, skipping if the same relationship already
+    /// connects the two claims in either direction. Delegates the dedup SQL to
+    /// [`EdgeRepository::create_symmetric_if_absent`] so the bidirectional
+    /// `WHERE NOT EXISTS` form lives in one place. Migrations 017/018 dropped
+    /// the unique triple index, so the explicit existence check (not
+    /// `ON CONFLICT`) is what prevents duplicates on re-run.
     async fn write_edge(
         &self,
         a: Uuid,
@@ -159,23 +160,7 @@ impl Policy {
             "verifier_rationale": v.map(|x| &x.rationale),
             "source":             "cross_source_matcher",
         });
-        sqlx::query(
-            "INSERT INTO edges (source_id, source_type, target_id, target_type,
-                                relationship, properties)
-             SELECT $1, 'claim', $2, 'claim', $3, $4
-             WHERE NOT EXISTS (
-                 SELECT 1 FROM edges
-                 WHERE ((source_id = $1 AND target_id = $2)
-                     OR (source_id = $2 AND target_id = $1))
-                   AND relationship = $3
-             )",
-        )
-        .bind(a)
-        .bind(b)
-        .bind(relationship)
-        .bind(Json(props))
-        .execute(&self.pool)
-        .await?;
+        EdgeRepository::create_symmetric_if_absent(&self.pool, a, b, relationship, props).await?;
         Ok(())
     }
 }

--- a/crates/epigraph-engine/tests/pipeline_end_to_end.rs
+++ b/crates/epigraph-engine/tests/pipeline_end_to_end.rs
@@ -6,10 +6,10 @@
 //! `status='promoted'` is written and a `CORROBORATES` edge is emitted.
 
 use async_trait::async_trait;
+use epigraph_db::repos::match_candidate::MatchCandidateRepo;
 use epigraph_engine::matching::calibration::MatcherConfig;
 use epigraph_engine::matching::pipeline::{run_pipeline, RunInputs};
 use epigraph_engine::matching::verifier::{Verdict, VerifierClient};
-use epigraph_db::repos::match_candidate::MatchCandidateRepo;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -307,7 +307,10 @@ async fn auto_promote_false_populates_pending_review_queue(pool: PgPool) {
     // The fresh per-test DB starts with an empty review queue.
     let repo = MatchCandidateRepo::new(pool.clone());
     assert!(
-        repo.list_pending(50).await.expect("list_pending").is_empty(),
+        repo.list_pending(50)
+            .await
+            .expect("list_pending")
+            .is_empty(),
         "review queue must start empty before the pipeline runs"
     );
 
@@ -321,8 +324,10 @@ async fn auto_promote_false_populates_pending_review_queue(pool: PgPool) {
 
     let pending = repo.list_pending(50).await.expect("list_pending");
     assert!(
-        pending.iter().any(|r| (r.claim_a == seed && r.claim_b == peer)
-            || (r.claim_a == peer && r.claim_b == seed)),
+        pending
+            .iter()
+            .any(|r| (r.claim_a == seed && r.claim_b == peer)
+                || (r.claim_a == peer && r.claim_b == seed)),
         "high-band pair must surface in the pending review queue under auto_promote=false"
     );
     assert!(

--- a/crates/epigraph-engine/tests/pipeline_end_to_end.rs
+++ b/crates/epigraph-engine/tests/pipeline_end_to_end.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use epigraph_engine::matching::calibration::MatcherConfig;
 use epigraph_engine::matching::pipeline::{run_pipeline, RunInputs};
 use epigraph_engine::matching::verifier::{Verdict, VerifierClient};
+use epigraph_db::repos::match_candidate::MatchCandidateRepo;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -204,7 +205,7 @@ async fn high_band_pair_emits_promoted_candidate_and_corroborates_edge(pool: PgP
 }
 
 #[sqlx::test(migrations = "../../migrations")]
-async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
+async fn auto_promote_false_stages_pending_for_review_and_skips_edge(pool: PgPool) {
     let agent_x = insert_agent(&pool).await;
     let agent_y = insert_agent(&pool).await;
     let v = vec![1.0_f32; 1536];
@@ -230,7 +231,14 @@ async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
         auto_promote: false,
     };
     let report = run_pipeline(&pool, inputs).await.expect("pipeline");
-    assert!(report.promoted >= 1);
+    assert!(
+        report.staged >= 1,
+        "auto_promote=false must STAGE for human review, got {report:?}"
+    );
+    assert_eq!(
+        report.promoted, 0,
+        "nothing is promoted when auto_promote=false, got {report:?}"
+    );
 
     let edge_count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*)::bigint FROM edges
@@ -255,7 +263,7 @@ async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
     };
     let exists: (i64,) = sqlx::query_as(
         "SELECT COUNT(*)::bigint FROM match_candidates
-         WHERE claim_a = $1 AND claim_b = $2 AND status = 'promoted'",
+         WHERE claim_a = $1 AND claim_b = $2 AND status = 'pending'",
     )
     .bind(lo)
     .bind(hi)
@@ -264,7 +272,62 @@ async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
     .expect("candidate count");
     assert_eq!(
         exists.0, 1,
-        "candidate row should be recorded even without edge"
+        "auto_promote=false must STAGE the candidate as 'pending' for human review, not silently 'promoted'"
+    );
+}
+
+/// LOAD-BEARING (B1): the human-review queue must now have a PRODUCER.
+/// Before this fix `Policy::act` only ever wrote `promoted`/`rejected`, so
+/// `MatchCandidateRepo::list_pending` — the reader behind the MCP
+/// `list_match_candidates`/`decide_match_candidate` tools and the API
+/// `pending[]` array — always returned empty in normal operation. With
+/// `auto_promote=false`, a high-band pair must now surface through
+/// `list_pending`, proving the producer→consumer path end-to-end (the real
+/// consumer API, not just a raw status check).
+#[sqlx::test(migrations = "../../migrations")]
+async fn auto_promote_false_populates_pending_review_queue(pool: PgPool) {
+    let agent_x = insert_agent(&pool).await;
+    let agent_y = insert_agent(&pool).await;
+    let v = vec![1.0_f32; 1536];
+    let seed = insert_claim(
+        &pool,
+        agent_x,
+        serde_json::json!({"paper_doi": "10.1/E"}),
+        &v,
+    )
+    .await;
+    let peer = insert_claim(
+        &pool,
+        agent_y,
+        serde_json::json!({"paper_doi": "10.1/F"}),
+        &v,
+    )
+    .await;
+
+    // The fresh per-test DB starts with an empty review queue.
+    let repo = MatchCandidateRepo::new(pool.clone());
+    assert!(
+        repo.list_pending(50).await.expect("list_pending").is_empty(),
+        "review queue must start empty before the pipeline runs"
+    );
+
+    let inputs = RunInputs {
+        seeds: vec![seed],
+        cfg: test_config(),
+        verifier: Box::new(AlwaysSameVerifier),
+        auto_promote: false,
+    };
+    run_pipeline(&pool, inputs).await.expect("pipeline");
+
+    let pending = repo.list_pending(50).await.expect("list_pending");
+    assert!(
+        pending.iter().any(|r| (r.claim_a == seed && r.claim_b == peer)
+            || (r.claim_a == peer && r.claim_b == seed)),
+        "high-band pair must surface in the pending review queue under auto_promote=false"
+    );
+    assert!(
+        pending.iter().all(|r| r.status == "pending"),
+        "list_pending must return only pending rows"
     );
 }
 

--- a/crates/epigraph-mcp/src/tools/matching.rs
+++ b/crates/epigraph-mcp/src/tools/matching.rs
@@ -15,13 +15,12 @@
 
 use rmcp::model::*;
 use serde::Serialize;
-use sqlx::types::Json;
 
 use crate::errors::{internal_error, invalid_params, parse_uuid, McpError};
 use crate::server::EpiGraphMcpFull;
 use crate::types::*;
 
-use epigraph_db::{ClaimRepository, MatchCandidateRepo};
+use epigraph_db::{ClaimRepository, EdgeRepository, MatchCandidateRepo};
 
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
@@ -161,9 +160,11 @@ pub async fn decide_match_candidate(
                 .map_err(internal_error)?;
 
             // Write CORROBORATES edge if it doesn't already exist (either
-            // direction). The unique-triple index was dropped in migration
-            // 109, so this explicit check is the only guard against
-            // duplicates from repeated `decide` calls.
+            // direction). The unique-triple index was dropped in migrations
+            // 017/018, so this explicit existence check — now centralized in
+            // `EdgeRepository::create_symmetric_if_absent` — is the only guard
+            // against duplicates from repeated `decide` calls. The
+            // are_all_current guard above stays here at the call site.
             let props = serde_json::json!({
                 "candidate_id":     candidate_id,
                 "score":            row.score,
@@ -172,21 +173,13 @@ pub async fn decide_match_candidate(
                 "decided_by":       acting_agent,
                 "source":           "cross_source_matcher",
             });
-            sqlx::query(
-                "INSERT INTO edges (source_id, source_type, target_id, target_type,
-                                     relationship, properties)
-                 SELECT $1, 'claim', $2, 'claim', 'CORROBORATES', $3
-                 WHERE NOT EXISTS (
-                     SELECT 1 FROM edges
-                     WHERE ((source_id = $1 AND target_id = $2)
-                         OR (source_id = $2 AND target_id = $1))
-                       AND relationship = 'CORROBORATES'
-                 )",
+            EdgeRepository::create_symmetric_if_absent(
+                &server.pool,
+                row.claim_a,
+                row.claim_b,
+                "CORROBORATES",
+                props,
             )
-            .bind(row.claim_a)
-            .bind(row.claim_b)
-            .bind(Json(props))
-            .execute(&server.pool)
             .await
             .map_err(internal_error)?;
         }

--- a/crates/epigraph-mcp/tests/matching_tools_smoke.rs
+++ b/crates/epigraph-mcp/tests/matching_tools_smoke.rs
@@ -36,6 +36,25 @@ async fn insert_claim(pool: &PgPool, agent: Uuid) -> Uuid {
     id
 }
 
+/// Insert a claim with `is_current = false` — a retired endpoint (superseded
+/// or marked-duplicate) that the `are_all_current` guard must refuse to
+/// promote an edge onto.
+async fn insert_retired_claim(pool: &PgPool, agent: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let content = format!("t19 retired {id}");
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, $2, sha256($2::bytea), 0.5, $3, false)",
+    )
+    .bind(id)
+    .bind(&content)
+    .bind(agent)
+    .execute(pool)
+    .await
+    .expect("retired claim");
+    id
+}
+
 async fn insert_agent(pool: &PgPool) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query(
@@ -280,5 +299,49 @@ async fn decide_match_candidate_rejected_in_read_only_mode(pool: PgPool) {
     assert!(
         format!("{err:?}").to_lowercase().contains("read-only"),
         "expected read-only refusal: {err:?}"
+    );
+}
+
+/// Guard survives the refactor: `are_all_current` lives at the MCP call site,
+/// NOT inside `EdgeRepository::create_symmetric_if_absent`. When one endpoint
+/// is `is_current = false`, promote must refuse and write NO edge. If a future
+/// edit folded the guard into the repo method (or dropped it), this catches it
+/// because the repo method has no notion of current-ness — backlog bug
+/// 5c7fc645 would re-open.
+#[sqlx::test(migrations = "../../migrations")]
+async fn decide_match_candidate_promote_blocked_when_endpoint_not_current(pool: PgPool) {
+    let server = build_server(pool.clone(), false).await; // write-enabled
+    let agent = insert_agent(&pool).await;
+    let live = insert_claim(&pool, agent).await;
+    let retired = insert_retired_claim(&pool, agent).await; // is_current = false
+    let cand = insert_candidate(&pool, live, retired, 0.97, "pending").await;
+
+    let err = tools::matching::decide_match_candidate(
+        &server,
+        DecideMatchCandidateParams {
+            candidate_id: cand.to_string(),
+            verdict: "promote".into(),
+        },
+    )
+    .await
+    .expect_err("promote must be refused when an endpoint is not current");
+    assert!(
+        format!("{err:?}").to_lowercase().contains("current"),
+        "refusal must cite the current-ness guard: {err:?}"
+    );
+
+    // The guard must short-circuit BEFORE any edge write.
+    let edge_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges WHERE relationship = 'CORROBORATES'
+         AND ((source_id = $1 AND target_id = $2) OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(live)
+    .bind(retired)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        edge_count.0, 0,
+        "no CORROBORATES edge may be written onto a retired claim"
     );
 }


### PR DESCRIPTION
## the dangling review queue gets a producer

`Policy::act` bound `match_candidates.status` to `"promoted"` unconditionally in both the AutoPromote and WriteContradicts arms; `auto_promote=false` only skipped the *edge* write. **No production path ever wrote `status='pending'`**, so the entire human-review surface — `decide_match_candidate`, `MatchCandidateRepo::list_pending`, the API `pending[]` array, MCP `list_match_candidates(status=pending)` — had consumers but **no producer** (a dead queue, confirmed against origin/main).

**Change:** gate the candidate status on the same `auto_promote` flag that gates the edge — `auto_promote=false` now STAGES the candidate as `pending` for human review instead of recording a `promoted` row with no edge (a half-state). `RunReport` splits `promoted`/`staged` honestly on the same flag. **(User-confirmed semantics.)**

**Verification (RED→GREEN):** with the fix reverted, `auto_promote_false_populates_pending_review_queue` (asserts `list_pending` is non-empty end-to-end — the real consumer API) and the `status='pending'` check both FAIL; with the fix all 6 `pipeline_end_to_end` tests pass, and the `auto_promote=true` path is unchanged (still promotes + corroborates).

**Stacked on T1** (base `refactor/edge-repo-symmetric-if-absent-2`). Matcher is dormant in prod → no live-data risk. **Do not merge before T1, and not without human review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)