### PR TITLE
chore(ci): relocate cargo target/ to /mnt to stop ENOSPC mid-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,18 @@ jobs:
             echo 'rustflags = ["-C", "link-arg=-fuse-ld=mold"]'
           } >> .cargo/config.toml
           mold --version
+      - name: Relocate cargo target/ to the large ephemeral disk
+        # The runner's root volume (/) has only ~14 GB free; this workspace's
+        # debug target/ tree plus the per-crate #[sqlx::test] integration test
+        # binaries exceed that, ENOSPC-killing the run partway through the
+        # serialized test suites (observed: dies at "Test (epigraph-api)",
+        # _diag log write fails with "No space left on device"). The runner's
+        # /mnt ephemeral disk has ~70 GB free, so point CARGO_TARGET_DIR there.
+        # Must run BEFORE rust-cache so the cache restores/saves at this path.
+        run: |
+          sudo mkdir -p /mnt/cargo-target
+          sudo chown "$USER:$USER" /mnt/cargo-target
+          echo "CARGO_TARGET_DIR=/mnt/cargo-target" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2.8.1
       - name: Build
         run: cargo build --workspace


### PR DESCRIPTION
Root cause of the broken CI across nearly all open PRs: the GitHub-hosted `ubuntu-latest` runner's `/` volume (~14 GB free) fills up partway through the build/test, so runs die at **Test (epigraph-api, serialized)** with `No space left on device`. Even the docs-only #234 fails — proving it's infra, not code.

This points `CARGO_TARGET_DIR` at the `/mnt` ephemeral disk (~70 GB free), placed before `rust-cache` so the cache honors the new path.

This branch is the **canary**: green here proves both the disk fix and a clean main baseline. Once green + merged, the other open PRs need a branch-update (their `pull_request` CI runs their own copy of `ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)