### PR TITLE
fix(mcp): log the swallowed search_scoped error in recall (diagnose 1564bdaf)

### DIFF
--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -157,11 +157,23 @@ pub async fn recall(
     let scoped = tags_opt.is_some() || agent_filter.is_some();
 
     // Try semantic search first, with any scope pushed into the query.
-    let results = if let Ok(hits) = server
+    let semantic = server
         .embedder
         .search_scoped(&params.query, limit, tags_opt, agent_filter)
-        .await
-    {
+        .await;
+    if let Err(ref e) = semantic {
+        // Surface the otherwise-swallowed semantic-search error: when this Errs,
+        // recall silently degrades to the empty/text-fallback path below and
+        // returns [] for queries that DO have matches (backlog 1564bdaf). Logging
+        // the runtime cause (embedder failure vs DB/query error) makes it diagnosable.
+        tracing::warn!(
+            error = %e,
+            query = %params.query,
+            scoped,
+            "recall: semantic search_scoped failed; degrading to text/empty fallback"
+        );
+    }
+    let results = if let Ok(hits) = semantic {
         let mut results = Vec::new();
         for (claim_id, similarity) in hits {
             if let Ok(Some(claim)) =


### PR DESCRIPTION
## What
`tools::memory::recall` discards the result of `McpEmbedder::search_scoped` via `if let Ok(hits) = ...`, so when semantic search **errors at runtime** it silently degrades to the text/empty fallback and returns `[]` — with **nothing logged**. This binds the `Result` and `tracing::warn!`s on `Err` (error + query + scoped) before it's consumed.

## Why
Backlog **1564bdaf** is still live: flat `recall()` returns `[]` in prod **even though #228 is deployed** (confirmed — the live binary contains #228's unique string literal + #233's `list_undecomposed`; not a stale deploy). A/B on live prod: `recall_with_context("DNA origami")` → rich hits, `recall("DNA origami")` → `[]`. The `search_by_embedding_scoped` SQL is fast/HNSW-indexed (10ms with a constant vector), so the failure is upstream in `search_scoped` (embedder `generate` or the bind) — but the `Err` is swallowed, so it can't be diagnosed from logs.

## Effect
Pure observability — control flow unchanged. After deploy, the next failing `recall()` will emit the actual runtime error in the epigraph-mcp-http journal, exposing the root cause so it can be fixed.

## Verifiability
Compiles (`cargo build -p epigraph-mcp`, exit 0) and clippy-clean (`--lib -- -D warnings`, exit 0). No behavior change; not runtime-verified here (the warn fires only on the live error path post-deploy). Interim workaround for the underlying bug: use `recall_with_context` / `find_workflow_hierarchical`.