### PR TITLE
feat(mcp): support labels in batch_submit_claims

### DIFF
--- a/crates/epigraph-mcp/src/tools/batch.rs
+++ b/crates/epigraph-mcp/src/tools/batch.rs
@@ -31,7 +31,7 @@ pub async fn batch_submit_claims(
             confidence: entry.confidence.unwrap_or(0.5),
             source_url: None,
             reasoning: None,
-            labels: vec![],
+            labels: entry.labels.clone(),
         };
 
         match crate::tools::claims::submit_claim(server, claim_params).await {

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -1315,6 +1315,12 @@ pub struct BatchClaimEntry {
 
     #[schemars(description = "Confidence 0.0-1.0")]
     pub confidence: Option<f64>,
+
+    #[schemars(
+        description = "Optional labels to attach to the new claim (e.g. ['backlog','bug'])"
+    )]
+    #[serde(default)]
+    pub labels: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/epigraph-mcp/tests/batch_submit_claims_labels_test.rs
+++ b/crates/epigraph-mcp/tests/batch_submit_claims_labels_test.rs
@@ -1,0 +1,55 @@
+use sqlx::PgPool;
+mod common;
+use common::*;
+
+/// Regression for backlog 9e15d187: `batch_submit_claims` dropped per-entry
+/// `labels`, unlike `submit_claim`. The batch path hard-coded `labels: vec![]`
+/// when delegating to `submit_claim`, so a `BatchClaimEntry` carrying
+/// `labels: ["capability-registry"]` lost its label at ingest — breaking
+/// label-at-ingest flows (e.g. weekly-capability-audit). This pins the fix:
+/// labels supplied on a batch entry must survive to the persisted claim.
+#[sqlx::test(migrations = "../../migrations")]
+async fn batch_submit_claims_attaches_per_entry_labels(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+
+    let content = "batched claim carrying a label";
+    let result = epigraph_mcp::tools::batch::batch_submit_claims(
+        &server,
+        epigraph_mcp::types::BatchSubmitClaimsParams {
+            claims: vec![epigraph_mcp::types::BatchClaimEntry {
+                content: content.into(),
+                evidence_data: "ev".into(),
+                evidence_type: "logical".into(),
+                confidence: Some(0.8),
+                labels: vec!["capability-registry".into()],
+            }],
+        },
+    )
+    .await
+    .unwrap();
+
+    // The batch response reports counts, not per-entry claim_ids; confirm the
+    // single entry submitted cleanly before asserting on its persisted labels.
+    let summary = first_text(&result);
+    assert_eq!(
+        summary.get("submitted").and_then(|v| v.as_i64()),
+        Some(1),
+        "expected exactly one submitted claim, got {summary}"
+    );
+    assert_eq!(
+        summary.get("errors").and_then(|v| v.as_i64()),
+        Some(0),
+        "expected no batch errors, got {summary}"
+    );
+
+    let (labels,): (Vec<String>,) =
+        sqlx::query_as("SELECT labels FROM claims WHERE content = $1 AND is_current = true")
+            .bind(content)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        labels.contains(&"capability-registry".to_string()),
+        "batch entry label was dropped; persisted labels = {labels:?}"
+    );
+}


### PR DESCRIPTION
**Evidence:** backlog 9e15d187 — the batch path dropped per-entry labels unlike `submit_claim` (it hard-coded `labels: vec![]` when delegating), breaking weekly-capability-audit's `capability-registry` labeling at ingest.

**Reasoning:** Mirror `SubmitClaimParams.labels` exactly on `BatchClaimEntry` (`Vec<String>` with `#[serde(default)]`, same schemars doc) and pass `entry.labels.clone()` through. `batch_submit_claims` delegates to `submit_claim`, which applies labels post-create via `ClaimRepository::update_labels`; there is no separate batch ingest path to mirror, so the passthrough is the whole fix.

**Verification:** New integration test `batch_submit_claims_attaches_per_entry_labels` fails first against the old code (`persisted labels = []`) and passes after the fix. Full CI gate green: `cargo build`, `cargo clippy --workspace --locked -- -D warnings`, `cargo fmt --check`, `cargo test -p epigraph-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)