### PR TITLE
fix(mcp): repoint find_workflow semantic search to claims.embedding

### DIFF
--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -386,13 +386,11 @@ pub async fn find_workflow(
     server: &EpiGraphMcpFull,
     params: FindWorkflowParams,
 ) -> Result<CallToolResult, McpError> {
-    let limit = params.limit.unwrap_or(5).clamp(1, 20);
-    let min_truth = params.min_truth.unwrap_or(0.3);
-
     // Generate embedding once — reused for both semantic search and behavioral
     // affinity. Failure here is non-fatal: we still want the ILIKE fallback to
-    // run (workflows commonly lack evidence embeddings, and offline embedders
-    // shouldn't blank the whole tool).
+    // run (offline embedders shouldn't blank the whole tool). The post-embed
+    // pipeline (extracted to mirror recall.rs's recall_with_context split) lets
+    // integration tests skip the OpenAI embedder via `__test_only`.
     let pgvec_opt = match server.embedder.generate(&params.goal).await {
         Ok(v) => Some(format_pgvector(&v)),
         Err(e) => {
@@ -401,11 +399,38 @@ pub async fn find_workflow(
         }
     };
 
-    // Semantic search via evidence embeddings (only when embedding is available).
+    find_workflow_post_embed(server, &params, pgvec_opt).await
+}
+
+/// Post-embedding pipeline: shared by `find_workflow` and the
+/// `__test_only::find_workflow_with_pgvec` entry point that lets integration
+/// tests skip the OpenAI embedder (no API key available in CI / sandbox).
+///
+/// Recomputes `limit`/`min_truth` from `params` internally (rather than taking
+/// them as args) so the public wrapper stays minimal and the two extraction
+/// sites cannot drift, mirroring recall.rs's wrapper pattern.
+async fn find_workflow_post_embed(
+    server: &EpiGraphMcpFull,
+    params: &FindWorkflowParams,
+    pgvec_opt: Option<String>,
+) -> Result<CallToolResult, McpError> {
+    let limit = params.limit.unwrap_or(5).clamp(1, 20);
+    let min_truth = params.min_truth.unwrap_or(0.3);
+
+    // Semantic search over claims.embedding (workflow vectors live on claims,
+    // not evidence; evidence.embedding is 100% empty in prod). Scoped to the
+    // "workflow" label so only workflow claims compete for the budget.
+    let workflow_tag = vec!["workflow".to_string()];
     let semantic_hits = if let Some(pgvec) = pgvec_opt.as_deref() {
-        epigraph_db::EvidenceRepository::search_by_embedding(&server.pool, pgvec, limit * 3)
-            .await
-            .map_err(internal_error)?
+        ClaimRepository::search_by_embedding_scoped(
+            &server.pool,
+            pgvec,
+            limit * 3,
+            Some(&workflow_tag),
+            None,
+        )
+        .await
+        .map_err(internal_error)?
     } else {
         Vec::new()
     };
@@ -892,4 +917,24 @@ pub async fn deprecate_workflow(
         deprecated_ids,
         reason: params.reason,
     })
+}
+
+#[doc(hidden)]
+pub mod __test_only {
+    use super::{find_workflow_post_embed, EpiGraphMcpFull, FindWorkflowParams, McpError};
+    use rmcp::model::CallToolResult;
+
+    /// Integration-test entry point that skips the OpenAI embedder.
+    ///
+    /// Tests cannot call the real embedder (no API key in CI / sandbox),
+    /// so they pre-format a known pgvector literal and dispatch directly
+    /// into the post-embed pipeline. This is the same code that
+    /// `find_workflow` runs after `embedder.generate`.
+    pub async fn find_workflow_with_pgvec(
+        server: &EpiGraphMcpFull,
+        params: FindWorkflowParams,
+        pgvec: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        find_workflow_post_embed(server, &params, pgvec).await
+    }
 }

--- a/crates/epigraph-mcp/tests/find_workflow_semantic_test.rs
+++ b/crates/epigraph-mcp/tests/find_workflow_semantic_test.rs
@@ -1,0 +1,105 @@
+//! Regression test: find_workflow must surface workflow claims via semantic
+//! search over claims.embedding (not evidence.embedding, which is empty).
+//!
+//! Fails on the old code (EvidenceRepository::search_by_embedding -> zero hits
+//! on the semantic path because evidence.embedding is 100% NULL in prod).
+//! Passes on the fixed code (ClaimRepository::search_by_embedding_scoped).
+//!
+//! The goal string is intentionally NOT a substring of the claim content,
+//! so ILIKE cannot match it and any result with similarity > 0 can only have
+//! come from the semantic (vector) path.
+
+// rustfmt 1.8 sorts __test_only differently than older CI rustfmt; opt out so
+// both versions accept the file (mirrors recall_with_context.rs's header fix).
+#[rustfmt::skip]
+use epigraph_mcp::tools::workflows::__test_only::find_workflow_with_pgvec;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+use common::*;
+
+/// Build a 1536-d unit-ish pgvector literal. Component [0] is 1.0, rest 0.0.
+fn unit_pgvec_1536() -> String {
+    let mut v = vec!["0.0"; 1536];
+    v[0] = "1.0";
+    format!("[{}]", v.join(","))
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn find_workflow_semantic_path_uses_claims_embedding(pool: PgPool) {
+    // Seed agent + workflow claim.
+    let agent_id = seed_agent(&pool).await;
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id.as_bytes().iter().copied().cycle().take(32).collect();
+
+    // Content is valid JSON so parse_workflow_content returns a non-empty goal
+    // and non-empty steps, which enrich_workflow_result requires to emit Some.
+    // The content string intentionally contains NO substring that could match
+    // the query text "xyzzy_semantic_probe_42" via ILIKE.
+    let content = serde_json::json!({
+        "goal": "deploy containerised service",
+        "steps": ["build image", "push to registry", "restart service"],
+        "generation": 0,
+        "use_count": 0,
+        "success_count": 0,
+        "failure_count": 0,
+        "avg_variance": 0.0,
+    })
+    .to_string();
+
+    let pgvec = unit_pgvec_1536();
+
+    // Insert with claims.embedding set — this is what the fix queries.
+    sqlx::query(
+        "INSERT INTO claims \
+         (id, content, content_hash, truth_value, agent_id, is_current, labels, embedding) \
+         VALUES ($1, $2, $3, 0.7, $4, true, ARRAY['workflow']::text[], $5::vector)",
+    )
+    .bind(id)
+    .bind(&content)
+    .bind(&hash)
+    .bind(agent_id)
+    .bind(&pgvec)
+    .execute(&pool)
+    .await
+    .expect("seed workflow claim with embedding");
+
+    // Drive the post-embed pipeline directly (no OpenAI call, no API key needed).
+    // pgvec_opt = Some(pgvec) forces the semantic path.
+    // The query text "xyzzy_semantic_probe_42" does not appear in the claim, so
+    // any result arriving here came through the vector path, not ILIKE.
+    let server = build_test_server(pool.clone());
+    let params = epigraph_mcp::types::FindWorkflowParams {
+        goal: "xyzzy_semantic_probe_42".to_string(),
+        limit: Some(5),
+        min_truth: Some(0.0),
+    };
+    let result = find_workflow_with_pgvec(&server, params, Some(pgvec))
+        .await
+        .expect("find_workflow_with_pgvec");
+
+    let json = first_text(&result);
+    let arr = json.as_array().expect("result is array");
+    assert!(
+        !arr.is_empty(),
+        "semantic path must return the seeded workflow claim; got empty array. \
+         Old code (EvidenceRepository::search_by_embedding) returns zero because \
+         evidence.embedding is NULL. New code (ClaimRepository::search_by_embedding_scoped) \
+         finds the claim via claims.embedding."
+    );
+
+    let first = &arr[0];
+    assert_eq!(
+        first["workflow_id"].as_str().unwrap(),
+        id.to_string(),
+        "returned workflow id must match the seeded claim"
+    );
+
+    let similarity = first["similarity"].as_f64().unwrap_or(0.0);
+    assert!(
+        similarity > 0.0,
+        "similarity must be > 0 (semantic hit); ILIKE fallback emits 0.0 so \
+         similarity > 0 proves the vector path fired: got {similarity}"
+    );
+}


### PR DESCRIPTION
## Claim
`find_workflow`'s semantic search ran ANN over the **empty** `evidence.embedding` column, so it never returned vector hits — only its ILIKE text fallback worked. This repoints it to the populated `claims.embedding` (scoped to `workflow` claims), completing the pair with the `recall` fix (`6eeb50c`).

**Evidence:**
- `evidence.embedding` is **0 / 77,686** populated in prod; `claims.embedding` is **426,063 / 429,151** (124/129 `workflow`-labeled claims embedded).
- Live (deployed `epigraph-mcp`): `find_workflow("techniques for consolidating duplicate epistemic assertions…")` → `[]`; lexical `find_workflow("storytelling craft claims")` → 5 hits **all `similarity: 0.0`** (the hardcoded text-fallback marker) — i.e. the semantic path contributed nothing.
- Identical root cause to backlog `1564bdaf` / `4cdba7bc` (the `find_workflow` half; the `recall` half was fixed by `6eeb50c`).

**Reasoning:**
- Workflow vectors live on `claims.embedding`, not `evidence.embedding`. Swap `EvidenceRepository::search_by_embedding` → `ClaimRepository::search_by_embedding_scoped(pool, pgvec, limit*3, Some(&["workflow"]), None)`, mirroring exactly what `6eeb50c` did for `recall`. The return type (`ClaimEmbeddingHit`) and the downstream result-building loop are unchanged; the behavioral-affinity path and the ILIKE fallback are preserved.
- `find_workflow` is split into a thin embedding wrapper + `find_workflow_post_embed`, with a `#[doc(hidden)] pub mod __test_only` re-export (mirrors `recall.rs`) so the semantic path is testable without an OpenAI key.

**Verification:**
- New regression test `find_workflow_semantic_path_uses_claims_embedding`: seeds a `workflow` claim with a `claims.embedding` vector and queries with a **non-lexical** goal (`xyzzy_semantic_probe_42`) so a hit can only come from the vector path (ILIKE can't match) and asserts `similarity > 0`.
- **Proven regression guard:** reverting only the one line back to `evidence.embedding` makes the test FAIL (empty array); restoring the fix makes it pass.
- CI gate run foreground: `cargo fmt --all --check` ✅, `cargo clippy --workspace --locked -- -D warnings` ✅, `cargo build --workspace --locked` ✅, `cargo test -p epigraph-mcp --test find_workflow_semantic_test --test find_workflow_fallback_test` ✅.
- No new `sqlx::query!` macros (reuses the cached `search_by_embedding_scoped`; test seeds via runtime `sqlx::query`), so `.sqlx/` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)