### PR TITLE
feat(api,cli): set claim labels at creation (ingest_git needs no claims:admin)

### DIFF
--- a/crates/epigraph-api/src/routes/submit.rs
+++ b/crates/epigraph-api/src/routes/submit.rs
@@ -155,6 +155,14 @@ pub struct ClaimSubmission {
     /// Optional JSONB properties for extensible metadata (e.g., files_changed, commit_date)
     #[serde(default)]
     pub properties: Option<serde_json::Value>,
+
+    /// Optional labels to set on the claim at creation. Lets a multi-principal
+    /// writer (e.g. the git ingester, which creates claims under system/author/
+    /// orchestrator agents) label them atomically as the creator, instead of a
+    /// separate ownership-gated `PATCH /claims/{id}/labels` that would require
+    /// `claims:admin`. Applied only on the create path (mirrors `properties`).
+    #[serde(default)]
+    pub labels: Vec<String>,
 }
 
 /// Submission structure for evidence
@@ -1096,6 +1104,27 @@ async fn persist_packet(
                     ErrorResponse::new(
                         "DatabaseError",
                         format!("Failed to set claim properties: {}", e),
+                    ),
+                )
+            })?;
+    }
+
+    // Set labels at creation (parity with `claims.rs::create_claim`), so a
+    // multi-principal writer labels the claim it just created as the creator —
+    // no separate ownership-gated label PATCH (which would need `claims:admin`).
+    // Guarded on creation: a duplicate submit must not relabel another run's claim.
+    if was_created && !packet.claim.labels.is_empty() {
+        sqlx::query("UPDATE claims SET labels = $1 WHERE id = $2")
+            .bind(&packet.claim.labels)
+            .bind(claim_uuid)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ErrorResponse::new(
+                        "DatabaseError",
+                        format!("Failed to set claim labels: {}", e),
                     ),
                 )
             })?;
@@ -2246,6 +2275,7 @@ mod signature_verification_tests {
             agent_id,
             idempotency_key: None,
             properties: None,
+            labels: Vec::new(),
         }
     }
 

--- a/crates/epigraph-api/src/services/submission.rs
+++ b/crates/epigraph-api/src/services/submission.rs
@@ -255,6 +255,7 @@ mod tests {
                 agent_id: Uuid::new_v4(),
                 idempotency_key: None,
                 properties: None,
+                labels: Vec::new(),
             },
             evidence: vec![],
             reasoning_trace: ReasoningTraceSubmission {

--- a/crates/epigraph-api/tests/integration/idempotency_2p5_tests.rs
+++ b/crates/epigraph-api/tests/integration/idempotency_2p5_tests.rs
@@ -1109,3 +1109,57 @@ async fn submit_packet_claim_created_event_fires_once_not_on_dedup(pool: PgPool)
          (create_or_get's find branch never reaches create_strict)"
     );
 }
+
+/// Labels in the submit packet are applied AT CREATION (parity with
+/// `POST /claims`), so a multi-principal writer (e.g. the git ingester, which
+/// creates claims under system/author/orchestrator agents) labels them as the
+/// creator and needs no ownership-gated `PATCH /claims/{id}/labels` /
+/// `claims:admin`. Without this, the only way to label a not-owned claim was
+/// admin — the exact 403 the dev-DB e2e hit.
+#[sqlx::test(migrations = "../../migrations")]
+async fn submit_packet_sets_labels_at_creation(pool: PgPool) {
+    let agent = fixed_agent(57, "labels-at-creation-agent");
+    let created = AgentRepository::create(&pool, &agent)
+        .await
+        .expect("agent creation should succeed");
+    let agent_uuid: Uuid = created.id.into();
+
+    let mut packet = evidence_packet(agent_uuid, "Claim labelled at creation, not via PATCH");
+    packet["claim"]["labels"] = serde_json::json!([
+        "source:git-history",
+        "node:commit",
+        "repo:epigraph-io/epigraph"
+    ]);
+
+    let router = create_test_router(pool.clone());
+    let (status, body) = post_packet(&router, packet).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "submit with labels should be 201, got {status}: {body}"
+    );
+    let claim_id = Uuid::parse_str(
+        serde_json::from_str::<serde_json::Value>(&body).expect("json")["claim_id"]
+            .as_str()
+            .expect("claim_id present"),
+    )
+    .expect("claim_id parses");
+
+    // Read labels straight from the DB — proves they were set on the row, not
+    // just echoed in a response projection.
+    let labels: Vec<String> = sqlx::query_scalar("SELECT labels FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(&pool)
+        .await
+        .expect("labels query should succeed");
+    for expected in [
+        "source:git-history",
+        "node:commit",
+        "repo:epigraph-io/epigraph",
+    ] {
+        assert!(
+            labels.contains(&expected.to_string()),
+            "label '{expected}' must be set at creation; got {labels:?}"
+        );
+    }
+}

--- a/crates/epigraph-cli/src/bin/ingest_git.rs
+++ b/crates/epigraph-cli/src/bin/ingest_git.rs
@@ -981,6 +981,10 @@ struct ClaimSubmission {
     idempotency_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<serde_json::Value>,
+    /// Labels set on the claim AT CREATION by the server (creator-owned), so a
+    /// multi-principal writer needs no ownership-gated label PATCH / claims:admin.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1408,6 +1412,7 @@ fn build_packet(
         agent_id,
         idempotency_key: Some(format!("git:{}", commit.hash)),
         properties: Some(properties),
+        labels: Vec::new(), // set by submit_find_or_create at creation
     };
 
     // Use placeholder signature — the API server does not yet verify real Ed25519
@@ -1465,6 +1470,7 @@ fn build_repo_packet(repo_slug: &str, agent_id: Uuid, signer: &AgentSigner) -> E
             properties: Some(serde_json::json!({
                 "source": "git-history", "node": "repo", "repo": repo_slug
             })),
+            labels: Vec::new(), // set by submit_find_or_create at creation
         },
         evidence: vec![ev],
         reasoning_trace: ReasoningTraceSubmission {
@@ -1530,6 +1536,7 @@ fn build_pr_packet(meta: &PrMeta, orchestrator_id: Uuid) -> EpistemicPacket {
                 "url": url,
                 "author_login": meta.author_login, "orchestrator_agent_id": orchestrator_id,
             })),
+            labels: Vec::new(), // set by submit_find_or_create at creation
         },
         evidence: vec![ev],
         reasoning_trace: ReasoningTraceSubmission {
@@ -1543,52 +1550,28 @@ fn build_pr_packet(meta: &PrMeta, orchestrator_id: Uuid) -> EpistemicPacket {
     }
 }
 
-/// Add labels to an existing claim via `PATCH /api/v1/claims/{id}/labels`.
-///
-/// Route confirmed against `routes/claims.rs::update_labels`: the dedicated
-/// label endpoint takes `{ "add": [...], "remove": [...] }` (NOT the generic
-/// `patch_claim` body, which nests under `add_labels`). Idempotent server-side:
-/// re-adding an existing label is a no-op.
-#[allow(dead_code)]
-async fn apply_labels(
-    client: &reqwest::Client,
-    endpoint: &str,
-    id: Uuid,
-    labels: &[&str],
-) -> Result<(), String> {
-    let url = format!("{endpoint}/api/v1/claims/{id}/labels");
-    let resp = client
-        .patch(&url)
-        .json(&serde_json::json!({ "add": labels }))
-        .timeout(std::time::Duration::from_secs(15))
-        .send()
-        .await
-        .map_err(|e| format!("label PATCH: {e}"))?;
-    if resp.status().is_success() {
-        Ok(())
-    } else {
-        Err(format!(
-            "label PATCH {}: {}",
-            resp.status(),
-            resp.text().await.unwrap_or_default()
-        ))
-    }
-}
-
 /// Submit a packet and return its claim id. Because the packet carries a stable
 /// `idempotency_key`, a second call returns the same `claim_id` (`was_duplicate=true`),
 /// making this the find-or-create primitive for the hierarchy's nodes.
+///
+/// Labels are baked into the packet's claim so the SERVER sets them AT CREATION
+/// (as the creating principal), instead of a separate ownership-gated
+/// `PATCH /claims/{id}/labels` that would require `claims:admin` — the ingester
+/// creates claims under system/author/orchestrator agents it does not "own", so
+/// a post-hoc relabel would be rejected. Labels are applied only on the create
+/// path server-side; a duplicate submit leaves the existing claim's labels intact.
 #[allow(dead_code)]
 async fn submit_find_or_create(
     client: &reqwest::Client,
     endpoint: &str,
-    packet: &EpistemicPacket,
+    mut packet: EpistemicPacket,
     labels: &[&str],
 ) -> Result<Uuid, String> {
+    packet.claim.labels = labels.iter().map(|s| s.to_string()).collect();
     let url = format!("{endpoint}/api/v1/submit/packet");
     let resp = client
         .post(&url)
-        .json(packet)
+        .json(&packet)
         .timeout(std::time::Duration::from_secs(30))
         .send()
         .await
@@ -1604,9 +1587,6 @@ async fn submit_find_or_create(
         .json()
         .await
         .map_err(|e| format!("decode submit resp: {e}"))?;
-    if !labels.is_empty() {
-        apply_labels(client, endpoint, parsed.claim_id, labels).await?;
-    }
     Ok(parsed.claim_id)
 }
 
@@ -1625,7 +1605,7 @@ async fn ensure_repo_node(
     submit_find_or_create(
         client,
         endpoint,
-        &packet,
+        packet,
         &["source:git-history", "node:repo", &label],
     )
     .await
@@ -2198,7 +2178,7 @@ async fn run_pr_ingest(args: &Args) -> Result<(), String> {
     let pr_id = submit_find_or_create(
         &client,
         &args.endpoint,
-        &pr_packet,
+        pr_packet,
         &["source:git-history", "node:pr", &pr_label],
     )
     .await?;
@@ -2229,7 +2209,7 @@ async fn run_pr_ingest(args: &Args) -> Result<(), String> {
         let commit_id = submit_find_or_create(
             &client,
             &args.endpoint,
-            &packet,
+            packet,
             &["source:git-history", "node:commit", &commit_label],
         )
         .await?;


### PR DESCRIPTION
## Summary

Removes `ingest_git`'s need for `claims:admin`. The reconciler is a **multi-principal writer** — it creates the repo node under a fixed *system* agent, commits under *git-author* agents, the PR under the *orchestrator* — so its own principal owns none of them. It labeled them via a separate `PATCH /claims/{id}/labels`, which is `require_owner_or_admin` → **403 without `claims:admin`** (caught in the dev-DB e2e). `claims:admin` is a god-scope (claim delete, supersede, agent-key rotation, policies, global ownership bypass) — far too broad for an automated commit-ingestion job.

**Fix:** set labels **at creation**, by the creator — mirroring `POST /claims` (`create_claim` already UPDATEs labels inline on the create branch). Added `labels: Vec<String>` to `submit/packet`'s `ClaimSubmission` and set them in `persist_packet` on `was_created` only (next to the 2.5 `properties` write; runtime `sqlx::query` string → no `.sqlx` churn; a duplicate submit must not relabel another run's claim). `ingest_git` now bakes labels into each packet and **drops `apply_labels` entirely**.

**Result:** the reconciler runs on `claims:write` + `edges:write` + `agents:write` — no `claims:admin`, no new scope. (A narrow `claims:curate` "steward" tier remains a reasonable separate idea for genuine cross-principal curators like the backlog reconciler, but isn't needed here.)

## Verification
- `cargo clippy --workspace --locked -- -D warnings` clean (CI form); `cargo fmt --check` clean; production builds.
- Tests: `idempotency_2p5_tests` **13/13** (new `submit_packet_sets_labels_at_creation`), `submit_persistence_tests` **15/15**, `ingest_git` **115/115** — no regressions. (Pre-existing `--tests` clippy debt in `tests/common/mod.rs` + `claims_by_labels.rs` is unrelated and not CI-enforced.)
- **Live e2e** (fresh dev binary vs dev DB, **non-admin** token `claims:write`/`edges:write`/`agents:write`): ingested PR #257 → `exit 0`, **no 403**, PR node created with `source:git-history`/`node:pr`/`repo:epigraph-io/epigraph`; 12 commits; `resolved_links=1` (also exercised `RESOLVED_BY` linking).

Additive: `labels` is `#[serde(default)]`, so existing `submit/packet` callers (MCP, ingest_literature, …) are unaffected.

Targets `dev` (alongside Plan 2.5 / #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)