### PR TITLE
Backlog bug: The decomposition-cycle scheduled task has no executable path via MCP to

### DIFF
--- a/crates/epigraph-mcp/src/embed.rs
+++ b/crates/epigraph-mcp/src/embed.rs
@@ -11,6 +11,16 @@ pub struct McpEmbedder {
     http: reqwest::Client,
 }
 
+/// Whether an OpenAI API key string is unusable for embedding generation:
+/// absent, empty, or the literal `"mock"`. Mirrors the disabled-condition that
+/// `generate`/`generate_at_dim` apply inline (`.filter(|k| !k.is_empty() && *k
+/// != "mock")`); `embeddings_disabled` delegates here so the backfill guard and
+/// the generate path agree. Kept free-standing so it is unit-testable without a
+/// `PgPool`.
+fn key_disabled(key: Option<&str>) -> bool {
+    !matches!(key, Some(k) if !k.is_empty() && k != "mock")
+}
+
 /// Map a centroid dimension to the OpenAI model that produces it.
 /// Returns None for unsupported dims (caller treats as InvalidParams).
 #[must_use]
@@ -35,6 +45,17 @@ impl McpEmbedder {
     #[must_use]
     pub const fn is_mock(&self) -> bool {
         self.api_key.is_none()
+    }
+
+    /// True when no usable API key is configured, so `generate`/`generate_at_dim`
+    /// will reject every call. Mirrors their disabled-condition exactly — a
+    /// `None`, empty, or literal `"mock"` key — so batch callers (e.g.
+    /// `backfill_embeddings`) can fail loudly up front instead of churning a
+    /// whole batch into all-failed. Stricter than [`is_mock`](Self::is_mock),
+    /// which only catches the `None` case.
+    #[must_use]
+    pub fn embeddings_disabled(&self) -> bool {
+        key_disabled(self.api_key.as_deref())
     }
 
     /// Generate an embedding vector without storing it.
@@ -305,5 +326,26 @@ mod tests {
     fn model_for_dim_rejects_unknown_dim() {
         assert!(model_for_dim(1024).is_none());
         assert!(model_for_dim(0).is_none());
+    }
+
+    // `key_disabled` is the shared disabled-condition behind both `generate`
+    // and `embeddings_disabled`; pinning it keeps the backfill fail-loud guard
+    // from being bypassed by an empty or "mock" key.
+    #[test]
+    fn key_disabled_catches_none_empty_and_mock() {
+        assert!(super::key_disabled(None), "no key => disabled");
+        assert!(super::key_disabled(Some("")), "empty key => disabled");
+        assert!(
+            super::key_disabled(Some("mock")),
+            "literal mock => disabled"
+        );
+    }
+
+    #[test]
+    fn key_disabled_allows_a_real_key() {
+        assert!(
+            !super::key_disabled(Some("sk-real-key")),
+            "a real key => enabled"
+        );
     }
 }

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -63,6 +63,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     // ─── claims:write ──────────────────────────────────────────────────
     ("add_step", "claims:write"),
     ("assign_ownership", "claims:write"),
+    ("backfill_embeddings", "claims:write"),
     ("batch_submit_claims", "claims:write"),
     ("challenge_claim", "claims:write"),
     ("create_frame", "claims:write"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -874,7 +874,7 @@ impl EpiGraphMcpFull {
         tools::sheaf::reconcile_sheaf(self, params).await
     }
 
-    // ── Embeddings (1 tool) ──
+    // ── Embeddings (2 tools) ──
 
     #[tool(
         description = "Aggregate claim count + similarity stats for the embedding ball around a free-text query. Mirrors POST /api/v1/embeddings/neighborhood-density. Returns n_claims, mean/median cosine similarity, a squashed sparsity score, and breakdowns by level + source_type. Defaults: radius=0.30 (cosine distance), max_sample=500 (clamped to [1, 5000]). Use this to detect dense regions that warrant theme sub-splitting and to drive the nightly theme-maintenance workflow."
@@ -886,6 +886,17 @@ impl EpiGraphMcpFull {
         >,
     ) -> Result<CallToolResult, McpError> {
         crate::tools::embeddings::embedding_neighborhood_density(self, params).await
+    }
+
+    #[tool(
+        description = "Generate and store the missing claims.embedding vector for current, non-telemetry claims that lack one (the is_current AND embedding IS NULL gap the CLAUDE.md embedding-policy invariant tracks). Server-side, MCP-executable counterpart to the embed_backfill CLI: the embed stage of the decomposition-cycle's decompose→embed→cross-source-match pipeline. Selection is oldest-first so repeated runs drain the backlog monotonically. Params: limit (default 200, clamped 1..=2000), dry_run (default false — count candidates without writing; safe with no OpenAI key). Returns {candidates, embedded, failed, dry_run}. Errors if the server has no OPENAI_API_KEY and dry_run is false. Requires claims:write."
+    )]
+    async fn backfill_embeddings(
+        &self,
+        Parameters(params): Parameters<crate::tools::embeddings::BackfillEmbeddingsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        crate::tools::embeddings::backfill_embeddings(self, params).await
     }
 
     // ── Themes (1 tool) ──

--- a/crates/epigraph-mcp/src/tools/embeddings.rs
+++ b/crates/epigraph-mcp/src/tools/embeddings.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
-use crate::errors::{internal_error, McpError};
+use crate::errors::{internal_error, invalid_params, McpError};
 use crate::server::EpiGraphMcpFull;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -98,4 +98,114 @@ pub async fn embedding_neighborhood_density(
     Ok(CallToolResult::success(vec![Content::text(
         serde_json::to_string_pretty(&body).map_err(internal_error)?,
     )]))
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BackfillEmbeddingsParams {
+    /// Max claims to embed this run (default 200, clamped to 1..=2000). The
+    /// selection is ordered oldest-first so repeated scheduled runs drain the
+    /// backlog monotonically.
+    pub limit: Option<i64>,
+    /// When true, only count how many claims need embeddings and write nothing
+    /// (safe to run with no OpenAI key). Default false.
+    pub dry_run: Option<bool>,
+}
+
+/// `backfill_embeddings` — generate and store the missing `claims.embedding`
+/// vector for current, non-telemetry claims that lack one.
+///
+/// This is the server-side, MCP-executable counterpart to the `embed_backfill`
+/// CLI binary: it lets the scheduled decomposition-cycle task close the
+/// embedding gap (the `is_current AND embedding IS NULL` population the
+/// embedding-policy invariant in CLAUDE.md tracks) without shelling out. It is
+/// the `embed` stage of the decompose→embed→cross-source-match pipeline; the
+/// `decompose` stage stays the prepaid-LLM CLI primitive (no LLM provider is
+/// registered in the MCP process) and `cross-source-match` is already exposed
+/// as `find_cross_source_matches`.
+///
+/// Selection reuses `ClaimRepository::find_claims_needing_embeddings`, which
+/// excludes host-provenance telemetry and `is_current = false` rows per the
+/// invariant. Each vector is stored via `ClaimRepository::store_embedding`
+/// (an `UPDATE claims SET embedding`), so a failure on one claim is reported,
+/// not fatal — mirroring the CLI's per-row accounting.
+pub async fn backfill_embeddings(
+    server: &EpiGraphMcpFull,
+    params: BackfillEmbeddingsParams,
+) -> Result<CallToolResult, McpError> {
+    let limit = params.limit.unwrap_or(200).clamp(1, 2000);
+    let dry_run = params.dry_run.unwrap_or(false);
+
+    let rows = epigraph_db::ClaimRepository::find_claims_needing_embeddings(&server.pool, limit)
+        .await
+        .map_err(internal_error)?;
+    let candidates = rows.len();
+
+    if dry_run || candidates == 0 {
+        let body = serde_json::json!({
+            "candidates": candidates,
+            "embedded": 0,
+            "failed": 0,
+            "dry_run": dry_run,
+        });
+        return Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).map_err(internal_error)?,
+        )]));
+    }
+
+    // A mock embedder (no OPENAI_API_KEY on the server) would fail every
+    // `generate`. Fail loudly up front rather than reporting "all failed",
+    // so the scheduled task surfaces a config error instead of churning.
+    if server.embedder.embeddings_disabled() {
+        return Err(invalid_params(
+            "embeddings disabled: no OPENAI_API_KEY configured on the MCP server; \
+             cannot backfill (re-run with dry_run=true to only count candidates)",
+        ));
+    }
+
+    let mut embedded = 0usize;
+    let mut failed = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    for (claim_id, content) in rows {
+        match server.embedder.generate(&content).await {
+            Ok(vec) => {
+                let pgvec = crate::embed::format_pgvector(&vec);
+                match epigraph_db::ClaimRepository::store_embedding(&server.pool, claim_id, &pgvec)
+                    .await
+                {
+                    Ok(true) => embedded += 1,
+                    Ok(false) => {
+                        failed += 1;
+                        push_capped(&mut errors, format!("{claim_id}: store affected 0 rows"));
+                    }
+                    Err(e) => {
+                        failed += 1;
+                        push_capped(&mut errors, format!("{claim_id}: store failed: {e}"));
+                    }
+                }
+            }
+            Err(e) => {
+                failed += 1;
+                push_capped(&mut errors, format!("{claim_id}: embed failed: {e}"));
+            }
+        }
+    }
+
+    let body = serde_json::json!({
+        "candidates": candidates,
+        "embedded": embedded,
+        "failed": failed,
+        "dry_run": false,
+        "errors": errors,
+    });
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(&body).map_err(internal_error)?,
+    )]))
+}
+
+/// Append to a bounded error sample so a large failing batch does not return a
+/// multi-megabyte payload. Caps at 20 entries.
+fn push_capped(errors: &mut Vec<String>, msg: String) {
+    if errors.len() < 20 {
+        errors.push(msg);
+    }
 }

--- a/crates/epigraph-mcp/tests/backfill_embeddings_smoke.rs
+++ b/crates/epigraph-mcp/tests/backfill_embeddings_smoke.rs
@@ -1,0 +1,186 @@
+//! Smoke tests for the `backfill_embeddings` MCP tool — the server-side,
+//! MCP-executable embed stage of the decomposition-cycle pipeline.
+//!
+//! The build harness constructs the server with a MOCK embedder
+//! (`McpEmbedder::new(pool, None)`), so the real OpenAI generate+store happy
+//! path cannot run in CI (same scaffold boundary as the `decompose_claims`
+//! LLM call). These tests pin the two behaviors that DO run without a network
+//! round-trip: candidate selection (`dry_run`) and the fail-loud guard when
+//! the server has no API key. The generate→store mechanics themselves are
+//! covered by `ClaimRepository::store_embedding` /
+//! `find_claims_needing_embeddings` unit tests in epigraph-db.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_mcp::tools;
+use epigraph_mcp::tools::embeddings::BackfillEmbeddingsParams;
+use epigraph_mcp::{embed::McpEmbedder, EpiGraphMcpFull};
+use rmcp::model::{CallToolResult, RawContent};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn build_server(pool: PgPool, read_only: bool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0x2au8; 32]).expect("signer");
+    // None => mock embedder: `generate` errors, exercising the fail-loud guard.
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, read_only)
+}
+
+async fn insert_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, created_at, updated_at)
+         VALUES ($1, sha256($1::text::bytea), NOW(), NOW())",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("agent");
+    id
+}
+
+/// A current claim with `embedding IS NULL` — exactly what backfill targets.
+async fn insert_unembedded_claim(pool: &PgPool, agent: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let content = format!("backfill candidate {id} with enough length to pass filters");
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current, embedding)
+         VALUES ($1, $2, sha256($2::bytea), 0.5, $3, true, NULL)",
+    )
+    .bind(id)
+    .bind(&content)
+    .bind(agent)
+    .execute(pool)
+    .await
+    .expect("claim");
+    id
+}
+
+fn result_text(out: CallToolResult) -> String {
+    let first = out.content.first().cloned().expect("first content");
+    match first.raw {
+        RawContent::Text(t) => t.text,
+        other => panic!("expected text content, got {other:?}"),
+    }
+}
+
+fn parse(out: CallToolResult) -> serde_json::Value {
+    serde_json::from_str(&result_text(out)).expect("valid json body")
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn dry_run_counts_candidates_without_writing(pool: PgPool) {
+    let server = build_server(pool.clone(), false).await;
+    let agent = insert_agent(&pool).await;
+    for _ in 0..3 {
+        insert_unembedded_claim(&pool, agent).await;
+    }
+
+    let out = tools::embeddings::backfill_embeddings(
+        &server,
+        BackfillEmbeddingsParams {
+            limit: Some(100),
+            dry_run: Some(true),
+        },
+    )
+    .await
+    .expect("dry_run succeeds even with a mock embedder");
+
+    let body = parse(out);
+    assert_eq!(
+        body["candidates"], 3,
+        "all three NULL-embedding claims counted"
+    );
+    assert_eq!(body["embedded"], 0, "dry_run writes nothing");
+    assert_eq!(body["dry_run"], true);
+
+    // And nothing was actually written.
+    let still_null: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM claims WHERE embedding IS NULL AND agent_id = $1")
+            .bind(agent)
+            .fetch_one(&pool)
+            .await
+            .expect("count");
+    assert_eq!(still_null, 3, "dry_run must not have stored any embeddings");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn limit_is_respected_and_clamped(pool: PgPool) {
+    let server = build_server(pool.clone(), false).await;
+    let agent = insert_agent(&pool).await;
+    for _ in 0..5 {
+        insert_unembedded_claim(&pool, agent).await;
+    }
+
+    let out = tools::embeddings::backfill_embeddings(
+        &server,
+        BackfillEmbeddingsParams {
+            limit: Some(2),
+            dry_run: Some(true),
+        },
+    )
+    .await
+    .expect("dry_run");
+    assert_eq!(
+        parse(out)["candidates"],
+        2,
+        "limit caps the candidate window"
+    );
+
+    // limit below 1 clamps up to 1 rather than returning everything/nothing.
+    let out = tools::embeddings::backfill_embeddings(
+        &server,
+        BackfillEmbeddingsParams {
+            limit: Some(0),
+            dry_run: Some(true),
+        },
+    )
+    .await
+    .expect("dry_run");
+    assert_eq!(parse(out)["candidates"], 1, "limit 0 clamps to 1");
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn non_dry_run_with_mock_embedder_fails_loudly(pool: PgPool) {
+    let server = build_server(pool.clone(), false).await;
+    let agent = insert_agent(&pool).await;
+    insert_unembedded_claim(&pool, agent).await;
+
+    let err = tools::embeddings::backfill_embeddings(
+        &server,
+        BackfillEmbeddingsParams {
+            limit: Some(100),
+            dry_run: Some(false),
+        },
+    )
+    .await
+    .expect_err("must refuse to churn through a batch with no API key");
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("OPENAI_API_KEY") || msg.contains("embeddings disabled"),
+        "error must explain the missing-key cause: {msg}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn zero_candidates_succeeds_even_without_a_key(pool: PgPool) {
+    // No unembedded claims at all => candidates==0 short-circuits BEFORE the
+    // mock-embedder guard, so a scheduled run on a drained backlog is a clean
+    // no-op rather than a config error.
+    let server = build_server(pool.clone(), false).await;
+
+    let out = tools::embeddings::backfill_embeddings(
+        &server,
+        BackfillEmbeddingsParams {
+            limit: Some(100),
+            dry_run: Some(false),
+        },
+    )
+    .await
+    .expect("empty backlog is a no-op, not an error");
+
+    let body = parse(out);
+    assert_eq!(body["candidates"], 0);
+    assert_eq!(body["embedded"], 0);
+    assert_eq!(body["failed"], 0);
+}


### PR DESCRIPTION
## Summary
Added the embed-stage MCP tool `backfill_embeddings` (claims:write) — the server-side, MCP-executable counterpart to the existing `embed_backfill` CLI. It lets the externally-scheduled decomposition-cycle task drain the `is_current AND embedding IS NULL` gap (the CLAUDE.md embedding-policy invariant) without shelling out, reusing `find_claims_needing_embeddings` (telemetry/non-current excluded) + `store_embedding` + the server's existing McpEmbedder. Supports `dry_run` (count-only, key-free), `limit` (clamped 1..=2000), oldest-first ordering for monotonic progress, per-claim failure accounting, a capped error sample, and a fail-loud guard when the server has no usable OpenAI key. This closes gap (3) of the backlog item. Gaps (1) query and the match stage already had MCP tools (`query_undecomposed_claims`, `find_cross_source_matches`); gap (2) decompose remains the prepaid-LLM CLI primitive (see clarification_needed).

## Origin
Bridge dev request: `10e1b691-9f00-4cb0-908f-823e1d61d959`

Auto-developed by the bridge-dev pipeline. Review and merge when satisfied.