### PR TITLE
feat(scripts): server-side git-ingest reconciler (Plan 3)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,3 +87,49 @@ python3 scripts/backfill_source_strength.py --execute
 After --execute, run `reconcile_sheaf` (or wait for the next nightly
 graph-integrity task) so beliefs re-aggregate against the new
 discount weights. Idempotent — re-runs only touch rows still NULL.
+
+## git_ingest_reconciler.py
+
+Server-side git-ingest reconciler (Plan 3). Discovers newly-merged PRs
+across configured repos (read-only GitHub access via the `gh` CLI) and
+runs `ingest_git --pr-ingest` against the localhost EpiGraph API for
+each — continuous, cross-repo, idempotent commit ingestion with no
+external CI and no write-token spray. Stdlib-only; idempotent (Plan
+2.5) and stateless, so it is safe to run repeatedly on a cron.
+
+**Auth:** set `EPIGRAPH_GIT_INGEST_GITHUB_PAT` to a *read-only* PAT
+(injected as `GH_TOKEN` for the `gh` subprocesses), or leave it unset to
+fall back to the host's own `gh auth` token. Writes go to the localhost
+API, not GitHub — **no GitHub write scope is ever used**.
+
+**Install:**
+
+```bash
+# 1. Copy the template into the state dir and edit it (repos, endpoint, bin path):
+sudo mkdir -p /var/lib/epiclaw/git-ingest
+sudo cp scripts/git_ingest_reconciler.config.example.toml \
+        /var/lib/epiclaw/git-ingest/config.toml
+sudo $EDITOR /var/lib/epiclaw/git-ingest/config.toml
+
+# 2. Build the ingester this config points at (or use the deployed release path):
+cargo build --bin ingest_git   # → .cargo-target/debug/ingest_git
+
+# 3. Dry-run first (no API writes; proves discovery + range + argv end to end):
+EPIGRAPH_GIT_INGEST_GITHUB_PAT=ghp_readonly... \
+  python3 scripts/git_ingest_reconciler.py \
+    --config /var/lib/epiclaw/git-ingest/config.toml --dry-run
+```
+
+**Cron** (every 15 min; a `fcntl` lock in `state_dir/.lock` prevents
+overlapping runs):
+
+```
+*/15 * * * *  EPIGRAPH_GIT_INGEST_GITHUB_PAT=... /usr/bin/python3 /home/jeremy/epigraph/scripts/git_ingest_reconciler.py --config /var/lib/epiclaw/git-ingest/config.toml >> /var/log/git-ingest.log 2>&1
+```
+
+**Hard rule — do NOT enable the cron until Plan 2.5 is in prod**
+(`dev → main` merge + redeploy of the `ingest_git --pr-ingest`
+find-or-create / idempotency path). Until then, run the reconciler
+**only with `--dry-run`**. Enabling the live cron against a server that
+predates Plan 2.5 risks duplicate or malformed claim writes.
+

--- a/scripts/git_ingest_reconciler.config.example.toml
+++ b/scripts/git_ingest_reconciler.config.example.toml
@@ -1,0 +1,7 @@
+# scripts/git_ingest_reconciler.config.example.toml — copy to the state dir as config.toml
+repos = ["epigraph-io/epigraph"]   # pilot: epigraph only; add slugs to expand
+endpoint = "http://127.0.0.1:8080"
+window_minutes = 240               # generous overlap; idempotency (Plan 2.5) tolerates re-scan
+state_dir = "/var/lib/epiclaw/git-ingest"
+ingest_git_bin = "/home/jeremy/.cargo-target/debug/ingest_git"  # or the deployed release path
+# default_orchestrator_id = "<uuid of a registered agent>"  # used when a PR lacks the trailer

--- a/scripts/git_ingest_reconciler.py
+++ b/scripts/git_ingest_reconciler.py
@@ -135,3 +135,37 @@ def ensure_mirror(clone_url: str, state_dir: str, env: dict, slug_key: str | Non
         subprocess.run(["git", "clone", "--quiet", clone_url, str(d)],
                        check=True, capture_output=True, env=env)
     return str(d)
+
+def build_ingest_argv(pr, mirror, endpoint, rev_range, slug, *,
+                      default_orchestrator_id=None, ingest_git_bin="ingest_git", dry_run=False):
+    """Assemble the `ingest_git --pr-ingest` argv for one merged PR. `slug` is
+    the repo slug (`owner/repo`), `mirror` the local clone the binary reads, and
+    `rev_range` the PR's own commit range (from `compute_rev_range`). The
+    `--orchestrator-id` flag is only emitted when configured; otherwise the
+    ingester resolves the trailer / `EPIGRAPH_DEFAULT_ORCHESTRATOR_ID` itself."""
+    argv = [ingest_git_bin, "--pr-ingest",
+            "--repo-slug", slug, "--pr-number", str(pr.number),
+            "--pr-title", pr.title, "--pr-body", pr.body,
+            "--merge-sha", pr.merge_sha, "--merged-at", pr.merged_at,
+            "--pr-author", pr.author, "--rev-range", rev_range,
+            "--repo", mirror, "--endpoint", endpoint]
+    if default_orchestrator_id:
+        argv += ["--orchestrator-id", default_orchestrator_id]
+    if dry_run:
+        argv += ["--dry-run"]
+    return argv
+
+def ingest_pr(pr, mirror, endpoint, slug, *, default_orchestrator_id=None,
+              ingest_git_bin="ingest_git", dry_run=False) -> int:
+    """Compute the PR's commit range from the mirror, build the argv, and run
+    `ingest_git`. Returns the subprocess return code; logs (not raises) on a
+    non-zero exit so the caller can isolate per-PR failures."""
+    rng = compute_rev_range(mirror, pr.merge_sha)
+    argv = build_ingest_argv(pr, mirror, endpoint, rng, slug,
+                             default_orchestrator_id=default_orchestrator_id,
+                             ingest_git_bin=ingest_git_bin, dry_run=dry_run)
+    LOG.info("ingest PR #%s (%s): %s", pr.number, slug, " ".join(argv))
+    res = subprocess.run(argv, capture_output=True, text=True)
+    if res.returncode != 0:
+        LOG.error("ingest PR #%s failed (%s): %s", pr.number, res.returncode, res.stderr.strip()[:500])
+    return res.returncode

--- a/scripts/git_ingest_reconciler.py
+++ b/scripts/git_ingest_reconciler.py
@@ -69,3 +69,49 @@ def compute_rev_range(mirror: str, merge_sha: str) -> str:
     if n_parents >= 2:
         return f"{merge_sha}^1..{merge_sha}^2"
     return f"{merge_sha}~1..{merge_sha}"
+
+@dataclass
+class PullRequest:
+    number: int; title: str; body: str; merge_sha: str
+    base_sha: str; author: str; merged_at: str
+
+def _gh_json(args: list[str], env: dict) -> list | dict:
+    """Run `gh api ...` and parse JSON stdout.
+
+    With `--paginate` alone, `gh` emits one separate JSON array/object PER page
+    (concatenated, e.g. `[...]\n[...]`), which a single `json.loads` cannot
+    parse (raises `Extra data`). `--slurp` (gh >= 2.83) wraps all pages in one
+    outer JSON array, so the whole stdout is a single valid document. When
+    `--slurp` is in args we therefore flatten the outer page array back into
+    the flat list of rows the callers expect; otherwise we return the parsed
+    document as-is."""
+    res = subprocess.run(["gh", "api", *args], check=True, capture_output=True, text=True, env=env)
+    data = json.loads(res.stdout)
+    if "--slurp" in args:
+        return [row for page in data for row in (page if isinstance(page, list) else [page])]
+    return data
+
+def discover_merged_prs(slug: str, env: dict, window_minutes: int, now: datetime.datetime) -> list[PullRequest]:
+    cutoff = now - datetime.timedelta(minutes=window_minutes)
+    rows = _gh_json(
+        [f"repos/{slug}/pulls", "-X", "GET",
+         "--field", "state=closed", "--field", "sort=updated",
+         "--field", "direction=desc", "--field", "per_page=50",
+         "--paginate", "--slurp"],
+        env,
+    )
+    out = []
+    for r in rows:
+        ma = r.get("merged_at")
+        if not ma or not r.get("merge_commit_sha"):
+            continue
+        when = datetime.datetime.fromisoformat(ma.replace("Z", "+00:00"))
+        if when < cutoff:
+            continue
+        out.append(PullRequest(
+            number=int(r["number"]), title=r.get("title") or "",
+            body=r.get("body") or "", merge_sha=r["merge_commit_sha"],
+            base_sha=(r.get("base") or {}).get("sha") or "",
+            author=(r.get("user") or {}).get("login") or "", merged_at=ma,
+        ))
+    return out

--- a/scripts/git_ingest_reconciler.py
+++ b/scripts/git_ingest_reconciler.py
@@ -169,3 +169,49 @@ def ingest_pr(pr, mirror, endpoint, slug, *, default_orchestrator_id=None,
     if res.returncode != 0:
         LOG.error("ingest PR #%s failed (%s): %s", pr.number, res.returncode, res.stderr.strip()[:500])
     return res.returncode
+
+def run_once(cfg: Config, *, dry_run: bool, now: datetime.datetime | None = None) -> tuple[int, int]:
+    """Reconcile every configured repo once. Repo-level failures (mirror/discovery)
+    and per-PR failures are both logged and isolated — one bad repo or PR never
+    aborts the rest — and counted into the failure tally. Returns (ok, fail)."""
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    env = gh_env()
+    ok = fail = 0
+    for slug in cfg.repos:
+        try:
+            mirror = ensure_mirror(f"https://github.com/{slug}.git", cfg.state_dir, env, slug_key=slug)
+            prs = discover_merged_prs(slug, env, cfg.window_minutes, now)
+        except Exception as e:  # repo-level failure: log + continue
+            LOG.error("repo %s discovery failed: %s", slug, e); fail += 1; continue
+        for pr in prs:
+            try:
+                rc = ingest_pr(pr, mirror, cfg.endpoint, slug,
+                               default_orchestrator_id=cfg.default_orchestrator_id,
+                               ingest_git_bin=cfg.ingest_git_bin, dry_run=dry_run)
+                ok += (rc == 0); fail += (rc != 0)
+            except Exception as e:
+                LOG.error("PR #%s (%s) ingest raised: %s", pr.number, slug, e); fail += 1
+    return ok, fail
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Server-side git-ingest reconciler (Plan 3)")
+    ap.add_argument("--config", default=os.environ.get("GIT_INGEST_CONFIG",
+                    str(Path(DEFAULT_STATE_DIR) / "config.toml")))
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+    cfg = load_config(args.config)
+    lock_path = Path(cfg.state_dir) / ".lock"; lock_path.parent.mkdir(parents=True, exist_ok=True)
+    import fcntl
+    with open(lock_path, "w") as lf:
+        try:
+            fcntl.flock(lf, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            LOG.warning("another run holds the lock; exiting"); return 0
+        ok, fail = run_once(cfg, dry_run=args.dry_run)
+        LOG.info("done: %s ingested, %s failed", ok, fail)
+        return 1 if fail else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/git_ingest_reconciler.py
+++ b/scripts/git_ingest_reconciler.py
@@ -115,3 +115,23 @@ def discover_merged_prs(slug: str, env: dict, window_minutes: int, now: datetime
             author=(r.get("user") or {}).get("login") or "", merged_at=ma,
         ))
     return out
+
+def _mirror_dir(state_dir: str, slug_key: str) -> Path:
+    return Path(state_dir) / slug_key.replace("/", "__")
+
+def ensure_mirror(clone_url: str, state_dir: str, env: dict, slug_key: str | None = None) -> str:
+    """Maintain a per-repo local clone under `state_dir`. First call clones;
+    subsequent calls fetch+prune. `slug_key` (the repo slug) names the dir
+    (sanitised); defaults to `clone_url` so callers that pass a path can use it
+    directly. Production `clone_url` = `https://github.com/<slug>.git`; `gh`'s
+    credential helper or a PAT in `GH_TOKEN` (via `gh_env`) covers private
+    fetch. For the public-`epigraph` pilot no creds are needed."""
+    Path(state_dir).mkdir(parents=True, exist_ok=True)
+    d = _mirror_dir(state_dir, slug_key or clone_url)
+    if (d / "HEAD").exists() or (d / ".git").exists():
+        subprocess.run(["git", "-C", str(d), "fetch", "--prune", "origin"],
+                       check=True, capture_output=True, env=env)
+    else:
+        subprocess.run(["git", "clone", "--quiet", clone_url, str(d)],
+                       check=True, capture_output=True, env=env)
+    return str(d)

--- a/scripts/git_ingest_reconciler.py
+++ b/scripts/git_ingest_reconciler.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Server-side git-ingest reconciler (Plan 3).
+
+Discovers newly-merged PRs across configured repos (read-only GitHub access via
+the `gh` CLI) and runs `ingest_git --pr-ingest` against the localhost EpiGraph
+API for each. Idempotent (Plan 2.5), stateless, safe to run repeatedly on a cron.
+
+Auth: EPIGRAPH_GIT_INGEST_GITHUB_PAT (read-only) injected as GH_TOKEN, else the
+host's existing `gh auth` token. Writes go to the localhost API, not GitHub —
+no GitHub write scope is ever used.
+"""
+import argparse, datetime, json, logging, os, subprocess, sys, tempfile
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+LOG = logging.getLogger("git_ingest_reconciler")
+DEFAULT_ENDPOINT = "http://127.0.0.1:8080"
+DEFAULT_WINDOW_MINUTES = 60
+DEFAULT_STATE_DIR = "/var/lib/epiclaw/git-ingest"
+
+def gh_env(environ: dict | None = None) -> dict:
+    """Build the env for `gh` subprocesses. If a read-only PAT is configured,
+    inject it as GH_TOKEN; otherwise return a copy without GH_TOKEN so `gh`
+    uses its own stored auth (the CLI-bearer fallback)."""
+    environ = dict(os.environ if environ is None else environ)
+    pat = environ.get("EPIGRAPH_GIT_INGEST_GITHUB_PAT")
+    env = dict(environ)
+    env.pop("GH_TOKEN", None)
+    env.pop("GITHUB_TOKEN", None)
+    if pat:
+        env["GH_TOKEN"] = pat
+    return env
+
+@dataclass
+class Config:
+    repos: list[str] = field(default_factory=list)
+    endpoint: str = DEFAULT_ENDPOINT
+    window_minutes: int = DEFAULT_WINDOW_MINUTES
+    state_dir: str = DEFAULT_STATE_DIR
+    default_orchestrator_id: str | None = None
+    ingest_git_bin: str = "ingest_git"
+
+def load_config_str(text: str) -> Config:
+    data = tomllib.loads(text)
+    return Config(
+        repos=list(data.get("repos", [])),
+        endpoint=data.get("endpoint", DEFAULT_ENDPOINT),
+        window_minutes=int(data.get("window_minutes", DEFAULT_WINDOW_MINUTES)),
+        state_dir=data.get("state_dir", DEFAULT_STATE_DIR),
+        default_orchestrator_id=data.get("default_orchestrator_id"),
+        ingest_git_bin=data.get("ingest_git_bin", "ingest_git"),
+    )
+
+def load_config(path: str) -> Config:
+    return load_config_str(Path(path).read_text())

--- a/scripts/git_ingest_reconciler.py
+++ b/scripts/git_ingest_reconciler.py
@@ -54,3 +54,18 @@ def load_config_str(text: str) -> Config:
 
 def load_config(path: str) -> Config:
     return load_config_str(Path(path).read_text())
+
+def compute_rev_range(mirror: str, merge_sha: str) -> str:
+    """The PR's own commits. For a --merge commit (2 parents): base..head =
+    `M^1..M^2`. For a squash (1 parent): the single commit `M~1..M`. Rebase
+    merges (the PR's commits as a linear run with one parent each) are not
+    distinguishable from a single squash here; logged by the caller and handled
+    as the squash case for the tip commit."""
+    out = subprocess.run(
+        ["git", "-C", mirror, "rev-list", "--parents", "-n", "1", merge_sha],
+        check=True, capture_output=True, text=True,
+    ).stdout.split()
+    n_parents = len(out) - 1  # first token is the commit itself
+    if n_parents >= 2:
+        return f"{merge_sha}^1..{merge_sha}^2"
+    return f"{merge_sha}~1..{merge_sha}"

--- a/scripts/tests/test_git_ingest_reconciler.py
+++ b/scripts/tests/test_git_ingest_reconciler.py
@@ -156,5 +156,47 @@ class MainLoopTests(unittest.TestCase):
         self.assertEqual(calls, [1,2])          # both attempted (failure isolated)
         self.assertEqual((n_ok,n_fail),(1,1))
 
+def _resolve_ingest_git():
+    """Locate the built `ingest_git` binary across the tree's possible target
+    dirs. The global ~/.cargo/config.toml sets build.target-dir to
+    /home/jeremy/.cargo-target, so the binary is OUTSIDE both REPO/.cargo-target
+    and an unset $CARGO_TARGET_DIR. `cargo metadata`'s target_directory honors
+    both the global config and $CARGO_TARGET_DIR, so it is the one authoritative
+    source; the remaining candidates are belt-and-suspenders for CI variants."""
+    cands = []
+    try:
+        md = subprocess.run(
+            ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+            cwd=str(REPO), capture_output=True, text=True, check=True,
+        )
+        cands.append(Path(json.loads(md.stdout)["target_directory"]) / "debug" / "ingest_git")
+    except Exception:
+        pass
+    if os.environ.get("CARGO_TARGET_DIR"):
+        cands.append(Path(os.environ["CARGO_TARGET_DIR"]) / "debug" / "ingest_git")
+    cands.append(REPO / ".cargo-target" / "debug" / "ingest_git")
+    cands.append(REPO / "target" / "debug" / "ingest_git")
+    return next((c for c in cands if c.exists()), None)
+
+class IntegrationTest(unittest.TestCase):
+    def test_dry_run_against_real_repo_and_binary(self):
+        binp = _resolve_ingest_git()
+        if binp is None:
+            self.skipTest("ingest_git binary not built (run cargo build --bin ingest_git)")
+        with tempfile.TemporaryDirectory() as d:
+            g = lambda *a: subprocess.run(["git","-C",d,*a],check=True,capture_output=True)
+            subprocess.run(["git","init","-qb","main",d],check=True,capture_output=True)
+            g("config","user.email","t@t"); g("config","user.name","t")
+            Path(d,"a").write_text("1"); g("add","."); g("commit","-qm","base")
+            g("checkout","-qb","feat")
+            Path(d,"b").write_text("2"); g("add","."); g("commit","-qm","feat(x): add b\n\nEvidence:\n- e")
+            g("checkout","-q","main")
+            g("merge","--no-ff","-qm","Merge pull request #1 from feat","feat")
+            sha = subprocess.run(["git","-C",d,"rev-parse","HEAD"],capture_output=True,text=True).stdout.strip()
+            pr = gir.PullRequest(1,"feat(x): add b","Evidence: x",sha,"","t","2026-06-03T12:00:00Z")
+            rc = gir.ingest_pr(pr, d, "http://127.0.0.1:8080", "test/repo",
+                               ingest_git_bin=str(binp), dry_run=True)
+            self.assertEqual(rc, 0, "ingest_git --pr-ingest --dry-run should parse the real repo and exit 0")
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_git_ingest_reconciler.py
+++ b/scripts/tests/test_git_ingest_reconciler.py
@@ -119,5 +119,28 @@ class MirrorTests(unittest.TestCase):
             mirror2 = gir.ensure_mirror(remote, state, {})        # second call fetches
             self.assertEqual(mirror, mirror2)
 
+class ArgvTests(unittest.TestCase):
+    def test_build_ingest_argv(self):
+        pr = gir.PullRequest(number=252, title="fix(api): x", body="Resolves d531c585",
+                             merge_sha="2a31f8d", base_sha="b72e271", author="tylorsama",
+                             merged_at="2026-06-02T15:10:01Z")
+        argv = gir.build_ingest_argv(pr, mirror="/m", endpoint="http://127.0.0.1:8080",
+                                     rev_range="2a31f8d^1..2a31f8d^2", slug="epigraph-io/epigraph",
+                                     default_orchestrator_id="7b3a0c1e-0000-4000-8000-000000000001",
+                                     ingest_git_bin="ingest_git", dry_run=True)
+        self.assertEqual(argv[0], "ingest_git")
+        self.assertIn("--pr-ingest", argv)
+        # spot-check key flag/value pairs:
+        def val(flag): return argv[argv.index(flag)+1]
+        self.assertEqual(val("--repo-slug"), "epigraph-io/epigraph")
+        self.assertEqual(val("--pr-number"), "252")
+        self.assertEqual(val("--merge-sha"), "2a31f8d")
+        self.assertEqual(val("--rev-range"), "2a31f8d^1..2a31f8d^2")
+        self.assertEqual(val("--merged-at"), "2026-06-02T15:10:01Z")
+        self.assertEqual(val("--orchestrator-id"), "7b3a0c1e-0000-4000-8000-000000000001")
+        self.assertEqual(val("--repo"), "/m")
+        self.assertEqual(val("--endpoint"), "http://127.0.0.1:8080")
+        self.assertIn("--dry-run", argv)
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_git_ingest_reconciler.py
+++ b/scripts/tests/test_git_ingest_reconciler.py
@@ -142,5 +142,19 @@ class ArgvTests(unittest.TestCase):
         self.assertEqual(val("--endpoint"), "http://127.0.0.1:8080")
         self.assertIn("--dry-run", argv)
 
+class MainLoopTests(unittest.TestCase):
+    def test_runs_all_prs_and_isolates_failures(self):
+        cfg = gir.Config(repos=["o/r"], endpoint="http://x", state_dir="/tmp/st",
+                         default_orchestrator_id=None)
+        prs = [gir.PullRequest(1,"a","",f"s1","b","u","2026-06-03T11:59:00Z"),
+               gir.PullRequest(2,"b","",f"s2","b","u","2026-06-03T11:59:00Z")]
+        calls = []
+        with mock.patch.object(gir,"ensure_mirror",return_value="/m"), \
+             mock.patch.object(gir,"discover_merged_prs",return_value=prs), \
+             mock.patch.object(gir,"ingest_pr",side_effect=lambda pr,*a,**k:(calls.append(pr.number) or (1 if pr.number==1 else 0))):
+            n_ok, n_fail = gir.run_once(cfg, dry_run=False)
+        self.assertEqual(calls, [1,2])          # both attempted (failure isolated)
+        self.assertEqual((n_ok,n_fail),(1,1))
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_git_ingest_reconciler.py
+++ b/scripts/tests/test_git_ingest_reconciler.py
@@ -1,4 +1,5 @@
-import os, subprocess, sys, tempfile, unittest
+import datetime, json, os, subprocess, sys, tempfile, unittest
+from unittest import mock
 from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "scripts"))
@@ -39,6 +40,70 @@ class RangeTests(unittest.TestCase):
             Path(d,"a").write_text("2"); self._git(d,"add","."); self._git(d,"commit","-qm","squash")
             sha = subprocess.run(["git","-C",d,"rev-parse","HEAD"],capture_output=True,text=True).stdout.strip()
             self.assertEqual(gir.compute_rev_range(d, sha), f"{sha}~1..{sha}")
+
+class DiscoverTests(unittest.TestCase):
+    def test_filters_to_merged_within_window(self):
+        now = datetime.datetime(2026, 6, 3, 12, 0, tzinfo=datetime.timezone.utc)
+        rows = [
+            {"number":1,"title":"feat: x","body":"b","merge_commit_sha":"aaa","base":{"sha":"bbb"},
+             "user":{"login":"u"},"merged_at":"2026-06-03T11:30:00Z"},      # in window
+            {"number":2,"title":"old","body":"","merge_commit_sha":"ccc","base":{"sha":"ddd"},
+             "user":{"login":"u"},"merged_at":"2026-06-01T00:00:00Z"},        # too old
+            {"number":3,"title":"open","body":"","merge_commit_sha":None,"base":{"sha":"e"},
+             "user":{"login":"u"},"merged_at":None},                          # not merged
+        ]
+        with mock.patch.object(gir, "_gh_json", return_value=rows):
+            prs = gir.discover_merged_prs("epigraph-io/epigraph", {}, window_minutes=60, now=now)
+        self.assertEqual([p.number for p in prs], [1])
+        self.assertEqual(prs[0].merge_sha, "aaa")
+        self.assertEqual(prs[0].base_sha, "bbb")
+        self.assertEqual(prs[0].author, "u")
+
+    def test_paginated_slurp_pages_parse_through_real_gh_json(self):
+        # Regression for the --paginate + json.loads defect: gh --paginate WITHOUT
+        # --slurp emits one JSON array per page, concatenated ("[...]\n[...]"), which
+        # a single json.loads cannot parse. --slurp wraps all pages in ONE outer
+        # array. This test mocks subprocess.run (NOT _gh_json), so the real parse
+        # path runs against the two-page slurp shape; the older DiscoverTests mocked
+        # _gh_json and never exercised it.
+        now = datetime.datetime(2026, 6, 3, 12, 0, tzinfo=datetime.timezone.utc)
+        page1 = [
+            {"number": 1, "title": "feat: x", "body": "b", "merge_commit_sha": "aaa",
+             "base": {"sha": "bbb"}, "user": {"login": "u"},
+             "merged_at": "2026-06-03T11:30:00Z"},               # in window
+            {"number": 2, "title": "old", "body": "", "merge_commit_sha": "ccc",
+             "base": {"sha": "ddd"}, "user": {"login": "u"},
+             "merged_at": "2026-06-01T00:00:00Z"},                # too old
+        ]
+        page2 = [
+            {"number": 4, "title": "feat: y", "body": "", "merge_commit_sha": "eee",
+             "base": {"sha": "fff"}, "user": {"login": "v"},
+             "merged_at": "2026-06-03T11:45:00Z"},               # in window (page 2)
+            {"number": 3, "title": "open", "body": "", "merge_commit_sha": None,
+             "base": {"sha": "e"}, "user": {"login": "u"}, "merged_at": None},  # not merged
+        ]
+        # --slurp output is one outer array of pages, each page a JSON array.
+        slurp_stdout = json.dumps([page1, page2])
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=slurp_stdout, stderr="")
+        with mock.patch.object(gir.subprocess, "run", return_value=completed) as run:
+            prs = gir.discover_merged_prs("epigraph-io/epigraph", {}, window_minutes=60, now=now)
+        # Both pages' in-window merged PRs survive (1 from page1, 4 from page2); the
+        # too-old #2 and unmerged #3 are dropped. Proves cross-page flattening works.
+        self.assertEqual(sorted(p.number for p in prs), [1, 4])
+        # The call MUST request --slurp (alongside --paginate); without it the real
+        # gh would emit concatenated arrays and json.loads would raise. This pins
+        # the fix so a future drop of --slurp fails the suite.
+        called_args = run.call_args.args[0]
+        self.assertIn("--paginate", called_args)
+        self.assertIn("--slurp", called_args)
+
+    def test_concatenated_pages_without_slurp_would_crash(self):
+        # Documents WHY --slurp is required: the pre-fix shape (concatenated
+        # per-page arrays, no outer wrapper) is what plain --paginate emits, and a
+        # single json.loads raises JSONDecodeError ("Extra data") on it.
+        concatenated = '[{"number": 1}]\n[{"number": 2}]\n'
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(concatenated)
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_git_ingest_reconciler.py
+++ b/scripts/tests/test_git_ingest_reconciler.py
@@ -1,4 +1,4 @@
-import os, sys, unittest
+import os, subprocess, sys, tempfile, unittest
 from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "scripts"))
@@ -18,6 +18,27 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(cfg.repos, ["epigraph-io/epigraph"])
         self.assertEqual(cfg.endpoint, "http://127.0.0.1:8080")  # default
         self.assertGreater(cfg.window_minutes, 0)
+
+class RangeTests(unittest.TestCase):
+    def _git(self, d, *a): subprocess.run(["git","-C",d,*a], check=True, capture_output=True)
+    def test_merge_commit_two_parents(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._git(d,"init","-qb","main"); self._git(d,"config","user.email","t@t"); self._git(d,"config","user.name","t")
+            Path(d,"a").write_text("1"); self._git(d,"add","."); self._git(d,"commit","-qm","base")
+            self._git(d,"checkout","-qb","feat")
+            Path(d,"b").write_text("2"); self._git(d,"add","."); self._git(d,"commit","-qm","feat(x): add b")
+            self._git(d,"checkout","-q","main")
+            self._git(d,"merge","--no-ff","-qm","Merge pull request #1","feat")
+            sha = subprocess.run(["git","-C",d,"rev-parse","HEAD"],capture_output=True,text=True).stdout.strip()
+            rng = gir.compute_rev_range(d, sha)
+            self.assertEqual(rng, f"{sha}^1..{sha}^2")
+    def test_single_parent_squash(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._git(d,"init","-qb","main"); self._git(d,"config","user.email","t@t"); self._git(d,"config","user.name","t")
+            Path(d,"a").write_text("1"); self._git(d,"add","."); self._git(d,"commit","-qm","base")
+            Path(d,"a").write_text("2"); self._git(d,"add","."); self._git(d,"commit","-qm","squash")
+            sha = subprocess.run(["git","-C",d,"rev-parse","HEAD"],capture_output=True,text=True).stdout.strip()
+            self.assertEqual(gir.compute_rev_range(d, sha), f"{sha}~1..{sha}")
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_git_ingest_reconciler.py
+++ b/scripts/tests/test_git_ingest_reconciler.py
@@ -1,0 +1,23 @@
+import os, sys, unittest
+from pathlib import Path
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+import git_ingest_reconciler as gir  # noqa: E402
+
+class AuthTests(unittest.TestCase):
+    def test_pat_env_injected_as_gh_token(self):
+        env = gir.gh_env({"EPIGRAPH_GIT_INGEST_GITHUB_PAT": "ghp_abc"})
+        self.assertEqual(env.get("GH_TOKEN"), "ghp_abc")
+    def test_no_pat_falls_back_to_gh_auth(self):
+        env = gir.gh_env({})  # no PAT
+        self.assertNotIn("GH_TOKEN", env)  # gh uses its own stored auth
+
+class ConfigTests(unittest.TestCase):
+    def test_defaults_and_repos(self):
+        cfg = gir.load_config_str('repos = ["epigraph-io/epigraph"]\n')
+        self.assertEqual(cfg.repos, ["epigraph-io/epigraph"])
+        self.assertEqual(cfg.endpoint, "http://127.0.0.1:8080")  # default
+        self.assertGreater(cfg.window_minutes, 0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_git_ingest_reconciler.py
+++ b/scripts/tests/test_git_ingest_reconciler.py
@@ -105,5 +105,19 @@ class DiscoverTests(unittest.TestCase):
         with self.assertRaises(json.JSONDecodeError):
             json.loads(concatenated)
 
+class MirrorTests(unittest.TestCase):
+    def test_clone_then_fetch(self):
+        with tempfile.TemporaryDirectory() as remote, tempfile.TemporaryDirectory() as state:
+            subprocess.run(["git","init","-qb","main",remote],check=True,capture_output=True)
+            for cmd in (["config","user.email","t@t"],["config","user.name","t"]):
+                subprocess.run(["git","-C",remote,*cmd],check=True,capture_output=True)
+            Path(remote,"a").write_text("1")
+            subprocess.run(["git","-C",remote,"add","."],check=True,capture_output=True)
+            subprocess.run(["git","-C",remote,"commit","-qm","c1"],check=True,capture_output=True)
+            mirror = gir.ensure_mirror(remote, state, {})         # first call clones
+            self.assertTrue(Path(mirror, ".git").exists() or Path(mirror, "HEAD").exists())
+            mirror2 = gir.ensure_mirror(remote, state, {})        # second call fetches
+            self.assertEqual(mirror, mirror2)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`scripts/git_ingest_reconciler.py` — a standalone, stdlib-only VPC cron driver that continuously ingests merged PRs across configured repos. Per cycle, for each repo it discovers PRs merged within an overlapping time window (read-only `gh`), `git fetch`es a local mirror, computes each PR's own commit range from its merge commit, and runs `ingest_git --pr-ingest` against the **localhost** EpiGraph API.

Final subsystem of the commit-ingestion program. **Supersedes design-doc §5's per-repo GitHub Actions approach** — external `ubuntu-latest` runners + the VPC-firewalled API would have required spraying a write-capable prod token across every repo's CI and distributing the binary. The reconciler needs **no external CI, no write-token spray, no binary distribution, and never executes PR code** (reads git metadata only). Spec/plan: `docs/superpowers/specs/2026-06-03-plan-3-git-ingest-reconciler-design.md`, `docs/superpowers/plans/2026-06-03-plan-3-git-ingest-reconciler-impl.md`. Targets `dev` (where Plan 2.5 lives).

### Design
- **Auth chain:** `EPIGRAPH_GIT_INGEST_GITHUB_PAT` → injected as `GH_TOKEN`, else `gh`'s own stored auth. Read-only; localhost API needs no token.
- **Stateless** (no cursor) — Plan 2.5's durable idempotency makes the overlapping re-scan a no-op.
- **Range:** `M^1..M^2` for a `--merge` merge commit (the PR's own commits), `M~1..M` for a squash.
- **Resilience:** `flock` against overlapping runs; per-repo and per-PR failure isolation (log + continue); `--dry-run`.
- **Pilot:** `epigraph-io/epigraph` only; expand via the config list.

## Adversarial review caught a real bug
The review of the discovery task found a plan-inherited defect: `gh api --paginate` emits **one JSON array per page**, so a single `json.loads` would `JSONDecodeError` on the pilot repo's >50 closed PRs — discovery would silently ingest nothing. Unit tests (mocking `_gh_json`) and the integration test (bypassing `gh`) structurally couldn't catch it; only review could. Fixed with `--slurp` + page-flattening, plus two regression tests (`test_concatenated_pages_without_slurp_would_crash`, `test_paginated_slurp_pages_parse_through_real_gh_json`).

## Verification (local)
- `python3 -m py_compile` clean; `python3 -m unittest` **12/12** — auth chain, config, range (2-parent + squash), mirror clone/fetch, discovery (+ pagination regressions), argv build, main-loop failure isolation, and a **real-git + real-`ingest_git` `--dry-run` integration test** (ran, not skipped). No ruff/black (not installed).

## ⚠️ Rollout gate (do not enable live yet)
The live cron must **not** be enabled until **Plan 2.5 reaches `main`/prod** (`dev → main` + redeploy) — until then cross-run find-or-create still 500s. Until then, run only with `--dry-run`. The README documents this. Recommended sequence after merge: dry-run against `epigraph`'s real merged PRs → promote 2.5 to prod → enable the cron for `epigraph` → expand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)