### PR TITLE
chore: back-merge main into dev (resync; pulls #264 perspective-lens reads)

### DIFF
--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -283,6 +283,17 @@ pub async fn get_claim(
 ) -> Result<CallToolResult, McpError> {
     let id = parse_uuid(&params.claim_id)?;
     let claim_id = ClaimId::from_uuid(id);
+
+    // Resolve the optional (frame, perspective) lens up front (both-or-neither,
+    // parse, existence) so a bad lens fails fast before any belief compute.
+    let lens = crate::tools::lens::resolve_lens(
+        params.frame_id.as_deref(),
+        params.perspective_id.as_deref(),
+    )?;
+    if let Some((frame_id, perspective_id)) = lens {
+        crate::tools::lens::validate_lens_exists(&server.pool, frame_id, perspective_id).await?;
+    }
+
     let claim = ClaimRepository::get_by_id(&server.pool, claim_id)
         .await
         .map_err(internal_error)?
@@ -297,11 +308,44 @@ pub async fn get_claim(
         .await
         .map_err(internal_error)?;
 
+    // Additive lensed belief: compute the claim's belief under the chosen lens.
+    // Frame/perspective existence is already validated, so a compute failure
+    // here is a genuine internal error (single-claim tool → propagate, no
+    // page-degrade semantics).
+    let lensed_belief = match lens {
+        Some((frame_id, perspective_id)) => {
+            let interval = epigraph_engine::belief_query::get_perspective_belief(
+                &server.pool,
+                id,
+                frame_id,
+                perspective_id,
+            )
+            .await
+            .map_err(|e| match e {
+                epigraph_engine::BeliefQueryError::FrameNotFound(fid) => {
+                    invalid_params(format!("frame {fid} not found"))
+                }
+                epigraph_engine::BeliefQueryError::ParseMasses(msg) => {
+                    invalid_params(format!("invalid mass function: {msg}"))
+                }
+                other => internal_error(other),
+            })?;
+            Some(LensedBelief::from_interval(
+                frame_id,
+                perspective_id,
+                &interval,
+            ))
+        }
+        None => None,
+    };
+
     #[derive(serde::Serialize)]
     struct GetClaimResponse {
         #[serde(flatten)]
         claim: ClaimResponse,
         classification: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        lensed_belief: Option<LensedBelief>,
     }
 
     success_json(&GetClaimResponse {
@@ -317,6 +361,7 @@ pub async fn get_claim(
             supersedes: claim.supersedes.map(|s| s.as_uuid().to_string()),
         },
         classification,
+        lensed_belief,
     })
 }
 

--- a/crates/epigraph-mcp/src/tools/ds.rs
+++ b/crates/epigraph-mcp/src/tools/ds.rs
@@ -240,6 +240,19 @@ pub async fn get_belief(
     let claim_id = parse_uuid(&params.claim_id)?;
     let frame_id = params.frame_id.as_deref().map(parse_uuid).transpose()?;
 
+    // Optional (frame, perspective) lens. For get_belief the rule is one-sided:
+    // frame_id may legitimately appear alone (the existing framed-but-unlensed
+    // path); only perspective_id present requires frame_id. Validate + check
+    // existence up front so a bad lens fails fast.
+    let lens = crate::tools::lens::resolve_lens_get_belief(
+        params.frame_id.as_deref(),
+        params.perspective_id.as_deref(),
+    )?;
+    if let Some((lens_frame, lens_perspective)) = lens {
+        crate::tools::lens::validate_lens_exists(&server.pool, lens_frame, lens_perspective)
+            .await?;
+    }
+
     let interval = epigraph_engine::belief_query::get_belief(&server.pool, claim_id, frame_id)
         .await
         .map_err(|e| match e {
@@ -255,6 +268,36 @@ pub async fn get_belief(
             other => internal_error(other),
         })?;
 
+    // Additive lensed interval, computed under the chosen (frame, perspective).
+    // The top-level belief/plausibility/etc above stay the global (unlensed)
+    // values. Existence already validated → a compute failure is internal.
+    let lensed_belief = match lens {
+        Some((lens_frame, lens_perspective)) => {
+            let lensed = epigraph_engine::belief_query::get_perspective_belief(
+                &server.pool,
+                claim_id,
+                lens_frame,
+                lens_perspective,
+            )
+            .await
+            .map_err(|e| match e {
+                epigraph_engine::BeliefQueryError::FrameNotFound(id) => {
+                    invalid_params(format!("frame {id} not found"))
+                }
+                epigraph_engine::BeliefQueryError::ParseMasses(msg) => {
+                    invalid_params(format!("invalid mass function: {msg}"))
+                }
+                other => internal_error(other),
+            })?;
+            Some(LensedBelief::from_interval(
+                lens_frame,
+                lens_perspective,
+                &lensed,
+            ))
+        }
+        None => None,
+    };
+
     let ignorance = interval.plausibility - interval.belief;
     success_json(&BeliefResponse {
         claim_id: claim_id.to_string(),
@@ -265,6 +308,7 @@ pub async fn get_belief(
         mass_on_conflict: interval.mass_on_conflict,
         mass_on_missing: interval.mass_on_missing,
         source: interval.source,
+        lensed_belief,
     })
 }
 

--- a/crates/epigraph-mcp/src/tools/lens.rs
+++ b/crates/epigraph-mcp/src/tools/lens.rs
@@ -1,0 +1,175 @@
+//! Shared validation for the optional `(frame, perspective)` read lens.
+//!
+//! The four context-delivery read tools (`recall`, `recall_with_context`,
+//! `get_claim`, `get_belief`) accept an optional `(frame_id, perspective_id)`
+//! pair. This module centralises the parse + both-or-neither + existence
+//! checks so the rule is identical across tools and the existence round-trips
+//! run ONCE per call (before any per-claim page loop), not per claim.
+//!
+//! Note on not-found semantics: `get_perspective_belief` silently reduces an
+//! unknown `perspective_id` to the global belief (the engine `unwrap_or_default`
+//! reduce-to-global guarantee), so a typo'd UUID would otherwise return
+//! global-as-lensed. The existence checks here surface that as an error instead.
+//! The codebase has no dedicated not-found `ErrorCode`; per convention
+//! (`ds.rs::get_belief`, `claims.rs::get_claim`) not-found is `INVALID_PARAMS`.
+
+use epigraph_db::{FrameRepository, PerspectiveRepository, PgPool};
+use uuid::Uuid;
+
+use crate::errors::{internal_error, invalid_params, McpError};
+
+/// Parse one optional lens UUID, naming the field on failure (spec §8 wants the
+/// error to say *which* id was malformed).
+fn parse_lens_uuid(field: &str, raw: &str) -> Result<Uuid, McpError> {
+    Uuid::parse_str(raw).map_err(|e| invalid_params(format!("invalid {field} UUID: {e}")))
+}
+
+/// Resolve the both-or-neither lens pair to `Option<(frame_id, perspective_id)>`.
+///
+/// - both `None` → `Ok(None)` (today's lens-free behaviour).
+/// - both `Some` → parse each (naming the field on error) → `Ok(Some((f, p)))`.
+/// - exactly one `Some` → `invalid_params` (a lens needs both).
+///
+/// This is the rule for `recall`, `recall_with_context`, and `get_claim`.
+/// `get_belief` has a one-sided rule (frame may appear alone); use
+/// [`resolve_lens_get_belief`] there.
+///
+/// # Errors
+/// `INVALID_PARAMS` when exactly one of the pair is supplied, or when a present
+/// id is not a valid UUID.
+pub fn resolve_lens(
+    frame_id: Option<&str>,
+    perspective_id: Option<&str>,
+) -> Result<Option<(Uuid, Uuid)>, McpError> {
+    match (frame_id, perspective_id) {
+        (None, None) => Ok(None),
+        (Some(f), Some(p)) => {
+            let frame = parse_lens_uuid("frame_id", f)?;
+            let perspective = parse_lens_uuid("perspective_id", p)?;
+            Ok(Some((frame, perspective)))
+        }
+        (Some(_), None) | (None, Some(_)) => Err(invalid_params(
+            "a lens needs both frame_id and perspective_id",
+        )),
+    }
+}
+
+/// Resolve the lens for `get_belief`, whose `frame_id` may legitimately appear
+/// alone (its pre-existing framed-but-unlensed behaviour). The lens is active
+/// only when `perspective_id` is present, and then `frame_id` is required.
+///
+/// Returns `Ok(None)` when no `perspective_id` was supplied (the caller keeps
+/// its existing global/framed path); `Ok(Some((frame, perspective)))` when a
+/// full lens is requested.
+///
+/// # Errors
+/// `INVALID_PARAMS` when `perspective_id` is present without `frame_id`, or when
+/// a present id is not a valid UUID.
+pub fn resolve_lens_get_belief(
+    frame_id: Option<&str>,
+    perspective_id: Option<&str>,
+) -> Result<Option<(Uuid, Uuid)>, McpError> {
+    match perspective_id {
+        None => Ok(None),
+        Some(p) => {
+            let frame = frame_id
+                .ok_or_else(|| invalid_params("perspective_id requires frame_id for a lens"))?;
+            let frame = parse_lens_uuid("frame_id", frame)?;
+            let perspective = parse_lens_uuid("perspective_id", p)?;
+            Ok(Some((frame, perspective)))
+        }
+    }
+}
+
+/// Verify both the frame and perspective exist BEFORE any belief compute, so a
+/// typo'd UUID fails fast (and the page loop is never entered with a bad lens).
+///
+/// Must be called once per tool invocation, not per claim.
+///
+/// # Errors
+/// `INVALID_PARAMS` naming the missing entity (codebase convention surfaces
+/// not-found as `INVALID_PARAMS`; there is no separate not-found code).
+/// `INTERNAL_ERROR` on a database failure.
+pub async fn validate_lens_exists(
+    pool: &PgPool,
+    frame_id: Uuid,
+    perspective_id: Uuid,
+) -> Result<(), McpError> {
+    if FrameRepository::get_by_id(pool, frame_id)
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err(invalid_params(format!("frame {frame_id} not found")));
+    }
+    if PerspectiveRepository::get_by_id(pool, perspective_id)
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err(invalid_params(format!(
+            "perspective {perspective_id} not found"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_lens_both_absent_is_none() {
+        assert!(resolve_lens(None, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn resolve_lens_only_one_present_errors() {
+        // Both directions of the both-or-neither rule must reject.
+        assert!(resolve_lens(Some(&Uuid::new_v4().to_string()), None).is_err());
+        assert!(resolve_lens(None, Some(&Uuid::new_v4().to_string())).is_err());
+    }
+
+    #[test]
+    fn resolve_lens_both_present_parses() {
+        let f = Uuid::new_v4();
+        let p = Uuid::new_v4();
+        let got = resolve_lens(Some(&f.to_string()), Some(&p.to_string()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, (f, p));
+    }
+
+    #[test]
+    fn resolve_lens_bad_uuid_names_the_field() {
+        let p = Uuid::new_v4().to_string();
+        let err = resolve_lens(Some("not-a-uuid"), Some(&p)).unwrap_err();
+        assert!(err.message.contains("frame_id"), "msg: {}", err.message);
+    }
+
+    #[test]
+    fn get_belief_frame_alone_is_unlensed() {
+        // frame_id alone is legitimate for get_belief (framed-but-unlensed).
+        assert!(
+            resolve_lens_get_belief(Some(&Uuid::new_v4().to_string()), None)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn get_belief_perspective_without_frame_errors() {
+        let p = Uuid::new_v4().to_string();
+        assert!(resolve_lens_get_belief(None, Some(&p)).is_err());
+    }
+
+    #[test]
+    fn get_belief_full_lens_parses() {
+        let f = Uuid::new_v4();
+        let p = Uuid::new_v4();
+        let got = resolve_lens_get_belief(Some(&f.to_string()), Some(&p.to_string()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, (f, p));
+    }
+}

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -157,6 +157,18 @@ pub async fn recall(
     let tags = params.tags;
     let tags_opt: Option<&[String]> = if tags.is_empty() { None } else { Some(&tags) };
 
+    // Resolve the optional (frame, perspective) lens up front (both-or-neither,
+    // parse, existence) so the bulk retrieval / ranking / min_truth path — all
+    // unchanged on the global truth_value — is never entered with a bad lens,
+    // and the existence round-trips run ONCE, not per claim.
+    let lens = crate::tools::lens::resolve_lens(
+        params.frame_id.as_deref(),
+        params.perspective_id.as_deref(),
+    )?;
+    if let Some((frame_id, perspective_id)) = lens {
+        crate::tools::lens::validate_lens_exists(&server.pool, frame_id, perspective_id).await?;
+    }
+
     // Hybrid retrieval: dense (claims.embedding) + lexical (content_tsv), RRF-fused.
     // On embedder failure, degrade to lexical-only — which, unlike the old ILIKE
     // fallback, still honors tag/agent scope because it filters in SQL.
@@ -199,6 +211,38 @@ pub async fn recall(
                 if hit.in_lexical {
                     matched_via.push("lexical".to_string());
                 }
+
+                // Additive lensed belief per returned claim. Degrade-not-fail:
+                // a compute error for ONE claim yields null + a warn, never an
+                // aborted page (spec §8). min_truth/ranking stay on `tv`.
+                let lensed_belief = match lens {
+                    Some((frame_id, perspective_id)) => {
+                        match epigraph_engine::belief_query::get_perspective_belief(
+                            &server.pool,
+                            hit.claim_id,
+                            frame_id,
+                            perspective_id,
+                        )
+                        .await
+                        {
+                            Ok(interval) => Some(LensedBelief::from_interval(
+                                frame_id,
+                                perspective_id,
+                                &interval,
+                            )),
+                            Err(e) => {
+                                tracing::warn!(
+                                    claim_id = %hit.claim_id,
+                                    error = %e,
+                                    "lensed belief compute failed; serving null lens for this claim"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    None => None,
+                };
+
                 results.push(RecallResult {
                     claim_id: hit.claim_id.to_string(),
                     content: claim.content,
@@ -206,6 +250,7 @@ pub async fn recall(
                     similarity: hit.dense_similarity.unwrap_or(0.0),
                     rrf_score: hit.rrf_score,
                     matched_via,
+                    lensed_belief,
                 });
             }
         }

--- a/crates/epigraph-mcp/src/tools/mod.rs
+++ b/crates/epigraph-mcp/src/tools/mod.rs
@@ -10,6 +10,7 @@ pub mod events;
 pub mod evolve_step;
 pub mod graph;
 pub mod ingestion;
+pub mod lens;
 pub mod link_epistemic;
 pub mod link_hierarchical;
 pub mod matching;

--- a/crates/epigraph-mcp/src/tools/perspectives.rs
+++ b/crates/epigraph-mcp/src/tools/perspectives.rs
@@ -134,6 +134,12 @@ pub async fn list_perspectives(
                 "perspective_type": r.perspective_type,
                 "confidence_calibration": r.confidence_calibration,
                 "created_at": r.created_at.to_rfc3339(),
+                // Lens maps so an agent can SEE what a perspective up/down-weights
+                // before choosing it as a (frame, perspective) lens. Serialize as
+                // a JSON object when present, `null` when the perspective sets no
+                // override (Option<HashMap> → object/null).
+                "source_reliability": r.source_reliability(),
+                "locality_reliability": r.locality_reliability(),
             })
         })
         .collect();

--- a/crates/epigraph-mcp/src/tools/recall.rs
+++ b/crates/epigraph-mcp/src/tools/recall.rs
@@ -111,6 +111,15 @@ pub struct RecallWithContextParams {
     /// `LlmProvider`; degrades to annotate-only when none is active. Default
     /// `false`.
     pub groundedness_gate: Option<bool>,
+    /// Optional lens frame UUID (from `list_frames`). Must be paired with
+    /// `perspective_id`. When both are set, each returned hit carries an
+    /// additive `lensed_belief` computed under that `(frame, perspective)` lens;
+    /// retrieval, rerank, and `min_truth` stay on the global `truth_value`.
+    pub frame_id: Option<String>,
+    /// Optional lens perspective UUID (from `list_perspectives`). Must be paired
+    /// with `frame_id`. The perspective's source/locality reliability re-weights
+    /// each hit's BBAs on-read.
+    pub perspective_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -132,6 +141,12 @@ pub struct RecallHit {
     /// was off/skipped. Surfaced alongside, NOT instead of, belief/truth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verdict: Option<epigraph_engine::rerank::Groundedness>,
+    /// Per-hit belief under the requested `(frame, perspective)` lens. Present
+    /// only when a lens was supplied; omitted (not null) otherwise so a
+    /// lens-free recall is byte-identical to today. Surfaced ALONGSIDE the
+    /// global `truth_value`, not instead of it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lensed_belief: Option<crate::types::LensedBelief>,
     pub truth_value: f64,
     pub paper: PaperMeta,
     pub section: Option<SectionMeta>,
@@ -261,6 +276,17 @@ pub async fn recall_with_context(
         .map_err(|e| internal_error(format!("embed query: {e}")))?;
     let pgvec = crate::embed::format_pgvector(&query_embedding);
 
+    // Resolve + existence-check the optional (frame, perspective) lens ONCE,
+    // before the page loop, so a bad lens fails fast and the bounded post-pass
+    // never round-trips the repo per claim for existence.
+    let lens = crate::tools::lens::resolve_lens(
+        params.frame_id.as_deref(),
+        params.perspective_id.as_deref(),
+    )?;
+    if let Some((frame_id, perspective_id)) = lens {
+        crate::tools::lens::validate_lens_exists(&server.pool, frame_id, perspective_id).await?;
+    }
+
     recall_with_context_post_embed(
         server,
         &params,
@@ -271,6 +297,7 @@ pub async fn recall_with_context(
         siblings_limit,
         corroborates_limit,
         neighbor_paragraphs_limit,
+        lens,
     )
     .await
 }
@@ -292,6 +319,7 @@ async fn recall_with_context_post_embed(
     siblings_limit: u32,
     corroborates_limit: u32,
     neighbor_paragraphs_limit: u32,
+    lens: Option<(Uuid, Uuid)>,
 ) -> Result<CallToolResult, McpError> {
     // Stage 3: candidate retrieval. Two paths:
     //
@@ -581,6 +609,9 @@ async fn recall_with_context_post_embed(
             similarity: hit.similarity,
             rerank_score,
             verdict,
+            // Populated by the bounded lens post-pass below (after the loop),
+            // once per page, keyed by paragraph_id. None until then.
+            lensed_belief: None,
             truth_value: core.truth_value,
             paper,
             section: ctx.section_meta.get(&paragraph_id).cloned(),
@@ -597,6 +628,39 @@ async fn recall_with_context_post_embed(
             neighbor_paragraphs_total,
             neighbor_paragraphs_truncated,
         });
+    }
+
+    // Bounded lens post-pass: when a lens is active, annotate each already-built
+    // hit with its lensed belief, keyed by paragraph_id. This does NOT touch
+    // retrieval, rerank, diverse selection, or min_truth (all on the global
+    // value). Per-claim degrade-not-fail: a compute error for ONE hit yields
+    // null + a warn, never an aborted page (spec §8).
+    if let Some((frame_id, perspective_id)) = lens {
+        for hit in &mut results {
+            match epigraph_engine::belief_query::get_perspective_belief(
+                &server.pool,
+                hit.paragraph_id,
+                frame_id,
+                perspective_id,
+            )
+            .await
+            {
+                Ok(interval) => {
+                    hit.lensed_belief = Some(crate::types::LensedBelief::from_interval(
+                        frame_id,
+                        perspective_id,
+                        &interval,
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        claim_id = %hit.paragraph_id,
+                        error = %e,
+                        "lensed belief compute failed; serving null lens for this claim"
+                    );
+                }
+            }
+        }
     }
 
     let corpus_scope = compute_corpus_scope(&server.pool)
@@ -1280,6 +1344,16 @@ pub mod __test_only {
         let siblings_limit = params.siblings_limit.unwrap_or(8);
         let corroborates_limit = params.corroborates_limit.unwrap_or(4);
         let neighbor_paragraphs_limit = params.neighbor_paragraphs_limit.unwrap_or(16);
+        // Mirror the real entry: resolve + existence-check the lens up front so
+        // integration tests exercise the same validation path.
+        let lens = crate::tools::lens::resolve_lens(
+            params.frame_id.as_deref(),
+            params.perspective_id.as_deref(),
+        )?;
+        if let Some((frame_id, perspective_id)) = lens {
+            crate::tools::lens::validate_lens_exists(&server.pool, frame_id, perspective_id)
+                .await?;
+        }
         recall_with_context_post_embed(
             server,
             &params,
@@ -1290,6 +1364,7 @@ pub mod __test_only {
             siblings_limit,
             corroborates_limit,
             neighbor_paragraphs_limit,
+            lens,
         )
         .await
     }

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -106,6 +106,65 @@ pub struct QueryUndecomposedClaimsParams {
 pub struct GetClaimParams {
     #[schemars(description = "The UUID of the claim to retrieve")]
     pub claim_id: String,
+
+    #[schemars(
+        description = "Optional lens frame UUID (from list_frames). Must be paired with perspective_id. \
+                       When both are set, the response carries an additive lensed_belief computed under that (frame, perspective) lens; the global truth_value is unchanged."
+    )]
+    #[serde(default)]
+    pub frame_id: Option<String>,
+
+    #[schemars(
+        description = "Optional lens perspective UUID (from list_perspectives). Must be paired with frame_id. \
+                       The perspective's source/locality reliability re-weights the claim's BBAs on-read."
+    )]
+    #[serde(default)]
+    pub perspective_id: Option<String>,
+}
+
+/// Additive per-claim belief computed under a `(frame, perspective)` lens.
+///
+/// Attached as an `Option<LensedBelief>` on the four context-delivery read
+/// tools (`recall`, `recall_with_context`, `get_claim`, `get_belief`) ONLY when
+/// a valid lens is supplied. Serialize-only with
+/// `#[serde(skip_serializing_if = "Option::is_none")]` on the field so a
+/// lens-free call is byte-identical to today (the key is omitted, never `null`).
+///
+/// Source: `epigraph_engine::belief_query::get_perspective_belief` —
+/// recomputes the claim's belief on-read, re-discounting every stored BBA by
+/// the perspective's reliability maps. Order claims by `pignistic_prob` (BetP).
+#[derive(Debug, Clone, Serialize)]
+pub struct LensedBelief {
+    /// Echoes the lens frame UUID.
+    pub frame_id: String,
+    /// Echoes the lens perspective UUID.
+    pub perspective_id: String,
+    /// Dempster-Shafer belief (lower probability bound) under the lens.
+    pub belief: f64,
+    /// Dempster-Shafer plausibility (upper probability bound) under the lens.
+    pub plausibility: f64,
+    /// Pignistic probability (BetP) under the lens — use for ordering.
+    pub pignistic_prob: f64,
+}
+
+impl LensedBelief {
+    /// Build from a computed `BeliefInterval`, carrying only the three lens
+    /// fields (spec §5 names exactly frame_id, perspective_id, belief,
+    /// plausibility, pignistic_prob — not mass/source/framed).
+    #[must_use]
+    pub fn from_interval(
+        frame_id: uuid::Uuid,
+        perspective_id: uuid::Uuid,
+        interval: &epigraph_engine::BeliefInterval,
+    ) -> Self {
+        Self {
+            frame_id: frame_id.to_string(),
+            perspective_id: perspective_id.to_string(),
+            belief: interval.belief,
+            plausibility: interval.plausibility,
+            pignistic_prob: interval.pignistic_prob,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -188,6 +247,20 @@ pub struct RecallParams {
     )]
     #[serde(default)]
     pub agent_id: Option<String>,
+
+    #[schemars(
+        description = "Optional lens frame UUID (from list_frames). Must be paired with perspective_id. \
+                       When both are set, each returned claim carries an additive lensed_belief computed under that (frame, perspective) lens. Ranking and min_truth stay on the global truth_value."
+    )]
+    #[serde(default)]
+    pub frame_id: Option<String>,
+
+    #[schemars(
+        description = "Optional lens perspective UUID (from list_perspectives). Must be paired with frame_id. \
+                       The perspective's source/locality reliability re-weights each claim's BBAs on-read."
+    )]
+    #[serde(default)]
+    pub perspective_id: Option<String>,
 }
 
 // ── Ingestion ──
@@ -602,6 +675,13 @@ pub struct GetBeliefParams {
         description = "Optional frame UUID. If provided, recomputes Bel/Pl/BetP from stored BBAs. If omitted, returns cached DS columns."
     )]
     pub frame_id: Option<String>,
+
+    #[schemars(
+        description = "Optional lens perspective UUID (from list_perspectives). Requires frame_id. \
+                       When set, the response also carries an additive lensed_belief computed under that (frame, perspective) lens; the existing global belief is unchanged."
+    )]
+    #[serde(default)]
+    pub perspective_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -735,6 +815,11 @@ pub struct RecallResult {
     pub rrf_score: f64,
     /// Which legs matched: subset of `["dense","lexical"]`.
     pub matched_via: Vec<String>,
+    /// Per-claim belief under the requested `(frame, perspective)` lens.
+    /// Present only when a lens was supplied; omitted (not null) otherwise, so
+    /// a lens-free recall is byte-identical to today.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lensed_belief: Option<LensedBelief>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1003,6 +1088,12 @@ pub struct BeliefResponse {
     pub mass_on_conflict: f64,
     pub mass_on_missing: f64,
     pub source: String,
+    /// Belief under the requested `(frame, perspective)` lens. Present only when
+    /// a perspective_id was supplied (frame_id required); omitted (not null)
+    /// otherwise so a lens-free get_belief is byte-identical to today. The
+    /// top-level belief/plausibility/etc remain the global (unlensed) values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lensed_belief: Option<LensedBelief>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/epigraph-mcp/tests/classify_test.rs
+++ b/crates/epigraph-mcp/tests/classify_test.rs
@@ -138,6 +138,8 @@ async fn get_claim_exposes_classification(pool: PgPool) {
         &server,
         GetClaimParams {
             claim_id: claim.to_string(),
+            frame_id: None,
+            perspective_id: None,
         },
     )
     .await

--- a/crates/epigraph-mcp/tests/get_claim.rs
+++ b/crates/epigraph-mcp/tests/get_claim.rs
@@ -30,6 +30,8 @@ async fn get_claim_returns_labels_and_retirement_state(pool: PgPool) {
         &server,
         GetClaimParams {
             claim_id: open_id.as_uuid().to_string(),
+            frame_id: None,
+            perspective_id: None,
         },
     )
     .await
@@ -55,6 +57,8 @@ async fn get_claim_returns_labels_and_retirement_state(pool: PgPool) {
         &server,
         GetClaimParams {
             claim_id: superseded_id.as_uuid().to_string(),
+            frame_id: None,
+            perspective_id: None,
         },
     )
     .await

--- a/crates/epigraph-mcp/tests/perspective_lens_reads.rs
+++ b/crates/epigraph-mcp/tests/perspective_lens_reads.rs
@@ -674,6 +674,115 @@ async fn plain_recall_lens_attaches_diverging_belief(pool: PgPool) {
     );
 }
 
+// ── plain recall (memory.rs) per-claim degrade-not-fail ─────────────────────
+
+/// Mirror of `recall_lens_degrades_one_bad_claim_without_failing_page` for the
+/// PLAIN `recall` (memory.rs lexical leg) path — which has its OWN lens
+/// post-pass loop, so the degrade-not-fail guarantee (spec §8/§9) must be pinned
+/// here too, not only on `recall_with_context`. Two lexically-recallable claims
+/// share a frame; one claim's stored `masses` is corrupted so
+/// `get_perspective_belief` returns `ParseMasses` for it only. `recall` with a
+/// lens must return `Ok` with the healthy claim carrying `lensed_belief` and the
+/// corrupted one omitting the key (page still served, not aborted).
+#[sqlx::test(migrations = "../../migrations")]
+async fn plain_recall_lens_degrades_one_bad_claim_without_failing_page(pool: PgPool) {
+    let agent = insert_agent(&pool).await;
+    let frame_row = FrameRepository::create(
+        &pool,
+        "ff_deg_plain",
+        None,
+        &["H0".to_string(), "H1".to_string()],
+    )
+    .await
+    .expect("frame");
+    let frame =
+        FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
+    let pgvec = unit_pgvec();
+
+    let good = insert_paragraph_claim(&pool, agent, &pgvec).await;
+    let bad = insert_paragraph_claim(&pool, agent, &pgvec).await;
+    store_bba(
+        &pool,
+        good,
+        frame_row.id,
+        agent,
+        &frame,
+        "western_clinical",
+        0.6,
+    )
+    .await;
+    store_bba(
+        &pool,
+        bad,
+        frame_row.id,
+        agent,
+        &frame,
+        "western_clinical",
+        0.6,
+    )
+    .await;
+
+    // Corrupt ONLY the bad claim's stored masses → from_json_masses fails →
+    // get_perspective_belief returns ParseMasses for this claim only.
+    sqlx::query("UPDATE mass_functions SET masses = '[1,2,3]'::jsonb WHERE claim_id = $1")
+        .bind(bad)
+        .execute(&pool)
+        .await
+        .expect("corrupt bad claim masses");
+
+    let persp = PerspectiveRepository::create(
+        &pool,
+        "deg-persp-plain",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("perspective");
+
+    let server = build_test_server(pool.clone());
+    let result = recall(
+        &server,
+        RecallParams {
+            query: "lens".to_string(),
+            min_truth: Some(0.0),
+            limit: Some(20),
+            tags: vec![],
+            agent_id: None,
+            frame_id: Some(frame_row.id.to_string()),
+            perspective_id: Some(persp.id.to_string()),
+        },
+    )
+    .await
+    .expect("recall must return Ok — one bad claim must not abort the whole page");
+
+    let arr = parse_json(&result);
+    let hits = arr.as_array().expect("recall returns an array");
+    let find = |id: Uuid| {
+        hits.iter()
+            .find(|h| h["claim_id"].as_str() == Some(&id.to_string()))
+    };
+
+    let good_hit = find(good).expect("healthy claim recalled via lexical leg");
+    assert!(
+        good_hit
+            .get("lensed_belief")
+            .and_then(|v| v.get("belief"))
+            .and_then(|b| b.as_f64())
+            .is_some(),
+        "healthy claim must carry a lensed_belief: {good_hit}"
+    );
+
+    let bad_hit = find(bad).expect("corrupted claim still recalled (page served, not aborted)");
+    assert!(
+        bad_hit.get("lensed_belief").is_none(),
+        "corrupted claim must omit lensed_belief (degraded to null) while the page is served: {bad_hit}"
+    );
+}
+
 // ── per-claim degrade-not-fail (spec §8/§9) ──────────────────────────────────
 
 /// Spec §8/§9: a lensed-compute error for ONE claim in a recall page must

--- a/crates/epigraph-mcp/tests/perspective_lens_reads.rs
+++ b/crates/epigraph-mcp/tests/perspective_lens_reads.rs
@@ -1,0 +1,835 @@
+//! Integration test for perspective-lens reads (spec
+//! `docs/superpowers/specs/2026-06-03-perspective-lens-reads-design.md`).
+//!
+//! Threads an optional `(frame_id, perspective_id)` lens into the four
+//! context-delivery read tools (`get_claim`, `get_belief`, `recall`,
+//! `recall_with_context`) and attaches an additive `lensed_belief` computed via
+//! `epigraph_engine::belief_query::get_perspective_belief`.
+//!
+//! The DISCRIMINATING proof is lifted from the engine fixture
+//! `crates/epigraph-engine/tests/perspective_frame_function.rs::get_perspective_belief_diverges_by_observer`:
+//! two observers (a SKEPTIC that down-weights `practitioner_interview` and a
+//! neutral BELIEVER) reach DIFFERENT lensed beliefs over the SAME stored
+//! evidence. Asserting `skeptic < believer` proves the lens actually flows
+//! through the tool — it is NOT a comparison against the stored `truth_value`
+//! (which is a constant 0.5, not the DS-computed global belief, so that would
+//! be a hollow baseline). The reduce-to-global leg (unmapped perspective ≈
+//! global within 1e-9) and the back-compat leg (no lens → key absent) round it
+//! out, plus the validation errors (only-one-of, unknown id).
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use epigraph_db::{FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool};
+use epigraph_ds::{FocalElement, FrameOfDiscernment, MassFunction};
+use epigraph_mcp::tools::claims::get_claim;
+use epigraph_mcp::tools::ds::get_belief;
+use epigraph_mcp::tools::memory::recall;
+use epigraph_mcp::tools::perspectives::list_perspectives;
+use epigraph_mcp::tools::recall::__test_only::recall_with_context_with_pgvec;
+use epigraph_mcp::tools::recall::RecallWithContextParams;
+use epigraph_mcp::types::{GetBeliefParams, GetClaimParams, ListPerspectivesParams, RecallParams};
+use rmcp::model::CallToolResult;
+use serde_json::Value;
+use uuid::Uuid;
+
+mod common;
+use common::build_test_server;
+
+// ── seeding helpers (mirror perspective_frame_function.rs + get_claim.rs) ─────
+
+async fn insert_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, created_at, updated_at) \
+         VALUES ($1, sha256($1::text::bytea), NOW(), NOW())",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("agent");
+    id
+}
+
+/// Seed a level-2 paragraph claim WITH an embedding and a paper-attribution
+/// edge, so the SAME claim is both lens-computable (it carries BBAs) and
+/// recallable via `recall_with_context` (the pipeline requires level=2 +
+/// paper). `truth_value` is a fixed 0.5 — deliberately NOT the DS belief.
+async fn insert_paragraph_claim(pool: &PgPool, agent: Uuid, embedding_pgvec: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let content = format!("lens claim {id}");
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current, properties, embedding) \
+         VALUES ($1, $2, sha256($2::bytea), 0.5, $3, true, jsonb_build_object('level', 2::int), $4::vector)",
+    )
+    .bind(id)
+    .bind(&content)
+    .bind(agent)
+    .bind(embedding_pgvec)
+    .execute(pool)
+    .await
+    .expect("paragraph claim");
+
+    let paper = Uuid::new_v4();
+    sqlx::query("INSERT INTO papers (id, doi, title) VALUES ($1, $2, $3)")
+        .bind(paper)
+        .bind(format!("10.test/{id}"))
+        .bind("lens test paper")
+        .execute(pool)
+        .await
+        .expect("paper");
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+         VALUES (gen_random_uuid(), $1, 'paper', $2, 'claim', 'asserts')",
+    )
+    .bind(paper)
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("paper-attribution edge");
+    id
+}
+
+/// Store a supporting BBA (mass on H0, rest on Θ) tagged with `evidence_type`.
+/// Copied from `perspective_frame_function.rs::store_bba`.
+async fn store_bba(
+    pool: &PgPool,
+    claim_id: Uuid,
+    frame_id: Uuid,
+    agent: Uuid,
+    frame: &FrameOfDiscernment,
+    evidence_type: &str,
+    mass: f64,
+) {
+    let mut bba = BTreeMap::new();
+    bba.insert(FocalElement::positive(BTreeSet::from([0])), mass);
+    bba.insert(FocalElement::theta(frame), 1.0 - mass);
+    let mf = MassFunction::new(frame.clone(), bba).unwrap();
+    MassFunctionRepository::store_with_perspective(
+        pool,
+        claim_id,
+        frame_id,
+        Some(agent),
+        None,
+        &mf.masses_to_json(),
+        None,
+        Some("discount"),
+        Some(1.0),
+        Some(evidence_type),
+        "unknown",
+        None,
+    )
+    .await
+    .expect("store bba");
+}
+
+/// The shared fixture: one claim with two differing-evidence-type BBAs on a
+/// binary frame, a SKEPTIC perspective that halves trust in
+/// `practitioner_interview`, and a BELIEVER (all-α=1.0) that is neutral and so
+/// reduces to the global belief.
+struct Fixture {
+    claim_id: Uuid,
+    frame_id: Uuid,
+    skeptic_id: Uuid,
+    believer_id: Uuid,
+}
+
+async fn seed_fixture(pool: &PgPool, embedding_pgvec: &str) -> Fixture {
+    let agent = insert_agent(pool).await;
+    let claim_id = insert_paragraph_claim(pool, agent, embedding_pgvec).await;
+    let frame_row = FrameRepository::create(
+        pool,
+        "ff_binary",
+        None,
+        &["H0".to_string(), "H1".to_string()],
+    )
+    .await
+    .expect("frame");
+    let frame =
+        FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
+
+    store_bba(
+        pool,
+        claim_id,
+        frame_row.id,
+        agent,
+        &frame,
+        "western_clinical",
+        0.6,
+    )
+    .await;
+    store_bba(
+        pool,
+        claim_id,
+        frame_row.id,
+        agent,
+        &frame,
+        "practitioner_interview",
+        0.7,
+    )
+    .await;
+
+    let skeptic = PerspectiveRepository::create(
+        pool,
+        "skeptic",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("skeptic");
+    let believer = PerspectiveRepository::create(
+        pool,
+        "believer",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("believer");
+    PerspectiveRepository::set_source_reliability(
+        pool,
+        skeptic.id,
+        &HashMap::from([
+            ("western_clinical".to_string(), 1.0),
+            ("practitioner_interview".to_string(), 0.3),
+        ]),
+    )
+    .await
+    .expect("skeptic map");
+    PerspectiveRepository::set_source_reliability(
+        pool,
+        believer.id,
+        &HashMap::from([
+            ("western_clinical".to_string(), 1.0),
+            ("practitioner_interview".to_string(), 1.0),
+        ]),
+    )
+    .await
+    .expect("believer map");
+
+    Fixture {
+        claim_id,
+        frame_id: frame_row.id,
+        skeptic_id: skeptic.id,
+        believer_id: believer.id,
+    }
+}
+
+fn parse_json(result: &CallToolResult) -> Value {
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text content block");
+    serde_json::from_str(&text).expect("response is JSON")
+}
+
+/// dim=1536 pgvector with all mass in slot 0 — every seeded paragraph shares it,
+/// so the flat-ANN recall is cosine-similar to the same query vector.
+fn unit_pgvec() -> String {
+    let mut v = vec!["0.0"; 1536];
+    v[0] = "1.0";
+    format!("[{}]", v.join(","))
+}
+
+fn rwc_params(
+    query: &str,
+    frame_id: Option<Uuid>,
+    perspective_id: Option<Uuid>,
+) -> RecallWithContextParams {
+    RecallWithContextParams {
+        query: query.to_string(),
+        limit: Some(10),
+        min_truth: Some(0.0),
+        centroid_dim: Some(1536),
+        paper_doi_filter: None,
+        siblings_limit: None,
+        corroborates_limit: None,
+        neighbor_paragraphs_limit: None,
+        diverse: None,
+        max_themes: None,
+        diversity_weight: None,
+        candidate_pool: None,
+        rerank: None,
+        rerank_pool_factor: None,
+        groundedness_gate: None,
+        frame_id: frame_id.map(|f| f.to_string()),
+        perspective_id: perspective_id.map(|p| p.to_string()),
+    }
+}
+
+// ── get_claim ─────────────────────────────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_claim_lens_diverges_by_perspective_and_is_absent_without_lens(pool: PgPool) {
+    let fx = seed_fixture(&pool, &unit_pgvec()).await;
+    let server = build_test_server(pool.clone());
+
+    // WITHOUT a lens → key absent (byte-identical back-compat).
+    let plain = get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: None,
+            perspective_id: None,
+        },
+    )
+    .await
+    .expect("get_claim plain");
+    let body = parse_json(&plain);
+    assert!(
+        body.get("lensed_belief").is_none(),
+        "no lens → lensed_belief key must be ABSENT (not null): {body}"
+    );
+
+    // WITH the skeptic lens → lensed_belief present, carrying the three fields.
+    let skeptic = get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(fx.frame_id.to_string()),
+            perspective_id: Some(fx.skeptic_id.to_string()),
+        },
+    )
+    .await
+    .expect("get_claim skeptic lens");
+    let s_body = parse_json(&skeptic);
+    let s_lens = &s_body["lensed_belief"];
+    assert_eq!(
+        s_lens["frame_id"].as_str().unwrap(),
+        fx.frame_id.to_string()
+    );
+    assert_eq!(
+        s_lens["perspective_id"].as_str().unwrap(),
+        fx.skeptic_id.to_string()
+    );
+    let skeptic_belief = s_lens["belief"].as_f64().expect("belief f64");
+
+    // WITH the believer lens → different belief from the SAME evidence.
+    let believer = get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(fx.frame_id.to_string()),
+            perspective_id: Some(fx.believer_id.to_string()),
+        },
+    )
+    .await
+    .expect("get_claim believer lens");
+    let believer_belief = parse_json(&believer)["lensed_belief"]["belief"]
+        .as_f64()
+        .expect("believer belief f64");
+
+    // Discriminating assert: skeptic trusts the practitioner interview LESS, so
+    // believes H0 less than the neutral believer. Proves the lens flows.
+    assert!(
+        skeptic_belief < believer_belief,
+        "skeptic lensed belief ({skeptic_belief}) must be < believer ({believer_belief})"
+    );
+
+    // The top-level global truth_value is UNCHANGED by the lens (additive).
+    assert!(
+        (s_body["truth_value"].as_f64().unwrap() - 0.5).abs() < 1e-9,
+        "lens must not overwrite the global truth_value"
+    );
+}
+
+// ── get_belief ────────────────────────────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn get_belief_lens_diverges_and_preserves_global(pool: PgPool) {
+    let fx = seed_fixture(&pool, &unit_pgvec()).await;
+    let server = build_test_server(pool.clone());
+
+    // frame_id alone (no perspective) → framed-but-unlensed; no lensed_belief.
+    let framed = get_belief(
+        &server,
+        GetBeliefParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(fx.frame_id.to_string()),
+            perspective_id: None,
+        },
+    )
+    .await
+    .expect("get_belief framed-unlensed");
+    let framed_body = parse_json(&framed);
+    assert!(
+        framed_body.get("lensed_belief").is_none(),
+        "frame alone (unlensed) → lensed_belief key absent: {framed_body}"
+    );
+    let global_belief = framed_body["belief"].as_f64().expect("global belief");
+
+    // skeptic lens → lensed_belief present and != the global framed belief.
+    let skeptic = get_belief(
+        &server,
+        GetBeliefParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(fx.frame_id.to_string()),
+            perspective_id: Some(fx.skeptic_id.to_string()),
+        },
+    )
+    .await
+    .expect("get_belief skeptic lens");
+    let s_body = parse_json(&skeptic);
+    // Top-level belief stays GLOBAL even under the lens.
+    assert!(
+        (s_body["belief"].as_f64().unwrap() - global_belief).abs() < 1e-9,
+        "top-level belief must remain the global framed value under a lens"
+    );
+    let skeptic_lensed = s_body["lensed_belief"]["belief"]
+        .as_f64()
+        .expect("skeptic lensed");
+    assert!(
+        skeptic_lensed < global_belief,
+        "skeptic lensed belief ({skeptic_lensed}) must fall below global ({global_belief})"
+    );
+
+    // believer (neutral) lens → reduces to global within 1e-9.
+    let believer = get_belief(
+        &server,
+        GetBeliefParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(fx.frame_id.to_string()),
+            perspective_id: Some(fx.believer_id.to_string()),
+        },
+    )
+    .await
+    .expect("get_belief believer lens");
+    let believer_lensed = parse_json(&believer)["lensed_belief"]["belief"]
+        .as_f64()
+        .expect("believer lensed");
+    assert!(
+        (believer_lensed - global_belief).abs() < 1e-9,
+        "neutral believer lens ({believer_lensed}) must reduce to global ({global_belief})"
+    );
+}
+
+// ── recall_with_context ──────────────────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn recall_with_context_lens_attaches_diverging_belief(pool: PgPool) {
+    let pgvec = unit_pgvec();
+    let fx = seed_fixture(&pool, &pgvec).await;
+    let server = build_test_server(pool.clone());
+
+    // No lens → the recalled hit has NO lensed_belief key.
+    let plain = recall_with_context_with_pgvec(&server, rwc_params("q", None, None), 1536, &pgvec)
+        .await
+        .expect("recall plain");
+    let p_body = parse_json(&plain);
+    let p_hit = p_body["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|h| h["paragraph_id"].as_str() == Some(&fx.claim_id.to_string()))
+        .expect("seeded claim recalled");
+    assert!(
+        p_hit.get("lensed_belief").is_none(),
+        "no lens → recall hit lensed_belief key absent: {p_hit}"
+    );
+
+    // skeptic lens → hit carries a lensed_belief.
+    let skeptic = recall_with_context_with_pgvec(
+        &server,
+        rwc_params("q", Some(fx.frame_id), Some(fx.skeptic_id)),
+        1536,
+        &pgvec,
+    )
+    .await
+    .expect("recall skeptic lens");
+    let s_belief = lensed_belief_for(&parse_json(&skeptic), fx.claim_id);
+
+    // believer lens → different belief for the SAME recalled claim.
+    let believer = recall_with_context_with_pgvec(
+        &server,
+        rwc_params("q", Some(fx.frame_id), Some(fx.believer_id)),
+        1536,
+        &pgvec,
+    )
+    .await
+    .expect("recall believer lens");
+    let b_belief = lensed_belief_for(&parse_json(&believer), fx.claim_id);
+
+    assert!(
+        s_belief < b_belief,
+        "recall: skeptic lensed belief ({s_belief}) must be < believer ({b_belief})"
+    );
+}
+
+fn lensed_belief_for(body: &Value, claim_id: Uuid) -> f64 {
+    let hit = body["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|h| h["paragraph_id"].as_str() == Some(&claim_id.to_string()))
+        .expect("seeded claim recalled");
+    hit["lensed_belief"]["belief"]
+        .as_f64()
+        .expect("lensed_belief.belief present on lensed recall hit")
+}
+
+// ── reduce-to-global (unmapped perspective) ──────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn unmapped_perspective_lens_equals_global(pool: PgPool) {
+    let fx = seed_fixture(&pool, &unit_pgvec()).await;
+    let server = build_test_server(pool.clone());
+
+    // A perspective with NO source_reliability map expresses no opinion → its
+    // lensed belief must reproduce the global framed belief exactly.
+    let plain_persp = PerspectiveRepository::create(
+        &pool,
+        "plain",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("plain perspective");
+
+    let global = parse_json(
+        &get_belief(
+            &server,
+            GetBeliefParams {
+                claim_id: fx.claim_id.to_string(),
+                frame_id: Some(fx.frame_id.to_string()),
+                perspective_id: None,
+            },
+        )
+        .await
+        .expect("global"),
+    )["belief"]
+        .as_f64()
+        .unwrap();
+
+    let lensed = parse_json(
+        &get_belief(
+            &server,
+            GetBeliefParams {
+                claim_id: fx.claim_id.to_string(),
+                frame_id: Some(fx.frame_id.to_string()),
+                perspective_id: Some(plain_persp.id.to_string()),
+            },
+        )
+        .await
+        .expect("plain-perspective lens"),
+    )["lensed_belief"]["belief"]
+        .as_f64()
+        .unwrap();
+
+    assert!(
+        (lensed - global).abs() < 1e-9,
+        "unmapped perspective lens ({lensed}) must equal global ({global})"
+    );
+}
+
+// ── validation ────────────────────────────────────────────────────────────
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn lens_validation_rejects_only_one_of_and_unknown_ids(pool: PgPool) {
+    let fx = seed_fixture(&pool, &unit_pgvec()).await;
+    let server = build_test_server(pool.clone());
+
+    // Only frame_id (no perspective) on get_claim → both-or-neither error.
+    let only_frame = get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(fx.frame_id.to_string()),
+            perspective_id: None,
+        },
+    )
+    .await;
+    assert!(only_frame.is_err(), "only frame_id must be rejected");
+
+    // Only perspective_id (no frame) on get_claim → error.
+    let only_persp = get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: None,
+            perspective_id: Some(fx.skeptic_id.to_string()),
+        },
+    )
+    .await;
+    assert!(only_persp.is_err(), "only perspective_id must be rejected");
+
+    // Unknown perspective UUID → not-found error (engine would silently reduce
+    // to global, so the tool MUST surface it).
+    let unknown_persp = get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(fx.frame_id.to_string()),
+            perspective_id: Some(Uuid::new_v4().to_string()),
+        },
+    )
+    .await;
+    assert!(
+        unknown_persp.is_err(),
+        "unknown perspective_id must be rejected"
+    );
+
+    // Unknown frame UUID → not-found error.
+    let unknown_frame = get_claim(
+        &server,
+        GetClaimParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: Some(Uuid::new_v4().to_string()),
+            perspective_id: Some(fx.skeptic_id.to_string()),
+        },
+    )
+    .await;
+    assert!(unknown_frame.is_err(), "unknown frame_id must be rejected");
+
+    // get_belief: perspective_id without frame_id → error (one-sided rule).
+    let gb_only_persp = get_belief(
+        &server,
+        GetBeliefParams {
+            claim_id: fx.claim_id.to_string(),
+            frame_id: None,
+            perspective_id: Some(fx.skeptic_id.to_string()),
+        },
+    )
+    .await;
+    assert!(
+        gb_only_persp.is_err(),
+        "get_belief perspective_id without frame_id must be rejected"
+    );
+}
+
+// ── plain recall (memory.rs, lexical leg — no embedder) ──────────────────────
+
+/// Spec §9 names `recall` in the discriminating test. With the mock embedder
+/// (no API key) the hybrid dense leg errors and `recall` falls back to the
+/// lexical `websearch_to_tsquery` leg, which needs no key — so the plain
+/// `recall` lens path IS exercisable. Seed content contains the word "lens"; we
+/// query it and assert the per-claim lensed_belief diverges skeptic-vs-believer.
+#[sqlx::test(migrations = "../../migrations")]
+async fn plain_recall_lens_attaches_diverging_belief(pool: PgPool) {
+    let fx = seed_fixture(&pool, &unit_pgvec()).await;
+    let server = build_test_server(pool.clone());
+
+    let recall_one = |frame: Option<Uuid>, perspective: Option<Uuid>| {
+        recall(
+            &server,
+            RecallParams {
+                query: "lens".to_string(),
+                min_truth: Some(0.0),
+                limit: Some(20),
+                tags: vec![],
+                agent_id: None,
+                frame_id: frame.map(|f| f.to_string()),
+                perspective_id: perspective.map(|p| p.to_string()),
+            },
+        )
+    };
+
+    // No lens → the recalled claim has NO lensed_belief key (back-compat).
+    let plain = recall_one(None, None).await.expect("recall plain");
+    let plain_arr = parse_json(&plain);
+    let p_hit = plain_arr
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|h| h["claim_id"].as_str() == Some(&fx.claim_id.to_string()))
+        .expect("seeded claim recalled via lexical leg");
+    assert!(
+        p_hit.get("lensed_belief").is_none(),
+        "no lens → recall result lensed_belief key absent: {p_hit}"
+    );
+
+    let recall_belief = |body: &Value| -> f64 {
+        body.as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["claim_id"].as_str() == Some(&fx.claim_id.to_string()))
+            .expect("seeded claim recalled")["lensed_belief"]["belief"]
+            .as_f64()
+            .expect("lensed_belief.belief on lensed recall result")
+    };
+
+    let skeptic = recall_one(Some(fx.frame_id), Some(fx.skeptic_id))
+        .await
+        .expect("recall skeptic lens");
+    let believer = recall_one(Some(fx.frame_id), Some(fx.believer_id))
+        .await
+        .expect("recall believer lens");
+
+    let s = recall_belief(&parse_json(&skeptic));
+    let b = recall_belief(&parse_json(&believer));
+    assert!(
+        s < b,
+        "plain recall: skeptic lensed belief ({s}) must be < believer ({b})"
+    );
+}
+
+// ── per-claim degrade-not-fail (spec §8/§9) ──────────────────────────────────
+
+/// Spec §8/§9: a lensed-compute error for ONE claim in a recall page must
+/// degrade to a null lens for THAT claim (warn-logged) while the rest of the
+/// page is served — it must NOT abort the whole call. We seed two recallable
+/// claims with valid BBAs on a shared frame, then CORRUPT one claim's stored
+/// `masses` (a JSON array instead of a `{focal: mass}` object) so
+/// `from_json_masses` returns `ParseMasses` for it only. recall_with_context
+/// with a lens must return `Ok`, the healthy claim carrying a `lensed_belief`
+/// and the corrupted one omitting the key.
+#[sqlx::test(migrations = "../../migrations")]
+async fn recall_lens_degrades_one_bad_claim_without_failing_page(pool: PgPool) {
+    let pgvec = unit_pgvec();
+    let agent = insert_agent(&pool).await;
+    let frame_row =
+        FrameRepository::create(&pool, "ff_deg", None, &["H0".to_string(), "H1".to_string()])
+            .await
+            .expect("frame");
+    let frame =
+        FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone()).unwrap();
+
+    let good = insert_paragraph_claim(&pool, agent, &pgvec).await;
+    let bad = insert_paragraph_claim(&pool, agent, &pgvec).await;
+    store_bba(
+        &pool,
+        good,
+        frame_row.id,
+        agent,
+        &frame,
+        "western_clinical",
+        0.6,
+    )
+    .await;
+    store_bba(
+        &pool,
+        bad,
+        frame_row.id,
+        agent,
+        &frame,
+        "western_clinical",
+        0.6,
+    )
+    .await;
+
+    // Corrupt ONLY the bad claim's stored masses → from_json_masses fails →
+    // get_perspective_belief returns ParseMasses for this claim only.
+    sqlx::query("UPDATE mass_functions SET masses = '[1,2,3]'::jsonb WHERE claim_id = $1")
+        .bind(bad)
+        .execute(&pool)
+        .await
+        .expect("corrupt bad claim masses");
+
+    let persp = PerspectiveRepository::create(
+        &pool,
+        "deg-persp",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("perspective");
+
+    let server = build_test_server(pool.clone());
+    let result = recall_with_context_with_pgvec(
+        &server,
+        rwc_params("q", Some(frame_row.id), Some(persp.id)),
+        1536,
+        &pgvec,
+    )
+    .await
+    .expect("recall must NOT fail despite one corrupt claim");
+    let body = parse_json(&result);
+    let hits = body["results"].as_array().expect("results array");
+
+    let good_hit = hits
+        .iter()
+        .find(|h| h["paragraph_id"].as_str() == Some(&good.to_string()))
+        .expect("healthy claim recalled");
+    assert!(
+        good_hit["lensed_belief"]["belief"].as_f64().is_some(),
+        "healthy claim must carry a lensed_belief: {good_hit}"
+    );
+
+    let bad_hit = hits
+        .iter()
+        .find(|h| h["paragraph_id"].as_str() == Some(&bad.to_string()))
+        .expect("corrupt claim still recalled (lens failure must not drop it)");
+    assert!(
+        bad_hit.get("lensed_belief").is_none(),
+        "corrupt claim must degrade to absent lensed_belief, not abort the page: {bad_hit}"
+    );
+}
+
+// ── list_perspectives discovery enrichment ───────────────────────────────────
+
+/// Spec §9 "Discovery": `list_perspectives` must surface the
+/// `source_reliability` / `locality_reliability` maps so an agent can SEE what a
+/// perspective up/down-weights before choosing it as a lens. Asserts the mapped
+/// perspective surfaces its values and an unmapped one is `null` — exercising
+/// both branches of `PerspectiveRow::source_reliability()`.
+#[sqlx::test(migrations = "../../migrations")]
+async fn list_perspectives_surfaces_reliability_maps(pool: PgPool) {
+    // skeptic carries a source_reliability map; we add a second WITHOUT one.
+    let fx = seed_fixture(&pool, &unit_pgvec()).await;
+    let plain = PerspectiveRepository::create(
+        &pool,
+        "no-map",
+        None,
+        None,
+        Some("analytical"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("plain perspective");
+    let server = build_test_server(pool.clone());
+
+    let result = list_perspectives(&server, ListPerspectivesParams { limit: Some(100) })
+        .await
+        .expect("list_perspectives");
+    let body = parse_json(&result);
+    let rows = body.as_array().expect("array of perspectives");
+
+    let skeptic_row = rows
+        .iter()
+        .find(|r| r["perspective_id"].as_str() == Some(&fx.skeptic_id.to_string()))
+        .expect("skeptic in listing");
+    // The mapped perspective surfaces its source_reliability values.
+    assert_eq!(
+        skeptic_row["source_reliability"]["practitioner_interview"]
+            .as_f64()
+            .expect("skeptic practitioner_interview reliability"),
+        0.3,
+        "list_perspectives must surface the source_reliability map"
+    );
+    assert!(
+        skeptic_row.get("name").and_then(|n| n.as_str()) == Some("skeptic"),
+        "list_perspectives must carry the name for lens choice"
+    );
+
+    let plain_row = rows
+        .iter()
+        .find(|r| r["perspective_id"].as_str() == Some(&plain.id.to_string()))
+        .expect("no-map perspective in listing");
+    // An unmapped perspective surfaces null (Option<HashMap> → null), so an
+    // agent sees it imposes no override.
+    assert!(
+        plain_row["source_reliability"].is_null(),
+        "unmapped perspective source_reliability must be null: {plain_row}"
+    );
+    assert!(
+        plain_row["locality_reliability"].is_null(),
+        "unmapped perspective locality_reliability must be null: {plain_row}"
+    );
+}

--- a/crates/epigraph-mcp/tests/recall_hybrid.rs
+++ b/crates/epigraph-mcp/tests/recall_hybrid.rs
@@ -62,6 +62,8 @@ async fn recall_falls_back_to_scope_honoring_lexical_when_embedder_down(pool: Pg
         limit: None,
         tags: vec!["keep".to_string()],
         agent_id: None,
+        frame_id: None,
+        perspective_id: None,
     };
     let out = recall(&server, params).await.expect("recall ok");
     let arr = parse_results(out);

--- a/crates/epigraph-mcp/tests/recall_with_context.rs
+++ b/crates/epigraph-mcp/tests/recall_with_context.rs
@@ -550,6 +550,8 @@ async fn explicit_3072_with_no_population_returns_invalid_params(pool: PgPool) {
         rerank: None,
         rerank_pool_factor: None,
         groundedness_gate: None,
+        frame_id: None,
+        perspective_id: None,
     };
 
     let result = recall_with_context(&server, params).await;
@@ -940,6 +942,8 @@ fn diverse_params_with_pool(
         rerank: None,
         rerank_pool_factor: None,
         groundedness_gate: None,
+        frame_id: None,
+        perspective_id: None,
     }
 }
 

--- a/docs/superpowers/specs/2026-06-03-perspective-lens-reads-design.md
+++ b/docs/superpowers/specs/2026-06-03-perspective-lens-reads-design.md
@@ -1,0 +1,150 @@
+# Perspective-lens reads — design
+
+- **Date:** 2026-06-03
+- **Status:** Approved (design); ready for implementation plan
+- **Scope:** thread an optional `(frame, perspective)` lens into four MCP read tools; compute-on-read; no storage/combine change
+- **Owner:** Jeremy Barton
+- **Backlog:** read-side realization of `23472d04` (the default-cache-scoping headline stays a separate, deferred concern — see §10)
+
+## 1. Context & motivation
+
+EpiGraph has a fully-built **per-perspective frame function** (PRs #206/#208/#218): a
+perspective carries `source_reliability` (evidence-type → α) and `locality_reliability`
+(locality-tag → factor) maps, and `epigraph_engine::belief_query::get_perspective_belief(pool,
+claim_id, frame_id, perspective_id)` recomputes a claim's belief **on-read**, re-discounting all
+of its BBAs by that perspective's weights (an absent/empty perspective reduces exactly to the
+global `get_belief`).
+
+But that machinery is **dormant in normal operation** (verified 2026-06-03): the default combine
+is single-global, and the paths through which agents actually **receive belief as context** —
+`recall`, `recall_with_context`, `get_claim`, `get_belief` — return only the global
+`truth_value`/`pignistic_prob`. There is no way for an agent to receive belief **through a chosen
+lens**. Only the explicit `scoped_belief` tool exposes one claim's lensed belief.
+
+**Goal:** let an agent **pick a `(frame, perspective)` lens per call** and have the belief it
+receives as context be computed under that lens — reusing the existing compute-on-read engine,
+with no write-path or cache change.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Optional `lens` input on `recall`, `recall_with_context`, `get_claim`, `get_belief`.
+- When a lens is present, attach a per-claim lensed belief computed via `get_perspective_belief`.
+- Enrich `list_perspectives` so an agent can discover and meaningfully choose a lens.
+- Fully backward-compatible: no lens → byte-identical responses to today.
+
+**Non-goals (out of scope for this spec)**
+- Making the **default cache** perspective-scoped (the `23472d04` headline — heavier; see §10).
+- Threading the lens into every belief-returning tool (`query_claims`, `get_neighborhood`, …) —
+  only the four context-delivery paths above. (`scoped_belief` already lenses single claims.)
+- A session-level default lens (a possible thin follow-up layered on this per-call version).
+- Any change to write paths, the combine, or storage.
+
+## 3. Lens input
+
+A flat optional pair on each of the four tools' params (mirrors how existing optional params are
+modelled in `crates/epigraph-mcp/src/types.rs`):
+
+```
+frame_id:       Option<String>   // UUID, from list_frames (binary_truth today)
+perspective_id: Option<String>   // UUID, from list_perspectives
+```
+
+- Both omitted → today's global behavior (no compute-on-read; no new fields).
+- Both present → lens applied (see §5).
+- Exactly one present → validation error (a lens needs both a frame and a perspective).
+- `perspective_id` is the canonical key (UUID). Name→id resolution is a **future convenience**,
+  not v1 (names are not guaranteed unique; resolving here would add ambiguity handling).
+
+> Why both (frame + perspective): per the design decision, the lens unit is `(frame, perspective)`
+> so the API future-proofs for non-binary frames even though `binary_truth` is the only live frame
+> today. `get_perspective_belief` already takes both.
+
+## 4. Discovery (so agents can choose a lens)
+
+- `list_frames` (exists, `crates/epigraph-mcp/src/tools/ds.rs::list_frames`) — already returns the
+  available frames; no change needed beyond confirming it returns `id` + `name`.
+- `list_perspectives` (`crates/epigraph-mcp/src/tools/perspectives.rs::list_perspectives`) —
+  **enrich** the response so each entry carries `id`, `name`, and the lens maps
+  (`source_reliability`, `locality_reliability`) read via `PerspectiveRow::source_reliability()` /
+  `locality_reliability()`. An agent picks a perspective by seeing what it up/down-weights.
+
+## 5. Behavior — lensed read
+
+When a valid `(frame_id, perspective_id)` lens is supplied, for **each claim in the response page**
+call `epigraph_engine::belief_query::get_perspective_belief(pool, claim_id, frame_id,
+perspective_id)` and attach:
+
+```
+lensed_belief: {
+  frame_id, perspective_id,
+  belief, plausibility, pignistic_prob
+}
+```
+
+- **Additive, not overwriting:** the existing global fields (`truth_value` / belief columns)
+  stay as-is so existing consumers don't break and the agent sees global vs. lensed side by side.
+  `lensed_belief` is `Option`, present only when a lens was requested.
+- `recall` / `recall_with_context`: compute for each returned claim (page already capped by
+  `limit` / neighborhood size). `recall`'s ranking/`min_truth` filtering is unchanged — it still
+  uses the global value; the lens only annotates the returned set (ranking by lensed belief is a
+  possible future option, explicitly not v1).
+- `get_claim` / `get_belief`: single claim → one compute. For `get_belief`, the lensed interval is
+  returned in `lensed_belief`; the tool's existing global return is preserved.
+
+## 6. Reuse / no new SQL in tool layer
+
+The tool layer calls the engine (`get_perspective_belief`) and the repo (`PerspectiveRepository`)
+— no new SQL in `crates/epigraph-mcp` (per CLAUDE.md "MCP tools call the repo/engine layer"). The
+bulk `recall` SQL is **unchanged**; the lens is a bounded post-pass over the already-selected page.
+
+## 7. Scope & registration
+
+- All four tools and `list_perspectives` are reads → scope `claims:read` (unchanged;
+  `scope_map.rs` already maps them — no new tool, so the coverage test is unaffected).
+- No new MCP tool is registered; this extends existing tool params + responses.
+
+## 8. Error handling
+
+| Condition | Result |
+|---|---|
+| only one of frame_id/perspective_id given | `McpError` invalid-params ("a lens needs both frame_id and perspective_id") |
+| frame_id / perspective_id not a UUID | `McpError` invalid-params, names which |
+| unknown frame_id or perspective_id | `McpError` not-found, names which |
+| claim has no BBAs on the frame / perspective expresses no opinion | `lensed_belief` reduces to the global interval (compute-on-read already does this; documented, not an error) |
+| per-claim lensed compute fails for one claim in a recall page | that claim's `lensed_belief` is null + a warn log; the rest of the page is unaffected (a lens annotation must not fail the whole recall) |
+
+## 9. Testing
+
+- **Discriminating test:** a perspective with a populated `source_reliability` map yields a
+  `lensed_belief` **different** from the global value for the same claim, via `recall`, `get_claim`,
+  and `get_belief`; an **empty/absent** perspective yields `lensed_belief` equal to global (the
+  reduce-to-global guarantee). Mirror the engine fixture used by `link_epistemic_smoke`.
+- **Back-compat:** no lens → response is byte-identical to current (no `lensed_belief` key, or
+  null) — a regression that would catch accidental shape changes.
+- **Validation:** only-one-of pair → error; unknown frame/perspective → error; one bad claim in a
+  page degrades to null `lensed_belief` not a whole-call failure.
+- **Discovery:** `list_perspectives` surfaces the `source_reliability`/`locality_reliability` maps.
+- Council-of-critics on tests (no tautologies, prove belief actually differs under the lens).
+
+## 10. Out of scope / future / backlog relationship
+
+- **Default-cache perspective-scoping** (`23472d04` headline): making the default combine compute
+  & cache per-perspective beliefs remains a separate, heavier item. This spec is the **read-side**
+  realization of the same goal; on landing, `23472d04` should be **re-scoped** (read-side done;
+  default-cache-scoping still open) rather than resolved.
+- Session-level / agent-default lens (auto-lens every read for a session).
+- Lens-aware ranking in `recall` (rank by lensed belief, not just annotate).
+- `perspective_id`-by-name resolution.
+- Threading the lens into other belief-returning tools (`query_claims`, `get_neighborhood`, …).
+
+## 11. Code anchors (for the plan)
+
+- Engine: `crates/epigraph-engine/src/belief_query.rs::get_perspective_belief(pool, claim_id,
+  frame_id, perspective_id)` (+ `get_belief`).
+- Read tools: `crates/epigraph-mcp/src/tools/recall.rs` (recall + recall_with_context),
+  `crates/epigraph-mcp/src/tools/claims.rs::get_claim`, the `get_belief` tool, params in
+  `crates/epigraph-mcp/src/types.rs`.
+- Discovery: `crates/epigraph-mcp/src/tools/perspectives.rs::list_perspectives`,
+  `crates/epigraph-mcp/src/tools/ds.rs::list_frames`,
+  `crates/epigraph-db/src/repos/perspective.rs` (`source_reliability`/`locality_reliability`).


### PR DESCRIPTION
Back-merge `main` → `dev` to resync the dev integration branch and pull a feature that reached `main` outside the dev gate.

**Evidence:**
- `dev` is 7 commits behind `main` (0 ahead). `git merge-base --is-ancestor origin/dev origin/main` is **true** → `dev` is a strict ancestor of `main`, so this is a clean fast-forward with zero conflicts.
- Commits on `main` not yet on `dev`:
  - `b92bf95` Merge pull request #267 from epigraph-io/dev *(promotion merge)*
  - `169a85c` Merge pull request #264 from epigraph-io/feat/perspective-lens-reads
  - `49443e4` test(mcp): pin plain-recall lens degrade-not-fail path
  - `af95028` test(mcp): lensed != global integration coverage for perspective-lens reads
  - `8ff8007` feat(mcp): enrich list_perspectives with source/locality reliability maps
  - `7af3feb` feat(mcp): perspective-lens reads — optional (frame,perspective) lens on the four read tools
  - `b5d4dec` docs(mcp): design spec for perspective-lens reads (read-side of 23472d04)

**Reasoning:**
- PR #264 (perspective-lens reads) is **real feature content** that landed on `main` without passing through `dev`. Until back-merged, `dev` is missing those four read-tool lenses, so any feature branched from `dev` would silently drop them — and the next promotion PR would re-surface a stale read path. Back-merging restores `dev` as the authoritative integration base.

**Verification:**
- CI on this PR validates that the dev-bound tree builds without regression (the original "does dev build cleanly" question).
- Merge with a **merge commit** (no squash) per repo norm. ⚠️ Head branch is `main` — do **NOT** delete the head branch on merge.
