### PR TITLE
security(deps): bump bytes 1.11.0 → 1.11.1 (RUSTSEC-2026-0007)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,9 +599,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"


### PR DESCRIPTION
## What

Bumps the transitive `bytes` dependency `1.11.0` → `1.11.1` to resolve **[RUSTSEC-2026-0007](https://github.com/advisories/GHSA-434x-w66g-qw3r)** — integer overflow in `bytes::BytesMut::reserve`. This is the advisory that shows up red on the `Security audit (advisory)` check (e.g. on #253).

## How

`bytes` has **no direct entry** in any `Cargo.toml` (it's pulled transitively via tower-http / tonic / epigraph-api), so this is a **Cargo.lock-only** change — `cargo update -p bytes` to the patched release. No manifest edits, no other packages touched (diff = 2 lines).

## Verification

- `cargo update -p bytes` → `bytes v1.11.0 -> v1.11.1`
- `cargo audit` no longer reports RUSTSEC-2026-0007 or any `bytes` advisory.

## Scope note — the advisory check will still be red after this

`cargo audit` currently flags **8** advisories repo-wide; this PR fixes only the `bytes` one. The rest are pre-existing and on unrelated crates, left for separate follow-ups:

| Crate | ID | Note |
|-------|----|------|
| rustls-webpki | RUSTSEC-2026-0098/0099/0104 | name-constraint / CRL-panic — needs a webpki bump |
| sqlx | RUSTSEC-2024-0363 | binary-protocol cast — needs sqlx ≥0.8.1 (may ripple) |
| rand | RUSTSEC-2026-0097 | unsound with a custom logger |
| rsa | RUSTSEC-2023-0071 | Marvin timing side-channel — no patched release |
| instant / paste / rustls-pemfile | RUSTSEC-2024-0384 / 2024-0436 / 2025-0134 | unmaintained-crate warnings |

Because the `Security audit (advisory)` check is non-blocking and the gating `test` job is unaffected, this PR is safe to merge on its own; it strictly reduces the advisory count from 8 → 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)