### PR TITLE
fix(mcp): derive tool count dynamically instead of hardcoded literals

### DIFF
--- a/crates/epigraph-mcp/src/main.rs
+++ b/crates/epigraph-mcp/src/main.rs
@@ -177,12 +177,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create embedder
     let embedder = McpEmbedder::new(pool.clone(), cli.openai_api_key);
 
-    let mode = if cli.read_only {
-        "read-only (33 tools)"
-    } else {
-        "full (58 tools)"
-    };
-    tracing::info!("EpiGraph MCP server running in {mode} mode");
+    let tool_count = EpiGraphMcpFull::all_tools_json()
+        .as_array()
+        .map_or(0, Vec::len);
+    let mode = if cli.read_only { "read-only" } else { "full" };
+    tracing::info!("EpiGraph MCP server running in {mode} ({tool_count} tools) mode");
 
     if let Some(addr) = &cli.listen {
         // ── HTTP transport (TCP or Unix socket) ────────────────────────

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -991,7 +991,7 @@ impl EpiGraphMcpFull {
 impl ServerHandler for EpiGraphMcpFull {
     fn get_info(&self) -> ServerInfo {
         let mode = if self.read_only { "read-only" } else { "full" };
-        let tool_count = if self.read_only { 35 } else { 64 };
+        let tool_count = Self::all_tools_json().as_array().map_or(0, Vec::len);
         ServerInfo {
             instructions: Some(format!(
                 "EpiGraph {mode} MCP server with {tool_count} epistemic tools."


### PR DESCRIPTION
## What
The MCP server reported a **hardcoded** tool count in two places, both out of date:
- `main.rs` startup log: `"full (58 tools)"` / `"read-only (33 tools)"`
- `server.rs` `get_info()` instructions: `if read_only { 35 } else { 64 }`

The server actually registers **72** tools. This replaces both with a dynamic count derived from `all_tools_json().as_array().len()` — the same source the REST discovery endpoint and the scope-coverage test already use.

## Why it matters
An agent reported the deployed `epigraph-mcp` as built from a stale WIP branch. **That was disproven** — the installed binary's sha256 matched a clean `origin/main` rebuild, and the live server serves all 72 tools (incl. `query_undecomposed_claims`). The stale `"58 tools"` literal is the **most plausible** thing that tripped up that agent (it's the only misleading signal in play), but I didn't capture the agent's actual reasoning — so that link is **inferred, not confirmed**. Either way, a count that drifts from reality is worth removing.

`read_only` doesn't filter the tool router (all tools register in both modes; writes are rejected at dispatch via `reject_if_read_only`), so `all_tools_json().len()` is the honest count for both modes.

## Verification
`scripts/verify.sh` green locally before push:
- `cargo fmt --check`
- `cargo clippy --workspace --locked -- -D warnings`
- `cargo build --workspace --locked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)