### PR TITLE
security(ci): triage RustSec advisories via .cargo/audit.toml ignore-list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,36 @@
+# cargo-audit ignore-list — triage of known RustSec advisories in Cargo.lock.
+#
+# The "Security audit (advisory)" CI job (.github/workflows/ci.yml) runs
+# `cargo audit` and is intentionally `continue-on-error: true` — advisory, not a
+# merge gate. (Foreman auto-merges epigraph PRs, so a hard gate would let any
+# newly-published transitive advisory red-light unrelated PRs.) This file lets
+# the job go GREEN on the *currently-triaged* advisories, so a genuinely NEW
+# advisory still turns it red as actionable signal rather than drowning in a
+# permanently-red check.
+#
+# Tracking: EpiGraph backlog claim a2fa31b1-b733-4f32-bdc2-6a0f0bd4c4ef
+# (sqlx 0.7->0.8 + reqwest 0.11->0.12 migrations). Remove entries from the
+# "deferred" group below as those migrations land. Re-review the "no fix"
+# group periodically in case upstream ships a patch.
+
+[advisories]
+ignore = [
+    # ── No fix available — accepted risk ────────────────────────────────────
+    "RUSTSEC-2023-0071", # rsa: Marvin timing side-channel. No fixed upstream
+                         #   release exists (pulled by epigraph-api).
+    "RUSTSEC-2026-0097", # rand: unsound with a custom logger. Both 0.8.5 and
+                         #   0.9.2 are flagged — no patched release yet.
+    "RUSTSEC-2024-0384", # instant: unmaintained. Transitive via `ascent`
+                         #   (Datalog engine) — not removable by us.
+    "RUSTSEC-2024-0436", # paste: unmaintained. Transitive via `ascent`.
+
+    # ── Deferred — cleared by the tracked migrations (backlog a2fa31b1) ──────
+    "RUSTSEC-2024-0363", # sqlx 0.7.4 binary-protocol cast. Fixed by sqlx 0.8.
+    "RUSTSEC-2026-0098", # rustls-webpki 0.101.7 name-constraint (URI). Old TLS
+                         #   stack via reqwest 0.11 + sqlx 0.7 -> rustls 0.21;
+                         #   cleared by reqwest 0.12 + sqlx 0.8.
+    "RUSTSEC-2026-0099", # rustls-webpki 0.101.7 name-constraint (wildcard).
+    "RUSTSEC-2026-0104", # rustls-webpki 0.101.7 CRL-parse panic.
+    "RUSTSEC-2025-0134", # rustls-pemfile 1.0.4 unmaintained. Same old TLS
+                         #   stack; reqwest 0.12 + sqlx 0.8 move to pemfile 2.x.
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,10 @@ jobs:
   # open PR the moment a new advisory lands on any transitive dependency —
   # and Foreman auto-merges epigraph PRs, so unrelated red CI is actively
   # harmful. continue-on-error keeps the result visible without blocking.
-  # The lockfile currently carries known advisories (bytes, rsa, rustls-webpki,
-  # sqlx, instant, …); flip this to a gate only once that backlog is triaged.
+  # Known advisories are triaged in `.cargo/audit.toml` (tracked: EpiGraph
+  # backlog a2fa31b1 — sqlx 0.7->0.8 + reqwest 0.11->0.12 migrations), so the
+  # job is GREEN on current advisories and a genuinely NEW one still turns it
+  # red. It stays advisory (continue-on-error) by design — not a gate.
   audit:
     name: Security audit (advisory)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds `.cargo/audit.toml` so the `Security audit (advisory)` CI job goes **green** on the currently-known advisories, while staying advisory (`continue-on-error`) so a genuinely **new** advisory still turns it red.

## Why this instead of bumping the deps

After tracing the graph (recorded in EpiGraph backlog `a2fa31b1`), **none of the remaining advisories is a clean bump**:

| Advisory | Crate | Status |
|---|---|---|
| RUSTSEC-2023-0071 | rsa | **no upstream fix** (Marvin timing side-channel) |
| RUSTSEC-2026-0097 | rand | **no fix** — 0.8.5 *and* 0.9.2 both affected |
| RUSTSEC-2024-0384 | instant | unmaintained, transitive via `ascent` |
| RUSTSEC-2024-0436 | paste | unmaintained, transitive via `ascent` |
| RUSTSEC-2024-0363 | sqlx | needs **sqlx 0.7→0.8** (breaking) |
| RUSTSEC-2026-0098/0099/0104 | rustls-webpki 0.101 | needs **reqwest 0.11→0.12 + sqlx 0.7→0.8** (the old rustls-0.21 stack is pulled by both) |
| RUSTSEC-2025-0134 | rustls-pemfile | same old stack |

`rsa` alone keeps the check red forever, so no bump strategy greens it — only a documented ignore-list does. This is exactly the remediation recommended in `a2fa31b1`.

## Structure

The ignore-list is split into two clearly-commented buckets:
- **No fix / accepted risk** — rsa, rand, instant, paste (re-review periodically)
- **Deferred — cleared by the tracked migrations** — sqlx 0363, webpki ×3, rustls-pemfile 0134; **removed from the list as sqlx 0.8 / reqwest 0.12 land** (backlog `a2fa31b1`)

## Verification

- `cargo audit` with the file → **exit 0** (was exit 1 / 8 vulnerabilities).
- Verified the config path empirically: cargo-audit 0.22.1 reads `.cargo/audit.toml`; a root `audit.toml` is **not** read.
- The ignored-ID set is **exactly equal** to the lock's current advisory set — no stale ignores (which would rot silently), no un-ignored advisories (which would stay red).

## Not changed

Kept `continue-on-error: true` — per the existing CI comment, a hard gate is harmful while Foreman auto-merges (a new transitive advisory would red-light unrelated PRs). The two breaking migrations remain tracked in `a2fa31b1`, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)