### PR TITLE
fix(engine): verify high-band pairs before writing CORROBORATES

### DIFF
--- a/crates/epigraph-db/tests/edge_repo_tests.rs
+++ b/crates/epigraph-db/tests/edge_repo_tests.rs
@@ -124,15 +124,24 @@ async fn reverse_direction_dedup_returns_false(pool: PgPool) {
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
     let claim_a = make_claim(agent_row.id, "claim A for symmetric dedup", 0.5);
     let claim_b = make_claim(agent_row.id, "claim B for symmetric dedup", 0.5);
-    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
-    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a)
+        .await
+        .unwrap()
+        .id
+        .into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b)
+        .await
+        .unwrap()
+        .id
+        .into();
 
     let props = serde_json::json!({"source": "cross_source_matcher", "score": 0.91});
 
     // Forward A→B: first edge of this relationship → inserts.
-    let inserted = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
-        .await
-        .expect("forward insert");
+    let inserted =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+            .await
+            .expect("forward insert");
     assert!(inserted, "first call must insert and return true");
     assert_eq!(
         incident_edge_count(&pool, a, b, "CORROBORATES").await,
@@ -165,21 +174,34 @@ async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) 
     let agent_row = AgentRepository::create(&pool, &agent).await.unwrap();
     let claim_a = make_claim(agent_row.id, "claim A for rel discrimination", 0.5);
     let claim_b = make_claim(agent_row.id, "claim B for rel discrimination", 0.5);
-    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a).await.unwrap().id.into();
-    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b).await.unwrap().id.into();
+    let a: uuid::Uuid = ClaimRepository::create(&pool, &claim_a)
+        .await
+        .unwrap()
+        .id
+        .into();
+    let b: uuid::Uuid = ClaimRepository::create(&pool, &claim_b)
+        .await
+        .unwrap()
+        .id
+        .into();
 
     let props = serde_json::json!({"source": "cross_source_matcher"});
 
-    let first = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
-        .await
-        .expect("corroborates insert");
+    let first =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "CORROBORATES", props.clone())
+            .await
+            .expect("corroborates insert");
     assert!(first, "CORROBORATES must insert");
 
     // A→B with a DIFFERENT relationship is a different edge → must insert.
-    let second = EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
-        .await
-        .expect("contradicts insert");
-    assert!(second, "contradicts is a distinct relationship → must insert");
+    let second =
+        EdgeRepository::create_symmetric_if_absent(&pool, a, b, "contradicts", props.clone())
+            .await
+            .expect("contradicts insert");
+    assert!(
+        second,
+        "contradicts is a distinct relationship → must insert"
+    );
 
     assert_eq!(
         incident_edge_count(&pool, a, b, "CORROBORATES").await,
@@ -200,5 +222,8 @@ async fn create_symmetric_if_absent_distinguishes_by_relationship(pool: PgPool) 
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(total.0, 2, "two distinct edges total (one per relationship)");
+    assert_eq!(
+        total.0, 2,
+        "two distinct edges total (one per relationship)"
+    );
 }

--- a/crates/epigraph-engine/src/matching/pipeline.rs
+++ b/crates/epigraph-engine/src/matching/pipeline.rs
@@ -28,6 +28,8 @@ pub struct RunReport {
     pub run_id: Uuid,
     pub scanned_pairs: usize,
     pub promoted: usize,
+    /// Candidates staged as `pending` for human review (`auto_promote=false`).
+    pub staged: usize,
     pub mid_band: usize,
     pub rejected: usize,
 }
@@ -115,10 +117,21 @@ pub async fn run_pipeline(pool: &PgPool, inputs: RunInputs) -> anyhow::Result<Ru
         }
     }
 
+    // When not auto-promoting, every AutoPromote/WriteContradicts decision
+    // above actually STAGED a `pending` candidate for human review (Policy
+    // wrote `status='pending'` under the same `auto_promote` flag), so report
+    // it honestly as `staged` rather than `promoted`.
+    let (promoted, staged) = if inputs.auto_promote {
+        (promoted, 0usize)
+    } else {
+        (0usize, promoted)
+    };
+
     Ok(RunReport {
         run_id,
         scanned_pairs: pairs.len(),
         promoted,
+        staged,
         mid_band,
         rejected,
     })

--- a/crates/epigraph-engine/src/matching/pipeline.rs
+++ b/crates/epigraph-engine/src/matching/pipeline.rs
@@ -58,12 +58,18 @@ pub async fn run_pipeline(pool: &PgPool, inputs: RunInputs) -> anyhow::Result<Ru
     let mut mid_features: Vec<MatchFeatures> = Vec::new();
     for (a, b) in &pairs {
         let f = score_pair(pool, *a, *b, &inputs.cfg.weights).await?;
-        if f.score >= inputs.cfg.bands.high {
-            policy
-                .act(PolicyAction::AutoPromote, *a, *b, &f, None)
-                .await?;
-            promoted += 1;
-        } else if f.score >= inputs.cfg.bands.mid {
+        // Route BOTH high- and mid-band pairs through the verifier. The former
+        // high-band fast path (`score >= bands.high`) auto-promoted to
+        // CORROBORATES with NO verification, which silently corroborated
+        // strongly-cosine but opposite-stance pairs — and missing-mass pairs
+        // whose `belief_alignment` fell back to the neutral 0.5 — because the
+        // contradiction check lives only in the verifier. Verifying the high
+        // band closes that hole; the second-pass dispatch below promotes only
+        // on Same/Paraphrase, writes `contradicts` on Contradicts, and rejects
+        // otherwise. Cost: high-band pairs now incur one verifier call;
+        // acceptable since `auto_promote` defaults off and a future
+        // `belief_alignment`-gated fast-path can re-optimize the clear cases.
+        if f.score >= inputs.cfg.bands.mid {
             mid_pairs.push((*a, *b));
             mid_features.push(f);
         } else {

--- a/crates/epigraph-engine/src/matching/policy.rs
+++ b/crates/epigraph-engine/src/matching/policy.rs
@@ -61,7 +61,11 @@ impl Policy {
         // queue (`decide_match_candidate`, `MatchCandidateRepo::list_pending`,
         // the API `pending[]` array) had no producer at all, so the whole
         // human-review surface was dead in normal operation.
-        let promote_status = if self.auto_promote { "promoted" } else { "pending" };
+        let promote_status = if self.auto_promote {
+            "promoted"
+        } else {
+            "pending"
+        };
 
         match action {
             PolicyAction::AutoPromote => {

--- a/crates/epigraph-engine/src/matching/policy.rs
+++ b/crates/epigraph-engine/src/matching/policy.rs
@@ -54,6 +54,15 @@ impl Policy {
         // doesn't accept these as args yet; we patch them in below.
         let features_json = serde_json::to_value(f)?;
 
+        // `auto_promote` gates BOTH the edge write (below) AND whether the
+        // candidate is committed (`promoted`) or staged for human review
+        // (`pending`). Before this, `auto_promote=false` left the row as
+        // `promoted` with no edge — a half-state — and the `pending` review
+        // queue (`decide_match_candidate`, `MatchCandidateRepo::list_pending`,
+        // the API `pending[]` array) had no producer at all, so the whole
+        // human-review surface was dead in normal operation.
+        let promote_status = if self.auto_promote { "promoted" } else { "pending" };
+
         match action {
             PolicyAction::AutoPromote => {
                 let id = self
@@ -63,7 +72,7 @@ impl Policy {
                         hi,
                         f.score,
                         features_json,
-                        "promoted",
+                        promote_status,
                         Some(self.run_id),
                     )
                     .await?;
@@ -83,7 +92,7 @@ impl Policy {
                         hi,
                         f.score,
                         features_json,
-                        "promoted",
+                        promote_status,
                         Some(self.run_id),
                     )
                     .await?;

--- a/crates/epigraph-engine/tests/pipeline_end_to_end.rs
+++ b/crates/epigraph-engine/tests/pipeline_end_to_end.rs
@@ -8,10 +8,10 @@
 //! without verification — see `high_band_pair_is_verified_not_blindly_corroborated`.
 
 use async_trait::async_trait;
+use epigraph_db::repos::match_candidate::MatchCandidateRepo;
 use epigraph_engine::matching::calibration::MatcherConfig;
 use epigraph_engine::matching::pipeline::{run_pipeline, RunInputs};
 use epigraph_engine::matching::verifier::{Verdict, VerifierClient};
-use epigraph_db::repos::match_candidate::MatchCandidateRepo;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -125,8 +125,7 @@ struct SpyVerifier {
 #[async_trait]
 impl VerifierClient for SpyVerifier {
     async fn verify(&self, pairs: &[(Uuid, Uuid)]) -> anyhow::Result<Vec<Verdict>> {
-        self.called
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.called.store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(pairs
             .iter()
             .map(|(a, b)| Verdict {
@@ -418,7 +417,10 @@ async fn auto_promote_false_populates_pending_review_queue(pool: PgPool) {
     // The fresh per-test DB starts with an empty review queue.
     let repo = MatchCandidateRepo::new(pool.clone());
     assert!(
-        repo.list_pending(50).await.expect("list_pending").is_empty(),
+        repo.list_pending(50)
+            .await
+            .expect("list_pending")
+            .is_empty(),
         "review queue must start empty before the pipeline runs"
     );
 
@@ -432,8 +434,10 @@ async fn auto_promote_false_populates_pending_review_queue(pool: PgPool) {
 
     let pending = repo.list_pending(50).await.expect("list_pending");
     assert!(
-        pending.iter().any(|r| (r.claim_a == seed && r.claim_b == peer)
-            || (r.claim_a == peer && r.claim_b == seed)),
+        pending
+            .iter()
+            .any(|r| (r.claim_a == seed && r.claim_b == peer)
+                || (r.claim_a == peer && r.claim_b == seed)),
         "high-band pair must surface in the pending review queue under auto_promote=false"
     );
     assert!(

--- a/crates/epigraph-engine/tests/pipeline_end_to_end.rs
+++ b/crates/epigraph-engine/tests/pipeline_end_to_end.rs
@@ -1,9 +1,11 @@
 //! T16: end-to-end pipeline test.
 //!
 //! A pair with identical embeddings and different paper_dois scores 0.40
-//! (only embed_cosine contributes; default weight 0.40). With bands.high
-//! lowered to 0.30, the pair auto-promotes: a `match_candidates` row with
-//! `status='promoted'` is written and a `CORROBORATES` edge is emitted.
+//! (only embed_cosine contributes; default weight 0.40). Clearing `bands.mid`
+//! routes the pair through the verifier; on a Same/`supports` verdict a
+//! `match_candidates` row with `status='promoted'` is written and a
+//! `CORROBORATES` edge is emitted. High-band pairs are NO LONGER auto-promoted
+//! without verification — see `high_band_pair_is_verified_not_blindly_corroborated`.
 
 use async_trait::async_trait;
 use epigraph_engine::matching::calibration::MatcherConfig;
@@ -57,8 +59,7 @@ async fn insert_claim(
     id
 }
 
-/// Always claims "supports" — used to assert the high-band path doesn't
-/// invoke the verifier (verifier verdicts never appear on the row).
+/// Always claims "supports" (→ `MatchVerdict::Same` → corroborate).
 struct AlwaysSameVerifier;
 
 #[async_trait]
@@ -114,6 +115,112 @@ impl VerifierClient for AlwaysDerivesFromVerifier {
     }
 }
 
+/// Records whether `verify` was invoked and returns a configurable
+/// relationship — lets a test PROVE the verifier was (or was not) consulted.
+struct SpyVerifier {
+    called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    relationship: &'static str,
+}
+
+#[async_trait]
+impl VerifierClient for SpyVerifier {
+    async fn verify(&self, pairs: &[(Uuid, Uuid)]) -> anyhow::Result<Vec<Verdict>> {
+        self.called
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok(pairs
+            .iter()
+            .map(|(a, b)| Verdict {
+                source_id: *a,
+                target_id: *b,
+                relationship: self.relationship.to_string(),
+                strength: 0.9,
+                rationale: "spy".to_string(),
+            })
+            .collect())
+    }
+}
+
+/// LOAD-BEARING (B2): a high-band pair MUST be sent to the verifier before it
+/// can become a CORROBORATES edge. Before this fix, `score >= bands.high`
+/// auto-promoted with NO verification, so a strongly-cosine but opposite-stance
+/// pair (or a missing-mass pair whose `belief_alignment` fell back to the
+/// neutral 0.5) silently corroborated. The `SpyVerifier` proves the verifier is
+/// now consulted on the high band; returning `contradicts` proves the pair does
+/// NOT corroborate.
+#[sqlx::test(migrations = "../../migrations")]
+async fn high_band_pair_is_verified_not_blindly_corroborated(pool: PgPool) {
+    let agent_x = insert_agent(&pool).await;
+    let agent_y = insert_agent(&pool).await;
+    let v = vec![1.0_f32; 1536];
+    let seed = insert_claim(
+        &pool,
+        agent_x,
+        serde_json::json!({"paper_doi": "10.1/G"}),
+        &v,
+    )
+    .await;
+    let peer = insert_claim(
+        &pool,
+        agent_y,
+        serde_json::json!({"paper_doi": "10.1/H"}),
+        &v,
+    )
+    .await;
+
+    let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let inputs = RunInputs {
+        seeds: vec![seed],
+        cfg: test_config(), // high=0.30, so the 0.40 pair is high-band
+        verifier: Box::new(SpyVerifier {
+            called: called.clone(),
+            relationship: "contradicts",
+        }),
+        auto_promote: true,
+    };
+    run_pipeline(&pool, inputs).await.expect("pipeline");
+
+    // THE load-bearing assertion: the high-band pair was sent to the verifier.
+    assert!(
+        called.load(std::sync::atomic::Ordering::SeqCst),
+        "high-band pair MUST be routed through the verifier before corroborating \
+         (the unverified fast-path was the bug)"
+    );
+
+    // The verifier said `contradicts`, so NO CORROBORATES edge may exist...
+    let corrob: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges
+         WHERE relationship = 'CORROBORATES'
+           AND ((source_id = $1 AND target_id = $2)
+             OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(seed)
+    .bind(peer)
+    .fetch_one(&pool)
+    .await
+    .expect("corroborates count");
+    assert_eq!(
+        corrob.0, 0,
+        "a verifier-rejected high-band pair must NOT auto-corroborate"
+    );
+
+    // ...and a `contradicts` edge IS written (auto_promote=true → WriteContradicts).
+    let contra: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint FROM edges
+         WHERE relationship = 'contradicts'
+           AND ((source_id = $1 AND target_id = $2)
+             OR (source_id = $2 AND target_id = $1))",
+    )
+    .bind(seed)
+    .bind(peer)
+    .fetch_one(&pool)
+    .await
+    .expect("contradicts count");
+    assert_eq!(
+        contra.0, 1,
+        "verifier `contradicts` verdict must write a contradicts edge"
+    );
+}
+
 /// Move bands so the canonical 0.40-score pair lands in the mid band, where
 /// the verifier is invoked.
 fn mid_band_config() -> MatcherConfig {
@@ -136,7 +243,7 @@ fn test_config() -> MatcherConfig {
 }
 
 #[sqlx::test(migrations = "../../migrations")]
-async fn high_band_pair_emits_promoted_candidate_and_corroborates_edge(pool: PgPool) {
+async fn high_band_pair_verified_then_promotes_and_corroborates(pool: PgPool) {
     let agent_x = insert_agent(&pool).await;
     let agent_y = insert_agent(&pool).await;
     let v = vec![1.0_f32; 1536];
@@ -167,8 +274,12 @@ async fn high_band_pair_emits_promoted_candidate_and_corroborates_edge(pool: PgP
         report.promoted >= 1,
         "expected ≥1 promotion, got {report:?}"
     );
-    // The high-band fast path should NOT touch the verifier, so mid_band == 0.
-    assert_eq!(report.mid_band, 0, "high-band pair leaked to verifier");
+    // High-band pairs are now routed THROUGH the verifier (the unverified
+    // fast-path was removed); on a `supports`→Same verdict they still promote.
+    assert_eq!(
+        report.mid_band, 1,
+        "high-band pair must be verified before promotion, got {report:?}"
+    );
 
     // CORROBORATES edge in either direction (write_edge sends the seed→peer
     // order, but assert symmetrically).

--- a/crates/epigraph-engine/tests/pipeline_end_to_end.rs
+++ b/crates/epigraph-engine/tests/pipeline_end_to_end.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use epigraph_engine::matching::calibration::MatcherConfig;
 use epigraph_engine::matching::pipeline::{run_pipeline, RunInputs};
 use epigraph_engine::matching::verifier::{Verdict, VerifierClient};
+use epigraph_db::repos::match_candidate::MatchCandidateRepo;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -204,7 +205,7 @@ async fn high_band_pair_emits_promoted_candidate_and_corroborates_edge(pool: PgP
 }
 
 #[sqlx::test(migrations = "../../migrations")]
-async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
+async fn auto_promote_false_stages_pending_for_review_and_skips_edge(pool: PgPool) {
     let agent_x = insert_agent(&pool).await;
     let agent_y = insert_agent(&pool).await;
     let v = vec![1.0_f32; 1536];
@@ -230,7 +231,14 @@ async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
         auto_promote: false,
     };
     let report = run_pipeline(&pool, inputs).await.expect("pipeline");
-    assert!(report.promoted >= 1);
+    assert!(
+        report.staged >= 1,
+        "auto_promote=false must STAGE for human review, got {report:?}"
+    );
+    assert_eq!(
+        report.promoted, 0,
+        "nothing is promoted when auto_promote=false, got {report:?}"
+    );
 
     let edge_count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*)::bigint FROM edges
@@ -255,7 +263,7 @@ async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
     };
     let exists: (i64,) = sqlx::query_as(
         "SELECT COUNT(*)::bigint FROM match_candidates
-         WHERE claim_a = $1 AND claim_b = $2 AND status = 'promoted'",
+         WHERE claim_a = $1 AND claim_b = $2 AND status = 'pending'",
     )
     .bind(lo)
     .bind(hi)
@@ -264,7 +272,62 @@ async fn auto_promote_false_records_candidate_but_skips_edge(pool: PgPool) {
     .expect("candidate count");
     assert_eq!(
         exists.0, 1,
-        "candidate row should be recorded even without edge"
+        "auto_promote=false must STAGE the candidate as 'pending' for human review, not silently 'promoted'"
+    );
+}
+
+/// LOAD-BEARING (B1): the human-review queue must now have a PRODUCER.
+/// Before this fix `Policy::act` only ever wrote `promoted`/`rejected`, so
+/// `MatchCandidateRepo::list_pending` — the reader behind the MCP
+/// `list_match_candidates`/`decide_match_candidate` tools and the API
+/// `pending[]` array — always returned empty in normal operation. With
+/// `auto_promote=false`, a high-band pair must now surface through
+/// `list_pending`, proving the producer→consumer path end-to-end (the real
+/// consumer API, not just a raw status check).
+#[sqlx::test(migrations = "../../migrations")]
+async fn auto_promote_false_populates_pending_review_queue(pool: PgPool) {
+    let agent_x = insert_agent(&pool).await;
+    let agent_y = insert_agent(&pool).await;
+    let v = vec![1.0_f32; 1536];
+    let seed = insert_claim(
+        &pool,
+        agent_x,
+        serde_json::json!({"paper_doi": "10.1/E"}),
+        &v,
+    )
+    .await;
+    let peer = insert_claim(
+        &pool,
+        agent_y,
+        serde_json::json!({"paper_doi": "10.1/F"}),
+        &v,
+    )
+    .await;
+
+    // The fresh per-test DB starts with an empty review queue.
+    let repo = MatchCandidateRepo::new(pool.clone());
+    assert!(
+        repo.list_pending(50).await.expect("list_pending").is_empty(),
+        "review queue must start empty before the pipeline runs"
+    );
+
+    let inputs = RunInputs {
+        seeds: vec![seed],
+        cfg: test_config(),
+        verifier: Box::new(AlwaysSameVerifier),
+        auto_promote: false,
+    };
+    run_pipeline(&pool, inputs).await.expect("pipeline");
+
+    let pending = repo.list_pending(50).await.expect("list_pending");
+    assert!(
+        pending.iter().any(|r| (r.claim_a == seed && r.claim_b == peer)
+            || (r.claim_a == peer && r.claim_b == seed)),
+        "high-band pair must surface in the pending review queue under auto_promote=false"
+    );
+    assert!(
+        pending.iter().all(|r| r.status == "pending"),
+        "list_pending must return only pending rows"
     );
 }
 


### PR DESCRIPTION
## high-band pairs are no longer corroborated unverified

`run_pipeline` auto-promoted every pair with `score >= bands.high` straight to a `CORROBORATES` edge with **no verifier call**. A strongly-cosine but **opposite-stance** pair — or a missing-mass pair whose `belief_alignment` fell back to the neutral 0.5 — therefore corroborated silently, because the contradiction check lives only in the mid-band verifier.

**Change (minimal, lever-a):** remove the unverified high-band fast path; pairs clearing `bands.mid` (now including the high band) go through the same verifier batch, whose existing dispatch promotes only on Same/Paraphrase, writes `contradicts` on Contradicts, else rejects. No `scorer.rs`/belief-struct change. Cost: high-band pairs now incur one verifier call — acceptable since `auto_promote` defaults off; a future `belief_alignment`-gated fast-path can re-optimize the clearly-aligned majority.

**Verification (RED→GREEN):** with the fast path restored, `high_band_pair_is_verified_not_blindly_corroborated` FAILS — a `SpyVerifier` proves `verify()` was never called and a `CORROBORATES` edge was written. With the fix the spy confirms the verifier is consulted, a `contradicts` verdict writes a contradicts edge, and **no** `CORROBORATES` edge exists. All 7 `pipeline_end_to_end` tests pass.

**Stacked on B1** (base `fix/matcher-emit-pending-for-review-queue`), which is stacked on T1. **Do not merge before B1, and not without human review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)