### PR TITLE
fix(api): stop auto-enqueueing cluster jobs on server startup

### DIFF
--- a/crates/epigraph-api/src/bin/server.rs
+++ b/crates/epigraph-api/src/bin/server.rs
@@ -4,7 +4,7 @@ use epigraph_api::{create_router, ApiConfig, AppState};
 #[cfg(feature = "db")]
 use epigraph_jobs::{
     cluster_graph::ClusterGraphHandler, theme_cluster_rebuild::ThemeClusterRebuildHandler,
-    EpiGraphJob, JobQueue, JobRunner, PostgresJobQueue,
+    JobQueue, JobRunner, PostgresJobQueue,
 };
 use std::sync::Arc;
 #[cfg(feature = "db")]
@@ -274,7 +274,6 @@ async fn main() {
         tracing::info!("EPIGRAPH_DISABLE_JOBS=1 set; skipping job runner registration");
     } else {
         let queue: Arc<dyn JobQueue> = Arc::new(PostgresJobQueue::new(job_pool.clone()));
-        let queue_for_cluster_cron = Arc::clone(&queue);
         let queue_for_theme_cron = Arc::clone(&queue);
         // Concrete handle for the stale-job reaper (recover_stale_jobs is a
         // PostgresJobQueue method, not part of the JobQueue trait).
@@ -315,75 +314,26 @@ async fn main() {
             }
         });
 
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(60)).await;
-            loop {
-                match (EpiGraphJob::ClusterGraph {
-                    resolution: 1.0,
-                    retain_runs: 3,
-                })
-                .into_job()
-                {
-                    Ok(job) => match queue_for_cluster_cron.enqueue_unique_pending(job).await {
-                        Ok(Some(_)) => tracing::info!("Enqueued nightly ClusterGraph job"),
-                        Ok(None) => tracing::info!(
-                            "ClusterGraph already pending; skipped duplicate nightly enqueue"
-                        ),
-                        Err(e) => tracing::error!(
-                            error = %e,
-                            "failed to enqueue nightly ClusterGraph job"
-                        ),
-                    },
-                    Err(e) => {
-                        tracing::error!(
-                            error = %e,
-                            "failed to serialize ClusterGraph job payload"
-                        );
-                    }
-                }
-                tokio::time::sleep(Duration::from_secs(86_400)).await;
-            }
-        });
-
-        // Sibling cron: ThemeClusterRebuild — staggered 30-minute warmup
-        // (vs ClusterGraph's 60 s) so ClusterGraph finishes its first run
-        // before ThemeClusterRebuild's `wipe_first` cascades into
-        // `graph_neighborhoods.theme_id` (ON DELETE CASCADE, migration
-        // 026).  Subsequent daily runs preserve the same offset.
-        // `skip_if_unchanged: true` makes this a cheap no-op on idle days.
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(1800)).await;
-            loop {
-                match (EpiGraphJob::ThemeClusterRebuild {
-                    max_themes: 50,
-                    min_claims_per_theme: 5,
-                    skip_if_unchanged: true,
-                })
-                .into_job()
-                {
-                    Ok(job) => match queue_for_theme_cron.enqueue_unique_pending(job).await {
-                        Ok(Some(_)) => tracing::info!("Enqueued nightly ThemeClusterRebuild job"),
-                        Ok(None) => tracing::info!(
-                            "ThemeClusterRebuild already pending; skipped duplicate nightly enqueue"
-                        ),
-                        Err(e) => tracing::error!(
-                            error = %e,
-                            "failed to enqueue nightly ThemeClusterRebuild job"
-                        ),
-                    },
-                    Err(e) => {
-                        tracing::error!(
-                            error = %e,
-                            "failed to serialize ThemeClusterRebuild job payload"
-                        );
-                    }
-                }
-                tokio::time::sleep(Duration::from_secs(86_400)).await;
-            }
-        });
+        // Nightly auto-enqueue is DISABLED for both ClusterGraph and
+        // ThemeClusterRebuild.
+        //
+        // The ThemeClusterRebuild rebuild (in-memory 1536-dim k-means, linfa
+        // n_runs=10 × elbow range, see theme_kmeans.rs) wedged epigraph-api
+        // for ~30 min after every restart — its cron fired 1800 s post-boot,
+        // so a bounce was effectively a forced full re-cluster. ClusterGraph
+        // (Louvain) likewise self-triggered ~60 s after boot. Both jobs are
+        // expensive and not latency-sensitive, so they should run on operator
+        // demand, not as an unconditional side effect of starting the server.
+        //
+        // Both handlers stay REGISTERED above (the theme handler borrows
+        // `queue_for_theme_cron` for its follow-up queue), so an operator can
+        // still trigger a one-off run by enqueuing a `ClusterGraph` or
+        // `ThemeClusterRebuild` job via the jobs API; nothing auto-enqueues
+        // either.
 
         tracing::info!(
-            "Job runner started (2 workers); nightly ClusterGraph + ThemeClusterRebuild jobs scheduled"
+            "Job runner started (2 workers); ClusterGraph + ThemeClusterRebuild \
+             auto-enqueue disabled (run on demand via the jobs API)"
         );
     }
 


### PR DESCRIPTION
## Summary

`epigraph-api` self-triggers two expensive background jobs shortly after every restart via startup crons in `crates/epigraph-api/src/bin/server.rs`:

- **ThemeClusterRebuild** — fires 1800 s (30 min) post-boot, forcing a full in-memory 1536-dim k-means re-cluster (linfa `n_runs=10` × elbow sweep, `theme_kmeans.rs`). This wedges the API for ~30 min after every restart, with no toggle.
- **ClusterGraph** (Louvain) — fires ~60 s post-boot on the same daily loop.

Both jobs are expensive and not latency-sensitive, so they shouldn't run as an unconditional side effect of starting the server.

## Change

- Remove both cron spawns. Neither job auto-enqueues anymore.
- **Both handlers stay registered**, so an operator can still trigger a one-off run by enqueuing a `ClusterGraph` / `ThemeClusterRebuild` job via the jobs API — "able to call, but not required."
- Drop the now-unused `EpiGraphJob` import and `queue_for_cluster_cron` binding; `queue_for_theme_cron` is still borrowed by the theme handler registration.
- Update the startup log line (it previously claimed both jobs were scheduled).
- Stale-job reaper left in place — still recovers orphaned operator-triggered runs.

Chose hard-remove over an env-gate: a re-enableable nightly wasn't requested and would diverge from `feat/theme-system-overhaul`, which moves theming out of Rust entirely.

## Verification

- `cargo fmt --check -p epigraph-api` clean
- `SQLX_OFFLINE=true cargo clippy -p epigraph-api --bin server --locked -- -D warnings` clean (only the pre-existing `sqlx-postgres` future-incompat note)

## Deploy note

Merging does **not** stop the live wedge — prod runs a binary rebuilt from `origin/main`. The symptom persists until `server` is rebuilt and epigraph-api restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)