### PR TITLE
security(oauth): require an email allowlist for external auto-provisioning

### DIFF
--- a/crates/epigraph-api/src/oauth/providers/cloudflare_access.rs
+++ b/crates/epigraph-api/src/oauth/providers/cloudflare_access.rs
@@ -30,6 +30,8 @@ pub struct CloudflareAccessProvider {
     audience: String,
     auto_provision: bool,
     default_scopes: Vec<String>,
+    allowed_emails: Vec<String>,
+    allowed_domains: Vec<String>,
     jwks: JwksCache,
 }
 
@@ -55,6 +57,8 @@ impl CloudflareAccessProvider {
             audience,
             auto_provision: cfg.auto_provision,
             default_scopes: cfg.default_scopes.clone(),
+            allowed_emails: cfg.allowed_emails.clone(),
+            allowed_domains: cfg.allowed_domains.clone(),
             jwks,
         })
     }
@@ -140,5 +144,11 @@ impl ExternalIdentityProvider for CloudflareAccessProvider {
     }
     fn default_scopes(&self) -> &[String] {
         &self.default_scopes
+    }
+    fn allowed_emails(&self) -> &[String] {
+        &self.allowed_emails
+    }
+    fn allowed_domains(&self) -> &[String] {
+        &self.allowed_domains
     }
 }

--- a/crates/epigraph-api/src/oauth/providers/config.rs
+++ b/crates/epigraph-api/src/oauth/providers/config.rs
@@ -54,6 +54,12 @@ pub struct ProvidersConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+// Reject unknown keys so a misspelled allowlist key (e.g. `allowed_email`
+// singular, or wrong nesting) fails the parse LOUDLY rather than silently
+// deserializing to an empty Vec via `#[serde(default)]` — which the allow-all
+// default in `email_is_allowed` would then treat as "permit everyone",
+// re-opening the exact over-broad default this allowlist exists to close.
+#[serde(deny_unknown_fields)]
 pub struct ProviderConfig {
     pub name: String,
     pub flow: ProviderFlow,
@@ -76,10 +82,78 @@ pub struct ProviderConfig {
     pub auto_provision: bool,
     #[serde(default)]
     pub default_scopes: Vec<String>,
+    /// Allowlist of exact email addresses permitted to auto-provision.
+    /// Empty (the serde default) together with `allowed_domains` empty means
+    /// allow-all (backward compatible). See [`email_is_allowed`].
+    #[serde(default)]
+    pub allowed_emails: Vec<String>,
+    /// Allowlist of email domains (the part after the last `@`) permitted to
+    /// auto-provision. Empty together with `allowed_emails` empty means allow-all.
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
 }
 
 fn default_true() -> bool {
     true
+}
+
+/// Decide whether `email` is permitted by the configured allowlists.
+///
+/// Semantics (deliberately conservative — this gate is security-sensitive):
+/// * Both lists empty -> `true` (allow-all; the gate is opt-in and backward
+///   compatible with the serde-default-empty config).
+/// * Otherwise -> `true` iff the trimmed, lowercased email EXACTLY matches some
+///   `allowed_emails` entry (compared case-insensitively after trimming the
+///   entry too) OR its domain (the substring after the LAST `@`, lowercased)
+///   matches some `allowed_domains` entry.
+/// * An empty email while an allowlist IS configured -> `false` (deny). This
+///   prevents an absent/`""` email (provision uses `unwrap_or_default()`) from
+///   slipping past a malformed empty allowlist entry.
+///
+/// `email_verified` is intentionally NOT a parameter: it is a call-site concern
+/// (provision checks it only when an allowlist is configured, and only for
+/// providers that don't already hardcode verification). Keeping it out keeps
+/// this helper a pure, total string predicate that is trivial to unit-test.
+pub fn email_is_allowed(
+    email: &str,
+    allowed_emails: &[String],
+    allowed_domains: &[String],
+) -> bool {
+    // Both empty => allow-all (opt-in gate, backward compatible).
+    if allowed_emails.is_empty() && allowed_domains.is_empty() {
+        return true;
+    }
+
+    let email = email.trim().to_ascii_lowercase();
+    // An allowlist is configured but the email is empty/absent => deny.
+    if email.is_empty() {
+        return false;
+    }
+
+    // Exact-address match (case-insensitive; trim the configured entries too so
+    // stray whitespace in TOML doesn't create a never-matching entry, and an
+    // empty/blank entry can never match the already-non-empty email).
+    if allowed_emails
+        .iter()
+        .any(|e| e.trim().to_ascii_lowercase() == email)
+    {
+        return true;
+    }
+
+    // Domain match on the substring after the LAST '@'. Without an '@' there is
+    // no domain to compare, so domain rules cannot match.
+    if let Some(idx) = email.rfind('@') {
+        let domain = &email[idx + 1..];
+        if !domain.is_empty()
+            && allowed_domains
+                .iter()
+                .any(|d| d.trim().to_ascii_lowercase() == domain)
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -235,6 +309,107 @@ default_scopes = ["claims:read"]
             cfg.validate(),
             Err(ProviderConfigError::InvalidName(_))
         ));
+    }
+
+    #[test]
+    fn allowlist_keys_parse_and_default_empty() {
+        // Absent keys default to empty (allow-all).
+        let cfg = ProvidersConfig::parse(sample_redirect()).unwrap();
+        assert!(cfg.providers[0].allowed_emails.is_empty());
+        assert!(cfg.providers[0].allowed_domains.is_empty());
+
+        // Present keys parse into the vecs.
+        let text = format!(
+            "{sample}allowed_emails = [\"jeremy.barton@gmail.com\"]\nallowed_domains = [\"baros.associates\"]\n",
+            sample = sample_redirect()
+        );
+        let cfg = ProvidersConfig::parse(&text).unwrap();
+        assert_eq!(
+            cfg.providers[0].allowed_emails,
+            vec!["jeremy.barton@gmail.com".to_string()]
+        );
+        assert_eq!(
+            cfg.providers[0].allowed_domains,
+            vec!["baros.associates".to_string()]
+        );
+    }
+
+    fn emails(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn both_lists_empty_allows_all() {
+        // Allow-all is the opt-in default; even an empty email is permitted when
+        // no allowlist is configured (matches pre-gate provisioning behavior).
+        assert!(email_is_allowed("anyone@example.com", &[], &[]));
+        assert!(email_is_allowed("", &[], &[]));
+    }
+
+    #[test]
+    fn exact_email_match_is_case_insensitive() {
+        let allowed = emails(&["jeremy.barton@gmail.com"]);
+        assert!(email_is_allowed("Jeremy.Barton@GMAIL.com", &allowed, &[]));
+    }
+
+    #[test]
+    fn email_whitespace_is_trimmed_before_match() {
+        let allowed = emails(&["jeremy.barton@gmail.com"]);
+        assert!(email_is_allowed(
+            "  jeremy.barton@gmail.com\t",
+            &allowed,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn unlisted_email_is_denied_when_allowlist_present() {
+        let allowed = emails(&["jeremy.barton@gmail.com"]);
+        assert!(!email_is_allowed("evil@attacker.com", &allowed, &[]));
+    }
+
+    #[test]
+    fn domain_allow_permits_any_address_in_domain() {
+        let domains = emails(&["baros.associates"]);
+        assert!(email_is_allowed("anyone@baros.associates", &[], &domains));
+        assert!(email_is_allowed("Someone@Baros.Associates", &[], &domains));
+    }
+
+    #[test]
+    fn domain_allow_does_not_permit_other_domains() {
+        // Allowed only via domain, not exact: an address in a DIFFERENT domain
+        // whose exact form is not listed must be denied.
+        let domains = emails(&["baros.associates"]);
+        assert!(!email_is_allowed("jeremy@gmail.com", &[], &domains));
+        // And a substring/suffix attack must not match: "evilbaros.associates"
+        // and "baros.associates.attacker.com" are different domains.
+        assert!(!email_is_allowed("x@evilbaros.associates", &[], &domains));
+        assert!(!email_is_allowed(
+            "x@baros.associates.attacker.com",
+            &[],
+            &domains
+        ));
+    }
+
+    #[test]
+    fn empty_email_denied_when_allowlist_configured() {
+        let allowed = emails(&["jeremy.barton@gmail.com"]);
+        assert!(!email_is_allowed("", &allowed, &[]));
+        assert!(!email_is_allowed("   ", &allowed, &[]));
+        // Also when only a domain allowlist is configured.
+        let domains = emails(&["baros.associates"]);
+        assert!(!email_is_allowed("", &[], &domains));
+    }
+
+    #[test]
+    fn domain_split_uses_last_at_sign() {
+        // Plus-addressing / multiple '@' (quoted local parts): the domain is the
+        // part after the LAST '@', so this resolves to "gmail.com".
+        let domains = emails(&["gmail.com"]);
+        assert!(email_is_allowed("weird@local@gmail.com", &[], &domains));
+        // And exact-match must NOT be fooled into treating a malformed address
+        // with no domain as allowed by a domain rule.
+        assert!(!email_is_allowed("nodomain", &[], &domains));
     }
 
     #[test]

--- a/crates/epigraph-api/src/oauth/providers/google.rs
+++ b/crates/epigraph-api/src/oauth/providers/google.rs
@@ -45,6 +45,8 @@ pub struct GoogleProvider {
     default_redirect_uri: Option<String>,
     auto_provision: bool,
     default_scopes: Vec<String>,
+    allowed_emails: Vec<String>,
+    allowed_domains: Vec<String>,
     jwks: JwksCache,
 }
 
@@ -102,6 +104,8 @@ impl GoogleProvider {
             default_redirect_uri,
             auto_provision: cfg.auto_provision,
             default_scopes: cfg.default_scopes.clone(),
+            allowed_emails: cfg.allowed_emails.clone(),
+            allowed_domains: cfg.allowed_domains.clone(),
             jwks,
         })
     }
@@ -196,6 +200,12 @@ impl ExternalIdentityProvider for GoogleProvider {
     }
     fn default_scopes(&self) -> &[String] {
         &self.default_scopes
+    }
+    fn allowed_emails(&self) -> &[String] {
+        &self.allowed_emails
+    }
+    fn allowed_domains(&self) -> &[String] {
+        &self.allowed_domains
     }
 }
 

--- a/crates/epigraph-api/src/oauth/providers/mod.rs
+++ b/crates/epigraph-api/src/oauth/providers/mod.rs
@@ -39,6 +39,16 @@ pub fn build_registry(path: &Path) -> Result<Arc<ProviderRegistry>, String> {
     let jwks = JwksCache::new();
 
     for p in cfg.providers {
+        // Security guardrail: an auto-provisioning provider with no email
+        // allowlist will mint a `human` client (carrying write scopes) for ANY
+        // identity the IdP authenticates. Warn loudly at load so an operator who
+        // forgot to populate the allowlist sees it in the logs.
+        if p.auto_provision && p.allowed_emails.is_empty() && p.allowed_domains.is_empty() {
+            tracing::warn!(
+                provider = %p.name,
+                "auto_provision enabled with no email allowlist — ALL authenticated identities will be provisioned"
+            );
+        }
         match p.flow {
             ProviderFlow::Redirect => {
                 let google =

--- a/crates/epigraph-api/src/oauth/providers/provision.rs
+++ b/crates/epigraph-api/src/oauth/providers/provision.rs
@@ -28,6 +28,49 @@ pub async fn provision_external_user_client(
     let email = identity.email.clone().unwrap_or_default();
     let name = identity.name.clone().unwrap_or_else(|| email.clone());
 
+    // Email-allowlist gate. Placed at the TOP of the find-or-create path — BEFORE
+    // get_by_client_id — so it covers BOTH the new-provision branch AND the
+    // existing-client branch (an identity provisioned once then later removed from
+    // the allowlist must stop authenticating), and ALL three call sites
+    // (token.rs, device.rs, and authorize.rs which calls this inner fn directly
+    // for the consent screen, bypassing the token-minting wrapper).
+    //
+    // Semantics: when the provider configures no allowlist (both lists empty) the
+    // gate is allow-all and the original behavior is preserved. When an allowlist
+    // IS configured we additionally require a verified email (Google may assert an
+    // unverified address; CloudflareAccess hardcodes email_verified=true so it is
+    // unaffected) and a case-insensitive match against the allowlist.
+    let allowed_emails = provider.allowed_emails();
+    let allowed_domains = provider.allowed_domains();
+    let allowlist_configured = !allowed_emails.is_empty() || !allowed_domains.is_empty();
+    if allowlist_configured {
+        let denied = !identity.email_verified
+            || !super::config::email_is_allowed(&email, allowed_emails, allowed_domains);
+        if denied {
+            tracing::warn!(
+                provider = provider.name(),
+                email = %email,
+                email_verified = identity.email_verified,
+                "Denied external provisioning: identity not in provider email allowlist"
+            );
+            emit_oauth_audit(
+                &state.db_pool,
+                "oauth_provision_denied",
+                false,
+                serde_json::json!({
+                    "provider": provider.name(),
+                    "subject": identity.subject,
+                    "email": email,
+                    "email_verified": identity.email_verified,
+                    "reason": "email_not_in_allowlist",
+                }),
+            );
+            return Err(ApiError::Forbidden {
+                reason: "email not authorized for this provider".into(),
+            });
+        }
+    }
+
     let oauth_client_id = format!("{}:{}", provider.name(), identity.subject);
 
     match OAuthClientRepository::get_by_client_id(&state.db_pool, &oauth_client_id).await {

--- a/crates/epigraph-api/src/oauth/providers/traits.rs
+++ b/crates/epigraph-api/src/oauth/providers/traits.rs
@@ -47,6 +47,21 @@ pub trait ExternalIdentityProvider: Send + Sync {
 
     fn auto_provision(&self) -> bool;
     fn default_scopes(&self) -> &[String];
+
+    /// Exact email addresses permitted to auto-provision through this provider.
+    /// An empty slice together with an empty [`Self::allowed_domains`] means
+    /// allow-all (the gate is opt-in). Default impl returns `&[]` so existing
+    /// and test providers keep compiling without edits.
+    fn allowed_emails(&self) -> &[String] {
+        &[]
+    }
+
+    /// Email domains (the part after the last `@`) permitted to auto-provision
+    /// through this provider. Empty together with [`Self::allowed_emails`] means
+    /// allow-all. Default impl returns `&[]`.
+    fn allowed_domains(&self) -> &[String] {
+        &[]
+    }
 }
 
 #[async_trait]

--- a/crates/epigraph-api/src/oauth/token.rs
+++ b/crates/epigraph-api/src/oauth/token.rs
@@ -74,6 +74,64 @@ pub struct TokenResponse {
     pub scope: String,
 }
 
+/// Pure allowlist decision for the `refresh_token` grant — re-evaluates the
+/// provider's email allowlist against the persisted identity at refresh time.
+///
+/// This closes the revocation hole: the provision gate
+/// ([`crate::oauth::providers::provision::provision_external_user_client`]) only
+/// runs on a full ID-token / authorization grant, but `handle_refresh_token`
+/// rotates a fresh 30-day refresh token on every call keyed solely on possession
+/// of a valid refresh token. Without re-checking here, an identity removed from
+/// the allowlist would keep renewing access indefinitely (status flip is the only
+/// other stop). Re-running the SAME `email_is_allowed` predicate makes the gate
+/// comment's "removed identities stop authenticating" guarantee true for refresh.
+///
+/// Returns `true` (issue tokens normally — SKIP the gate) when:
+/// * `client_id` has no `':'` (not a `{provider}:{subject}` external client —
+///   agent client_ids are hex pubkeys, service / DCR are `epigraph_{hex}`; gating
+///   these would lock agents/services out of refresh), OR
+/// * the prefix resolves to no registered provider via [`ProviderRegistry::by_name`]
+///   (unknown / removed provider — there is no allowlist left to consult here; whole-
+///   provider de-authorization is an operational `status='suspended'` action), OR
+/// * the resolved provider configures no allowlist (both lists empty — allow-all,
+///   backward compatible with [`crate::oauth::providers::config::email_is_allowed`]).
+///
+/// Returns `false` (DENY) only when an external client's provider HAS a configured
+/// allowlist and `persisted_email` (from `oauth_clients.legal_contact_email`, `""`
+/// when NULL) is not on it. `email_verified` is deliberately NOT consulted: it lives
+/// only on the original assertion (not on `OAuthClientRow`), verification was already
+/// enforced at provision time and does not lapse, and defaulting a missing flag to
+/// `false` would lock out every external client on rotation.
+///
+/// Gated on `feature = "db"` to match its only production caller
+/// (`handle_refresh_token` / `handle_authorization_code`); without the gate it is
+/// dead code under `--no-default-features` and trips `clippy -D warnings`.
+#[cfg(feature = "db")]
+fn refresh_allowed(
+    registry: &crate::oauth::providers::ProviderRegistry,
+    client_id: &str,
+    persisted_email: &str,
+) -> bool {
+    // Provider names are validated to `[a-z0-9-]+` (cannot contain ':'), so the
+    // FIRST ':' is the correct prefix splitter even when a subject embeds colons.
+    let Some((prefix, _)) = client_id.split_once(':') else {
+        return true; // non-external client (agent / service / DCR) — skip the gate.
+    };
+    let Some(provider) = registry.by_name(prefix) else {
+        return true; // unknown / removed provider — no allowlist to consult.
+    };
+    let allowed_emails = provider.allowed_emails();
+    let allowed_domains = provider.allowed_domains();
+    if allowed_emails.is_empty() && allowed_domains.is_empty() {
+        return true; // provider configures no allowlist — allow-all.
+    }
+    crate::oauth::providers::config::email_is_allowed(
+        persisted_email,
+        allowed_emails,
+        allowed_domains,
+    )
+}
+
 /// POST /oauth/token
 #[cfg(feature = "db")]
 pub async fn token_endpoint(
@@ -455,6 +513,38 @@ async fn handle_refresh_token(
         });
     }
 
+    // Re-run the provider email allowlist for external (`{provider}:{subject}`)
+    // clients BEFORE minting. The provision gate only fires on a full ID-token /
+    // authorization grant; refresh rotation re-issues a fresh 30d refresh on every
+    // call, so without this an identity removed from the allowlist keeps renewing
+    // access indefinitely. The old token was already revoked above (rotation), so a
+    // denied refresh correctly burns it — a deauthorized identity keeps no reusable
+    // token. SKIP (issue normally) for non-external clients and unconfigured
+    // allowlists; see [`refresh_allowed`].
+    if !refresh_allowed(
+        &state.providers,
+        &client.client_id,
+        client.legal_contact_email.as_deref().unwrap_or(""),
+    ) {
+        tracing::warn!(
+            client_id = %client.client_id,
+            "Denied token refresh: identity no longer in provider email allowlist"
+        );
+        crate::oauth::providers::provision::emit_oauth_audit(
+            &state.db_pool,
+            "oauth_refresh_denied",
+            false,
+            serde_json::json!({
+                "client_id": client.client_id,
+                "email": client.legal_contact_email,
+                "reason": "email_not_in_allowlist",
+            }),
+        );
+        return Err(ApiError::Forbidden {
+            reason: "email no longer authorized for this provider".into(),
+        });
+    }
+
     let ttl = match client.client_type.as_str() {
         "agent" => Duration::minutes(15),
         "human" => Duration::hours(1),
@@ -602,6 +692,37 @@ async fn handle_authorization_code(
     if client.status != "active" {
         return Err(ApiError::Forbidden {
             reason: format!("Client status is '{}', must be 'active'", client.status),
+        });
+    }
+
+    // Re-run the provider email allowlist before issuing tokens, mirroring
+    // handle_refresh_token, so the SAME invariant holds on every token-issuance
+    // path: an identity de-listed between consent (when the provision gate ran and
+    // minted this code) and code exchange is refused here rather than handed a 1h
+    // access token + 30d refresh. The single-use code was already consumed above,
+    // so a denied exchange burns it. SKIP for non-external clients / unconfigured
+    // allowlists; see [`refresh_allowed`].
+    if !refresh_allowed(
+        &state.providers,
+        &client.client_id,
+        client.legal_contact_email.as_deref().unwrap_or(""),
+    ) {
+        tracing::warn!(
+            client_id = %client.client_id,
+            "Denied authorization_code exchange: identity no longer in provider email allowlist"
+        );
+        crate::oauth::providers::provision::emit_oauth_audit(
+            &state.db_pool,
+            "oauth_authcode_denied",
+            false,
+            serde_json::json!({
+                "client_id": client.client_id,
+                "email": client.legal_contact_email,
+                "reason": "email_not_in_allowlist",
+            }),
+        );
+        return Err(ApiError::Forbidden {
+            reason: "email no longer authorized for this provider".into(),
         });
     }
 
@@ -794,5 +915,166 @@ mod assertion_tests {
         let client_id = hex::encode(pk);
 
         assert!(verify_agent_assertion(&assertion, &pk, &client_id).is_ok());
+    }
+}
+
+/// Unit tests for the pure `refresh_allowed` decision. DB-free: they build an
+/// in-memory `ProviderRegistry` with a stub provider whose allowlist is
+/// configurable, mirroring the `email_is_allowed` and registry tests. These cover
+/// the four branches the refresh re-gate must get right WITHOUT touching the DB.
+#[cfg(all(test, feature = "db"))]
+mod refresh_gate_tests {
+    use super::refresh_allowed;
+    use crate::oauth::providers::{
+        ExternalIdentity, ExternalIdentityProvider, ProviderError, ProviderRegistry,
+    };
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    /// A provider whose allowlist is supplied by the test, so we can exercise both
+    /// the configured-allowlist (deny/allow) and the empty-allowlist (allow-all)
+    /// branches — the default trait impls only give the allow-all path.
+    struct AllowlistProvider {
+        name: String,
+        grant: String,
+        allowed_emails: Vec<String>,
+        allowed_domains: Vec<String>,
+    }
+
+    #[async_trait]
+    impl ExternalIdentityProvider for AllowlistProvider {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn grant_type(&self) -> &str {
+            &self.grant
+        }
+        async fn validate(&self, _: &str) -> Result<ExternalIdentity, ProviderError> {
+            unimplemented!("not exercised by the pure refresh_allowed decision")
+        }
+        fn auto_provision(&self) -> bool {
+            true
+        }
+        fn default_scopes(&self) -> &[String] {
+            &[]
+        }
+        fn allowed_emails(&self) -> &[String] {
+            &self.allowed_emails
+        }
+        fn allowed_domains(&self) -> &[String] {
+            &self.allowed_domains
+        }
+    }
+
+    fn registry_with(
+        name: &str,
+        grant: &str,
+        allowed_emails: Vec<String>,
+        allowed_domains: Vec<String>,
+    ) -> ProviderRegistry {
+        let mut r = ProviderRegistry::empty();
+        r.register(
+            Arc::new(AllowlistProvider {
+                name: name.into(),
+                grant: grant.into(),
+                allowed_emails,
+                allowed_domains,
+            }) as Arc<dyn ExternalIdentityProvider>,
+            None,
+        )
+        .unwrap();
+        r
+    }
+
+    #[test]
+    fn allowlisted_external_client_is_allowed() {
+        // (a) External client whose persisted email IS on the provider allowlist.
+        let r = registry_with(
+            "google",
+            "google_id_token",
+            vec!["jeremy.barton@gmail.com".into()],
+            vec![],
+        );
+        assert!(refresh_allowed(
+            &r,
+            "google:107485523387294236292",
+            "jeremy.barton@gmail.com"
+        ));
+    }
+
+    #[test]
+    fn delisted_external_client_is_denied() {
+        // (b) External client whose persisted email is NOT on the allowlist (the
+        // revocation case): an identity removed from the allowlist must be denied.
+        let r = registry_with(
+            "google",
+            "google_id_token",
+            vec!["jeremy.barton@gmail.com".into()],
+            vec![],
+        );
+        assert!(!refresh_allowed(
+            &r,
+            "google:999999999999999999999",
+            "evil@attacker.com"
+        ));
+    }
+
+    #[test]
+    fn non_external_client_skips_gate() {
+        // (c) Non-external clients must NOT be affected by the gate. Agent client_ids
+        // are hex pubkeys and service/DCR are `epigraph_{hex}` — neither contains a
+        // ':' — so the gate skips (returns allowed) regardless of registry contents.
+        let r = registry_with(
+            "google",
+            "google_id_token",
+            vec!["jeremy.barton@gmail.com".into()],
+            vec![],
+        );
+        // hex pubkey (agent): no ':' → skip.
+        assert!(refresh_allowed(
+            &r,
+            "a1b2c3d4e5f6071829aabbccddeeff00112233445566778899aabbccddeeff00",
+            ""
+        ));
+        // service / DCR: no ':' → skip.
+        assert!(refresh_allowed(&r, "epigraph_deadbeefcafef00d", ""));
+        // unrecognized provider prefix (e.g. legacy underscore `google_<sub>` has no
+        // ':'; a colon-bearing id for an UNregistered provider also skips).
+        assert!(refresh_allowed(
+            &r,
+            "google_107485523387294236292",
+            "evil@attacker.com"
+        ));
+        assert!(refresh_allowed(
+            &r,
+            "removed-provider:subject",
+            "evil@attacker.com"
+        ));
+    }
+
+    #[test]
+    fn empty_allowlist_provider_allows_all() {
+        // (d) A registered provider that configures NO allowlist (both lists empty)
+        // is allow-all (backward compatible) — even an empty persisted email passes.
+        let r = registry_with("google", "google_id_token", vec![], vec![]);
+        assert!(refresh_allowed(
+            &r,
+            "google:any-subject",
+            "anyone@example.com"
+        ));
+        assert!(refresh_allowed(&r, "google:any-subject", ""));
+    }
+
+    #[test]
+    fn domain_allowlist_external_client() {
+        // Belt-and-braces: the domain branch of the allowlist also gates refresh.
+        let r = registry_with(
+            "google",
+            "google_id_token",
+            vec![],
+            vec!["baros.associates".into()],
+        );
+        assert!(refresh_allowed(&r, "google:sub", "anyone@baros.associates"));
+        assert!(!refresh_allowed(&r, "google:sub", "anyone@gmail.com"));
     }
 }

--- a/crates/epigraph-api/tests/oauth_authorization_code.rs
+++ b/crates/epigraph-api/tests/oauth_authorization_code.rs
@@ -527,6 +527,8 @@ fn google_cfg(jwks_url: &str) -> ProviderConfig {
         redirect_uri_env: None,
         auto_provision: true,
         default_scopes: vec!["claims:read".into()],
+        allowed_emails: vec![],
+        allowed_domains: vec![],
     }
 }
 

--- a/crates/epigraph-api/tests/oauth_db.rs
+++ b/crates/epigraph-api/tests/oauth_db.rs
@@ -65,6 +65,8 @@ fn google_cfg(jwks_url: &str, auto_provision: bool, env_suffix: &str) -> Provide
         redirect_uri_env: None,
         auto_provision,
         default_scopes: vec!["claims:read".into(), "claims:write".into()],
+        allowed_emails: vec![],
+        allowed_domains: vec![],
     }
 }
 

--- a/crates/epigraph-api/tests/oauth_http.rs
+++ b/crates/epigraph-api/tests/oauth_http.rs
@@ -58,6 +58,8 @@ fn google_cfg() -> ProviderConfig {
         redirect_uri_env: None,
         auto_provision: true,
         default_scopes: vec![],
+        allowed_emails: vec![],
+        allowed_domains: vec![],
     }
 }
 
@@ -79,6 +81,8 @@ fn cf_cfg() -> ProviderConfig {
         redirect_uri_env: None,
         auto_provision: true,
         default_scopes: vec![],
+        allowed_emails: vec![],
+        allowed_domains: vec![],
     }
 }
 

--- a/crates/epigraph-api/tests/oauth_redirect_flow.rs
+++ b/crates/epigraph-api/tests/oauth_redirect_flow.rs
@@ -31,6 +31,8 @@ fn google_cfg(jwks_url: &str, token_endpoint: &str) -> ProviderConfig {
         redirect_uri_env: None,
         auto_provision: true,
         default_scopes: vec!["claims:read".into()],
+        allowed_emails: vec![],
+        allowed_domains: vec![],
     }
 }
 

--- a/crates/epigraph-api/tests/oauth_token_grant.rs
+++ b/crates/epigraph-api/tests/oauth_token_grant.rs
@@ -37,6 +37,8 @@ fn google_cfg(jwks_url: &str) -> ProviderConfig {
         redirect_uri_env: None,
         auto_provision: true,
         default_scopes: vec!["claims:read".into()],
+        allowed_emails: vec![],
+        allowed_domains: vec![],
     }
 }
 
@@ -152,6 +154,8 @@ fn cf_cfg(jwks_url: &str) -> ProviderConfig {
         redirect_uri_env: None,
         auto_provision: true,
         default_scopes: vec!["claims:read".into()],
+        allowed_emails: vec![],
+        allowed_domains: vec![],
     }
 }
 

--- a/docs/superpowers/specs/2026-06-03-oauth-provision-email-allowlist-design.md
+++ b/docs/superpowers/specs/2026-06-03-oauth-provision-email-allowlist-design.md
@@ -1,0 +1,133 @@
+# OAuth external-provisioning email allowlist
+
+**Date:** 2026-06-03
+**Branch:** `security/oauth-provision-allowlist`
+**Type:** `security` (access-control hardening)
+
+## Problem
+
+EpiGraph's OAuth layer auto-provisions a per-user `human` OAuth client for any
+identity an external IdP (currently Google OIDC) authenticates, when the
+provider has `auto_provision = true`. The default Google provider in
+`providers.toml` grants a wide scope set including **write** scopes
+(`claims:write`, `edges:write`, `groups:manage`, `clients:register`,
+`agents:write`, …).
+
+Net effect: **any Google account that completes the OIDC flow receives a
+write-capable client on the knowledge graph.** Authentication is not
+authorization — Google proves *who* you are, not that you are *permitted*.
+
+This is the latent exposure recorded in memory
+`reference_mcp_manifest_not_scope_filtered` ("providers.toml
+auto_provision=true + write scopes → any Google acct gets graph write").
+
+### Current blast radius (verified against prod `epigraph` DB, 2026-06-03)
+
+Exactly one external client is provisioned:
+`google:107485523387294236292` = `jeremy.barton@gmail.com`, `status=active`,
+full scope set. That is the legitimate owner. **No rogue clients exist**, so no
+revocation/cleanup migration is required — the fix is purely preventive.
+
+## Goal
+
+Restrict external auto-provisioning to an operator-controlled **email
+allowlist** (exact addresses and/or whole domains), enforced on every path that
+mints a token for or creates an external client. Preserve backward
+compatibility: an empty allowlist means allow-all (opt-in gate).
+
+## Design
+
+### 1. Config surface (`providers.toml` / `ProviderConfig`)
+
+Two new optional, serde-default-empty fields per provider:
+
+- `allowed_emails: Vec<String>` — exact addresses.
+- `allowed_domains: Vec<String>` — match on the substring after the last `@`.
+
+Semantics, implemented by the pure predicate `email_is_allowed(email,
+allowed_emails, allowed_domains) -> bool`:
+
+- **Both lists empty ⇒ `true`** (allow-all; backward compatible).
+- Otherwise `true` iff trimmed/lowercased email exactly matches an
+  `allowed_emails` entry (case-insensitive, entries trimmed too) **or** its
+  domain matches an `allowed_domains` entry.
+- **Empty email while an allowlist is configured ⇒ `false`** (deny). Guards
+  against `unwrap_or_default()` producing `""`.
+- Domain split uses the **last** `@` (quoted-local-part / plus-address safety);
+  suffix attacks (`evilbaros.associates`, `baros.associates.attacker.com`) are
+  rejected because comparison is whole-label equality, not suffix.
+
+Initial prod config: `allowed_emails = ["jeremy.barton@gmail.com"]`.
+
+### 2. Provision-time gate (`provision.rs::provision_external_user_client`)
+
+A gate at the **top** of the find-or-create path, *before* `get_by_client_id`,
+so it covers both the new-provision and existing-client branches, and all
+callers of this inner fn:
+
+- `authorize.rs` (consent screen, calls the inner fn directly),
+- `token.rs::handle_external_grant` → `provision_external_user` (token mint),
+- `device.rs` → `provision_external_user` (device flow).
+
+When an allowlist is configured the gate additionally requires
+`identity.email_verified` (Google may assert an unverified address;
+CloudflareAccess hardcodes `email_verified = true`). On denial: emit an
+`oauth_provision_denied` security-audit row and return **HTTP 403**.
+
+### 3. Refresh-time re-check (`token.rs::handle_refresh_token`) — NEW
+
+The provision gate does **not** cover the `refresh_token` grant: that handler
+looks up the client by refresh token and re-mints using
+`client.granted_scopes`, checking only `status == "active"`. So an identity
+provisioned *then later removed* from the allowlist keeps a working, write-
+capable token for up to the 30-day refresh-token lifetime.
+
+To make de-listing take effect within the access-token TTL (≤1 h) we add a
+re-check in `handle_refresh_token`:
+
+1. Derive the provider name from the client_id prefix (`"{provider}:{subject}"`
+   — split on the first `:`).
+2. `state.providers.by_name(prefix)`. **If `None`** (the client is not an
+   external IdP-provisioned client — e.g. a directly-registered agent/service
+   client), **skip** the re-check entirely. This is what keeps non-external
+   clients unaffected.
+3. If the matched provider has an allowlist configured, evaluate
+   `email_is_allowed(client.legal_contact_email.unwrap_or_default(), …)` (the
+   provisioned email is persisted in `legal_contact_email`). On failure: emit an
+   `oauth_refresh_denied` audit row and return **HTTP 403**.
+
+This is defense-in-depth: it does not replace the provision gate; it closes the
+refresh window. No new SQL — operates on the already-fetched client row, so no
+`.sqlx/` regeneration.
+
+### 4. Load-time guardrail (`mod.rs::build_registry`)
+
+When a provider has `auto_provision = true` but **no** allowlist configured, log
+a `tracing::warn!` at registry build so an operator who forgot to populate the
+allowlist sees it.
+
+## Out of scope
+
+- Revocation of existing rows — none exist that need it (verified).
+- Dynamic client registration (`register.rs`) — issues agent/service clients
+  under a different trust model, not external IdP provisioning.
+- Per-scope authorization policy / role mapping — the allowlist is binary
+  (provision or not); scope shaping is a separate concern.
+
+## Verification plan
+
+- Unit tests on `email_is_allowed` (case-insensitivity, last-`@` split, suffix
+  rejection, empty-email-deny-when-configured, allow-all-when-empty) — present
+  in WIP.
+- New unit/handler test: a de-listed external client's refresh is rejected;
+  a non-external (no provider prefix) client's refresh is unaffected; an
+  allowlisted client's refresh still succeeds.
+- Adversarial completeness audit (workflow): enumerate *every* path that mints a
+  token or creates a human/external client and confirm each is gated.
+- CI gate before commit: `cargo fmt --check`, `cargo clippy --workspace
+  --locked -- -D warnings`, `cargo test` (oauth provider + token modules).
+
+## Provenance
+
+Resolves backlog claim (filed 2026-06-03). PR off `origin/main` on branch
+`security/oauth-provision-allowlist`.

--- a/providers.toml
+++ b/providers.toml
@@ -14,6 +14,11 @@ auth_endpoint     = "https://accounts.google.com/o/oauth2/v2/auth"
 token_endpoint    = "https://oauth2.googleapis.com/token"
 redirect_uri_env  = "EPIGRAPH_REDIRECT_URI"
 auto_provision    = true
+# authorized external users; empty list = allow ALL (insecure). Add emails/domains
+# before relying on this in prod. With auto_provision=true, any identity NOT on this
+# allowlist is refused (HTTP 403) before any client is created.
+allowed_emails    = ["jeremy.barton@gmail.com"]
+# allowed_domains = ["baros.associates"]
 default_scopes = [
   "claims:read", "claims:write", "claims:challenge",
   "evidence:read", "evidence:submit",
@@ -36,3 +41,7 @@ default_scopes = [
 # audience_env   = "CF_ACCESS_AUD"
 # auto_provision = true
 # default_scopes = ["claims:read", "claims:write", "evidence:read", "evidence:submit"]
+# # authorized external users; empty list = allow ALL (insecure). The same gate
+# # applies to every provider, so populate this before enabling CF in prod.
+# allowed_emails = []
+# allowed_domains = []


### PR DESCRIPTION
## Problem

The `google` OAuth provider runs with `auto_provision = true` and write scopes
(`claims:write`, `edges:write`, `groups:manage`, `agents:write`, `clients:register`, …).
`provision_external_user_client` minted a write-capable `human` client for **any**
Google-authenticated identity — there was no email/domain gate. Net effect: any Google
account that completed the OIDC flow could write the production graph. Authentication
is not authorization. (Backlog `b86cbb3f-508f-4308-9412-2551f0d32d5f`.)

## Fix — two-layer email allowlist

1. **Config surface** — opt-in `allowed_emails` / `allowed_domains` on each provider,
   evaluated by a pure, case-insensitive `email_is_allowed` predicate (trims entries,
   splits domain on the last `@`, rejects suffix/subdomain attacks, denies an empty
   email when an allowlist is set). **Both lists empty = allow-all** → backward
   compatible. `#[serde(deny_unknown_fields)]` ensures a misspelled key fails the
   parse instead of silently re-opening allow-all. A load-time `warn!` fires when
   `auto_provision` is on with no allowlist.
2. **Provision-time gate** — placed before `get_by_client_id`, covering the new- and
   existing-client branches and all three callers (authorize consent, external-grant
   token, device). Returns **HTTP 403** + an `oauth_provision_denied` audit row.
3. **Renewal re-check** — the provision gate did **not** cover token renewal:
   `handle_refresh_token` re-minted on `status=='active'` alone (rotation issues a
   fresh 30-day refresh each call → a de-listed identity could renew indefinitely).
   A pure `refresh_allowed` helper now re-checks the allowlist in **both**
   `handle_refresh_token` and `handle_authorization_code`, so **every** token-issuance
   path consults the allowlist. Non-external clients (agent/service/DCR — no
   `{provider}:` prefix) are skipped, so they are unaffected.

Initial config: `allowed_emails = ["jeremy.barton@gmail.com"]`.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --workspace --locked -- -D warnings` ✓
- `cargo test -p epigraph-api --lib oauth` → **34 passed** (incl. 5 new
  `refresh_gate_tests` + the allowlist predicate cases)
- oauth integration suite (`oauth_authorization_code`, `oauth_token_grant`,
  `oauth_http`, `oauth_db`, `oauth_redirect_flow`) ✓
- Live prod DB: the only external client is the owner (`jeremy.barton@gmail.com`),
  already allowlisted → **no revocation/cleanup migration needed**.

## ⚠️ Deploy is the hole-closing step — merging alone is not enough

The running `epigraph-api` loads `/home/jeremy/epigraph/providers.toml` (its cwd),
**not** the worktree copy in this branch. Because `email_is_allowed` is allow-all on
an empty config, deploying the new binary alone changes nothing. To actually close
the exposure:

1. Add `allowed_emails = ["jeremy.barton@gmail.com"]` to
   `/home/jeremy/epigraph/providers.toml` **and** `/home/jeremy/.epigraph-deploy/providers.toml`.
2. Restart `epigraph-api.service`.

(Both deployed files were verified to contain only known keys, so `deny_unknown_fields`
will not break boot. Optionally pin `EPIGRAPH_PROVIDERS_CONFIG` to an absolute path so
the loaded config is not cwd-dependent.)

Resolves `b86cbb3f-508f-4308-9412-2551f0d32d5f`.

Design spec: `docs/superpowers/specs/2026-06-03-oauth-provision-email-allowlist-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
