### PR TITLE
feat(nli): self-hosted CPU NLI cross-encoder + DST stance->BBA belief path (probe routing as bonus)

### DIFF
--- a/crates/epigraph-cli/src/enrichment/confidence.rs
+++ b/crates/epigraph-cli/src/enrichment/confidence.rs
@@ -303,8 +303,7 @@ mod tests {
     async fn test_skeptic_unrelated_evidence_flags_low_confidence() {
         let client =
             MockLlmClient::with_responses(vec![serde_json::json!({"rating": "UNRELATED"})]);
-        let result =
-            skeptic_probe(&client, None, "fix bug", &["updated README".to_string()]).await;
+        let result = skeptic_probe(&client, None, "fix bug", &["updated README".to_string()]).await;
         assert_eq!(result, EvidenceSupport::Unrelated);
         assert!((result.factor() - 0.4).abs() < f64::EPSILON);
     }

--- a/crates/epigraph-cli/src/enrichment/confidence.rs
+++ b/crates/epigraph-cli/src/enrichment/confidence.rs
@@ -8,6 +8,7 @@
 //! The final confidence is always ≤ the parser's value — LLM can only lower, never raise.
 
 use super::llm_client::LlmProvider;
+use super::nli_client::{mapping, NliClassifier};
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -98,11 +99,35 @@ Example: {{"rating": "STRONG_SUPPORT"}}"#
 /// Run the skeptic probe to assess evidence quality
 pub async fn skeptic_probe(
     client: &dyn LlmProvider,
+    nli: Option<&dyn NliClassifier>,
     claim: &str,
     evidence: &[String],
 ) -> EvidenceSupport {
     if evidence.is_empty() {
         return EvidenceSupport::Unrelated;
+    }
+
+    // Cheap/deterministic alternate producer: if an NLI service is wired and
+    // active, classify each (evidence -> claim) pair and aggregate, skipping
+    // the LLM round-trip entirely. Any per-pair NLI error falls back to the
+    // LLM path for the whole probe (do not silently mix producers).
+    if let Some(nli) = nli {
+        if nli.is_active() {
+            let mut per_pair = Vec::with_capacity(evidence.len());
+            let mut ok = true;
+            for e in evidence {
+                match nli.classify(e, claim).await {
+                    Ok(s) => per_pair.push(mapping::support_of_pair(&s)),
+                    Err(_) => {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+            if ok {
+                return mapping::aggregate_support(&per_pair);
+            }
+        }
     }
 
     let prompt = build_skeptic_prompt(claim, evidence);
@@ -168,6 +193,7 @@ Example: {{"rating": "CONSISTENT"}}"#
 /// Run the coherence probe to check cross-claim consistency
 pub async fn coherence_probe(
     client: &dyn LlmProvider,
+    nli: Option<&dyn NliClassifier>,
     claim: &str,
     scope: &str,
     prior_claims: &[(String, f64)],
@@ -175,6 +201,28 @@ pub async fn coherence_probe(
     // First claim in a scope is always consistent
     if prior_claims.is_empty() {
         return CoherenceResult::Consistent;
+    }
+
+    // NLI alternate producer: classify each (prior claim -> new claim) pair
+    // and aggregate (contradiction dominates). Falls back to the LLM path on
+    // any NLI error.
+    if let Some(nli) = nli {
+        if nli.is_active() {
+            let mut per_pair = Vec::with_capacity(prior_claims.len());
+            let mut ok = true;
+            for (text, _truth) in prior_claims {
+                match nli.classify(text, claim).await {
+                    Ok(s) => per_pair.push(mapping::coherence_of_pair(&s)),
+                    Err(_) => {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+            if ok {
+                return mapping::aggregate_coherence(&per_pair);
+            }
+        }
     }
 
     let prompt = build_coherence_prompt(claim, scope, prior_claims);
@@ -232,6 +280,7 @@ mod tests {
             MockLlmClient::with_responses(vec![serde_json::json!({"rating": "STRONG_SUPPORT"})]);
         let result = skeptic_probe(
             &client,
+            None,
             "add truth validation",
             &["Plan requires it".to_string()],
         )
@@ -244,7 +293,8 @@ mod tests {
     async fn test_skeptic_weak_support_lowers_confidence() {
         let client =
             MockLlmClient::with_responses(vec![serde_json::json!({"rating": "WEAK_SUPPORT"})]);
-        let result = skeptic_probe(&client, "add feature", &["some evidence".to_string()]).await;
+        let result =
+            skeptic_probe(&client, None, "add feature", &["some evidence".to_string()]).await;
         assert_eq!(result, EvidenceSupport::WeakSupport);
         assert!((result.factor() - 0.7).abs() < f64::EPSILON);
     }
@@ -253,7 +303,8 @@ mod tests {
     async fn test_skeptic_unrelated_evidence_flags_low_confidence() {
         let client =
             MockLlmClient::with_responses(vec![serde_json::json!({"rating": "UNRELATED"})]);
-        let result = skeptic_probe(&client, "fix bug", &["updated README".to_string()]).await;
+        let result =
+            skeptic_probe(&client, None, "fix bug", &["updated README".to_string()]).await;
         assert_eq!(result, EvidenceSupport::Unrelated);
         assert!((result.factor() - 0.4).abs() < f64::EPSILON);
     }
@@ -261,7 +312,7 @@ mod tests {
     #[tokio::test]
     async fn test_skeptic_handles_no_evidence_commits() {
         let client = MockLlmClient::new(); // Won't be called
-        let result = skeptic_probe(&client, "chore: update deps", &[]).await;
+        let result = skeptic_probe(&client, None, "chore: update deps", &[]).await;
         assert_eq!(result, EvidenceSupport::Unrelated);
     }
 
@@ -269,7 +320,7 @@ mod tests {
     async fn test_skeptic_handles_api_failure() {
         let client = MockLlmClient::new();
         client.set_malformed(true);
-        let result = skeptic_probe(&client, "claim", &["evidence".to_string()]).await;
+        let result = skeptic_probe(&client, None, "claim", &["evidence".to_string()]).await;
         // Should default to WeakSupport on failure
         assert_eq!(result, EvidenceSupport::WeakSupport);
     }
@@ -281,7 +332,7 @@ mod tests {
         let client =
             MockLlmClient::with_responses(vec![serde_json::json!({"rating": "CONSISTENT"})]);
         let prior = vec![("define Claim model".to_string(), 0.6)];
-        let result = coherence_probe(&client, "add truth validation", "core", &prior).await;
+        let result = coherence_probe(&client, None, "add truth validation", "core", &prior).await;
         assert_eq!(result, CoherenceResult::Consistent);
         assert!((result.factor() - 1.0).abs() < f64::EPSILON);
     }
@@ -291,7 +342,8 @@ mod tests {
         let client =
             MockLlmClient::with_responses(vec![serde_json::json!({"rating": "CONTRADICTION"})]);
         let prior = vec![("add truth validation".to_string(), 0.6)];
-        let result = coherence_probe(&client, "remove truth validation", "core", &prior).await;
+        let result =
+            coherence_probe(&client, None, "remove truth validation", "core", &prior).await;
         assert_eq!(result, CoherenceResult::Contradiction);
         assert!((result.factor() - 0.5).abs() < f64::EPSILON);
     }
@@ -299,7 +351,7 @@ mod tests {
     #[tokio::test]
     async fn test_coherence_first_claim_in_scope_always_passes() {
         let client = MockLlmClient::new(); // Won't be called
-        let result = coherence_probe(&client, "first claim", "core", &[]).await;
+        let result = coherence_probe(&client, None, "first claim", "core", &[]).await;
         assert_eq!(result, CoherenceResult::Consistent);
     }
 
@@ -373,5 +425,94 @@ mod tests {
             (result - expected).abs() < 1e-10,
             "Expected {expected}, got {result}"
         );
+    }
+
+    // --- NLI alternate-producer routing (BONUS path; backlog 97244690) ---
+
+    use crate::enrichment::nli_client::{NliClassifier, NliError, NliScores};
+    use async_trait::async_trait;
+
+    /// Deterministic in-process NLI fake: returns scripted scores per call,
+    /// or signals inactive / error. No network, no model.
+    struct FakeNli {
+        scripted: std::sync::Mutex<Vec<Result<NliScores, ()>>>,
+        active: bool,
+    }
+    impl FakeNli {
+        fn active(scripted: Vec<Result<NliScores, ()>>) -> Self {
+            Self {
+                scripted: std::sync::Mutex::new(scripted),
+                active: true,
+            }
+        }
+    }
+    #[async_trait]
+    impl NliClassifier for FakeNli {
+        fn is_active(&self) -> bool {
+            self.active
+        }
+        async fn classify(&self, _p: &str, _h: &str) -> Result<NliScores, NliError> {
+            let mut g = self.scripted.lock().unwrap();
+            match g.remove(0) {
+                Ok(s) => Ok(s),
+                Err(()) => Err(NliError::RequestFailed("boom".into())),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn coherence_routes_to_nli_and_contradiction_dominates() {
+        // Two prior claims: first consistent (entailment), second contradicting.
+        // Aggregation must report Contradiction WITHOUT any LLM call (mock has
+        // no scripted response, so if the LLM path fired it would default to
+        // Tension -- a different value -- making this non-tautological).
+        let llm = MockLlmClient::new();
+        let nli = FakeNli::active(vec![
+            Ok(NliScores {
+                entailment: 0.85,
+                neutral: 0.10,
+                contradiction: 0.05,
+            }),
+            Ok(NliScores {
+                entailment: 0.05,
+                neutral: 0.15,
+                contradiction: 0.80,
+            }),
+        ]);
+        let prior = vec![
+            ("x is true".to_string(), 0.6),
+            ("x is true".to_string(), 0.6),
+        ];
+        let r = coherence_probe(&llm, Some(&nli), "x is false", "core", &prior).await;
+        assert_eq!(r, CoherenceResult::Contradiction);
+    }
+
+    #[tokio::test]
+    async fn skeptic_nli_error_falls_back_to_llm_path() {
+        // NLI errors on the only pair -> probe must use the LLM mock, which is
+        // scripted to STRONG_SUPPORT. StrongSupport is NOT skeptic_probe's
+        // WeakSupport error/parse-failure default, so a pass proves the LLM
+        // path actually consumed the scripted response (required_fix #4: the
+        // earlier WEAK_SUPPORT script was tautological with the default).
+        let llm =
+            MockLlmClient::with_responses(vec![serde_json::json!({"rating": "STRONG_SUPPORT"})]);
+        let nli = FakeNli::active(vec![Err(())]);
+        let r = skeptic_probe(&llm, Some(&nli), "claim", &["some evidence".to_string()]).await;
+        assert_eq!(r, EvidenceSupport::StrongSupport);
+    }
+
+    #[tokio::test]
+    async fn skeptic_routes_to_nli_when_active() {
+        // NLI strong-entailment -> StrongSupport; the LLM mock is scripted to
+        // CONTRADICTS, so if the probe wrongly used the LLM it would return
+        // Contradicts. Asserting StrongSupport proves NLI took precedence.
+        let llm = MockLlmClient::with_responses(vec![serde_json::json!({"rating": "CONTRADICTS"})]);
+        let nli = FakeNli::active(vec![Ok(NliScores {
+            entailment: 0.90,
+            neutral: 0.07,
+            contradiction: 0.03,
+        })]);
+        let r = skeptic_probe(&llm, Some(&nli), "claim", &["strong proof".to_string()]).await;
+        assert_eq!(r, EvidenceSupport::StrongSupport);
     }
 }

--- a/crates/epigraph-cli/src/enrichment/mod.rs
+++ b/crates/epigraph-cli/src/enrichment/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod confidence;
 pub mod llm_client;
+pub mod nli_client;
 pub mod prompts;

--- a/crates/epigraph-cli/src/enrichment/nli_client.rs
+++ b/crates/epigraph-cli/src/enrichment/nli_client.rs
@@ -1,0 +1,285 @@
+//! Client + pure mapping for the self-hosted NLI cross-encoder service.
+//!
+//! This is the Rust half of backlog item 97244690's BONUS path: an
+//! alternate, cheap, deterministic PRODUCER for the same 3-way stance
+//! signal the LLM probes in [`super::confidence`] emit. (The item's
+//! CANONICAL deliverable is the DST belief path in
+//! `scripts/lib/nli_stance.py`; this module feeds the parser-confidence
+//! multiplier, not BetP belief ordering.) The probes hold the STRUCTURED
+//! inputs (claim text, prior-claim list, evidence list), so we route at the
+//! probe level -- NOT by wrapping [`super::llm_client::LlmProvider`], whose
+//! only method takes a rendered English prompt (reverse-parsing it would
+//! make prompt wording a parsing contract, and the process-wide provider
+//! registry would risk routing unrelated relationship/rerank calls to an
+//! NLI-only model).
+//!
+//! All judgement logic (logit->enum thresholds + multi-pair aggregation)
+//! lives in the pure [`mapping`] module so it tests with no network/model.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// 3-way NLI distribution returned by the service.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct NliScores {
+    pub entailment: f64,
+    pub neutral: f64,
+    pub contradiction: f64,
+}
+
+/// Errors from the NLI client.
+#[derive(Debug, thiserror::Error)]
+pub enum NliError {
+    #[error("NLI service not configured (set NLI_SERVICE_URL)")]
+    NotConfigured,
+    #[error("NLI request failed: {0}")]
+    RequestFailed(String),
+    #[error("NLI returned malformed response: {0}")]
+    Malformed(String),
+}
+
+/// Abstract per-pair classifier so the probes can be tested against a
+/// deterministic in-process fake (no HTTP), and the real client swapped in.
+#[async_trait]
+pub trait NliClassifier: Send + Sync {
+    fn is_active(&self) -> bool;
+    async fn classify(&self, premise: &str, hypothesis: &str) -> Result<NliScores, NliError>;
+}
+
+/// HTTP client for the FastAPI service behind Caddy.
+#[derive(Debug, Clone)]
+pub struct NliClient {
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl NliClient {
+    /// Construct from an explicit base URL (e.g. `http://localhost/nli`).
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Construct from `NLI_SERVICE_URL`; `None` when unset/empty so callers
+    /// transparently fall back to the LLM probe path.
+    pub fn from_env() -> Option<Self> {
+        match std::env::var("NLI_SERVICE_URL") {
+            Ok(u) if !u.is_empty() => Some(Self::new(u)),
+            _ => None,
+        }
+    }
+}
+
+#[async_trait]
+impl NliClassifier for NliClient {
+    fn is_active(&self) -> bool {
+        !self.base_url.is_empty()
+    }
+
+    async fn classify(&self, premise: &str, hypothesis: &str) -> Result<NliScores, NliError> {
+        let resp = self
+            .http
+            .post(&self.base_url)
+            .json(&serde_json::json!({ "premise": premise, "hypothesis": hypothesis }))
+            .send()
+            .await
+            .map_err(|e| NliError::RequestFailed(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(NliError::RequestFailed(format!("HTTP {}", resp.status())));
+        }
+        resp.json::<NliScores>()
+            .await
+            .map_err(|e| NliError::Malformed(e.to_string()))
+    }
+}
+
+/// Pure, network-free judgement logic. All thresholds and aggregation
+/// rules live here so they are unit-testable and auditable in one place.
+pub mod mapping {
+    use super::NliScores;
+    use crate::enrichment::confidence::{CoherenceResult, EvidenceSupport};
+
+    /// The dominant (argmax) NLI label.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NliLabel {
+        Entailment,
+        Neutral,
+        Contradiction,
+    }
+
+    /// Argmax over the 3 scores. Ties resolve toward the SAFER label
+    /// (Contradiction > Neutral > Entailment) so the producer never
+    /// over-confidently asserts agreement on a tie.
+    pub fn dominant(s: &NliScores) -> NliLabel {
+        let mut best = NliLabel::Contradiction;
+        let mut best_v = s.contradiction;
+        if s.neutral > best_v {
+            best = NliLabel::Neutral;
+            best_v = s.neutral;
+        }
+        if s.entailment > best_v {
+            best = NliLabel::Entailment;
+        }
+        best
+    }
+
+    /// Map a single coherence pair (prior claim = premise, new claim =
+    /// hypothesis) to the existing [`CoherenceResult`] enum.
+    ///
+    /// Entailment -> Consistent, Contradiction -> Contradiction. Neutral is
+    /// the ambiguous middle: treated as Tension only when contradiction is a
+    /// meaningful runner-up (>= 0.20), else Consistent (unrelated != conflict).
+    pub fn coherence_of_pair(s: &NliScores) -> CoherenceResult {
+        match dominant(s) {
+            NliLabel::Entailment => CoherenceResult::Consistent,
+            NliLabel::Contradiction => CoherenceResult::Contradiction,
+            NliLabel::Neutral => {
+                if s.contradiction >= 0.20 {
+                    CoherenceResult::Tension
+                } else {
+                    CoherenceResult::Consistent
+                }
+            }
+        }
+    }
+
+    /// Map a single evidence pair (evidence = premise, claim = hypothesis)
+    /// to the existing [`EvidenceSupport`] enum.
+    pub fn support_of_pair(s: &NliScores) -> EvidenceSupport {
+        match dominant(s) {
+            NliLabel::Entailment => {
+                if s.entailment >= 0.75 {
+                    EvidenceSupport::StrongSupport
+                } else {
+                    EvidenceSupport::WeakSupport
+                }
+            }
+            NliLabel::Contradiction => EvidenceSupport::Contradicts,
+            NliLabel::Neutral => EvidenceSupport::Unrelated,
+        }
+    }
+
+    /// Aggregate per-prior-claim coherence judgements into one result for the
+    /// new claim. CONTRADICTION DOMINATES: any contradicting prior -> Contradiction;
+    /// else any tension -> Tension; else Consistent. Mirrors the probe's
+    /// conservative-default posture (confidence can only be lowered).
+    pub fn aggregate_coherence(per_pair: &[CoherenceResult]) -> CoherenceResult {
+        if per_pair.contains(&CoherenceResult::Contradiction) {
+            CoherenceResult::Contradiction
+        } else if per_pair.contains(&CoherenceResult::Tension) {
+            CoherenceResult::Tension
+        } else {
+            CoherenceResult::Consistent
+        }
+    }
+
+    /// Aggregate per-evidence support judgements. Take the STRONGEST stance
+    /// toward the claim: StrongSupport if any strongly supports AND none
+    /// contradicts; Contradicts if any contradicts and none strongly
+    /// supports; on conflict (both present) downgrade to WeakSupport; else
+    /// the max of the remaining.
+    pub fn aggregate_support(per_pair: &[EvidenceSupport]) -> EvidenceSupport {
+        if per_pair.is_empty() {
+            return EvidenceSupport::Unrelated;
+        }
+        let strong = per_pair.contains(&EvidenceSupport::StrongSupport);
+        let contra = per_pair.contains(&EvidenceSupport::Contradicts);
+        match (strong, contra) {
+            (true, true) => EvidenceSupport::WeakSupport,
+            (true, false) => EvidenceSupport::StrongSupport,
+            (false, true) => EvidenceSupport::Contradicts,
+            (false, false) => {
+                if per_pair.contains(&EvidenceSupport::WeakSupport) {
+                    EvidenceSupport::WeakSupport
+                } else {
+                    EvidenceSupport::Unrelated
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mapping::*;
+    use super::*;
+    use crate::enrichment::confidence::{CoherenceResult, EvidenceSupport};
+
+    fn scores(e: f64, n: f64, c: f64) -> NliScores {
+        NliScores {
+            entailment: e,
+            neutral: n,
+            contradiction: c,
+        }
+    }
+
+    #[test]
+    fn dominant_breaks_ties_toward_contradiction() {
+        // All equal -> safer label, never silently Consistent.
+        assert_eq!(dominant(&scores(0.34, 0.33, 0.33)), NliLabel::Entailment);
+        assert_eq!(dominant(&scores(0.33, 0.33, 0.34)), NliLabel::Contradiction);
+        assert_eq!(dominant(&scores(0.5, 0.5, 0.5)), NliLabel::Contradiction);
+    }
+
+    #[test]
+    fn contradiction_argmax_maps_to_contradiction() {
+        assert_eq!(
+            coherence_of_pair(&scores(0.05, 0.15, 0.80)),
+            CoherenceResult::Contradiction
+        );
+    }
+
+    #[test]
+    fn neutral_with_low_contradiction_is_not_tension() {
+        // Unrelated (high neutral, tiny contradiction) must NOT be reported
+        // as conflict -- that is the false-positive this threshold guards.
+        assert_eq!(
+            coherence_of_pair(&scores(0.05, 0.90, 0.05)),
+            CoherenceResult::Consistent
+        );
+    }
+
+    #[test]
+    fn neutral_with_meaningful_contradiction_is_tension() {
+        assert_eq!(
+            coherence_of_pair(&scores(0.10, 0.60, 0.30)),
+            CoherenceResult::Tension
+        );
+    }
+
+    #[test]
+    fn weak_entailment_is_not_strong_support() {
+        // Argmax entailment but below 0.75 -> WeakSupport, not StrongSupport.
+        assert_eq!(
+            support_of_pair(&scores(0.55, 0.40, 0.05)),
+            EvidenceSupport::WeakSupport
+        );
+        assert_eq!(
+            support_of_pair(&scores(0.85, 0.10, 0.05)),
+            EvidenceSupport::StrongSupport
+        );
+    }
+
+    #[test]
+    fn aggregate_coherence_lets_one_contradiction_dominate() {
+        let pairs = [
+            CoherenceResult::Consistent,
+            CoherenceResult::Consistent,
+            CoherenceResult::Contradiction,
+        ];
+        assert_eq!(aggregate_coherence(&pairs), CoherenceResult::Contradiction);
+    }
+
+    #[test]
+    fn aggregate_support_downgrades_on_conflict() {
+        // A source that strongly supports AND another that contradicts is
+        // NOT reported as StrongSupport -- conflict downgrades to Weak.
+        let pairs = [
+            EvidenceSupport::StrongSupport,
+            EvidenceSupport::Contradicts,
+        ];
+        assert_eq!(aggregate_support(&pairs), EvidenceSupport::WeakSupport);
+    }
+}

--- a/crates/epigraph-cli/src/enrichment/nli_client.rs
+++ b/crates/epigraph-cli/src/enrichment/nli_client.rs
@@ -276,10 +276,7 @@ mod tests {
     fn aggregate_support_downgrades_on_conflict() {
         // A source that strongly supports AND another that contradicts is
         // NOT reported as StrongSupport -- conflict downgrades to Weak.
-        let pairs = [
-            EvidenceSupport::StrongSupport,
-            EvidenceSupport::Contradicts,
-        ];
+        let pairs = [EvidenceSupport::StrongSupport, EvidenceSupport::Contradicts];
         assert_eq!(aggregate_support(&pairs), EvidenceSupport::WeakSupport);
     }
 }

--- a/scripts/lib/nli_stance.py
+++ b/scripts/lib/nli_stance.py
@@ -1,0 +1,162 @@
+"""NLI -> Dempster-Shafer BBA stance mapping for the EpiGraph belief path.
+
+This is part 2 of backlog item 97244690 (the canonical, invariant-mandated
+deliverable). The NLI cross-encoder service (services/nli) produces a 3-way
+{entailment, neutral, contradiction} distribution for a (premise, hypothesis)
+pair. This module converts that distribution into a Dempster-Shafer basic
+belief assignment (BBA) over a two-hypothesis {support, refute} frame and
+submits it as evidence so it feeds the DST/pignistic belief ordering
+(BetP) -- NOT the parser-confidence multiplier.
+
+The mapping (a textbook NLI->BBA transfer):
+
+    entailment    -> m({support})          = m({0})
+    contradiction -> m({refute})           = m({1})
+    neutral       -> m({support, refute})  = m(Theta)   (ignorance)
+
+Because the NLI probabilities already sum to 1.0, this is a valid BBA with
+no renormalization: neutral mass becomes uncommitted mass on the whole
+frame (Theta), which is exactly TBM's representation of "no evidence for
+either side" -- the correct semantics for an NLI "neutral" verdict.
+
+Design notes:
+  - The PURE mapping (`nli_to_bba`) imports nothing heavy and is unit-tested
+    with no network or service. It is the only part runtime-verifiable on the
+    constrained build box.
+  - The I/O helpers (`fetch_nli`, `submit_nli_stance`) lazily import requests
+    / the shared _api_client so the pure path stays import-light, and submit
+    via the EpiGraph HTTP evidence endpoint (POST /api/v1/frames/:id/evidence)
+    -- the HTTP surface of the submit_ds_evidence MCP tool -- per
+    feedback_no_raw_sql (Python scripts call the API, never raw SQL or MCP
+    stdio). Both routes hit the same MassFunctionRepository + belief layer.
+
+The {support, refute} frame is conventionally indexed [support=0, refute=1].
+The submitting claim represents the "support" hypothesis, so hypothesis_index
+is 0 (the evidence endpoint also defaults an unassigned claim to index 0).
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+# Frame contract: index 0 = "support", index 1 = "refute". Theta (the full
+# frame {support, refute}) is keyed "0,1" in the masses dict, matching the
+# epigraph-ds / evidence-endpoint comma-separated-index convention.
+# THETA_KEY="0,1" assumes a TWO-hypothesis {support, refute} frame; for a
+# larger frame the ignorance key would be all indices joined by commas.
+SUPPORT_KEY = "0"
+REFUTE_KEY = "1"
+THETA_KEY = "0,1"
+
+
+def nli_to_bba(scores: dict) -> dict[str, float]:
+    """Map an NLI {entailment, neutral, contradiction} distribution to a
+    Dempster-Shafer BBA over the {support, refute} frame.
+
+    Returns a masses dict keyed by comma-separated hypothesis indices:
+      {"0": m(support), "1": m(refute), "0,1": m(Theta)}.
+
+    The three input probabilities are clamped to [0, 1] and renormalized to
+    sum to 1.0 (defensive: the service already normalizes, but a caller may
+    pass rounded or partial values). A zero-mass focal element is omitted so
+    the BBA is minimal. Raises ValueError if all three are zero/missing.
+    """
+    e = max(0.0, float(scores.get("entailment", 0.0)))
+    n = max(0.0, float(scores.get("neutral", 0.0)))
+    c = max(0.0, float(scores.get("contradiction", 0.0)))
+    total = e + n + c
+    if total <= 0.0:
+        raise ValueError(
+            f"NLI scores sum to {total}; cannot build a BBA from "
+            f"{scores!r}"
+        )
+    e, n, c = e / total, n / total, c / total
+
+    masses: dict[str, float] = {}
+    if e > 0.0:
+        masses[SUPPORT_KEY] = e
+    if c > 0.0:
+        masses[REFUTE_KEY] = c
+    if n > 0.0:
+        masses[THETA_KEY] = n
+    return masses
+
+
+async def fetch_nli(
+    premise: str,
+    hypothesis: str,
+    service_url: Optional[str] = None,
+    timeout_secs: float = 30.0,
+) -> dict:
+    """Call POST /nli on the cross-encoder service and return the raw
+    {entailment, neutral, contradiction, model, stub} dict.
+
+    `service_url` defaults to NLI_SERVICE_URL (e.g. http://localhost/nli).
+    Lazily imports httpx so the pure mapping path needs no HTTP deps.
+    Raises RuntimeError if the service is unconfigured or the call fails.
+    """
+    url = service_url or os.environ.get("NLI_SERVICE_URL", "")
+    if not url:
+        raise RuntimeError(
+            "NLI service not configured (set NLI_SERVICE_URL or pass "
+            "service_url)"
+        )
+    import httpx  # lazy: only the I/O path needs it
+
+    async with httpx.AsyncClient(timeout=timeout_secs) as http:
+        resp = await http.post(
+            url, json={"premise": premise, "hypothesis": hypothesis}
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+def submit_nli_stance(
+    claim_id: str,
+    frame_id: str,
+    premise: str,
+    hypothesis: str,
+    reliability: float = 1.0,
+    service_url: Optional[str] = None,
+    evidence_type: Optional[str] = "nli_cross_encoder",
+):
+    """End-to-end: fetch the NLI distribution for (premise, hypothesis), map
+    it to a {support, refute} BBA, and submit it to the DST belief path via
+    the EpiGraph HTTP evidence endpoint.
+
+    `premise` is the evidence/prior text; `hypothesis` is the claim under
+    assessment (entailment of the claim by the evidence -> support). The
+    evidence is submitted with `reliability` as the discount factor so the
+    frame-function source-reliability machinery can re-weight it per
+    perspective at query time.
+
+    Returns the parsed evidence-submission response (belief, plausibility,
+    pignistic_prob, ...). Synchronous wrapper around the async fetch; lazily
+    imports asyncio + the shared _api_client (which calls the HTTP API, never
+    raw SQL or MCP stdio -- feedback_no_raw_sql).
+    """
+    import asyncio
+
+    scores = asyncio.run(fetch_nli(premise, hypothesis, service_url=service_url))
+    masses = nli_to_bba(scores)
+
+    # Lazy import: keep the pure mapping path free of the requests/jwt deps.
+    import sys
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from _api_client import EpiGraphClient  # noqa: E402
+
+    # The /frames/:id/evidence route is guarded by bearer_auth_middleware
+    # (valid-JWT, no per-route scope check); claims:write matches the
+    # write-path convention used elsewhere by _api_client callers.
+    client = EpiGraphClient(scopes=["claims:write"])
+    body = {
+        "claim_id": claim_id,
+        "reliability": reliability,
+        "masses": masses,
+    }
+    if evidence_type is not None:
+        body["evidence_type"] = evidence_type
+    resp = client.post(f"/api/v1/frames/{frame_id}/evidence", json=body)
+    resp.raise_for_status()
+    return resp.json()

--- a/scripts/lib/test_nli_stance.py
+++ b/scripts/lib/test_nli_stance.py
@@ -1,0 +1,84 @@
+"""Unit tests for the pure NLI -> DST BBA stance mapping (nli_stance.py).
+
+Run: python -m pytest scripts/lib/test_nli_stance.py
+These exercise ONLY the network-free `nli_to_bba` mapping -- the part 2
+deliverable's load-bearing logic. The HTTP fetch + evidence submit need the
+running NLI service and EpiGraph API and are NOT exercised here (deployment).
+"""
+import math
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from nli_stance import (  # noqa: E402
+    REFUTE_KEY,
+    SUPPORT_KEY,
+    THETA_KEY,
+    nli_to_bba,
+)
+
+
+def _mass_sum(bba):
+    return sum(bba.values())
+
+
+def test_entailment_becomes_support_mass():
+    bba = nli_to_bba({"entailment": 0.8, "neutral": 0.15, "contradiction": 0.05})
+    # entailment -> m(support)=m({0}); contradiction -> m(refute)=m({1});
+    # neutral -> m(Theta)=m({0,1}).
+    assert math.isclose(bba[SUPPORT_KEY], 0.8, abs_tol=1e-9)
+    assert math.isclose(bba[REFUTE_KEY], 0.05, abs_tol=1e-9)
+    assert math.isclose(bba[THETA_KEY], 0.15, abs_tol=1e-9)
+
+
+def test_contradiction_becomes_refute_mass():
+    # A contradiction-dominant distribution must put most mass on refute
+    # (index 1), NOT support -- guards the entailment/contradiction column
+    # order, the single most damaging wiring bug.
+    bba = nli_to_bba({"entailment": 0.05, "neutral": 0.15, "contradiction": 0.80})
+    assert bba[REFUTE_KEY] > bba[SUPPORT_KEY]
+    assert math.isclose(bba[REFUTE_KEY], 0.80, abs_tol=1e-9)
+
+
+def test_neutral_becomes_theta_ignorance():
+    # Pure-neutral input is total ignorance: ALL mass on Theta (the whole
+    # frame), none committed to either singleton. This is the TBM semantics
+    # of "no evidence either way" and is what makes neutral != refute.
+    bba = nli_to_bba({"entailment": 0.0, "neutral": 1.0, "contradiction": 0.0})
+    assert bba == {THETA_KEY: 1.0}
+    assert SUPPORT_KEY not in bba
+    assert REFUTE_KEY not in bba
+
+
+def test_masses_sum_to_one():
+    for scores in (
+        {"entailment": 0.33, "neutral": 0.34, "contradiction": 0.33},
+        {"entailment": 0.7, "neutral": 0.2, "contradiction": 0.1},
+        {"entailment": 0.0, "neutral": 0.5, "contradiction": 0.5},
+    ):
+        assert math.isclose(_mass_sum(nli_to_bba(scores)), 1.0, abs_tol=1e-9)
+
+
+def test_unnormalized_input_is_renormalized():
+    # Caller passes values summing to 2.0; mapping must renormalize so the
+    # BBA is valid (mass sums to 1.0), preserving ratios.
+    bba = nli_to_bba({"entailment": 1.0, "neutral": 0.5, "contradiction": 0.5})
+    assert math.isclose(_mass_sum(bba), 1.0, abs_tol=1e-9)
+    assert math.isclose(bba[SUPPORT_KEY], 0.5, abs_tol=1e-9)  # 1.0 / 2.0
+
+
+def test_zero_mass_focal_elements_omitted():
+    # No entailment -> no m({0}) key at all (minimal BBA), not a zero entry.
+    bba = nli_to_bba({"entailment": 0.0, "neutral": 0.4, "contradiction": 0.6})
+    assert SUPPORT_KEY not in bba
+    assert set(bba.keys()) == {REFUTE_KEY, THETA_KEY}
+
+
+def test_all_zero_scores_raise():
+    with pytest.raises(ValueError):
+        nli_to_bba({"entailment": 0.0, "neutral": 0.0, "contradiction": 0.0})
+    with pytest.raises(ValueError):
+        nli_to_bba({})

--- a/services/nli/Caddyfile.snippet
+++ b/services/nli/Caddyfile.snippet
@@ -1,0 +1,9 @@
+# Append into the VM Caddyfile (Caddy listens on :80; the VPC firewall
+# blocks direct container ports -- see memory feedback_caddy_proxy).
+# Assumes the nli container is reachable at nli:8000 (compose service name)
+# or 127.0.0.1:8000 (host-run). NLI_SERVICE_URL for the Rust client is then
+# http://<vm-host>/nli (or http://localhost/nli on-box).
+
+handle_path /nli* {
+    reverse_proxy 127.0.0.1:8000
+}

--- a/services/nli/Dockerfile
+++ b/services/nli/Dockerfile
@@ -1,0 +1,27 @@
+# CPU-only NLI cross-encoder service. Build is NOT exercised on the
+# 2.7GB-free dev box (the torch+model layer needs more RAM/disk); it is a
+# deployment artifact for the GPU/larger VM (see memory project_vm_gpu_upgrade).
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# System deps for sentencepiece / tokenizers build wheels.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py ./
+
+# Pre-cache the model into the image so first request is not a cold pull.
+# Skipped automatically when NLI_STUB=1 is set at build time.
+ARG NLI_MODEL=MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli
+ENV NLI_MODEL=${NLI_MODEL}
+RUN python -c "import os; \
+  os.environ.get('NLI_STUB')=='1' or __import__('transformers').pipeline('text-classification', model=os.environ['NLI_MODEL'], top_k=None, device=-1)" || true
+
+EXPOSE 8000
+# 2 workers keeps RAM bounded; the model is loaded per-worker on first call.
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/services/nli/README.md
+++ b/services/nli/README.md
@@ -1,0 +1,78 @@
+# epigraph-nli — CPU NLI cross-encoder microservice
+
+Alternate, cheap, deterministic, batchable PRODUCER for the 3-way
+entail/neutral/contradiction signal used across EpiGraph's stance
+machinery. **This is a cost/latency/determinism optimization of an
+already-working path, NOT a new capability** (backlog item 97244690).
+
+The item has two halves:
+
+1. **This service + its Rust HTTP client** — the producer of the 3-way
+   distribution.
+2. **`scripts/lib/nli_stance.py`** — the canonical consumer that maps the
+   distribution to a Dempster-Shafer BBA over a `{support, refute}` frame
+   (`entailment -> m(support)`, `contradiction -> m(refute)`,
+   `neutral -> m(Theta)` = ignorance) and submits it to the DST belief
+   path (`submit_ds_evidence`). This is what feeds pignistic/BetP belief
+   ordering, the invariant-mandated path.
+
+A secondary (BONUS) consumer wires the same distribution into the Rust
+enrichment probes (`coherence_probe` / `skeptic_probe` in
+`crates/epigraph-cli/src/enrichment/confidence.rs`), which feed the
+parser-confidence multiplier on the commit-ingest path. That is NOT the
+DST belief path and is an optional convenience, not the item's deliverable.
+
+## Contract
+
+`POST /nli` `{"premise": str, "hypothesis": str}` ->
+`{"entailment": f, "neutral": f, "contradiction": f, "model": str, "stub": bool}`
+(probabilities sum to 1.0). Behind Caddy at `http://<host>/nli`.
+
+## Model
+
+`MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli` (~184M), MNLI head label
+order `[entailment, neutral, contradiction]`. Loaded lazily on first call.
+A startup assertion (`_get_pipe`) refuses to serve if the loaded model's
+`config.id2label` does not match this pinned order — a wrong checkpoint
+with a transposed head would otherwise silently invert every stance.
+
+## Run
+
+- Stub (no model, for tests / smoke on small boxes):
+  `NLI_STUB=1 uvicorn app:app --port 8000` then `NLI_STUB=1 pytest`.
+- Real model: `uvicorn app:app --port 8000` (needs ~1.5GB RAM + the
+  weights; do NOT run on the 2.7GB-free dev box).
+- Container: `docker build -t epigraph-nli services/nli` then run with
+  `-p 8000:8000`; front with the `Caddyfile.snippet` stanza.
+
+## Wiring (DST belief path — the canonical consumer)
+
+`scripts/lib/nli_stance.py` is the item's part-2 deliverable:
+
+```python
+from lib.nli_stance import nli_to_bba, submit_nli_stance
+
+# Pure mapping (network-free, unit-tested):
+masses = nli_to_bba({"entailment": 0.8, "neutral": 0.15, "contradiction": 0.05})
+# -> {"0": 0.8, "1": 0.05, "0,1": 0.15}   ({support, refute}; "0,1" = Theta)
+
+# End-to-end (needs the NLI service + the EpiGraph API up):
+submit_nli_stance(claim_id, frame_id, premise=evidence, hypothesis=claim,
+                  reliability=0.9)
+```
+
+`submit_nli_stance` fetches the distribution from `POST /nli`, maps it to
+the BBA above, and submits it via the EpiGraph HTTP evidence endpoint
+(`POST /api/v1/frames/:id/evidence` through `_api_client.py`), which is the
+HTTP surface of the `submit_ds_evidence` MCP tool — both hit the same
+`MassFunctionRepository` + belief-query layer. Python scripts call the
+HTTP API (per `feedback_no_raw_sql`), not the MCP stdio transport.
+
+## Wiring (Rust probes — BONUS, parser-confidence path)
+
+The Rust client (`crates/epigraph-cli/src/enrichment/nli_client.rs`) is
+constructed from `NLI_SERVICE_URL`; pass it to `coherence_probe` /
+`skeptic_probe` to route stance classification to this service instead of
+an LLM. When the env var is unset the probes use the existing LLM path
+unchanged. This adjusts parser confidence (`combined_confidence`), not the
+DST belief ordering.

--- a/services/nli/app.py
+++ b/services/nli/app.py
@@ -1,0 +1,165 @@
+"""Self-hosted CPU NLI cross-encoder microservice.
+
+Exposes a single deterministic-on-fixed-input endpoint that scores a
+(premise, hypothesis) pair into a 3-way natural-language-inference
+distribution {entailment, neutral, contradiction}. It is an ALTERNATE,
+cheap, batchable PRODUCER for the 3-way signal the EpiGraph enrichment
+probes (coherence_probe / skeptic_probe in crates/epigraph-cli) already
+emit via per-call LLM round-trips -- NOT a new capability. See
+backlog item 97244690 and services/nli/README.md.
+
+Model: tasksource / MoritzLaurer DeBERTa-v3-base-MNLI family (~184M).
+The model is loaded LAZILY on first /nli call so the process starts
+(and `import app` in tests) without pulling weights. Set NLI_STUB=1 to
+short-circuit the model entirely and return a deterministic lexical
+stub -- the only mode usable on the 2.7GB-free / no-GPU build box.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+# MNLI head label order for the DeBERTa-v3-MNLI family is
+# [entailment, neutral, contradiction] (id2label of the published
+# checkpoints). Pinned here so the Rust client and tests share one
+# contract; verify against the loaded model's config.id2label at startup.
+LABELS = ("entailment", "neutral", "contradiction")
+MODEL_NAME = os.environ.get(
+    "NLI_MODEL", "MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli"
+)
+MAX_CHARS = int(os.environ.get("NLI_MAX_CHARS", "4000"))
+
+app = FastAPI(title="epigraph-nli", version="0.1.0")
+
+
+class NliRequest(BaseModel):
+    premise: str = Field(..., min_length=1)
+    hypothesis: str = Field(..., min_length=1)
+
+
+class NliResponse(BaseModel):
+    entailment: float
+    neutral: float
+    contradiction: float
+    model: str
+    stub: bool
+
+
+_pipe = None
+_pipe_lock = threading.Lock()
+
+
+def _stub_scores(premise: str, hypothesis: str) -> tuple[float, float, float]:
+    """Deterministic lexical stand-in used when NLI_STUB=1.
+
+    Pure token-overlap heuristic with an explicit negation flip. It is NOT
+    an NLI model and makes no accuracy claim; its ONLY contract is to be a
+    deterministic, model-free oracle so the service and its Rust client can
+    be wired and tested on a box that cannot host the 184M checkpoint.
+    Returns probabilities summing to 1.0.
+    """
+    p = set(premise.lower().split())
+    h = set(hypothesis.lower().split())
+    if not h:
+        return (0.0, 1.0, 0.0)
+    overlap = len(p & h) / len(h)
+    negators = {"not", "no", "never", "cannot", "n't", "without"}
+    flip = bool((p ^ h) & negators)
+    if flip and overlap >= 0.5:
+        return (0.05, 0.15, 0.80)
+    if overlap >= 0.6:
+        return (0.80, 0.15, 0.05)
+    if overlap <= 0.1:
+        return (0.05, 0.90, 0.05)
+    return (0.20, 0.70, 0.10)
+
+
+def _get_pipe():
+    global _pipe
+    if _pipe is not None:
+        return _pipe
+    with _pipe_lock:
+        if _pipe is None:
+            # Imported lazily so test collection / stub mode never needs torch.
+            from transformers import pipeline  # type: ignore
+
+            _pipe = pipeline(
+                "text-classification",
+                model=MODEL_NAME,
+                top_k=None,  # return ALL class scores
+                device=-1,  # CPU
+            )
+            # Deploy-time guard (required_fix #5): a wrong checkpoint with a
+            # different head order would silently invert every stance. Verify
+            # the loaded model's id2label matches the pinned LABELS contract.
+            id2label = getattr(getattr(_pipe, "model", None), "config", None)
+            id2label = getattr(id2label, "id2label", None)
+            if id2label:
+                loaded = tuple(
+                    str(id2label[i]).lower() for i in sorted(id2label)
+                )
+                if loaded != LABELS:
+                    raise RuntimeError(
+                        "NLI model label order "
+                        f"{loaded} does not match the pinned contract "
+                        f"{LABELS}; refusing to serve a silently-inverted "
+                        "stance. Set NLI_MODEL to a checkpoint whose "
+                        "config.id2label is [entailment, neutral, "
+                        "contradiction]."
+                    )
+    return _pipe
+
+
+def _model_scores(premise: str, hypothesis: str) -> tuple[float, float, float]:
+    pipe = _get_pipe()
+    # transformers text-pair input; truncate defensively.
+    out = pipe(
+        {"text": premise[:MAX_CHARS], "text_pair": hypothesis[:MAX_CHARS]},
+        truncation=True,
+    )
+    # Deploy-time guard (required_fix #5): with top_k=None the documented
+    # return is a flat list[{label, score}], but some transformers versions
+    # wrap a single input in an extra list (list[list[...]]). Unwrap one
+    # level so a version bump does not silently produce all-zero scores.
+    if out and isinstance(out[0], list):
+        out = out[0]
+    if not isinstance(out, list):
+        raise RuntimeError(
+            f"unexpected NLI pipeline output shape: {type(out)!r}"
+        )
+    # out is a list of {label, score}; map by lowercased label.
+    scores = {d["label"].lower(): float(d["score"]) for d in out}
+    return (
+        scores.get("entailment", 0.0),
+        scores.get("neutral", 0.0),
+        scores.get("contradiction", 0.0),
+    )
+
+
+def _stub_enabled() -> bool:
+    return os.environ.get("NLI_STUB", "0") == "1"
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok", "model": MODEL_NAME, "stub": _stub_enabled()}
+
+
+@app.post("/nli", response_model=NliResponse)
+def nli(req: NliRequest) -> NliResponse:
+    stub = _stub_enabled()
+    if stub:
+        e, n, c = _stub_scores(req.premise, req.hypothesis)
+    else:
+        e, n, c = _model_scores(req.premise, req.hypothesis)
+    return NliResponse(
+        entailment=e,
+        neutral=n,
+        contradiction=c,
+        model="stub" if stub else MODEL_NAME,
+        stub=stub,
+    )

--- a/services/nli/requirements.txt
+++ b/services/nli/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+pydantic==2.7.4
+# Model path only (heavy; not installed in the stub-test image layer):
+transformers==4.41.2
+torch==2.3.1
+sentencepiece==0.2.0

--- a/services/nli/test_app.py
+++ b/services/nli/test_app.py
@@ -1,0 +1,60 @@
+"""Unit tests for the NLI service in stub mode (no model download).
+
+Run: NLI_STUB=1 pytest services/nli/test_app.py
+These assert the HTTP contract the Rust NliClient depends on; they do NOT
+claim NLI accuracy (the stub is a lexical stand-in, asserted as such).
+"""
+import os
+
+os.environ["NLI_STUB"] = "1"  # set before importing app
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app as nli_app  # noqa: E402
+
+client = TestClient(nli_app.app)
+
+
+def _post(premise, hypothesis):
+    r = client.post("/nli", json={"premise": premise, "hypothesis": hypothesis})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_response_has_all_three_labels_and_stub_flag():
+    body = _post("the sky is blue", "the sky is blue")
+    assert set(["entailment", "neutral", "contradiction"]).issubset(body)
+    assert body["stub"] is True
+    assert body["model"] == "stub"
+
+
+def test_probabilities_normalize_to_one():
+    body = _post("cells divide by mitosis", "mitosis divides cells")
+    total = body["entailment"] + body["neutral"] + body["contradiction"]
+    assert abs(total - 1.0) < 1e-9
+
+
+def test_stub_is_deterministic():
+    a = _post("force equals mass times acceleration", "F = m a")
+    b = _post("force equals mass times acceleration", "F = m a")
+    assert a == b
+
+
+def test_stub_flags_negation_as_contradiction_dominant():
+    # Direction sensitivity: a negated near-restatement must put the most
+    # mass on contradiction, NOT entailment. Guards the label wiring so a
+    # future label-order regression in app.py is caught.
+    body = _post("the reaction is exothermic", "the reaction is not exothermic")
+    assert body["contradiction"] > body["entailment"]
+    assert body["contradiction"] >= body["neutral"]
+
+
+def test_unrelated_inputs_are_neutral_dominant():
+    body = _post("the stock market rose today", "photosynthesis requires light")
+    assert body["neutral"] > body["entailment"]
+    assert body["neutral"] > body["contradiction"]
+
+
+def test_missing_field_is_422():
+    r = client.post("/nli", json={"premise": "only premise"})
+    assert r.status_code == 422


### PR DESCRIPTION
## What

Adds a self-hosted CPU NLI cross-encoder microservice (DeBERTa-v3-MNLI family, ~184M, `MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli`) producing a 3-way entail/neutral/contradiction distribution, plus **two consumers** of that signal. Implements both halves of backlog item `97244690`.

### Part 1 — the producer
- `services/nli/` — FastAPI app (`POST /nli {premise,hypothesis} -> {entailment,neutral,contradiction}`), lazy model load, `NLI_STUB=1` deterministic stub mode, `Dockerfile`, `Caddyfile.snippet` (port-80 reverse proxy per the VPC-firewall/Caddy invariant), pytest, README. A startup assertion refuses to serve if the loaded model's `config.id2label` does not match the pinned `[entailment, neutral, contradiction]` order, and the model path unwraps the list-of-lists output some `transformers` versions emit.
- `crates/epigraph-cli/src/enrichment/nli_client.rs` — env-gated `NliClient` (HTTP) behind an `NliClassifier` trait.

### Part 2 — the CANONICAL consumer (DST belief path)
- `scripts/lib/nli_stance.py` — the item's belief deliverable: a pure `nli_to_bba()` mapping the distribution to a Dempster-Shafer BBA over a `{support, refute}` frame (`entailment -> m({0})`, `contradiction -> m({1})`, `neutral -> m({0,1})` = Theta/ignorance), plus `submit_nli_stance()` which fetches `/nli` and submits the BBA to the DST belief path via the EpiGraph HTTP evidence endpoint (`POST /api/v1/frames/:id/evidence`, the HTTP surface of the `submit_ds_evidence` MCP tool — same `MassFunctionRepository` + pignistic layer). This feeds DST/pignistic (BetP) belief ordering, the invariant-mandated path. Because the NLI probabilities already sum to 1.0, the mapping is a valid BBA with no renormalization; neutral mass on Theta is exactly TBM's "no evidence either way".

### BONUS consumer (parser-confidence path)
- `coherence_probe` / `skeptic_probe` gain an `Option<&dyn NliClassifier>`: when wired+active they classify structured pairs via NLI (pure `mapping` module: argmax with safe tie-break, neutral-vs-contradiction threshold, weak-vs-strong entailment, contradiction-dominates / conflict-downgrade aggregation) and aggregate; otherwise the existing LLM path runs byte-for-byte unchanged. This adjusts `combined_confidence` (the parser multiplier), NOT belief ordering, so it is explicitly a bonus, not the item's DST deliverable.

## Design note (why not wrap LlmProvider)

`LlmProvider::complete_json` takes a rendered English prompt. Wrapping it would make prompt wording a parsing contract and risk the process-wide provider registry routing unrelated relationship/rerank calls to an NLI-only model. We route at the probe level instead, where the structured inputs are still in hand. The probes have ZERO non-test callers (verified by grep), so the signature change ripples only to in-module tests.

## Verifiability

VERIFIED here (no DB/network/model): `SQLX_OFFLINE=true cargo test -p epigraph-cli --lib enrichment::` (53 passed: pure mapping boundary tests + FakeNli-driven probe routing/fallback; the fallback test scripts the LLM mock to STRONG_SUPPORT and asserts StrongSupport, a non-default value, so it proves the LLM path actually ran); `cargo clippy -p epigraph-cli --lib` and `--profile test --lib` clean; `python -m pytest scripts/lib/test_nli_stance.py` (7 passed: the `nli_to_bba` BBA mapping); `NLI_STUB=1 python -m pytest services/nli/test_app.py` (6 passed: HTTP contract, no model).

NOT runtime-verified here (deployment-time on the larger GPU VM): the real ~184M model download + `config.id2label` assertion + model-path output-shape guard; the end-to-end `submit_nli_stance` path (`POST /nli` fetch + `POST /api/v1/frames/:id/evidence` submit) is **wired and pure-mapping-unit-tested but NOT exercised end-to-end** (needs the NLI service + EpiGraph API up); `docker build services/nli`; the Caddy :80 proxy. These OOM / exceed the 4-core/2.7GB-free, no-GPU, no-API-key build box.

No DB migration; no SQL; `.sqlx/` untouched (the Rust client is pure HTTP + in-memory logic). This PR implements both halves of the item but does NOT assert backlog resolution — the orchestrator owns the `resolve_backlog_item` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
