### PR TITLE
feat(ingest): structured-source-first preprocessor (arXiv HTML + OpenStax CNXML -> DocumentExtraction)

### DIFF
--- a/crates/epigraph-ingest/tests/fixtures/sample_arxiv.html
+++ b/crates/epigraph-ingest/tests/fixtures/sample_arxiv.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>raw head title (ignored)</title><style>.x{}</style></head>
+<body>
+  <h1>Structured Source-First Ingestion for Epistemic Graphs</h1>
+  <div class="authors">Ada Lovelace, Charles Babbage and Grace Hopper</div>
+  <div class="abstract">
+    <p>We present a structure-recovery preprocessor that maps arXiv HTML into a
+    hierarchical extraction schema. It recovers sections and paragraphs without
+    invoking a language model.</p>
+  </div>
+  <section>
+    <h2>Introduction</h2>
+    <p>Scientific HTML such as ar5iv pages carries explicit section structure.
+    Exploiting that structure avoids lossy OCR. The preprocessor walks headings
+    and accumulates section text. <math><mi>E</mi><mo>=</mo><mi>m</mi></math>
+    appears inline but is skipped by the parser.</p>
+  </section>
+  <section>
+    <h2>Method</h2>
+    <p>The parser tracks a heading stack and flushes a section when a new
+    heading of level two or greater begins. Each recovered section becomes one
+    node in the downstream hierarchy. Tiny sections under fifty characters are
+    discarded to suppress navigation noise.</p>
+  </section>
+  <footer>nav junk that must be skipped</footer>
+</body>
+</html>

--- a/crates/epigraph-ingest/tests/fixtures/sample_arxiv_extraction.json
+++ b/crates/epigraph-ingest/tests/fixtures/sample_arxiv_extraction.json
@@ -38,7 +38,7 @@
   "sections": [
     {
       "title": "Introduction",
-      "summary": "Scientific HTML such as ar5iv pages carries explicit section structure.",
+      "summary": "Section: Introduction",
       "paragraphs": [
         {
           "compound": "Scientific HTML such as ar5iv pages carries explicit section structure.",
@@ -52,7 +52,7 @@
     },
     {
       "title": "Method",
-      "summary": "The parser tracks a heading stack and flushes a section when a new heading of level two or greater begins.",
+      "summary": "Section: Method",
       "paragraphs": [
         {
           "compound": "The parser tracks a heading stack and flushes a section when a new heading of level two or greater begins.",

--- a/crates/epigraph-ingest/tests/fixtures/sample_arxiv_extraction.json
+++ b/crates/epigraph-ingest/tests/fixtures/sample_arxiv_extraction.json
@@ -1,0 +1,69 @@
+{
+  "source": {
+    "title": "Structured Source-First Ingestion for Epistemic Graphs",
+    "source_type": "Paper",
+    "authors": [
+      {
+        "name": "Ada Lovelace",
+        "affiliations": [],
+        "roles": [
+          "author"
+        ]
+      },
+      {
+        "name": "Charles Babbage",
+        "affiliations": [],
+        "roles": [
+          "author"
+        ]
+      },
+      {
+        "name": "Grace Hopper",
+        "affiliations": [],
+        "roles": [
+          "author"
+        ]
+      }
+    ],
+    "doi": "10.48550/arXiv.2603.04139",
+    "uri": "https://arxiv.org/html/2603.04139v1",
+    "metadata": {
+      "extractor": "extract_html.py",
+      "extraction_stage": "structure_recovery_only",
+      "arxiv_id": "2603.04139"
+    }
+  },
+  "thesis": "We present a structure-recovery preprocessor that maps arXiv HTML into a hierarchical extraction schema. It recovers sections and paragraphs without invoking a language model.",
+  "thesis_derivation": "TopDown",
+  "sections": [
+    {
+      "title": "Introduction",
+      "summary": "Scientific HTML such as ar5iv pages carries explicit section structure.",
+      "paragraphs": [
+        {
+          "compound": "Scientific HTML such as ar5iv pages carries explicit section structure.",
+          "supporting_text": "Scientific HTML such as ar5iv pages carries explicit section structure. Exploiting that structure avoids lossy OCR. The preprocessor walks headings and accumulates section text. appears inline but is skipped by the parser.",
+          "atoms": [],
+          "generality": [],
+          "confidence": 0.8,
+          "methodology": "structured_html_parse"
+        }
+      ]
+    },
+    {
+      "title": "Method",
+      "summary": "The parser tracks a heading stack and flushes a section when a new heading of level two or greater begins.",
+      "paragraphs": [
+        {
+          "compound": "The parser tracks a heading stack and flushes a section when a new heading of level two or greater begins.",
+          "supporting_text": "The parser tracks a heading stack and flushes a section when a new heading of level two or greater begins. Each recovered section becomes one node in the downstream hierarchy. Tiny sections under fifty characters are discarded to suppress navigation noise.",
+          "atoms": [],
+          "generality": [],
+          "confidence": 0.8,
+          "methodology": "structured_html_parse"
+        }
+      ]
+    }
+  ],
+  "relationships": []
+}

--- a/crates/epigraph-ingest/tests/fixtures/sample_openstax_extraction.json
+++ b/crates/epigraph-ingest/tests/fixtures/sample_openstax_extraction.json
@@ -1,0 +1,52 @@
+{
+  "source": {
+    "title": "Electric Charge and Coulomb's Law",
+    "source_type": "Textbook",
+    "authors": [
+      {
+        "name": "OpenStax",
+        "affiliations": [
+          "Rice University"
+        ],
+        "roles": [
+          "publisher"
+        ]
+      }
+    ],
+    "doi": "openstax:sample-physics",
+    "journal": "OpenStax Textbook",
+    "metadata": {
+      "extractor": "extract_textbook.py",
+      "extraction_stage": "structure_recovery_only",
+      "book_slug": "sample-physics",
+      "license": ""
+    }
+  },
+  "thesis": null,
+  "thesis_derivation": "TopDown",
+  "sections": [
+    {
+      "title": "Ch 1: Electrostatics > Electric Charge and Coulomb's Law",
+      "summary": "The electrostatic force between two point charges is proportional to the product of the charges and inversely proportional to the square of the distance between them, as expressed by [equation] in standard form.",
+      "paragraphs": [
+        {
+          "compound": "The electrostatic force between two point charges is proportional to the product of the charges and inversely proportional to the square of the distance between them, as expressed by [equation] in standard form.",
+          "supporting_text": "The electrostatic force between two point charges is proportional to the product of the charges and inversely proportional to the square of the distance between them, as expressed by [equation] in standard form.",
+          "atoms": [],
+          "generality": [],
+          "confidence": 0.85,
+          "methodology": "textbook_assertion"
+        },
+        {
+          "compound": "Coulomb is defined as: the SI unit of electric charge, equal to the charge transported by a constant current of one ampere in one second",
+          "supporting_text": "Coulomb is defined as: the SI unit of electric charge, equal to the charge transported by a constant current of one ampere in one second",
+          "atoms": [],
+          "generality": [],
+          "confidence": 0.9,
+          "methodology": "textbook_assertion"
+        }
+      ]
+    }
+  ],
+  "relationships": []
+}

--- a/crates/epigraph-ingest/tests/fixtures/sample_openstax_extraction.json
+++ b/crates/epigraph-ingest/tests/fixtures/sample_openstax_extraction.json
@@ -27,7 +27,7 @@
   "sections": [
     {
       "title": "Ch 1: Electrostatics > Electric Charge and Coulomb's Law",
-      "summary": "The electrostatic force between two point charges is proportional to the product of the charges and inversely proportional to the square of the distance between them, as expressed by [equation] in standard form.",
+      "summary": "Section: Ch 1: Electrostatics > Electric Charge and Coulomb's Law",
       "paragraphs": [
         {
           "compound": "The electrostatic force between two point charges is proportional to the product of the charges and inversely proportional to the square of the distance between them, as expressed by [equation] in standard form.",

--- a/crates/epigraph-ingest/tests/fixtures/sample_openstax_module.cnxml
+++ b/crates/epigraph-ingest/tests/fixtures/sample_openstax_module.cnxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:m="http://www.w3.org/1998/Math/MathML" class="">
+  <title>Electric Charge and Coulomb's Law</title>
+  <metadata>
+    <md:content-id>m00042</md:content-id>
+    <md:uuid>11111111-2222-3333-4444-555555555555</md:uuid>
+  </metadata>
+  <content>
+    <section>
+      <title>Coulomb's Law</title>
+      <para id="p1">The electrostatic force between two point charges is proportional to the product of the charges and inversely proportional to the square of the distance between them, as expressed by <math><mi>F</mi><mo>=</mo><mi>k</mi></math> in standard form.</para>
+      <para id="p2">In this section, we will explore charge.</para>
+    </section>
+  </content>
+  <glossary>
+    <definition>
+      <term>Coulomb</term>
+      <meaning>the SI unit of electric charge, equal to the charge transported by a constant current of one ampere in one second</meaning>
+    </definition>
+  </glossary>
+</document>

--- a/crates/epigraph-ingest/tests/structured_source_glue.rs
+++ b/crates/epigraph-ingest/tests/structured_source_glue.rs
@@ -17,7 +17,11 @@ fn assert_no_collisions(plan: &epigraph_ingest::builder::IngestPlan) {
         plan.claims.len(),
         "every planned claim id must be distinct (no L1 section == L2 paragraph collision)"
     );
-    for e in plan.edges.iter().filter(|e| e.relationship == "decomposes_to") {
+    for e in plan
+        .edges
+        .iter()
+        .filter(|e| e.relationship == "decomposes_to")
+    {
         assert_ne!(
             e.source_id, e.target_id,
             "decomposes_to must never be a self-loop (section id == paragraph id)"
@@ -45,7 +49,11 @@ fn arxiv_html_maps_to_valid_document_extraction_hierarchy() {
         Some("10.48550/arXiv.2603.04139"),
         "arXiv id must derive the 10.48550 DOI"
     );
-    assert_eq!(doc.source.authors.len(), 3, "joined author blob split into 3");
+    assert_eq!(
+        doc.source.authors.len(),
+        3,
+        "joined author blob split into 3"
+    );
     assert!(doc.thesis.is_some(), "abstract becomes the thesis");
 
     // Two h2 sections, each exactly one paragraph (HTML loses intra-section
@@ -106,20 +114,25 @@ fn openstax_cnxml_maps_to_valid_document_extraction_hierarchy() {
     // transitional para is dropped.
     assert_eq!(doc.sections.len(), 1);
     let paras = &doc.sections[0].paragraphs;
-    assert_eq!(paras.len(), 2, "1 real para + 1 definition; transitional dropped");
+    assert_eq!(
+        paras.len(),
+        2,
+        "1 real para + 1 definition; transitional dropped"
+    );
     assert!(
         paras.iter().all(|p| p.atoms.is_empty()),
         "no atoms in structure recovery"
     );
     assert!(
-        paras.iter().any(|p| p.supporting_text.contains("[equation]")),
+        paras
+            .iter()
+            .any(|p| p.supporting_text.contains("[equation]")),
         "inline MathML must be rendered as the [equation] placeholder"
     );
     assert!(
-        doc.sections[0]
-            .paragraphs
-            .iter()
-            .all(|p| !p.supporting_text.contains("In this section, we will explore")),
+        doc.sections[0].paragraphs.iter().all(|p| !p
+            .supporting_text
+            .contains("In this section, we will explore")),
         "transitional paragraph must be filtered out"
     );
 
@@ -129,11 +142,18 @@ fn openstax_cnxml_maps_to_valid_document_extraction_hierarchy() {
     assert_eq!(by_level(1), 1, "one module -> one section");
     assert_eq!(by_level(2), 2, "two surviving paragraphs");
     assert_eq!(by_level(3), 0, "no atoms yet");
-    let dec = plan.edges.iter().filter(|e| e.relationship == "decomposes_to").count();
+    let dec = plan
+        .edges
+        .iter()
+        .filter(|e| e.relationship == "decomposes_to")
+        .count();
     assert_eq!(dec, 2, "section->para x2 (no thesis in this fixture)");
     // 2 paragraphs in one section -> exactly 1 continues_argument edge.
     assert_eq!(
-        plan.edges.iter().filter(|e| e.relationship == "continues_argument").count(),
+        plan.edges
+            .iter()
+            .filter(|e| e.relationship == "continues_argument")
+            .count(),
         1
     );
 }

--- a/crates/epigraph-ingest/tests/structured_source_glue.rs
+++ b/crates/epigraph-ingest/tests/structured_source_glue.rs
@@ -1,5 +1,29 @@
 use epigraph_ingest::builder::build_ingest_plan;
 use epigraph_ingest::schema::{DocumentExtraction, SourceType};
+use std::collections::HashSet;
+
+/// Regression guard for backlog b5518801: every planned claim must have a
+/// DISTINCT id and no `decomposes_to` edge may be a self-loop. The original
+/// emitters set a section's `summary` to the verbatim text of its first
+/// paragraph's `compound`; since `compound_claim_id` hashes content with no
+/// level in the material, the L1 section and its first L2 paragraph collapsed
+/// onto the SAME UUID — a self-loop `decomposes_to(section, section)` and a
+/// duplicate-id insert. Claim/edge COUNTS are blind to this (the builder pushes
+/// both colliding claims regardless), so we assert id distinctness directly.
+fn assert_no_collisions(plan: &epigraph_ingest::builder::IngestPlan) {
+    let ids: HashSet<uuid::Uuid> = plan.claims.iter().map(|c| c.id).collect();
+    assert_eq!(
+        ids.len(),
+        plan.claims.len(),
+        "every planned claim id must be distinct (no L1 section == L2 paragraph collision)"
+    );
+    for e in plan.edges.iter().filter(|e| e.relationship == "decomposes_to") {
+        assert_ne!(
+            e.source_id, e.target_id,
+            "decomposes_to must never be a self-loop (section id == paragraph id)"
+        );
+    }
+}
 
 // The fixtures are the VERBATIM output of the Python preprocessors:
 //   sample_arxiv_extraction.json      <- scripts/extract_html.py on sample_arxiv.html
@@ -52,6 +76,7 @@ fn arxiv_html_maps_to_valid_document_extraction_hierarchy() {
     // Now the actual glue->builder contract: a thesis(L0) + 2 sections(L1) +
     // 2 paragraphs(L2), zero atoms(L3), and the structural edges.
     let plan = build_ingest_plan(&doc);
+    assert_no_collisions(&plan);
     let by_level = |l: u8| plan.claims.iter().filter(|c| c.level == l).count();
     assert_eq!(by_level(0), 1, "thesis");
     assert_eq!(by_level(1), 2, "sections");
@@ -99,6 +124,7 @@ fn openstax_cnxml_maps_to_valid_document_extraction_hierarchy() {
     );
 
     let plan = build_ingest_plan(&doc);
+    assert_no_collisions(&plan);
     let by_level = |l: u8| plan.claims.iter().filter(|c| c.level == l).count();
     assert_eq!(by_level(1), 1, "one module -> one section");
     assert_eq!(by_level(2), 2, "two surviving paragraphs");

--- a/crates/epigraph-ingest/tests/structured_source_glue.rs
+++ b/crates/epigraph-ingest/tests/structured_source_glue.rs
@@ -1,0 +1,113 @@
+use epigraph_ingest::builder::build_ingest_plan;
+use epigraph_ingest::schema::{DocumentExtraction, SourceType};
+
+// The fixtures are the VERBATIM output of the Python preprocessors:
+//   sample_arxiv_extraction.json      <- scripts/extract_html.py on sample_arxiv.html
+//   sample_openstax_extraction.json   <- scripts/extract_textbook.py on sample_openstax_module.cnxml
+// Regen commands are documented in the spec and in scripts/README.md. If a
+// parser changes, regenerate the fixture; this test then enforces the new
+// contract deliberately.
+
+#[test]
+fn arxiv_html_maps_to_valid_document_extraction_hierarchy() {
+    let json = include_str!("fixtures/sample_arxiv_extraction.json");
+    let doc: DocumentExtraction =
+        serde_json::from_str(json).expect("arXiv fixture must be a valid DocumentExtraction");
+
+    // Source mapping the glue is responsible for.
+    assert_eq!(doc.source.source_type, SourceType::Paper);
+    assert_eq!(
+        doc.source.doi.as_deref(),
+        Some("10.48550/arXiv.2603.04139"),
+        "arXiv id must derive the 10.48550 DOI"
+    );
+    assert_eq!(doc.source.authors.len(), 3, "joined author blob split into 3");
+    assert!(doc.thesis.is_some(), "abstract becomes the thesis");
+
+    // Two h2 sections, each exactly one paragraph (HTML loses intra-section
+    // paragraph boundaries -> Section maps to a single Paragraph).
+    assert_eq!(doc.sections.len(), 2);
+    for s in &doc.sections {
+        assert_eq!(s.paragraphs.len(), 1, "one paragraph per HTML section");
+        let p = &s.paragraphs[0];
+        assert!(!p.compound.is_empty(), "compound is required + non-empty");
+        assert!(
+            p.atoms.is_empty(),
+            "structure recovery emits NO atoms; the LLM stage fills them"
+        );
+    }
+
+    // The skipped <math> content must not have leaked into the text.
+    let all_text: String = doc
+        .sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .map(|p| p.supporting_text.clone())
+        .collect();
+    assert!(
+        !all_text.contains("E=m") && !all_text.contains("E = m"),
+        "MathML inside <math> must be skipped, not extracted"
+    );
+
+    // Now the actual glue->builder contract: a thesis(L0) + 2 sections(L1) +
+    // 2 paragraphs(L2), zero atoms(L3), and the structural edges.
+    let plan = build_ingest_plan(&doc);
+    let by_level = |l: u8| plan.claims.iter().filter(|c| c.level == l).count();
+    assert_eq!(by_level(0), 1, "thesis");
+    assert_eq!(by_level(1), 2, "sections");
+    assert_eq!(by_level(2), 2, "paragraphs");
+    assert_eq!(by_level(3), 0, "no atoms yet — pre-LLM structure recovery");
+
+    let rel = |r: &str| plan.edges.iter().filter(|e| e.relationship == r).count();
+    // thesis->S1, thesis->S2, S1->P1, S2->P2 = 4 decomposes_to.
+    assert_eq!(rel("decomposes_to"), 4);
+    // 2 sections -> exactly 1 section_follows.
+    assert_eq!(rel("section_follows"), 1);
+    // 1 paragraph per section -> no continues_argument (needs >=2 paras/section).
+    assert_eq!(rel("continues_argument"), 0);
+}
+
+#[test]
+fn openstax_cnxml_maps_to_valid_document_extraction_hierarchy() {
+    let json = include_str!("fixtures/sample_openstax_extraction.json");
+    let doc: DocumentExtraction =
+        serde_json::from_str(json).expect("OpenStax fixture must be a valid DocumentExtraction");
+
+    assert_eq!(doc.source.source_type, SourceType::Textbook);
+    assert_eq!(doc.source.doi.as_deref(), Some("openstax:sample-physics"));
+
+    // One module -> one section. CNXML preserves real <para> boundaries, so the
+    // surviving real paragraph + the glossary definition = 2 paragraphs; the
+    // transitional para is dropped.
+    assert_eq!(doc.sections.len(), 1);
+    let paras = &doc.sections[0].paragraphs;
+    assert_eq!(paras.len(), 2, "1 real para + 1 definition; transitional dropped");
+    assert!(
+        paras.iter().all(|p| p.atoms.is_empty()),
+        "no atoms in structure recovery"
+    );
+    assert!(
+        paras.iter().any(|p| p.supporting_text.contains("[equation]")),
+        "inline MathML must be rendered as the [equation] placeholder"
+    );
+    assert!(
+        doc.sections[0]
+            .paragraphs
+            .iter()
+            .all(|p| !p.supporting_text.contains("In this section, we will explore")),
+        "transitional paragraph must be filtered out"
+    );
+
+    let plan = build_ingest_plan(&doc);
+    let by_level = |l: u8| plan.claims.iter().filter(|c| c.level == l).count();
+    assert_eq!(by_level(1), 1, "one module -> one section");
+    assert_eq!(by_level(2), 2, "two surviving paragraphs");
+    assert_eq!(by_level(3), 0, "no atoms yet");
+    let dec = plan.edges.iter().filter(|e| e.relationship == "decomposes_to").count();
+    assert_eq!(dec, 2, "section->para x2 (no thesis in this fixture)");
+    // 2 paragraphs in one section -> exactly 1 continues_argument edge.
+    assert_eq!(
+        plan.edges.iter().filter(|e| e.relationship == "continues_argument").count(),
+        1
+    );
+}

--- a/scripts/extract_html.py
+++ b/scripts/extract_html.py
@@ -221,7 +221,14 @@ def html_to_document_extraction(html: str, url: str = "") -> DocumentExtractionO
         sections_out.append(
             SectionOut(
                 title=s.title,
-                summary=first_sentence(s.text),
+                # Derive the L1 summary from the section TITLE, not the body's
+                # first sentence. The body first sentence is verbatim the first
+                # paragraph's `compound`; since compound_claim_id hashes content
+                # with no level in the material, an identical string collides the
+                # section (L1) and its first paragraph (L2) onto the SAME UUID,
+                # producing a decomposes_to self-loop and a duplicate-id insert
+                # (backlog b5518801). A title-derived summary is hash-distinct.
+                summary=f"Section: {s.title}",
                 paragraphs=[
                     ParagraphOut(
                         compound=first_sentence(s.text),

--- a/scripts/extract_html.py
+++ b/scripts/extract_html.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Structured-source-first parser for scientific-paper HTML (arXiv/ar5iv/PMC).
+
+Harvested from EpigraphV2/scripts/extract_html.py (HTMLTextExtractor,
+html_to_structure, extract_arxiv_id, fetch_html). Ported LLM-free: this layer
+recovers SOURCE STRUCTURE (title/authors/abstract/sections), then maps it onto
+the live hierarchical DocumentExtraction (crates/epigraph-ingest/src/document/schema.rs)
+so the output can be handed to the extract-claims LLM stage and then
+`mcp__epigraph__ingest_document`.
+
+SCOPE — structure recovery only:
+  * Emits levels 0-2 (thesis from abstract, one Section per heading, one
+    Paragraph per section). atoms/generality are LEFT EMPTY; the extract-claims
+    skill's Stage-3 decomposition fills them.
+  * HTML collapses each section's prose into a single text blob (no reliable
+    paragraph boundaries in arbitrary HTML), so each Section maps to exactly
+    ONE Paragraph. (CNXML, by contrast, preserves real <para> boundaries.)
+  * <math>/MathML is SKIPPED by the parser (SKIP_TAGS); equations are not
+    extracted. Flagged limitation, acceptable for structure recovery.
+
+Usage:
+    python3 scripts/extract_html.py https://arxiv.org/html/2603.04139v1 \
+        --output /home/jeremy/tmp/extractions/
+    python3 scripts/extract_html.py path/to/page.html --from-file \
+        --uri https://arxiv.org/html/2603.04139v1 --output /home/jeremy/tmp/extractions/
+
+The --from-file mode parses a local HTML file (no network) — used by tests and
+for offline/airgapped operation.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import urllib.request
+from html.parser import HTMLParser
+from pathlib import Path
+
+# Import the shared mapping module (scripts/ is the package root at runtime).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib.document_extraction import (  # noqa: E402
+    Author,
+    DocumentExtractionOut,
+    ParagraphOut,
+    SectionOut,
+    first_sentence,
+)
+
+
+class _ParsedSection:
+    __slots__ = ("title", "text", "level")
+
+    def __init__(self, title: str, level: int = 2):
+        self.title = title
+        self.text = ""
+        self.level = level
+
+
+class HTMLTextExtractor(HTMLParser):
+    """Minimal HTML-to-text parser preserving section structure.
+
+    Verbatim port of V2 HTMLTextExtractor: <math> is in SKIP_TAGS so equations
+    are dropped; h1=title, h2-h4=section boundaries; abstract + author blocks
+    detected by class/id substring.
+    """
+
+    SKIP_TAGS = {"script", "style", "nav", "footer", "header", "noscript", "svg", "math"}
+    HEADING_TAGS = {"h1", "h2", "h3", "h4"}
+
+    def __init__(self):
+        super().__init__()
+        self.title = ""
+        self.authors = ""
+        self.abstract = ""
+        self.sections: list[_ParsedSection] = []
+        self._current_section: _ParsedSection | None = None
+        self._skip_depth = 0
+        self._in_abstract = False
+        self._abstract_buf: list[str] = []
+        self._text_buf: list[str] = []
+        self._heading_buf: list[str] = []
+        self._in_heading = False
+        self._heading_level = 0
+        self._title_found = False
+        self._in_authors = False
+        self._authors_buf: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs_dict = dict(attrs)
+        if tag in self.SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if self._skip_depth > 0:
+            return
+        cls = attrs_dict.get("class", "") or ""
+        tid = attrs_dict.get("id", "") or ""
+        if "abstract" in cls.lower() or "abstract" in tid.lower():
+            self._in_abstract = True
+        if "author" in cls.lower() and tag in ("div", "span", "p", "section"):
+            self._in_authors = True
+        if tag in self.HEADING_TAGS:
+            self._in_heading = True
+            self._heading_level = int(tag[1])
+            self._heading_buf = []
+        if tag == "h1" and not self._title_found:
+            self._in_heading = True
+            self._heading_level = 1
+            self._heading_buf = []
+
+    def handle_endtag(self, tag):
+        if tag in self.SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+            return
+        if self._skip_depth > 0:
+            return
+        if tag in self.HEADING_TAGS or (tag == "h1" and not self._title_found):
+            self._in_heading = False
+            heading_text = re.sub(r"\s+", " ", " ".join(self._heading_buf)).strip()
+            if self._heading_level == 1 and not self._title_found:
+                self.title = heading_text
+                self._title_found = True
+            elif heading_text and self._heading_level >= 2:
+                self._flush_section()
+                self._current_section = _ParsedSection(title=heading_text, level=self._heading_level)
+            self._heading_buf = []
+        if tag in ("div", "section", "blockquote") and self._in_abstract and self._abstract_buf:
+            self.abstract = re.sub(r"\s+", " ", " ".join(self._abstract_buf)).strip()
+            self._in_abstract = False
+        if tag in ("div", "section") and self._in_authors:
+            self._in_authors = False
+            authors_text = re.sub(r"\s+", " ", " ".join(self._authors_buf)).strip()
+            if authors_text and not self.authors:
+                self.authors = authors_text
+
+    def handle_data(self, data):
+        if self._skip_depth > 0:
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._in_heading:
+            self._heading_buf.append(text)
+            return
+        if self._in_abstract:
+            self._abstract_buf.append(text)
+        if self._in_authors:
+            self._authors_buf.append(text)
+        if self._current_section is not None:
+            self._text_buf.append(text)
+
+    def _flush_section(self):
+        if self._current_section and self._text_buf:
+            self._current_section.text = re.sub(r"\s+", " ", " ".join(self._text_buf)).strip()
+            if len(self._current_section.text) > 50:  # skip tiny sections (V2 rule)
+                self.sections.append(self._current_section)
+        self._text_buf = []
+
+    def finalize(self):
+        self._flush_section()
+        if not self.abstract and self.sections:
+            for s in self.sections:
+                if "abstract" in s.title.lower():
+                    self.abstract = s.text[:2000]
+                    break
+
+
+def extract_arxiv_id(url: str) -> str:
+    """Extract an arXiv ID from a URL (verbatim V2 regex)."""
+    m = re.search(r"(\d{4}\.\d{4,5})(v\d+)?", url or "")
+    return m.group(1) if m else ""
+
+
+def fetch_html(url: str) -> str:
+    """Download HTML content from a URL (verbatim V2 fetch)."""
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "EpiGraph/1.0 (epistemic-research; +https://github.com/epigraph-io)",
+            "Accept": "text/html",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted source URLs)
+        charset = resp.headers.get_content_charset() or "utf-8"
+        return resp.read().decode(charset, errors="replace")
+
+
+def _split_authors(joined: str) -> list[Author]:
+    """HTML yields one joined author blob; best-effort comma/semicolon split."""
+    if not joined:
+        return []
+    parts = re.split(r"\s*(?:,|;| and )\s*", joined)
+    names = [p.strip() for p in parts if p.strip() and len(p.strip()) > 1]
+    return [Author(name=n, roles=["author"]) for n in names] or [Author(name=joined, roles=["author"])]
+
+
+def html_to_document_extraction(html: str, url: str = "") -> DocumentExtractionOut:
+    """Parse HTML and map to the live DocumentExtraction shape.
+
+    arXiv: source_type=Paper, uri=url, doi=10.48550/arXiv.<id>; abstract becomes
+    the (top-down) thesis; each recovered section -> one Section with one
+    Paragraph (HTML has no reliable intra-section paragraph boundaries).
+    """
+    parser = HTMLTextExtractor()
+    parser.feed(html)
+    parser.finalize()
+
+    doi = None
+    arxiv_id = extract_arxiv_id(url) if "arxiv.org" in (url or "") else ""
+    if arxiv_id:
+        doi = f"10.48550/arXiv.{arxiv_id}"
+    if not doi:
+        m = re.search(r"10\.\d{4,}/[^\s<>\"]+", html)
+        if m:
+            doi = m.group(0).rstrip(".,;)")
+
+    sections_out: list[SectionOut] = []
+    for s in parser.sections:
+        if "abstract" in s.title.lower():
+            continue  # abstract becomes the thesis, not a body section
+        sections_out.append(
+            SectionOut(
+                title=s.title,
+                summary=first_sentence(s.text),
+                paragraphs=[
+                    ParagraphOut(
+                        compound=first_sentence(s.text),
+                        supporting_text=s.text,
+                        confidence=0.8,
+                        methodology="structured_html_parse",
+                    )
+                ],
+            )
+        )
+
+    return DocumentExtractionOut(
+        title=parser.title or (f"arXiv:{arxiv_id}" if arxiv_id else "Untitled"),
+        source_type="Paper",
+        doi=doi,
+        uri=url or None,
+        authors=_split_authors(parser.authors),
+        thesis=(parser.abstract or None),
+        thesis_derivation="TopDown",
+        sections=sections_out,
+        metadata={
+            "extractor": "extract_html.py",
+            "extraction_stage": "structure_recovery_only",
+            "arxiv_id": arxiv_id or None,
+        },
+    )
+
+
+def _basename_for(url: str, title: str) -> str:
+    arxiv_id = extract_arxiv_id(url)
+    base = arxiv_id if arxiv_id else hashlib.md5(url.encode()).hexdigest()[:12]  # noqa: S324
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", (title or "")[:50]).strip("_")
+    return f"{base}_{slug}" if slug else base
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Parse paper HTML into DocumentExtraction JSON")
+    ap.add_argument("input", help="URL, or local .html path with --from-file")
+    ap.add_argument("--from-file", action="store_true", help="Treat input as a local HTML file (no network)")
+    ap.add_argument("--uri", default="", help="Source URI to record when reading --from-file")
+    ap.add_argument("--output", "-o", default="/home/jeremy/tmp/extractions/")
+    args = ap.parse_args()
+
+    if args.from_file:
+        html = Path(args.input).read_text(encoding="utf-8", errors="replace")
+        url = args.uri or args.input
+    else:
+        url = args.input.strip()
+        html = fetch_html(url)
+
+    doc = html_to_document_extraction(html, url).to_dict()
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{_basename_for(url, doc['source']['title'])}_extraction.json"
+    out_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False))
+    print(f"Title:    {doc['source']['title'][:70]}")
+    print(f"Sections: {len(doc['sections'])}")
+    print(f"DOI:      {doc['source'].get('doi') or '(none)'}")
+    print(f"Wrote:    {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_textbook.py
+++ b/scripts/extract_textbook.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Structured-source-first parser for OpenStax textbooks (CNXML source).
+
+Harvested from EpigraphV2/scripts/extract_textbook.py — STRUCTURAL SYMBOLS ONLY:
+parse_books_xml, parse_collection_xml, _parse_content_level, _parse_chapter,
+parse_module, _extract_content_blocks, _extract_text, _extract_terms,
+_parse_table_rows. The V2 LLM stage (llm_complete / filter_chapter_claims /
+extract_relationships, including the litellm `anthropic` provider branch) is
+DELIBERATELY NOT PORTED: it is superseded by the extract-claims skill
+(hierarchical compound->atoms decomposition), and the litellm/Anthropic-SDK path
+violates the prepaid-OAuth claude-CLI invariant (feedback_claude_cli_oauth).
+Structure recovery needs no LLM.
+
+This layer recovers source structure (book/chapter/module/paragraph) and maps it
+onto the live hierarchical DocumentExtraction (crates/epigraph-ingest/src/document/schema.rs):
+  * source_type=Textbook, doi=openstax:<slug>, authors=[OpenStax publisher].
+  * thesis = book title sentence (TopDown).
+  * Each module -> one Section (title = 'Ch N: <chapter> > <module>').
+  * Each real <para> >=50 chars and each glossary <definition> -> one Paragraph
+    (CNXML preserves real paragraph boundaries, unlike arbitrary HTML).
+  * atoms/generality LEFT EMPTY — the extract-claims LLM Stage-3 fills them.
+  * <math>/MathML inside a paragraph is replaced by the literal token
+    '[equation]' (V2 _extract_text behaviour); equations are not extracted.
+
+Usage:
+    git clone --depth 1 https://github.com/openstax/osbooks-college-physics.git /tmp/phys
+    python3 scripts/extract_textbook.py /tmp/phys --output /home/jeremy/tmp/extractions/
+    python3 scripts/extract_textbook.py /tmp/phys --book college-physics --max-modules 5
+"""
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib.document_extraction import (  # noqa: E402
+    Author,
+    DocumentExtractionOut,
+    ParagraphOut,
+    SectionOut,
+    first_sentence,
+)
+
+NS = {
+    "col": "http://cnx.rice.edu/collxml",
+    "md": "http://cnx.rice.edu/mdml",
+    "cnxml": "http://cnx.rice.edu/cnxml",
+    "m": "http://www.w3.org/1998/Math/MathML",
+    "container": "https://openstax.org/namespaces/book-container",
+}
+
+
+@dataclass
+class Module:
+    module_id: str
+    title: str
+    uuid: str
+    content_blocks: list[dict] = field(default_factory=list)
+    is_introduction: bool = False
+
+
+@dataclass
+class Chapter:
+    title: str
+    chapter_number: int
+    module_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Part:
+    title: str
+    chapters: list[Chapter] = field(default_factory=list)
+
+
+@dataclass
+class BookStructure:
+    title: str
+    slug: str
+    license: str
+    parts: list[Part] = field(default_factory=list)
+
+    def all_chapters(self) -> list[Chapter]:
+        return [ch for part in self.parts for ch in part.chapters]
+
+
+def _local_tag(el) -> str:
+    tag = el.tag
+    return tag.split("}")[-1] if "}" in tag else tag
+
+
+def _text_of(el):
+    return el.text.strip() if el is not None and el.text else None
+
+
+# ── Collection (book) parser — verbatim V2 structural logic ──────────────────
+
+def parse_books_xml(repo_path: Path) -> list[dict]:
+    tree = ET.parse(repo_path / "META-INF" / "books.xml")
+    root = tree.getroot()
+    return [
+        {"slug": b.get("slug", ""), "style": b.get("style", ""), "href": b.get("href", "")}
+        for b in root.findall("container:book", NS)
+    ]
+
+
+def parse_collection_xml(collection_path: Path) -> BookStructure:
+    tree = ET.parse(collection_path)
+    root = tree.getroot()
+    title = _text_of(root.find("col:metadata/md:title", NS)) or ""
+    slug = _text_of(root.find("col:metadata/md:slug", NS)) or ""
+    license_el = root.find("col:metadata/md:license", NS)
+    license_text = license_el.get("url", "") if license_el is not None else ""
+    content_el = root.find("col:content", NS)
+    parts = _parse_content_level(content_el, chapter_counter=[0])
+    return BookStructure(title=title, slug=slug, license=license_text, parts=parts)
+
+
+def _parse_content_level(content_el, chapter_counter: list[int]) -> list[Part]:
+    if content_el is None:
+        return []
+    parts: list[Part] = []
+    for child in content_el:
+        tag = _local_tag(child)
+        if tag != "subcollection":
+            continue
+        sub_title = _text_of(child.find("md:title", NS)) or "Untitled"
+        sub_content = child.find("col:content", NS)
+        has_nested = sub_content is not None and any(
+            _local_tag(c) == "subcollection" for c in sub_content
+        )
+        if has_nested:
+            part = Part(title=sub_title)
+            for inner in sub_content:
+                if _local_tag(inner) == "subcollection":
+                    chapter_counter[0] += 1
+                    part.chapters.append(_parse_chapter(inner, chapter_counter[0]))
+            parts.append(part)
+        else:
+            chapter_counter[0] += 1
+            ch = _parse_chapter(child, chapter_counter[0])
+            if not parts or parts[-1].chapters:
+                parts.append(Part(title=""))
+            parts[-1].chapters.append(ch)
+    return parts
+
+
+def _parse_chapter(subcoll_el, chapter_num: int) -> Chapter:
+    title = _text_of(subcoll_el.find("md:title", NS)) or "Untitled"
+    content_el = subcoll_el.find("col:content", NS)
+    module_ids = []
+    if content_el is not None:
+        for mod_el in content_el.findall("col:module", NS):
+            doc_id = mod_el.get("document", "")
+            if doc_id:
+                module_ids.append(doc_id)
+    return Chapter(title=title, chapter_number=chapter_num, module_ids=module_ids)
+
+
+# ── Module (CNXML) parser — verbatim V2 structural logic ─────────────────────
+
+def parse_module(module_path: Path) -> Module:
+    tree = ET.parse(module_path)
+    root = tree.getroot()
+    doc_class = root.get("class", "")
+    title = _text_of(root.find("cnxml:title", NS)) or ""
+    md_id = _text_of(root.find("cnxml:metadata/md:content-id", NS)) or module_path.parent.name
+    uuid = _text_of(root.find("cnxml:metadata/md:uuid", NS)) or ""
+    module = Module(module_id=md_id, title=title, uuid=uuid,
+                    is_introduction=(doc_class == "introduction"))
+    content_el = root.find("cnxml:content", NS)
+    if content_el is not None:
+        _extract_content_blocks(content_el, module)
+    glossary_el = root.find("cnxml:glossary", NS)
+    if glossary_el is not None:
+        for defn in glossary_el.findall("cnxml:definition", NS):
+            term_el = defn.find("cnxml:term", NS)
+            meaning_el = defn.find("cnxml:meaning", NS)
+            if term_el is not None and meaning_el is not None:
+                module.content_blocks.append({
+                    "type": "definition",
+                    "term": _extract_text(term_el),
+                    "meaning": _extract_text(meaning_el),
+                })
+    return module
+
+
+def _extract_content_blocks(element, module: Module, section_title: str = ""):
+    for child in element:
+        tag = _local_tag(child)
+        if tag == "section":
+            sec_class = child.get("class", "")
+            if sec_class in ("knowledge-check", "references", "learning-objectives"):
+                continue
+            sec_title_el = child.find("cnxml:title", NS)
+            sec_title = _extract_text(sec_title_el) if sec_title_el is not None else ""
+            _extract_content_blocks(child, module, section_title=sec_title or section_title)
+        elif tag == "para":
+            text = _extract_text(child).strip()
+            if len(text) >= 50:
+                module.content_blocks.append({
+                    "type": "paragraph",
+                    "id": child.get("id", ""),
+                    "text": text,
+                    "section": section_title,
+                })
+        elif tag == "table":
+            caption_el = child.find("cnxml:caption", NS)
+            caption = _extract_text(caption_el) if caption_el is not None else ""
+            rows = _parse_table_rows(child)
+            if caption or rows:
+                row_text = "; ".join(" | ".join(c) for c in rows[:6])
+                module.content_blocks.append({
+                    "type": "table", "caption": caption, "text": row_text[:1000],
+                    "section": section_title,
+                })
+
+
+def _extract_text(el) -> str:
+    """Recursively extract text; <math> becomes the literal token '[equation]'."""
+    if el is None:
+        return ""
+    parts = []
+    if el.text:
+        parts.append(el.text)
+    for child in el:
+        ct = _local_tag(child)
+        if ct in ("term", "emphasis", "link", "span", "sup", "sub"):
+            parts.append(_extract_text(child))
+        elif ct == "list":
+            items = [_extract_text(i).strip() for i in child.findall("cnxml:item", NS)]
+            if items:
+                parts.append("; ".join(items))
+        elif ct in ("cite", "note", "media", "iframe"):
+            pass
+        elif ct == "math" or ct.endswith("}math"):
+            parts.append("[equation]")
+        else:
+            parts.append(_extract_text(child))
+        if child.tail:
+            parts.append(child.tail)
+    return "".join(parts)
+
+
+def _parse_table_rows(table_el) -> list[list[str]]:
+    rows = []
+    for tgroup in table_el.findall("cnxml:tgroup", NS):
+        for sect in ("thead", "tbody"):
+            section = tgroup.find(f"cnxml:{sect}", NS)
+            if section is None:
+                continue
+            for row_el in section.findall("cnxml:row", NS):
+                cells = [_extract_text(e).strip() for e in row_el.findall("cnxml:entry", NS)]
+                if cells:
+                    rows.append(cells)
+    return rows
+
+
+# ── Mapping to the live DocumentExtraction ───────────────────────────────────
+
+_TRANSITIONAL = [
+    re.compile(r"^in this (section|chapter|module), (we|you) will", re.I),
+    re.compile(r"^by the end of this section", re.I),
+    re.compile(r"^(refer to |see |consider |imagine )", re.I),
+]
+
+
+def _is_transitional(text: str) -> bool:
+    if text.count(".") + text.count("?") + text.count("!") <= 2:
+        return any(p.search(text) for p in _TRANSITIONAL)
+    return False
+
+
+def _module_to_section(module: Module, chapter: Chapter, book_title: str) -> SectionOut | None:
+    sect_title = f"Ch {chapter.chapter_number}: {chapter.title} > {module.title}"
+    paragraphs: list[ParagraphOut] = []
+    for block in module.content_blocks:
+        if block["type"] == "paragraph":
+            text = block["text"]
+            if len(text) < 80 or _is_transitional(text):
+                continue
+            paragraphs.append(ParagraphOut(
+                compound=first_sentence(text), supporting_text=text,
+                confidence=0.85, methodology="textbook_assertion",
+            ))
+        elif block["type"] == "definition":
+            stmt = f"{block['term']} is defined as: {block['meaning']}"
+            paragraphs.append(ParagraphOut(
+                compound=first_sentence(stmt), supporting_text=stmt,
+                confidence=0.90, methodology="textbook_assertion",
+            ))
+        elif block["type"] == "table" and block.get("caption"):
+            paragraphs.append(ParagraphOut(
+                compound=first_sentence(f"Table: {block['caption']}"),
+                supporting_text=block.get("text", ""),
+                confidence=0.80, methodology="textbook_assertion",
+            ))
+    if not paragraphs:
+        return None
+    return SectionOut(title=sect_title, summary=first_sentence(paragraphs[0].supporting_text),
+                      paragraphs=paragraphs)
+
+
+def book_to_document_extraction(repo_path: Path, book_info: dict, max_modules: int = 0) -> DocumentExtractionOut:
+    collection_path = (repo_path / "META-INF" / book_info["href"]).resolve()
+    book = parse_collection_xml(collection_path)
+    sections_out: list[SectionOut] = []
+    seen = 0
+    for chapter in book.all_chapters():
+        for mod_id in chapter.module_ids:
+            module_path = repo_path / "modules" / mod_id / "index.cnxml"
+            if not module_path.exists():
+                continue
+            sec = _module_to_section(parse_module(module_path), chapter, book.title)
+            if sec is not None:
+                sections_out.append(sec)
+            seen += 1
+            if max_modules and seen >= max_modules:
+                break
+        if max_modules and seen >= max_modules:
+            break
+    return DocumentExtractionOut(
+        title=book.title or book.slug,
+        source_type="Textbook",
+        doi=f"openstax:{book.slug}",
+        authors=[Author(name="OpenStax", affiliations=["Rice University"], roles=["publisher"])],
+        journal="OpenStax Textbook",
+        thesis=first_sentence(book.title) if book.title else None,
+        thesis_derivation="TopDown",
+        sections=sections_out,
+        metadata={
+            "extractor": "extract_textbook.py",
+            "extraction_stage": "structure_recovery_only",
+            "book_slug": book.slug,
+            "license": book.license,
+        },
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Parse OpenStax CNXML into DocumentExtraction JSON")
+    ap.add_argument("repo_path", help="Path to a cloned OpenStax repo")
+    ap.add_argument("--book", help="Process only this book slug (default: all)")
+    ap.add_argument("--max-modules", type=int, default=0, help="Cap modules per book (0 = all)")
+    ap.add_argument("--output", default="/home/jeremy/tmp/extractions/")
+    args = ap.parse_args()
+
+    repo_path = Path(args.repo_path)
+    books = parse_books_xml(repo_path)
+    if args.book:
+        books = [b for b in books if b["slug"] == args.book]
+        if not books:
+            print(f"book {args.book!r} not found", file=sys.stderr)
+            sys.exit(1)
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for b in books:
+        doc = book_to_document_extraction(repo_path, b, max_modules=args.max_modules).to_dict()
+        out_path = out_dir / f"openstax_{b['slug']}_extraction.json"
+        out_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False))
+        print(f"Book:     {doc['source']['title'][:60]}")
+        print(f"Sections: {len(doc['sections'])}")
+        print(f"Wrote:    {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_textbook.py
+++ b/scripts/extract_textbook.py
@@ -300,7 +300,14 @@ def _module_to_section(module: Module, chapter: Chapter, book_title: str) -> Sec
             ))
     if not paragraphs:
         return None
-    return SectionOut(title=sect_title, summary=first_sentence(paragraphs[0].supporting_text),
+    # Derive the L1 summary from the section TITLE, not the first paragraph's
+    # supporting_text. first_sentence(paragraphs[0].supporting_text) is verbatim
+    # paragraphs[0].compound; since compound_claim_id hashes content with no
+    # level in the material, that identical string collides the section (L1) and
+    # its first paragraph (L2) onto the SAME UUID — a decomposes_to self-loop and
+    # a duplicate-id insert (backlog b5518801). A title-derived summary is
+    # hash-distinct from every child compound.
+    return SectionOut(title=sect_title, summary=f"Section: {sect_title}",
                       paragraphs=paragraphs)
 
 

--- a/scripts/lib/document_extraction.py
+++ b/scripts/lib/document_extraction.py
@@ -1,0 +1,185 @@
+"""Map structured-source parser output to the live hierarchical DocumentExtraction JSON.
+
+This is the net-new glue for backlog b5518801. The fetch/parse layer
+(extract_html.py, extract_textbook.py) recovers source structure
+(title/authors/sections/paragraphs/supporting_text). This module maps that
+recovered structure onto the schema the live MCP `ingest_document` tool parses:
+`epigraph_ingest::schema::DocumentExtraction` (crates/epigraph-ingest/src/document/schema.rs).
+
+IMPORTANT — emit the RUST shape, not the SKILL.md example shape:
+  * paragraph key is `compound` (a String), NOT `compound_claim`
+  * `atoms` is a list[str], NOT a list of objects
+  * `thesis` is a plain string|null, NOT an object {claim, confidence, source}
+  * cross-claim edges use `source_path`/`target_path`, NOT `source_atom`/`target_atom`
+The builder `build_ingest_plan` (crates/epigraph-ingest/src/document/builder.rs)
+is what consumes this; its tests in lib.rs pin these exact field names.
+
+SCOPE: structure recovery only. This preprocessor does NOT produce atoms or
+generality scores — those require the LLM Stage-3 decomposition in the
+extract-claims skill (.claude/skills/extract-claims/SKILL.md), which rewrites
+`compound` and fills `atoms`/`generality` downstream. Every paragraph here is
+emitted with `atoms: []` and a provisional `compound` (the first sentence /
+truncation of the recovered text); the full text is preserved verbatim in
+`supporting_text` so the LLM stage has the source material.
+
+CANONICAL evidence_type set (crates/epigraph-ingest/src/common/evidence_type.rs):
+regulatory, empirical, statistical, logical, testimonial, circumstantial,
+conversational. Anything outside this set is dropped to None by the Rust
+normalizer, so we omit the field rather than guess.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# Canonical SourceType variants (serde renames are PascalCase — match schema.rs).
+SOURCE_TYPES = {
+    "Paper",
+    "Textbook",
+    "InternalDocument",
+    "Report",
+    "Transcript",
+    "Legal",
+    "Tabular",
+}
+
+# Canonical evidence_type values (lower-case keys per evidence_type.rs).
+EVIDENCE_TYPES = {
+    "regulatory",
+    "empirical",
+    "statistical",
+    "logical",
+    "testimonial",
+    "circumstantial",
+    "conversational",
+}
+
+# Max chars for the provisional compound (mirrors V2 statement = text[:500]).
+_COMPOUND_MAX = 500
+
+
+def first_sentence(text: str, max_chars: int = _COMPOUND_MAX) -> str:
+    """Provisional compound = first sentence, else a hard truncation.
+
+    The LLM Stage-3 decomposition rewrites this; we only need a non-empty,
+    representative string because `Paragraph.compound` is a required field with
+    no serde default and `build_ingest_plan` hashes it into the claim id.
+    """
+    text = re.sub(r"\s+", " ", text or "").strip()
+    if not text:
+        return ""
+    # First sentence terminator followed by whitespace; keep the terminator.
+    m = re.search(r"[.!?](?:\s|$)", text)
+    if m and m.end() <= max_chars:
+        return text[: m.end()].strip()
+    return text[:max_chars].strip()
+
+
+@dataclass
+class Author:
+    name: str
+    affiliations: list[str] = field(default_factory=list)
+    roles: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "affiliations": self.affiliations,
+            "roles": self.roles,
+        }
+
+
+@dataclass
+class ParagraphOut:
+    """Maps to Rust `Paragraph`. compound is required + non-empty."""
+
+    compound: str
+    supporting_text: str = ""
+    confidence: float = 0.8
+    methodology: Optional[str] = None
+    evidence_type: Optional[str] = None
+    page: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "compound": self.compound,
+            "supporting_text": self.supporting_text,
+            # atoms intentionally empty: filled by the LLM Stage-3 decomposition.
+            "atoms": [],
+            "generality": [],
+            "confidence": self.confidence,
+        }
+        if self.methodology:
+            out["methodology"] = self.methodology
+        et = (self.evidence_type or "").strip().lower()
+        if et in EVIDENCE_TYPES:
+            out["evidence_type"] = et
+        if self.page is not None:
+            out["page"] = self.page
+        return out
+
+
+@dataclass
+class SectionOut:
+    """Maps to Rust `Section`."""
+
+    title: str
+    summary: str = ""
+    paragraphs: list[ParagraphOut] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "summary": self.summary,
+            "paragraphs": [p.to_dict() for p in self.paragraphs],
+        }
+
+
+@dataclass
+class DocumentExtractionOut:
+    """Maps to Rust `DocumentExtraction` — the JSON ingest_document parses."""
+
+    title: str
+    source_type: str = "Paper"
+    doi: Optional[str] = None
+    uri: Optional[str] = None
+    authors: list[Author] = field(default_factory=list)
+    journal: Optional[str] = None
+    year: Optional[int] = None
+    metadata: Optional[dict[str, Any]] = None
+    thesis: Optional[str] = None
+    thesis_derivation: str = "TopDown"
+    sections: list[SectionOut] = field(default_factory=list)
+    # relationships use source_path/target_path (claim-path strings), not atoms.
+    relationships: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.source_type not in SOURCE_TYPES:
+            raise ValueError(
+                f"source_type {self.source_type!r} not in canonical set {sorted(SOURCE_TYPES)}"
+            )
+        source: dict[str, Any] = {
+            "title": self.title,
+            "source_type": self.source_type,
+            "authors": [a.to_dict() for a in self.authors],
+        }
+        if self.doi:
+            source["doi"] = self.doi
+        if self.uri:
+            source["uri"] = self.uri
+        if self.journal:
+            source["journal"] = self.journal
+        if self.year is not None:
+            source["year"] = self.year
+        if self.metadata is not None:
+            source["metadata"] = self.metadata
+        doc: dict[str, Any] = {
+            "source": source,
+            "thesis": self.thesis,
+            "thesis_derivation": self.thesis_derivation,
+            "sections": [s.to_dict() for s in self.sections],
+            "relationships": self.relationships,
+        }
+        return doc

--- a/scripts/tests/test_structured_source_parsers.py
+++ b/scripts/tests/test_structured_source_parsers.py
@@ -1,0 +1,103 @@
+"""Offline tests for the structured-source preprocessors (backlog b5518801).
+
+Run: python3 -m unittest scripts/tests/test_structured_source_parsers.py
+No network, no API keys, no LLM — pure stdlib parsing of committed fixtures.
+Also (re)writes the two Rust fixtures consumed by
+crates/epigraph-ingest/tests/structured_source_glue.rs so Python and Rust
+never drift; CI runs this before `cargo test -p epigraph-ingest`.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+import extract_html  # noqa: E402
+import extract_textbook  # noqa: E402
+from lib.document_extraction import EVIDENCE_TYPES, SOURCE_TYPES  # noqa: E402
+
+FIX = REPO / "crates" / "epigraph-ingest" / "tests" / "fixtures"
+
+
+def _assert_canonical(doc: dict) -> None:
+    """Every contract the Rust ingester depends on, checked structurally."""
+    assert doc["source"]["source_type"] in SOURCE_TYPES
+    for sec in doc["sections"]:
+        assert sec["title"], "section title required"
+        for p in sec["paragraphs"]:
+            assert p["compound"].strip(), "compound required + non-empty"
+            assert p["atoms"] == [], "structure recovery emits no atoms"
+            assert isinstance(p["generality"], list)
+            if "evidence_type" in p:
+                assert p["evidence_type"] in EVIDENCE_TYPES
+    for rel in doc["relationships"]:
+        assert "source_path" in rel and "target_path" in rel, (
+            "relationships use source_path/target_path (Rust shape), "
+            "NOT source_atom/target_atom (SKILL.md shape)"
+        )
+
+
+class TestArxivHtml(unittest.TestCase):
+    def test_maps_and_skips_math(self):
+        html = (FIX / "sample_arxiv.html").read_text()
+        doc = extract_html.html_to_document_extraction(
+            html, "https://arxiv.org/html/2603.04139v1"
+        ).to_dict()
+        _assert_canonical(doc)
+        self.assertEqual(doc["source"]["source_type"], "Paper")
+        self.assertEqual(doc["source"]["doi"], "10.48550/arXiv.2603.04139")
+        self.assertEqual(len(doc["source"]["authors"]), 3)
+        self.assertEqual(len(doc["sections"]), 2, "two h2 sections (abstract excluded)")
+        self.assertTrue(doc["thesis"], "abstract becomes thesis")
+        body = " ".join(
+            p["supporting_text"] for s in doc["sections"] for p in s["paragraphs"]
+        )
+        self.assertNotIn("E=m", body, "<math> must be skipped")
+        # Regenerate the Rust fixture deterministically.
+        (FIX / "sample_arxiv_extraction.json").write_text(
+            json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
+        )
+
+
+class TestOpenStaxCnxml(unittest.TestCase):
+    def test_module_maps_filters_transitional_and_placeholders_math(self):
+        mod = extract_textbook.parse_module(FIX / "sample_openstax_module.cnxml")
+        chapter = extract_textbook.Chapter(
+            title="Electrostatics", chapter_number=1, module_ids=[mod.module_id]
+        )
+        section = extract_textbook._module_to_section(mod, chapter, "Sample Physics")
+        self.assertIsNotNone(section)
+        doc = extract_textbook.DocumentExtractionOut(
+            title=mod.title,
+            source_type="Textbook",
+            doi="openstax:sample-physics",
+            authors=[
+                extract_textbook.Author(
+                    name="OpenStax", affiliations=["Rice University"], roles=["publisher"]
+                )
+            ],
+            journal="OpenStax Textbook",
+            sections=[section],
+            metadata={
+                "extractor": "extract_textbook.py",
+                "extraction_stage": "structure_recovery_only",
+                "book_slug": "sample-physics",
+                "license": "",
+            },
+        ).to_dict()
+        _assert_canonical(doc)
+        paras = doc["sections"][0]["paragraphs"]
+        self.assertEqual(len(paras), 2, "1 real para + 1 definition; transitional dropped")
+        joined = " ".join(p["supporting_text"] for p in paras)
+        self.assertIn("[equation]", joined, "inline MathML -> [equation] placeholder")
+        self.assertNotIn("In this section, we will explore", joined)
+        (FIX / "sample_openstax_extraction.json").write_text(
+            json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a structure-recovery preprocessor that sits in front of the existing extract-claims LLM stage and `ingest_document`. It fetches/parses structured scientific sources and maps them onto the live hierarchical `DocumentExtraction` schema (`crates/epigraph-ingest/src/document/schema.rs`), so when a source has explicit structure (arXiv HTML/ar5iv/PMC, OpenStax CNXML) the pipeline exploits it instead of falling back to OCR/agent-prose reading.

Resolves backlog b5518801.

- `scripts/lib/document_extraction.py` — net-new glue: dataclasses + serializer that emit the **canonical Rust shape** (`compound` string, `atoms: []`, `thesis` string|null, relationships keyed by `source_path`/`target_path`) — NOT the SKILL.md example shape (`compound_claim`, atom objects, `source_atom`).
- `scripts/extract_html.py` — arXiv-HTML parser harvested from EpigraphV2 (LLM-free), `source_type=Paper`, derives the `10.48550/arXiv.<id>` DOI.
- `scripts/extract_textbook.py` — OpenStax CNXML parser harvested from EpigraphV2 (**structural symbols only**; the V2 LLM/litellm-anthropic stage is dropped per `feedback_claude_cli_oauth` and because the extract-claims skill is the canonical decomposition), `source_type=Textbook`.

## Scope (honest)

This is **structure recovery, not extraction**. The preprocessor emits levels 0–2 (thesis/section/paragraph) with `atoms: []` and a provisional `compound` (first sentence of the recovered text); the downstream extract-claims Stage-3 LLM decomposition rewrites `compound` and fills `atoms`/`generality`. MathML is skipped (HTML) or rendered as `[equation]` (CNXML) — equations are not extracted. HTML collapses each section into one paragraph; CNXML preserves real paragraph boundaries.

## Out of scope / follow-ups

- Wiring this as the preferred path in the `paper-monitor`/`research-ingest` scheduled tasks lives in **epiclaw-host** (different repo) and is intentionally not in this PR — follow-up.
- End-to-end `ingest_document` against a live graph (needs Postgres + OAuth + MCP server).

## Verifiability

NOT runtime/deployment-verified end-to-end. Verified offline only, with no network / no API keys / no LLM:
- `python3 -m unittest scripts/tests/test_structured_source_parsers.py` — parses committed HTML+CNXML fixtures, asserts the canonical-schema contract (compound non-empty, atoms empty, evidence_type in closed set, source_path/target_path keys), MathML handling, and transitional-paragraph filtering; regenerates the two Rust fixtures. **Observed: 2 ok.**
- `SQLX_OFFLINE=true cargo test -p epigraph-ingest --test structured_source_glue` — deserializes the verbatim parser output into `DocumentExtraction` and runs `build_ingest_plan`, asserting claim levels (L0–L2, zero L3 atoms) and `decomposes_to`/`section_follows`/`continues_argument` edge counts. **Observed: 2 passed.** Full crate suite `cargo test -p epigraph-ingest` = **25 passed / 0 failed**. `epigraph-ingest` is a pure crate (no sqlx), so this runs in the 4-core/2.7GB box.

What was NOT verified here: the live `ingest_document` end-to-end (Postgres + OAuth + MCP), the `fetch_html` network path (only `--from-file` is tested), the full book/collection-walking layer (`parse_books_xml`/`parse_collection_xml`/`book_to_document_extraction` — reachable only via CLI `main()`, needs a real OpenStax clone; the OpenStax test exercises `parse_module` + `_module_to_section` directly), and the downstream extract-claims LLM Stage-3 (out of scope by design).

No DB migration; no `.sqlx/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
