### PR TITLE
feat(mcp): add link_epistemic tool for belief-wiring epistemic edges

### DIFF
--- a/crates/epigraph-db/src/lib.rs
+++ b/crates/epigraph-db/src/lib.rs
@@ -60,9 +60,9 @@ pub use pool::{create_pool, create_pool_from_options, create_pool_with_options};
 pub use repos::{
     ActivityRepository, AgentKeyRepository, AgentKeyRow, AgentRepository, AnalysisRecord,
     AnalysisRepository, BehavioralExecutionRepository, BehavioralExecutionRow, ChallengeRepository,
-    ChallengeRow, ClaimEmbeddingHit, ClaimEncryptionRepository, ClaimEncryptionRow,
-    ClaimNeighborBetpRow, ClaimRepository, ClaimSummary, ClaimThemeRepository, ClaimThemeRow,
-    ClaimVersionRepository, ClaimVersionRow, CommunityRepository, ContextRepository,
+    ChallengeRow, ClaimBeliefColumns, ClaimEmbeddingHit, ClaimEncryptionRepository,
+    ClaimEncryptionRow, ClaimNeighborBetpRow, ClaimRepository, ClaimSummary, ClaimThemeRepository,
+    ClaimThemeRow, ClaimVersionRepository, ClaimVersionRow, CommunityRepository, ContextRepository,
     CounterfactualRepository, CounterfactualRow, DivergenceRepository, EdgeEncryptionRepository,
     EdgeEncryptionRow, EdgeRepository, EmbeddingShareRepository, EmbeddingShareRow,
     EntityRepository, EntityRow, EpistemicEdgePairRow, EventRepository, EventRow,

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -10,6 +10,18 @@ use uuid::Uuid;
 /// Repository for Claim operations
 pub struct ClaimRepository;
 
+/// Cached Dempster–Shafer belief columns for a claim, as read by
+/// [`ClaimRepository::get_belief_columns`].
+///
+/// Each field is `Option` because the column is NULL on claims that have never
+/// had a BBA combined onto them (the edge-wiring recompute populates them).
+#[derive(Debug, Clone, Copy, sqlx::FromRow, serde::Serialize)]
+pub struct ClaimBeliefColumns {
+    pub belief: Option<f64>,
+    pub plausibility: Option<f64>,
+    pub pignistic_prob: Option<f64>,
+}
+
 /// Result row for [`ClaimRepository::search_by_embedding`].
 ///
 /// `similarity` is `1 - cosine_distance`, in `[0, 1]` for non-degenerate
@@ -266,6 +278,37 @@ impl ClaimRepository {
         .fetch_optional(pool)
         .await?;
         Ok(flag.flatten())
+    }
+
+    /// Read a claim's cached Dempster–Shafer belief columns
+    /// (`belief`, `plausibility`, `pignistic_prob`).
+    ///
+    /// These are the columns the edge-wiring recompute path
+    /// (`MassFunctionRepository::update_claim_belief`) writes — distinct from
+    /// `truth_value`, which the recompute leaves untouched. Callers that need
+    /// the *post-wire* combined belief (e.g. the MCP `link_epistemic` readback)
+    /// must read these columns, NOT `truth_value`; the unframed
+    /// `belief_query::get_belief` path reads `truth_value` and so does not
+    /// reflect a recompute.
+    ///
+    /// Returns `Ok(None)` when the claim does not exist; the columns inside
+    /// [`ClaimBeliefColumns`] are individually `Option` (NULL when the claim
+    /// has never had a BBA combined onto it).
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn get_belief_columns(
+        pool: &PgPool,
+        claim_id: ClaimId,
+    ) -> Result<Option<ClaimBeliefColumns>, DbError> {
+        let id: Uuid = claim_id.into();
+        let row: Option<ClaimBeliefColumns> =
+            sqlx::query_as("SELECT belief, plausibility, pignistic_prob FROM claims WHERE id = $1")
+                .bind(id)
+                .fetch_optional(pool)
+                .await?;
+        Ok(row)
     }
 
     /// Shallow-merge `patch` into the claim's `properties` JSONB (`||`),

--- a/crates/epigraph-db/src/repos/mod.rs
+++ b/crates/epigraph-db/src/repos/mod.rs
@@ -65,8 +65,8 @@ pub use agent_key::{AgentKeyRepository, AgentKeyRow};
 pub use analysis::{AnalysisRecord, AnalysisRepository, ClaimSummary};
 pub use challenge::{ChallengeRepository, ChallengeRow, GapChallengeRow};
 pub use claim::{
-    ClaimEmbeddingHit, ClaimPairDistance, ClaimRepository, EvolveStepResult, HybridHit,
-    LineageHead, PatchClaimDiff, PatchClaimInput,
+    ClaimBeliefColumns, ClaimEmbeddingHit, ClaimPairDistance, ClaimRepository, EvolveStepResult,
+    HybridHit, LineageHead, PatchClaimDiff, PatchClaimInput,
 };
 pub use claim_theme::{
     centroid_columns_for_dim, BoundaryClaimRow, ClaimThemeRepository, ClaimThemeRow,

--- a/crates/epigraph-mcp/src/scope_map.rs
+++ b/crates/epigraph-mcp/src/scope_map.rs
@@ -75,6 +75,7 @@ pub const SCOPE_MAP: &[(&str, &str)] = &[
     ("improve_workflow_hierarchy", "claims:write"),
     ("ingest_document", "claims:write"),
     ("ingest_workflow", "claims:write"),
+    ("link_epistemic", "claims:write"),
     ("link_hierarchical", "claims:write"),
     ("memorize", "claims:write"),
     ("patch_claim", "claims:write"),

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -402,6 +402,17 @@ impl EpiGraphMcpFull {
         tools::link_hierarchical::link_hierarchical(self, params).await
     }
 
+    #[tool(
+        description = "Create a BELIEF-AFFECTING epistemic edge between two existing claims and wire it into Dempster-Shafer belief propagation. Direction is source -> target ('source RELATIONSHIP target'). Valid relationships: supports, corroborates, elaborates, generalizes, specializes (these STRENGTHEN the target's belief), contradicts, refutes (these WEAKEN it). On first creation, builds a mass function from the source claim's belief interval and recomputes the target claim's combined belief, then emits an edge.added event; the response reports was_created, belief_wired, and the target's resulting {belief, plausibility, pignistic_prob}. Idempotent on (source, target, relationship): a re-hit returns the existing edge with was_created=false and belief_wired=false (no re-wire). For supersedes use supersede_claim instead."
+    )]
+    async fn link_epistemic(
+        &self,
+        Parameters(params): Parameters<LinkEpistemicParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_if_read_only()?;
+        tools::link_epistemic::link_epistemic(self, params).await
+    }
+
     // ── Paper Queries (3 tools) ──
 
     #[tool(description = "Look up a paper by its DOI, returning title, authors, and claims.")]

--- a/crates/epigraph-mcp/src/tools/link_epistemic.rs
+++ b/crates/epigraph-mcp/src/tools/link_epistemic.rs
@@ -1,0 +1,332 @@
+//! `link_epistemic` — belief-affecting epistemic edge creation between claims.
+//!
+//! Counterpart to the generic `POST /api/v1/edges` HTTP route's create→wire
+//! path, scoped to claim↔claim epistemic relationships. Unlike the deliberately
+//! inert [`link_hierarchical`](super::link_hierarchical) tool (no DS recompute,
+//! no event), this tool mirrors `routes/edges.rs::create_edge`: on first
+//! creation it builds a Dempster–Shafer mass function from the **source** claim's
+//! belief interval and recomputes the **target** claim's combined belief, then
+//! emits the `edge.added` durable event.
+//!
+//! Direction convention: `source -> target` means "source `relationship`
+//! target" (a `supports` edge: source is evidence for / strengthens target),
+//! matching `epigraph_engine::sheaf::restriction_kind_with_profile`.
+//!
+//! Tight contract:
+//! - both endpoints are existing claims (`source_type`/`target_type` are always
+//!   `"claim"`, not caller-controllable),
+//! - `relationship` must be one of [`EPISTEMIC_RELATIONSHIPS`] (lowercase
+//!   canonical strings; `supersedes` is intentionally excluded — it has
+//!   dedicated semantics in `supersede_claim`),
+//! - idempotent on `(source, target, relationship)`: a re-hit returns the
+//!   existing edge with `was_created=false`, `belief_wired=false`, and performs
+//!   no re-wire (matching the HTTP route, where wiring only fires on first
+//!   creation).
+//!
+//! Deferred vs the HTTP route (tracked as follow-ups): per-edge provenance
+//! recording, 1-hop `propagate_to_dependents` (an HTTP-only concern per the
+//! engine comment), and the legacy BP `factors`-table INSERT (a separate
+//! subsystem from the CDST recompute that moves belief here).
+
+use rmcp::model::*;
+
+use crate::errors::{internal_error, invalid_params, parse_uuid, McpError};
+use crate::server::EpiGraphMcpFull;
+use crate::types::{LinkEpistemicBelief, LinkEpistemicParams, LinkEpistemicResponse};
+
+use epigraph_core::ClaimId;
+use epigraph_db::{ClaimRepository, EdgeRepository, EventRepository};
+use epigraph_engine::edge_factor::{auto_wire_edge_if_epistemic, EdgeFactorOutcome};
+
+/// Allowed epistemic relationship strings — the engine's non-neutral relations
+/// **minus `supersedes`**, as lowercase canonical strings (matching the
+/// `epigraph-core::relationships` constants and the engine's internal
+/// `to_ascii_lowercase`).
+///
+/// Deliberately NOT validated against `routes/edges.rs::VALID_RELATIONSHIPS`:
+/// that HTTP whitelist stores only UPPER-CASE `CONTRADICTS`/`CORROBORATES` and
+/// is case-sensitive, while the engine lowercases internally. The real invariant
+/// (asserted by the coverage-guard test) is that every entry maps to a
+/// **non-Neutral** `RestrictionKind`, which is what actually moves belief.
+///
+/// `supersedes` is excluded on purpose: it has dedicated semantics
+/// (`supersede_claim`, scope `claims:admin`, flips `is_current=false` + nulls
+/// the superseded claim's embedding). Letting any `claims:write` agent write a
+/// bare `supersedes` edge here would create an inconsistent state.
+pub const EPISTEMIC_RELATIONSHIPS: &[&str] = &[
+    "supports",
+    "corroborates",
+    "elaborates",
+    "generalizes",
+    "specializes",
+    "contradicts",
+    "refutes",
+];
+
+fn is_epistemic_relationship(s: &str) -> bool {
+    EPISTEMIC_RELATIONSHIPS.contains(&s)
+}
+
+fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(value).map_err(internal_error)?,
+    )]))
+}
+
+pub async fn link_epistemic(
+    server: &EpiGraphMcpFull,
+    params: LinkEpistemicParams,
+) -> Result<CallToolResult, McpError> {
+    do_link_epistemic(server, params).await
+}
+
+/// Core logic factored out so integration tests can call it directly without
+/// round-tripping through the rmcp dispatch layer (mirrors
+/// `do_link_hierarchical`).
+pub async fn do_link_epistemic(
+    server: &EpiGraphMcpFull,
+    params: LinkEpistemicParams,
+) -> Result<CallToolResult, McpError> {
+    let source_id = parse_uuid(&params.source_claim_id)?;
+    let target_id = parse_uuid(&params.target_claim_id)?;
+
+    // Tight allow-list — lowercase canonical epistemic relations only.
+    if !is_epistemic_relationship(&params.relationship) {
+        return Err(invalid_params(format!(
+            "invalid relationship '{}'. Valid epistemic types: {}",
+            params.relationship,
+            EPISTEMIC_RELATIONSHIPS.join(", "),
+        )));
+    }
+
+    // No self-loops — both endpoints are claims so equal UUIDs always loop.
+    if source_id == target_id {
+        return Err(invalid_params(
+            "self-loops are not allowed (source and target are the same claim)",
+        ));
+    }
+
+    let pool = &server.pool;
+
+    // Verify both claims exist via the repo layer (SQL stays in epigraph-db).
+    // Disambiguate which side is missing.
+    if ClaimRepository::get_by_id(pool, ClaimId::from_uuid(source_id))
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err(invalid_params(format!(
+            "source_claim_id {source_id} not found"
+        )));
+    }
+    if ClaimRepository::get_by_id(pool, ClaimId::from_uuid(target_id))
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err(invalid_params(format!(
+            "target_claim_id {target_id} not found"
+        )));
+    }
+
+    let (edge_row, was_created) = EdgeRepository::create_if_not_exists(
+        pool,
+        source_id,
+        "claim",
+        target_id,
+        "claim",
+        &params.relationship,
+        params.properties.clone(),
+        None,
+        None,
+    )
+    .await
+    .map_err(internal_error)?;
+
+    // Belief wiring only fires on first creation (mirrors the HTTP route, where
+    // an idempotent re-hit returns the stored row and never re-wires).
+    //
+    // The BBA is attributed to the SOURCE claim's agent_id ("A's author asserts
+    // A SUPPORTS B"), NOT the caller — exactly as the HTTP wrapper
+    // `trigger_edge_ds_recomputation` does. Resolved here via a runtime query
+    // (no `query!` macro → zero .sqlx offline-data churn).
+    let mut belief_wired = false;
+    if was_created {
+        let source_agent_id: Option<uuid::Uuid> =
+            sqlx::query_scalar("SELECT agent_id FROM claims WHERE id = $1")
+                .bind(source_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(internal_error)?;
+
+        if let Some(agent_id) = source_agent_id {
+            // Best-effort: a recompute error must not lose the durable edge.
+            // `belief_wired` is true ONLY when the engine actually materialized
+            // a BBA and recomputed the target (`Wired`). The other outcomes
+            // (SourceFactorless / Vacuous / NonEpistemic / None-on-error) move
+            // no belief, so we honestly report `belief_wired=false`.
+            let outcome = auto_wire_edge_if_epistemic(
+                pool,
+                true, // was_created already gated above
+                edge_row.id,
+                source_id,
+                "claim",
+                target_id,
+                "claim",
+                &params.relationship,
+                agent_id,
+            )
+            .await;
+            belief_wired = matches!(outcome, Some(EdgeFactorOutcome::Wired));
+        }
+
+        // Emit the durable `edge.added` event (best-effort; never fail the call
+        // on a publish error). Actor = the MCP signer agent, mirroring
+        // `emit_tool_invoked`'s actor resolution.
+        let actor_id = server.agent_id().await.ok();
+        let _ = EventRepository::publish_or_log(
+            pool,
+            "edge.added",
+            actor_id,
+            &serde_json::json!({
+                "edge_id": edge_row.id,
+                "source_type": "claim",
+                "source_id": source_id,
+                "target_type": "claim",
+                "target_id": target_id,
+                "relationship": params.relationship,
+            }),
+        )
+        .await;
+    }
+
+    // Best-effort readback of the target's cached DS columns — the ones the
+    // recompute wrote (belief / plausibility / pignistic_prob). NOT the unframed
+    // `belief_query::get_belief`, which reads `truth_value` and so would NOT
+    // reflect the wire.
+    let target_belief =
+        match ClaimRepository::get_belief_columns(pool, ClaimId::from_uuid(target_id)).await {
+            Ok(Some(cols)) => match (cols.belief, cols.plausibility, cols.pignistic_prob) {
+                (Some(belief), Some(plausibility), Some(pignistic_prob)) => {
+                    Some(LinkEpistemicBelief {
+                        belief,
+                        plausibility,
+                        pignistic_prob,
+                    })
+                }
+                // Claim with no BBA yet → NULL DS columns → belief not reportable.
+                _ => None,
+            },
+            // Missing row: belief not reportable.
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(
+                    target = %target_id,
+                    error = ?e,
+                    "link_epistemic: target belief readback failed (non-fatal)"
+                );
+                None
+            }
+        };
+
+    success_json(&LinkEpistemicResponse {
+        edge_id: edge_row.id.to_string(),
+        was_created,
+        relationship: params.relationship,
+        belief_wired,
+        target_belief,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use epigraph_engine::sheaf::{
+        restriction_kind_with_profile, RestrictionKind, RestrictionProfile,
+    };
+
+    /// Coverage guard (the most important test): EVERY exposed epistemic
+    /// relationship must map to a NON-Neutral `RestrictionKind` under the
+    /// default scientific profile — otherwise the tool would advertise a
+    /// belief-affecting edge that is actually inert. Also catches drift if the
+    /// engine's `restriction_kind_with_profile` mapping changes.
+    ///
+    /// We assert the engine mapping ONLY (not membership in
+    /// `routes/edges.rs::VALID_RELATIONSHIPS`): that HTTP whitelist is
+    /// UPPER-CASE and case-sensitive, so a membership check would spuriously
+    /// fail on our lowercase canonical strings. The engine mapping is the real
+    /// invariant that governs belief.
+    #[test]
+    fn every_epistemic_relationship_maps_to_non_neutral() {
+        let profile = RestrictionProfile::scientific();
+        for rel in EPISTEMIC_RELATIONSHIPS {
+            let kind = restriction_kind_with_profile(rel, &profile);
+            assert!(
+                !matches!(kind, RestrictionKind::Neutral),
+                "epistemic relationship '{rel}' maps to RestrictionKind::Neutral \
+                 (inert) — it would not move belief; remove it from \
+                 EPISTEMIC_RELATIONSHIPS or fix the engine mapping. Got: {kind:?}"
+            );
+        }
+    }
+
+    /// Pin the polarity split from the spec §4 table: the five positive
+    /// relationships strengthen the target (`Positive`), the two negative ones
+    /// weaken it (`Negative`). This catches an accidental sign flip in the
+    /// engine mapping that the bare non-Neutral guard would miss.
+    #[test]
+    fn epistemic_relationship_polarities_match_spec() {
+        let profile = RestrictionProfile::scientific();
+        for rel in [
+            "supports",
+            "corroborates",
+            "elaborates",
+            "generalizes",
+            "specializes",
+        ] {
+            assert!(
+                matches!(
+                    restriction_kind_with_profile(rel, &profile),
+                    RestrictionKind::Positive(_)
+                ),
+                "'{rel}' must be a Positive (strengthening) restriction"
+            );
+        }
+        for rel in ["contradicts", "refutes"] {
+            assert!(
+                matches!(
+                    restriction_kind_with_profile(rel, &profile),
+                    RestrictionKind::Negative(_)
+                ),
+                "'{rel}' must be a Negative (weakening) restriction"
+            );
+        }
+    }
+
+    /// The 7-entry set is exactly the documented surface: no `supersedes`, no
+    /// structural relationships, no duplicates.
+    #[test]
+    fn epistemic_set_is_the_documented_seven() {
+        assert_eq!(
+            EPISTEMIC_RELATIONSHIPS.len(),
+            7,
+            "EPISTEMIC_RELATIONSHIPS must be exactly the 7 documented relations"
+        );
+        assert!(
+            !is_epistemic_relationship("supersedes"),
+            "supersedes must NOT be exposed — it belongs to supersede_claim"
+        );
+        for structural in ["decomposes_to", "section_follows", "continues_argument"] {
+            assert!(
+                !is_epistemic_relationship(structural),
+                "structural relationship '{structural}' must not be in the epistemic set"
+            );
+        }
+        assert!(!is_epistemic_relationship("relates_to"));
+        assert!(!is_epistemic_relationship(""));
+        assert!(
+            !is_epistemic_relationship("SUPPORTS"),
+            "matcher is case-sensitive on the lowercase canonical form"
+        );
+    }
+}

--- a/crates/epigraph-mcp/src/tools/mod.rs
+++ b/crates/epigraph-mcp/src/tools/mod.rs
@@ -10,6 +10,7 @@ pub mod events;
 pub mod evolve_step;
 pub mod graph;
 pub mod ingestion;
+pub mod link_epistemic;
 pub mod link_hierarchical;
 pub mod matching;
 pub mod memory;

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -788,6 +788,64 @@ pub struct LinkHierarchicalResponse {
     pub created: bool,
 }
 
+/// Parameters for the `link_epistemic` MCP tool.
+///
+/// Wires two existing claims with a **belief-affecting** epistemic relationship
+/// (`supports`, `corroborates`, `elaborates`, `generalizes`, `specializes`,
+/// `contradicts`, `refutes`) and triggers Dempster–Shafer recomputation on the
+/// **target** claim. Direction is `source -> target` ("source `relationship`
+/// target"). Unlike `link_hierarchical` (which is deliberately inert), this
+/// tool mirrors `POST /api/v1/edges`'s create→wire path: on first creation it
+/// builds a BBA from the source claim's belief interval and recomputes the
+/// target's combined belief. Idempotent on `(source, target, relationship)`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LinkEpistemicParams {
+    #[schemars(description = "UUID of the source claim (the evidence / asserting side)")]
+    pub source_claim_id: String,
+
+    #[schemars(description = "UUID of the target claim (the side whose belief is recomputed)")]
+    pub target_claim_id: String,
+
+    #[schemars(
+        description = "Epistemic relationship type. One of: supports, corroborates, elaborates, generalizes, specializes, contradicts, refutes. (supersedes is intentionally NOT accepted — use supersede_claim.)"
+    )]
+    pub relationship: String,
+
+    #[schemars(description = "Optional arbitrary JSON object attached to the edge.")]
+    #[serde(default)]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// Belief interval echoed back in [`LinkEpistemicResponse`] so the caller can
+/// observe the target claim's combined belief after the wire.
+#[derive(Debug, Serialize)]
+pub struct LinkEpistemicBelief {
+    pub belief: f64,
+    pub plausibility: f64,
+    pub pignistic_prob: f64,
+}
+
+/// Response for the `link_epistemic` MCP tool.
+///
+/// `was_created=true` means a new edge row was inserted and belief wiring was
+/// attempted; `false` means an edge with the same `(source, target,
+/// relationship)` already existed (idempotent re-hit — no re-wire). `belief_wired`
+/// is `true` only when the engine actually materialized a BBA and recomputed
+/// the target (engine outcome `Wired`); it is `false` for idempotent re-hits and
+/// for the no-op wiring outcomes (source has no belief interval, vacuous
+/// transfer, or a recompute error). `target_belief` is a best-effort read of the
+/// target's cached DS columns after the recompute (`None` if the target carries
+/// no belief yet or the read failed).
+#[derive(Debug, Serialize)]
+pub struct LinkEpistemicResponse {
+    pub edge_id: String,
+    pub was_created: bool,
+    pub relationship: String,
+    pub belief_wired: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_belief: Option<LinkEpistemicBelief>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct IngestDocumentResponse {
     pub paper_id: String,

--- a/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
+++ b/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
@@ -1,0 +1,347 @@
+//! End-to-end smoke test for the `link_epistemic` MCP tool.
+//!
+//! Drives `do_link_epistemic` directly against a `sqlx::test` pool so the
+//! happy / belief-moves / idempotent / validation / 404-equivalent paths all
+//! exercise the same repo + engine layer the production rmcp dispatcher uses.
+//!
+//! Unlike `link_hierarchical` (inert), this tool wires belief: a `supports`
+//! edge must RAISE the target's combined `pignistic_prob`, a `contradicts`
+//! edge must LOWER it, and an idempotent re-hit must NOT re-apply. The
+//! belief-move assertions mirror the engine fixture
+//! `crates/epigraph-engine/tests/intra_source_discount_regression.rs`:
+//!
+//!   * the SOURCE claim must carry a populated belief interval (belief =
+//!     plausibility = 0.9), else `auto_wire_ds_for_edge` short-circuits to
+//!     `SourceFactorless` and writes no BBA;
+//!   * the move is asserted against the target's cached `pignistic_prob`
+//!     column (the column the recompute writes), NOT the unframed
+//!     `belief_query::get_belief`, which reads `truth_value` and would show no
+//!     movement.
+
+mod common;
+
+use common::{build_test_server, seed_claim, seed_claim_with_belief};
+use epigraph_mcp::tools::link_epistemic::do_link_epistemic;
+use epigraph_mcp::types::LinkEpistemicParams;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(serde::Deserialize)]
+struct Belief {
+    #[allow(dead_code)]
+    belief: f64,
+    #[allow(dead_code)]
+    plausibility: f64,
+    pignistic_prob: f64,
+}
+
+#[derive(serde::Deserialize)]
+struct LinkEpistemicResponse {
+    edge_id: String,
+    was_created: bool,
+    relationship: String,
+    belief_wired: bool,
+    target_belief: Option<Belief>,
+}
+
+fn parse_response(result: &rmcp::model::CallToolResult) -> LinkEpistemicResponse {
+    let text = result
+        .content
+        .first()
+        .expect("at least one content block")
+        .as_text()
+        .expect("text content")
+        .text
+        .clone();
+    serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("LinkEpistemicResponse JSON: {e}; raw={text}"))
+}
+
+/// Read the target's cached pignistic probability directly from the column the
+/// edge-wiring recompute writes (mirrors `read_betp` in the engine fixture).
+/// Returns `None` when the column is still NULL (no BBA combined yet).
+async fn read_betp(pool: &PgPool, claim_id: Uuid) -> Option<f64> {
+    sqlx::query_scalar::<_, Option<f64>>("SELECT pignistic_prob FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
+        .await
+        .expect("read pignistic_prob")
+}
+
+async fn edge_count(pool: &PgPool, source: Uuid, target: Uuid, relationship: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM edges \
+         WHERE source_id = $1 AND target_id = $2 AND relationship = $3 \
+           AND source_type = 'claim' AND target_type = 'claim'",
+    )
+    .bind(source)
+    .bind(target)
+    .bind(relationship)
+    .fetch_one(pool)
+    .await
+    .expect("count edges")
+}
+
+// ── supports raises the target's belief, and is idempotent ──────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn supports_raises_target_belief_and_is_idempotent(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    // High-commitment source so the wire produces `Wired` (not SourceFactorless).
+    let source = seed_claim_with_belief(&pool, 0.9, 0.9, Some(0.9)).await;
+    // Target starts neutral: NULL DS columns, truth_value 0.5.
+    let target = seed_claim(&pool, "target claim", 0.5).await;
+
+    assert!(
+        read_betp(&pool, target).await.is_none(),
+        "target must start with NULL pignistic_prob (no BBA yet)"
+    );
+
+    let first = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "supports".to_string(),
+            properties: Some(serde_json::json!({"note": "evidence A"})),
+        },
+    )
+    .await
+    .expect("supports wire succeeds");
+    let first_resp = parse_response(&first);
+
+    assert!(
+        first_resp.was_created,
+        "first call must report was_created=true"
+    );
+    assert!(
+        first_resp.belief_wired,
+        "supports from a high-belief source must wire belief (engine outcome Wired)"
+    );
+    assert_eq!(first_resp.relationship, "supports");
+
+    // The target's combined belief must have moved UP from the 0.5 neutral
+    // point — this is the whole point of an epistemic (vs hierarchical) edge.
+    let betp = read_betp(&pool, target)
+        .await
+        .expect("target must have a computed pignistic_prob after the supports wire");
+    assert!(
+        betp > 0.5,
+        "supports edge must raise the target's pignistic_prob above the 0.5 neutral point, got {betp}"
+    );
+    // The response's target_belief must reflect that same post-recompute value.
+    let resp_betp = first_resp
+        .target_belief
+        .as_ref()
+        .expect("response must carry target_belief after a successful wire")
+        .pignistic_prob;
+    assert!(
+        (resp_betp - betp).abs() < 1e-9,
+        "response target_belief.pignistic_prob ({resp_betp}) must match the DB column ({betp})"
+    );
+
+    // Edge row exists exactly once with the round-tripped properties.
+    let props: serde_json::Value = sqlx::query_scalar(
+        "SELECT properties FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'supports'",
+    )
+    .bind(source)
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .expect("edge row");
+    assert_eq!(
+        props,
+        serde_json::json!({"note": "evidence A"}),
+        "properties must round-trip onto the edge row"
+    );
+
+    // ── Idempotent re-hit: same triple → was_created=false, no re-wire ──
+    let pre_betp = read_betp(&pool, target).await.expect("betp present");
+    let second = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "supports".to_string(),
+            properties: Some(serde_json::json!({"note": "evidence A"})),
+        },
+    )
+    .await
+    .expect("idempotent re-run succeeds");
+    let second_resp = parse_response(&second);
+
+    assert!(
+        !second_resp.was_created,
+        "second identical call must report was_created=false (dedup hit)"
+    );
+    assert!(
+        !second_resp.belief_wired,
+        "idempotent re-hit must NOT re-wire belief"
+    );
+    assert_eq!(
+        second_resp.edge_id, first_resp.edge_id,
+        "dedup hit must return the existing edge_id"
+    );
+    assert_eq!(
+        edge_count(&pool, source, target, "supports").await,
+        1,
+        "exactly one edge row after the idempotent re-run"
+    );
+    let post_betp = read_betp(&pool, target).await.expect("betp present");
+    assert!(
+        (post_betp - pre_betp).abs() < 1e-9,
+        "idempotent re-hit must NOT change the target's belief: before={pre_betp}, after={post_betp}"
+    );
+}
+
+// ── contradicts lowers the target's belief ──────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn contradicts_lowers_target_belief(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    let source = seed_claim_with_belief(&pool, 0.9, 0.9, Some(0.9)).await;
+    let target = seed_claim(&pool, "target under attack", 0.5).await;
+
+    let resp = parse_response(
+        &do_link_epistemic(
+            &server,
+            LinkEpistemicParams {
+                source_claim_id: source.to_string(),
+                target_claim_id: target.to_string(),
+                relationship: "contradicts".to_string(),
+                properties: None,
+            },
+        )
+        .await
+        .expect("contradicts wire succeeds"),
+    );
+
+    assert!(resp.was_created);
+    assert!(
+        resp.belief_wired,
+        "contradicts from a high-belief source must wire belief"
+    );
+
+    let betp = read_betp(&pool, target)
+        .await
+        .expect("target must have a computed pignistic_prob after the contradicts wire");
+    assert!(
+        betp < 0.5,
+        "contradicts edge must lower the target's pignistic_prob below the 0.5 neutral point, got {betp}"
+    );
+}
+
+// ── validation: relationship not in the epistemic set ───────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn structural_relationship_is_rejected(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    let source = seed_claim(&pool, "s", 0.5).await;
+    let target = seed_claim(&pool, "t", 0.5).await;
+
+    let err = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            // structural relationship — valid for link_hierarchical, rejected here
+            relationship: "decomposes_to".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("decomposes_to must be rejected by the epistemic allow-list");
+    let msg = err.message.to_string();
+    assert!(msg.contains("invalid relationship"), "got: {msg}");
+    assert!(
+        msg.contains("supports"),
+        "error should list the valid set; got: {msg}"
+    );
+    assert_eq!(
+        edge_count(&pool, source, target, "decomposes_to").await,
+        0,
+        "no edge written on validation failure"
+    );
+}
+
+// ── validation: supersedes is excluded (belongs to supersede_claim) ─────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn supersedes_is_rejected(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    let source = seed_claim(&pool, "newer", 0.5).await;
+    let target = seed_claim(&pool, "older", 0.5).await;
+
+    let err = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "supersedes".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("supersedes must be rejected — it has dedicated semantics in supersede_claim");
+    assert!(
+        err.message.to_string().contains("invalid relationship"),
+        "got: {}",
+        err.message
+    );
+    assert_eq!(
+        edge_count(&pool, source, target, "supersedes").await,
+        0,
+        "no supersedes edge written"
+    );
+}
+
+// ── validation: self-loop ───────────────────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn self_loop_is_rejected(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    let claim = seed_claim(&pool, "loop", 0.5).await;
+
+    let err = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: claim.to_string(),
+            target_claim_id: claim.to_string(),
+            relationship: "supports".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("self-loops must be rejected");
+    assert!(
+        err.message.to_lowercase().contains("self-loop"),
+        "error should mention self-loops; got: {}",
+        err.message
+    );
+}
+
+// ── 404-equivalent: missing target claim ────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn missing_target_claim_is_rejected(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    let source = seed_claim_with_belief(&pool, 0.9, 0.9, Some(0.9)).await;
+    let bogus = Uuid::new_v4();
+
+    let err = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: bogus.to_string(),
+            relationship: "supports".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect_err("missing target claim must error");
+    let msg = err.message.to_string();
+    assert!(
+        msg.contains("target_claim_id") && msg.contains(&bogus.to_string()),
+        "error should identify the missing side and its UUID; got: {msg}"
+    );
+}

--- a/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
+++ b/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
@@ -231,6 +231,77 @@ async fn contradicts_lowers_target_belief(pool: PgPool) {
     );
 }
 
+// ── SourceFactorless: durable edge written even when belief is NOT wired ─────
+
+/// The common production case: the SOURCE claim has an agent but no stored
+/// belief interval (NULL DS columns), so `auto_wire_ds_for_edge` short-circuits
+/// to `SourceFactorless` and materializes no BBA. The key resilience guarantee
+/// (spec §7) is that the durable edge row + `edge.added` event are STILL written
+/// and the call still succeeds — `was_created=true` WITH `belief_wired=false` —
+/// while the target's belief is left untouched. The other belief tests only
+/// reach `belief_wired=false` via the idempotent re-hit (where `was_created` is
+/// also false), so this pins the distinct created-but-not-wired branch.
+#[sqlx::test(migrations = "../../migrations")]
+async fn factorless_source_writes_durable_edge_without_wiring(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    // `seed_claim` plants an agent_id but leaves belief/plausibility/pignistic
+    // NULL → the engine finds no source interval → SourceFactorless.
+    let source = seed_claim(&pool, "factorless source", 0.5).await;
+    let target = seed_claim(&pool, "untouched target", 0.5).await;
+
+    let resp = parse_response(
+        &do_link_epistemic(
+            &server,
+            LinkEpistemicParams {
+                source_claim_id: source.to_string(),
+                target_claim_id: target.to_string(),
+                relationship: "supports".to_string(),
+                properties: Some(serde_json::json!({"note": "no source belief"})),
+            },
+        )
+        .await
+        .expect("link must succeed even when the source has no belief interval"),
+    );
+
+    assert!(
+        resp.was_created,
+        "the durable edge must be created even though belief is not wired"
+    );
+    assert!(
+        !resp.belief_wired,
+        "a source with no stored belief interval must short-circuit to \
+         SourceFactorless — no BBA, no wire"
+    );
+    assert!(
+        resp.target_belief.is_none(),
+        "no BBA combined → response target_belief must be None"
+    );
+    assert!(
+        read_betp(&pool, target).await.is_none(),
+        "the target's pignistic_prob must remain NULL — no recompute happened"
+    );
+    assert_eq!(
+        edge_count(&pool, source, target, "supports").await,
+        1,
+        "the durable edge row must persist exactly once despite the no-op wire"
+    );
+
+    // Properties still round-trip onto the durable edge.
+    let props: serde_json::Value = sqlx::query_scalar(
+        "SELECT properties FROM edges WHERE source_id = $1 AND target_id = $2 AND relationship = 'supports'",
+    )
+    .bind(source)
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .expect("edge row");
+    assert_eq!(
+        props,
+        serde_json::json!({"note": "no source belief"}),
+        "properties must round-trip even when belief is not wired"
+    );
+}
+
 // ── validation: relationship not in the epistemic set ───────────────────────
 
 #[sqlx::test(migrations = "../../migrations")]

--- a/docs/superpowers/specs/2026-06-03-link-epistemic-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-03-link-epistemic-mcp-design.md
@@ -84,8 +84,17 @@ Exposed set = the engine's non-neutral epistemic relations **minus `supersedes`*
 | negative (weaken target)     | `contradicts`, `refutes` |
 
 Define these as a constant `EPISTEMIC_RELATIONSHIPS` in the MCP crate (mirror of how
-`link_hierarchical` defines `HIERARCHICAL_RELATIONSHIPS`). Validation rejects anything else
-(structural types, unknown strings, and `supersedes`) with an error that lists the valid set.
+`link_hierarchical` defines `HIERARCHICAL_RELATIONSHIPS`), using the **lowercase canonical**
+strings (matching the `epigraph-core::relationships` constants and the engine's internal
+`to_ascii_lowercase`). Validation rejects anything else (structural types, unknown strings, and
+`supersedes`) with an error that lists the valid set.
+
+> **Case note (resolved):** the MCP tool owns this constant and does **not** route through
+> `routes/edges.rs::is_valid_relationship`. That HTTP whitelist (`VALID_RELATIONSHIPS`) stores
+> only UPPER-CASE `CONTRADICTS`/`CORROBORATES` and is case-sensitive, whereas the engine
+> lowercases internally — so a "must be in `VALID_RELATIONSHIPS`" check would spuriously fail.
+> The coverage guard (§8) therefore asserts the **non-Neutral engine mapping only**, which is
+> the property that actually governs belief.
 
 ### `supersedes` exclusion (deliberate)
 The engine treats `supersedes` as a negative restriction, but `supersedes` has dedicated
@@ -154,9 +163,11 @@ edge exists-but-unwired; v1 relies on `recompute_beliefs`.)
 ## 8. Testing
 
 - **Coverage guard (most important):** a test asserting **every** `EPISTEMIC_RELATIONSHIPS`
-  entry (a) is present in `routes/edges.rs::VALID_RELATIONSHIPS`, and (b) maps to a
-  **non-Neutral** `RestrictionKind` via the engine's `restriction_kind_with_profile`. This makes
-  it impossible to expose an inert relationship, and catches drift if either list changes.
+  entry maps to a **non-Neutral** `RestrictionKind` via the engine's
+  `restriction_kind_with_profile` (with the default `RestrictionProfile::scientific()`). This
+  makes it impossible to expose an inert relationship and catches drift if the engine mapping
+  changes. (We do **not** assert membership in `routes/edges.rs::VALID_RELATIONSHIPS` — see the
+  case note in §4; the engine mapping, not the HTTP whitelist, is the real invariant.)
 - **Validation unit tests:** accept each of the 7 epistemic types; reject `decomposes_to`,
   an unknown string, and `supersedes`; reject self-loop.
 - **DB integration** (small DB per CLAUDE.md — `epigraph_db_repo_test` or `#[sqlx::test]`):

--- a/docs/superpowers/specs/2026-06-03-link-epistemic-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-03-link-epistemic-mcp-design.md
@@ -1,0 +1,187 @@
+# `link_epistemic` MCP tool — design
+
+- **Date:** 2026-06-03
+- **Status:** Approved (design); ready for implementation plan
+- **Scope:** one new MCP tool in `crates/epigraph-mcp`; no schema change
+- **Owner:** Jeremy Barton
+
+## 1. Context & motivation
+
+Agents can already write **structural** edges between claims via the MCP
+`link_hierarchical` tool, but that tool is deliberately *inert*: it accepts only
+`decomposes_to`/`section_follows`/`continues_argument` and does **no** Dempster–Shafer
+recomputation, **no** factor inserts, **no** `edge.added` event, and **no** provenance
+(see `crates/epigraph-mcp/src/tools/link_hierarchical.rs` header comment).
+
+There is **no MCP path to write epistemic edges** (`supports`, `contradicts`, …).
+The HTTP route `crates/epigraph-api/src/routes/edges.rs::create_edge` already does this
+correctly: it creates the edge, then on first creation calls
+`trigger_edge_ds_recomputation` → `auto_wire_edge_if_epistemic`
+(`crates/epigraph-engine/src/edge_factor.rs`), which builds a DS mass function from the
+source claim's belief interval and **recomputes the target claim's combined belief**, plus
+records provenance and emits `edge.added`.
+
+**Goal:** give agents a `link_epistemic` MCP tool with *parity to the HTTP route* — write an
+epistemic edge AND wire it into belief propagation — so agents can express supports/contradicts
+relationships that actually move belief.
+
+### Key fact that drives the design
+A bare `EdgeRepository::create*` writes only a row in the `edges` table. The edge is **inert**
+(no BBA, no belief change) until `auto_wire_edge_if_epistemic` runs. Therefore the new tool
+**must call the engine wiring fn**, not merely write the edge (the `link_hierarchical` path is
+the wrong template; `create_edge` is the right one).
+
+## 2. Goals / non-goals
+
+**Goals**
+- New MCP tool `link_epistemic(source_claim_id, target_claim_id, relationship, properties?)`.
+- Accept the engine's non-neutral epistemic relationships (below) and wire belief on creation.
+- Idempotent on `(source, target, relationship)`, matching the HTTP route and `link_hierarchical`.
+- Honor the repo convention: routes and MCP both call the shared repo/engine layer; no duplicated logic.
+
+**Non-goals (explicitly out of scope for v1)**
+- `supersedes` edges (see §4 exclusion).
+- Edges between non-claim node types (claim↔claim only, like `link_hierarchical`).
+- A per-edge strength/weight override knob (the engine's default restriction profile is used;
+  a `properties.weight` override is a possible future extension, not v1).
+- Any change to `link_hierarchical` (its inert contract stays intact).
+
+## 3. Tool surface
+
+```
+link_epistemic(
+  source_claim_id: String,   // UUID
+  target_claim_id: String,   // UUID
+  relationship:    String,   // one of the epistemic set in §4
+  properties:      Option<serde_json::Value>,
+)
+```
+Direction convention: **source → target** means "source `relationship` target"
+(e.g. a `supports` edge: source is evidence for / strengthens target). This matches
+`restriction_kind_with_profile` in `crates/epigraph-engine/src/sheaf.rs`.
+
+**Response** (so the agent can see the effect):
+```json
+{
+  "edge_id": "<uuid>",
+  "was_created": true,
+  "relationship": "supports",
+  "belief_wired": true,
+  "target_belief": { "belief": 0.x, "plausibility": 0.x, "pignistic_prob": 0.x }
+}
+```
+- `belief_wired=false` is returned when the edge was created but wiring failed (see §7), or
+  when `was_created=false` (idempotent re-hit — no re-wire, consistent with the HTTP route).
+- `target_belief` reflects the target claim's combined belief after recompute (best-effort read).
+
+## 4. Allowed relationships
+
+Exposed set = the engine's non-neutral epistemic relations **minus `supersedes`**:
+
+| Direction effect | relationships |
+|---|---|
+| positive (strengthen target) | `supports`, `corroborates`, `elaborates`, `generalizes`, `specializes` |
+| negative (weaken target)     | `contradicts`, `refutes` |
+
+Define these as a constant `EPISTEMIC_RELATIONSHIPS` in the MCP crate (mirror of how
+`link_hierarchical` defines `HIERARCHICAL_RELATIONSHIPS`). Validation rejects anything else
+(structural types, unknown strings, and `supersedes`) with an error that lists the valid set.
+
+### `supersedes` exclusion (deliberate)
+The engine treats `supersedes` as a negative restriction, but `supersedes` has dedicated
+semantics: the `supersede_claim` tool (scope `claims:admin`) creates the relationship **and**
+flips `is_current=false` + nulls the superseded claim's embedding
+(`crates/epigraph-db/src/repos/claim.rs::supersede`). Allowing any `claims:write` agent to
+write a bare `supersedes` edge here would create an inconsistent state (supersedes edge, both
+claims still `is_current`). The repo CLAUDE.md also reserves `supersedes`/`is_current` for
+epistemic claim replacement, not generic edges. So `supersedes` stays exclusively with
+`supersede_claim`.
+
+## 5. Behavior (mirror of `routes/edges.rs::create_edge`)
+
+1. Parse `source_claim_id`/`target_claim_id` as UUIDs (clear error on failure).
+2. Reject self-loop (`source == target`) — matches `link_hierarchical` and core `Edge::new`.
+3. Verify both claims exist (matches `link_hierarchical`'s existence check).
+4. Reject `relationship ∉ EPISTEMIC_RELATIONSHIPS`.
+5. `EdgeRepository::create_if_not_exists(src,"claim",tgt,"claim",&rel,props,None,None)`
+   → `(edge_row, was_created)`.
+6. If `was_created`:
+   - Call the engine wiring (`auto_wire_edge_if_epistemic`, same entry the HTTP route uses via
+     `trigger_edge_ds_recomputation`) to build the BBA and recompute the **target** belief.
+   - Record provenance from the caller's auth context (as the HTTP route does when authenticated).
+   - Emit the `edge.added` event.
+7. If `!was_created`: return the existing edge, `belief_wired=false`, no re-wire (idempotent).
+8. Read the target claim's `{belief, plausibility, pignistic_prob}` for the response (best-effort).
+
+### Reuse / no duplication
+Per repo CLAUDE.md ("HTTP routes and MCP tools both call the repo layer; do not duplicate"):
+the MCP tool calls the **same** `EdgeRepository` methods and the **same** engine wiring fn the
+HTTP route calls. If `create_edge`'s create→wire→provenance→event sequence is non-trivial to
+share, extract a small reusable helper (e.g. `create_and_wire_epistemic_edge`) — placed where
+both `epigraph-api` and `epigraph-mcp` can call it (engine or a shared service module) — and
+have **both** the HTTP route and the MCP tool delegate to it. Decide extraction granularity in
+the plan; the invariant is: one implementation of the create-and-wire logic, two call sites.
+
+## 6. Scope & registration
+
+- Scope: **`claims:write`** (same tier as `link_hierarchical`; no admin needed since
+  `supersedes` is excluded). Add `("link_epistemic", "claims:write")` to
+  `crates/epigraph-mcp/src/scope_map.rs`; the existing `every_registered_tool_has_a_scope`
+  coverage test enforces the mapping.
+- Register the `#[tool(...)]` method on `EpiGraphMcpFull` (alongside `link_hierarchical`),
+  with a description that states it writes a belief-affecting epistemic edge and lists the
+  valid relationships and the direction convention.
+- Tool count in `get_info` instructions is derived from `list_all().len()` (post PR #258), so
+  it updates automatically.
+
+## 7. Error handling
+
+| Condition | Result |
+|---|---|
+| bad UUID | `McpError` invalid-params, names which id |
+| self-loop | `McpError` invalid-params |
+| missing source/target claim | `McpError` not-found, names which |
+| relationship not in set | `McpError` invalid-params, lists valid set |
+| edge created but wiring fails | **success** with `belief_wired=false` + hint to call `recompute_beliefs` (the edge row is the durable commit; `recompute_beliefs` is idempotent and retry-safe) |
+
+Rationale for the wiring-failure choice: the durable fact (the edge) must not be lost on a
+transient recompute error, and the agent gets an explicit signal that belief wasn't updated so
+it can re-trigger. (Note: because wiring only runs on `was_created`, a naive retry of
+`link_epistemic` would find `was_created=false` and skip re-wire — so the recovery path is
+`recompute_beliefs`, not a re-call. The plan may optionally make wiring re-runnable when the
+edge exists-but-unwired; v1 relies on `recompute_beliefs`.)
+
+## 8. Testing
+
+- **Coverage guard (most important):** a test asserting **every** `EPISTEMIC_RELATIONSHIPS`
+  entry (a) is present in `routes/edges.rs::VALID_RELATIONSHIPS`, and (b) maps to a
+  **non-Neutral** `RestrictionKind` via the engine's `restriction_kind_with_profile`. This makes
+  it impossible to expose an inert relationship, and catches drift if either list changes.
+- **Validation unit tests:** accept each of the 7 epistemic types; reject `decomposes_to`,
+  an unknown string, and `supersedes`; reject self-loop.
+- **DB integration** (small DB per CLAUDE.md — `epigraph_db_repo_test` or `#[sqlx::test]`):
+  - `supports` edge raises the target's belief (vs. pre-state).
+  - `contradicts` edge lowers it.
+  - second identical call → `was_created=false`, belief unchanged (no double-application).
+  - `properties` round-trips onto the edge row.
+- Tests reviewed against the council-of-critics standard (no tautologies, no happy-path-only).
+
+## 9. Code anchors (for the implementation plan)
+
+- Template tool: `crates/epigraph-mcp/src/tools/link_hierarchical.rs` (+ `tools/mod.rs`,
+  `server.rs` registration, `types.rs` params, `scope_map.rs`).
+- Edge repo: `crates/epigraph-db/src/repos/edge.rs::create_if_not_exists` (returns
+  `(EdgeRow, bool)`).
+- Engine wiring: `crates/epigraph-engine/src/edge_factor.rs::auto_wire_edge_if_epistemic`
+  / `auto_wire_ds_for_edge`; restriction mapping in
+  `crates/epigraph-engine/src/sheaf.rs::restriction_kind_with_profile`.
+- HTTP reference path: `crates/epigraph-api/src/routes/edges.rs::create_edge`,
+  `trigger_edge_ds_recomputation`, `is_valid_relationship`, `VALID_RELATIONSHIPS`.
+- Canonical relationship constants: `crates/epigraph-core/src/edge.rs` (`relationships` module).
+
+## 10. Out of scope / future
+
+- Per-edge strength/weight override (`properties.weight` → restriction factor).
+- Epistemic edges between non-claim nodes.
+- Re-runnable wiring for an exists-but-unwired edge (v1 uses `recompute_beliefs`).
+- Exposing `supersedes` (stays with `supersede_claim`).


### PR DESCRIPTION
## Summary

Adds a new MCP tool, `link_epistemic`, that lets agents write epistemic edges (`supports` / `contradicts` / etc.) which auto-wire Dempster-Shafer belief, mirroring `routes/edges.rs::create_edge`. This closes the gap that `link_hierarchical` is intentionally inert (it writes a hierarchy edge but never touches belief), leaving agents with no MCP path to create a belief-wiring relationship.

Design spec in-repo: [`docs/superpowers/specs/2026-06-03-link-epistemic-mcp-design.md`](docs/superpowers/specs/2026-06-03-link-epistemic-mcp-design.md)

## What changed

- New MCP tool `link_epistemic` (`crates/epigraph-mcp/src/tools/link_epistemic.rs`) that validates inputs, creates the edge via the shared `EdgeRepository::create_if_not_exists`, and wires belief via the same engine entry the HTTP route uses (`auto_wire_edge_if_epistemic`).
- `scope_map` entry mapping `link_epistemic -> claims:write`.
- Read-only DB accessor `ClaimRepository::get_belief_columns` (`crates/epigraph-db`) to read back the target's actual belief/plausibility/pignistic_prob columns for the tool response.
- Unit + DB integration tests (`crates/epigraph-mcp/tests/link_epistemic_smoke.rs`).
- `supersedes` is **excluded** from this tool's relationship set; it stays with `supersede_claim`. The tool owns its own lowercase `EPISTEMIC_RELATIONSHIPS` const (the documented seven) and rejects `supersedes`.

## Verification

- `cargo fmt --check` PASS
- `cargo clippy --workspace --locked -- -D warnings` PASS
- `cargo build` PASS
- Unit tests (6/6) PASS
- DB integration tests (35/35) PASS, including: belief moves **up** on `supports`, **down** on `contradicts`, and re-applying the same edge is **idempotent** (`was_created=false` / `belief_wired=false`, no re-apply).
- DATABASE_URL used for the integration tests: `postgres://epigraph:epigraph@localhost:5432/epigraph_db_repo_test`

## Deferred (non-blocking)

- Belief wiring is CORRECT. do_link_epistemic calls the same engine entry the HTTP route uses (auto_wire_edge_if_epistemic) with source_id/target_id in the correct positions. auto_wire_ds_for_edge reads the SOURCE claim's interval, applies the RestrictionKind transmission factor, stores the BBA on the TARGET, and recomputes the TARGET's combined belief -> a supports edge strengthens the TARGET (not source). Wiring fires ONLY on was_created (line 154), and belief_wired is set true ONLY on EdgeFactorOutcome::Wired (line 180); idempotent re-hit returns was_created=false/belief_wired=false with no re-apply. Integration tests supports_raises_target_belief_and_is_idempotent and contradicts_lowers_target_belief confirm target moves up/down vs a captured pre-state, and a direction swap would read the target's NULL interval -> SourceFactorless -> belief_wired=false, failing the test. No finding to fix; recorded as confirmation.
- DELIBERATE, CORRECT deviation from the blueprint. The blueprint said to read back target belief via belief_query::get_belief(pool, target, None). That unframed (frame_id=None) path returns BeliefInterval::cached_from_truth(claim.truth_value) (belief_query.rs line 165) — it reads truth_value, which the edge recompute leaves untouched, so it would report a stale 0.5 and never reflect the wire. The implementer instead added ClaimRepository::get_belief_columns reading the actual belief/plausibility/pignistic_prob columns the recompute writes (MassFunctionRepository::update_claim_belief). The smoke test's assertion (resp_betp - column_betp).abs() < 1e-9 plus betp>0.5 / betp<0.5 directly discriminates this; the blueprint approach would have failed it. This is a correctness improvement, not a defect — flagged so the PR reviewer sees the intentional choice.
- Coverage guard is correct and would catch an inert relationship. every_epistemic_relationship_maps_to_non_neutral asserts restriction_kind_with_profile(rel, scientific()) != Neutral for all 7 entries, and epistemic_relationship_polarities_match_spec pins the 5-positive/2-negative split (catches an engine sign flip the bare non-Neutral guard would miss). It correctly does NOT assert VALID_RELATIONSHIPS membership (that HTTP whitelist is UPPER-CASE + case-sensitive via .contains, while the tool owns its own lowercase EPISTEMIC_RELATIONSHIPS const and never calls is_valid_relationship). supersedes is rejected (excluded from the const + tested in supersedes_is_rejected and epistemic_set_is_the_documented_seven). All validation guards (bad-UUID via parse_uuid, self-loop, missing-claim both sides, invalid-relationship) present and tested.
- No regression of the working HTTP route and no wiring/SQL duplication. create_edge is untouched; SQL lives in EdgeRepository::create_if_not_exists and wiring in epigraph_engine::edge_factor (both shared). The only duplicated logic is a ~6-line 'SELECT agent_id FROM claims' runtime query (sqlx::query_scalar, not the ! macro -> zero .sqlx offline-data churn) which the HTTP route also has inline in trigger_edge_ds_recomputation. The spec's optional shared create_and_wire_epistemic_edge helper was deliberately not extracted (blueprint overrode in favor of direct calls, mirroring link_hierarchical). Also verified: emitting edge.added even when the source agent_id is NULL is NOT a divergence — the HTTP route emits edge.added in a separate side-effect block (edges.rs line 637) independent of the recompute outcome. scope_map entry (link_epistemic -> claims:write) added and every_registered_tool_has_a_scope / scope_map_has_no_stale_entries pass; reject_if_read_only() gate matches link_hierarchical.
- The durable-edge resilience contract (spec §7: was_created=true WITH belief_wired=false when the source has no belief interval → EdgeFactorOutcome::SourceFactorless) is untested. Every belief-wiring test seeds the source via seed_claim_with_belief (always Wired); the only belief_wired=false case in the suite is the idempotent re-hit, where was_created is ALSO false. The was_created=true + belief_wired=false branch is a COMMON production case (most claims have NULL DS columns), and it is the key guarantee that a transient/no-op wire never loses the durable edge row — yet nothing pins it. The code is correct on read (the if-was_created block still inserts the edge and emits edge.added before wiring is attempted; belief_wired is set false on any non-Wired outcome), it is just not locked in by a test.
- Atomicity (Epistemic Commit Protocol): the feat(mcp) impl commit 465f274 bundles the new read-only repo accessor ClaimRepository::get_belief_columns (crates/epigraph-db) with the MCP tool. Defensible as one feature (the accessor exists solely to serve the tool's target_belief readback, and CLAUDE.md forbids raw SQL in the MCP layer), but a strict reading of one-commit-one-decision would split the db accessor into its own commit. Does not affect the verdict; commit message is otherwise exemplary (full Evidence/Reasoning/Verification schema, accurate 6/6 + 35/35 test claims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
