### PR TITLE
fix(matcher): exclude operational self-log claims from cross-source candidates

### DIFF
--- a/calibration.toml
+++ b/calibration.toml
@@ -184,9 +184,14 @@ include_agent_id = false
 # scoring. `workflow_step` artifacts (e.g. content "Body") dominate the
 # high-cosine candidate pool on prod (806/838 of embed_cosine>=0.90 pairs)
 # without being substantive cross-source claims; `telemetry` is host noise.
+# 2026-06-15: extended with EpiClaw/scheduled-task self-narration labels. A prod
+# dry-run staged 31/44 pending candidates from operational self-logs (daily
+# journals, graph-integrity/theme/data-integrity maintenance runs, ingest-session
+# logs) — they share heavy boilerplate, score >0.80 cosine, and evade
+# workflow_step/telemetry because they carry date-stamps + ops tags instead.
 # Set `exclude_labels = []` to disable.
 [matcher.eligibility]
-exclude_labels = ["workflow_step", "telemetry"]
+exclude_labels = ["workflow_step", "telemetry", "maintenance", "graph-integrity", "maintenance-log", "theme-maintenance", "data-integrity", "system-health", "journal", "daily-journal", "digest", "nightly-digest", "session-log", "scheduled-task", "reconciliation-complete", "conflict-resolution", "research-ingest"]
 
 [matcher.fan_out]
 max_per_claim = 32


### PR DESCRIPTION
## Summary
Extends `[matcher.eligibility] exclude_labels` with 15 operational self-narration labels so EpiClaw daily-journal syntheses and graph-integrity/theme/data-integrity maintenance-run telemetry stop entering cross-source candidate generation.

## Evidence (first prod run of the recalibrated matcher)
The 2026-06-02 recalibration (renormalized scorer + bands `mid=0.80/high=1.01`) landed and works — a `cross_source_sweep --dry-run` over 500 prod seeds reached the verifier (mid_band **0→436**, vs. always-0 under the old diluted scorer). But **31 of 44** staged pending candidates were operational self-logs that share boilerplate, score >0.80 cosine, and the verifier mislabels "paraphrase". They evade `["workflow_step","telemetry"]` because they carry date-stamp + ops-tag labels instead.

## Change
Config-only (no rebuild). Adds: `maintenance, graph-integrity, maintenance-log, theme-maintenance, data-integrity, system-health, journal, daily-journal, digest, nightly-digest, session-log, scheduled-task, reconciliation-complete, conflict-resolution, research-ingest`. Deliberately **not** `global/sheaf/architecture/paper-ingest` (those tag genuine content). The engine reads `exclude_labels` at runtime and drops carrying claims from both sides of candidate generation before scoring.

## Verification (live prod, no edges written)
- **count-only A/B, identical 500-seed window:** mid_band **436 → 131** (−70%; also −70% verifier LLM cost/sweep).
- **real-verifier dry-run under new filter:** queue **44 → 11** pending, all legitimate cross-source relationships (ABP/MIPS active-matter physics, semantic-entropy↔DeBERTa, AUROC, agent/working-memory), zero operational pollution, zero false-positive corroborations.

Full writeup: `~/e2e-logs/matcher-sweep-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)