### PR TITLE
fix(api): accept form-urlencoded at /oauth/token (RFC 6749), not just JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_with",
  "sha2",
  "sqlx 0.7.4",

--- a/crates/epigraph-api/Cargo.toml
+++ b/crates/epigraph-api/Cargo.toml
@@ -64,6 +64,7 @@ tower = { version = "0.5", features = ["util", "timeout"] }  # Service abstracti
 tower-http = { version = "0.5", features = ["trace", "cors"] }  # HTTP middleware
 serde = { workspace = true }  # Serialization
 serde_json = { workspace = true }  # JSON support
+serde_urlencoded = "0.7"  # OAuth token endpoint body (application/x-www-form-urlencoded, RFC 6749)
 serde_with = { workspace = true }  # Helper macros for serde
 toml = "0.8"  # provider config parsing
 uuid = { workspace = true }  # UUID support

--- a/crates/epigraph-api/src/oauth/token.rs
+++ b/crates/epigraph-api/src/oauth/token.rs
@@ -5,12 +5,38 @@
 //! - refresh_token (all client types)
 //! - external provider grant types (registered via providers.toml; e.g. google_id_token, cloudflare_access_jwt)
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{header::CONTENT_TYPE, HeaderMap, StatusCode},
+    Json,
+};
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ApiError;
 use crate::state::AppState;
+
+/// Parse a token request from either `application/x-www-form-urlencoded` — the OAuth 2.0
+/// standard body for the token endpoint (RFC 6749 §4.1.3), sent by claude.ai and other
+/// RFC 6749 / remote-MCP clients — or `application/json`, used by EpiGraph's own agents.
+/// Defaults to form-encoded when the Content-Type is absent, per the spec.
+#[cfg(feature = "db")]
+fn parse_token_request(headers: &HeaderMap, body: &[u8]) -> Result<TokenRequest, ApiError> {
+    let ct = headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if ct.starts_with("application/json") {
+        serde_json::from_slice(body).map_err(|e| ApiError::BadRequest {
+            message: format!("invalid JSON token request: {e}"),
+        })
+    } else {
+        serde_urlencoded::from_bytes(body).map_err(|e| ApiError::BadRequest {
+            message: format!("invalid form-encoded token request: {e}"),
+        })
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct TokenRequest {
@@ -52,8 +78,10 @@ pub struct TokenResponse {
 #[cfg(feature = "db")]
 pub async fn token_endpoint(
     State(state): State<AppState>,
-    Json(req): Json<TokenRequest>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Result<(StatusCode, Json<TokenResponse>), ApiError> {
+    let req = parse_token_request(&headers, &body)?;
     match req.grant_type.as_str() {
         "client_credentials" => handle_client_credentials(&state, &req).await,
         "refresh_token" => handle_refresh_token(&state, &req).await,
@@ -74,7 +102,8 @@ pub async fn token_endpoint(
 #[cfg(not(feature = "db"))]
 pub async fn token_endpoint(
     State(_state): State<AppState>,
-    Json(_req): Json<TokenRequest>,
+    _headers: HeaderMap,
+    _body: Bytes,
 ) -> Result<(StatusCode, Json<TokenResponse>), ApiError> {
     Err(ApiError::ServiceUnavailable {
         service: "database required for OAuth2".to_string(),

--- a/crates/epigraph-api/tests/oauth_authorization_code.rs
+++ b/crates/epigraph-api/tests/oauth_authorization_code.rs
@@ -397,6 +397,29 @@ async fn authorization_code_missing_code_is_invalid_request() {
 }
 
 #[tokio::test]
+async fn token_endpoint_accepts_form_urlencoded_body() {
+    // OAuth 2.0 token requests are application/x-www-form-urlencoded (RFC 6749 §4.1.3) —
+    // what claude.ai and other remote-MCP clients send. Regression for the 415
+    // Unsupported Media Type that broke the live connector when the handler was JSON-only:
+    // a form body must REACH the handler (missing `code` -> 400), not be rejected at 415.
+    use axum::http::header;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/oauth/token")
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(
+            "grant_type=authorization_code&code_verifier=x&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback",
+        ))
+        .unwrap();
+    let resp = app().oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "form-encoded token request must reach the handler (400 missing code), not 415"
+    );
+}
+
+#[tokio::test]
 async fn authorization_server_metadata_has_required_fields() {
     let (status, body) = get_json(app(), "/.well-known/oauth-authorization-server").await;
     assert_eq!(status, StatusCode::OK);


### PR DESCRIPTION
## Summary
The live claude.ai MCP connector failed at the **token exchange**: `POST /oauth/token → 415 Unsupported Media Type`. `register → 201`, `authorize → 303`, Google `callback → 200`, `consent → 303` all succeeded; only the token step broke.

**Cause:** the handler was `Json<TokenRequest>` (JSON-only), but OAuth 2.0 token requests are `application/x-www-form-urlencoded` (RFC 6749 §4.1.3) — which claude.ai (and any RFC 6749 client) sends. The Phase-2 tests passed only because they sent JSON, encoding the same wrong assumption as the code.

**Fix:** parse the token body by `Content-Type` — `application/json` for EpiGraph's own agents (preserved), otherwise `serde_urlencoded` (the OAuth standard, and the default when Content-Type is absent). `TokenRequest` is a flat `Option<String>` struct, so it deserializes cleanly from both.

## Test Plan
- [x] New `token_endpoint_accepts_form_urlencoded_body`: form body reaches the handler (400 missing-code), not 415
- [x] `oauth_authorization_code` suite **19/19** incl DB-backed redeem (happy/pkce/reuse/expiry/clients) — JSON path still works
- [x] `cargo clippy -p epigraph-api --locked -- -D warnings` clean; `cargo fmt --check` clean; `Cargo.lock` updated for the `serde_urlencoded` direct dep
- [x] Verified live against prod after hotfix (see below)

## Note
Hotfix-deployed to prod ahead of merge to unblock the connector (only `epigraph-api` rebuilt; no migration change). This PR brings `main` in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)