### PR TITLE
chore(ci): add scripts/verify.sh mirroring the CI test-job gates

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# verify.sh — local / agent pre-commit gate.
+#
+# Runs the same static checks the CI `test` job enforces (see
+# .github/workflows/ci.yml), so `cargo build` + `cargo test` alone don't let a
+# formatting or lint failure slip through to CI. KEEP THIS IN SYNC WITH ci.yml.
+#
+# Usage:
+#   ./scripts/verify.sh            # fmt + clippy + build (+ workspace tests if DATABASE_URL is set)
+#   DATABASE_URL=postgres://epigraph:epigraph@localhost:5432/<testdb> ./scripts/verify.sh
+#
+# The DB-backed (#[sqlx::test]) tests require a reachable Postgres; they are run
+# only when DATABASE_URL is set (CI provides a postgres service). Without it,
+# the static gates that local dev most often forgets — fmt + clippy — still run.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+step() { printf '\n==> %s\n' "$*"; }
+
+step "cargo fmt --check"
+cargo fmt --check
+
+step "cargo clippy --workspace --locked -- -D warnings"
+cargo clippy --workspace --locked -- -D warnings
+
+step "cargo build --workspace --locked"
+cargo build --workspace --locked
+
+if [ -n "${DATABASE_URL:-}" ]; then
+  step "cargo test --workspace --locked"
+  cargo test --workspace --locked
+
+  # DB crates use #[sqlx::test]; serialize within each binary (CI does the same).
+  for pkg in epigraph-db epigraph-api epigraph-engine epigraph-mcp; do
+    step "cargo test -p ${pkg} --locked -- --test-threads=1"
+    cargo test -p "${pkg}" --locked -- --test-threads=1
+  done
+else
+  step "SKIP tests — set DATABASE_URL to run the workspace + DB-backed suites"
+fi
+
+printf '\n\xE2\x9C\x85 verify passed\n'


### PR DESCRIPTION
## Summary
Adds `scripts/verify.sh` — a single local/agent pre-commit gate that runs the same static checks the CI `test` job enforces, so `cargo build` + `cargo test` alone no longer let a **formatting** or **clippy** failure slip through to CI (as happened on #245, which failed only at `cargo fmt --check`).

Runs, in CI order:
- `cargo fmt --check`
- `cargo clippy --workspace --locked -- -D warnings`
- `cargo build --workspace --locked`
- when `DATABASE_URL` is set: `cargo test --workspace --locked` + the serialized per-package DB suites

Without `DATABASE_URL` it runs fmt + clippy + build (the gates local dev most often forgets) and skips the DB-backed tests. It mirrors `.github/workflows/ci.yml` and is documented to be kept in sync (CI keeps its own steps + service infra; this is the dev/agent convenience entrypoint).

## Test Plan
- [x] `./scripts/verify.sh` on this branch: fmt clean, clippy clean (`-D warnings`), build green → "✅ verify passed"
- [x] Script is `chmod +x` and `cd`s to the repo root so it runs from anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)