### PR TITLE
fix(workflow-ingest): guard against empty Phase.summary violating claims_content_not_empty

### DIFF
--- a/crates/epigraph-ingest/src/workflow/builder.rs
+++ b/crates/epigraph-ingest/src/workflow/builder.rs
@@ -62,7 +62,29 @@ pub fn build_ingest_plan(extraction: &WorkflowExtraction) -> IngestPlan {
 
     for (pi, phase) in extraction.phases.iter().enumerate() {
         let phase_path = format!("phases[{pi}]");
-        let phase_hash = content_hash(&phase.summary);
+        // BUGFIX (k1-trace-bug): `Phase.summary` carries `#[serde(default)]` in
+        // schema.rs so it silently defaults to `""` when the field is omitted from
+        // JSON input. Passing an empty string as `content` to
+        // `ClaimRepository::create_with_id_if_absent` violates the DB constraint
+        // `claims_content_not_empty` (`length(TRIM(BOTH FROM content)) > 0`).
+        //
+        // Root-cause line: this was `content_hash(&phase.summary)` / `content:
+        // phase.summary.clone()` with no guard — any caller that omits `summary`
+        // would trigger the constraint, regardless of `canonical_name`.
+        // `improve_workflow_hierarchy` with `parent_canonical_name =
+        // "weekly-capability-audit"` was the first observed trigger, but the bug
+        // affects every code path that reaches `build_ingest_plan`.
+        //
+        // Fix: fall back to `phase.title` (always required, never empty) when
+        // `summary` is blank. The hash is computed from whichever string ends up as
+        // the claim content so the deterministic ID stays consistent with what is
+        // actually persisted.
+        let phase_content = if phase.summary.trim().is_empty() {
+            phase.title.clone()
+        } else {
+            phase.summary.clone()
+        };
+        let phase_hash = content_hash(&phase_content);
         let phase_id = compound_claim_id(&phase_hash, canonical_name);
         phase_ids.push(phase_id);
         path_index.insert(phase_path.clone(), phase_id);
@@ -74,7 +96,7 @@ pub fn build_ingest_plan(extraction: &WorkflowExtraction) -> IngestPlan {
         // `properties.level` (1 vs 2) to disambiguate phase from step when needed.
         claims.push(PlannedClaim {
             id: phase_id,
-            content: phase.summary.clone(),
+            content: phase_content,
             level: 1,
             properties: serde_json::json!({
                 "level": 1,
@@ -251,5 +273,94 @@ pub fn root_workflow_id(extraction: &WorkflowExtraction) -> Uuid {
 impl crate::common::walker::Walker for WorkflowExtraction {
     fn build_ingest_plan(&self) -> IngestPlan {
         build_ingest_plan(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::schema::ThesisDerivation;
+    use crate::workflow::schema::{Phase, Step, WorkflowSource};
+
+    fn extraction_with_empty_phase_summary() -> WorkflowExtraction {
+        WorkflowExtraction {
+            source: WorkflowSource {
+                canonical_name: "weekly-capability-audit".to_string(),
+                goal: "Audit weekly capabilities".to_string(),
+                generation: 1,
+                parent_canonical_name: Some("weekly-capability-audit".to_string()),
+                authors: vec![],
+                expected_outcome: None,
+                tags: vec![],
+                metadata: serde_json::json!({}),
+            },
+            thesis: Some("Thesis text".to_string()),
+            thesis_derivation: ThesisDerivation::TopDown,
+            phases: vec![Phase {
+                title: "Capability Review".to_string(),
+                summary: "".to_string(), // empty — serde default; triggers constraint bug
+                steps: vec![Step {
+                    compound: "Review all capabilities".to_string(),
+                    rationale: "Need to know what we have".to_string(),
+                    operations: vec!["List capabilities".to_string()],
+                    generality: vec![1],
+                    confidence: 0.9,
+                }],
+            }],
+            relationships: vec![],
+        }
+    }
+
+    /// Regression: a Phase with `summary = ""` (the serde default when the field
+    /// is omitted from JSON) must NOT produce a PlannedClaim with empty content,
+    /// because the DB enforces `claims_content_not_empty` CHECK
+    /// `(length(TRIM(BOTH FROM content)) > 0)`.
+    ///
+    /// Root cause: `Phase.summary` is `#[serde(default)]` (schema.rs:54), so it
+    /// defaults to `""`. `build_ingest_plan` previously passed `phase.summary.clone()`
+    /// directly as `PlannedClaim.content` for level-1 phase claims without guarding
+    /// against an empty value. The fix falls back to `phase.title` when `summary`
+    /// is blank, which is always present and required.
+    #[test]
+    fn phase_with_empty_summary_falls_back_to_title() {
+        let extraction = extraction_with_empty_phase_summary();
+        let plan = build_ingest_plan(&extraction);
+
+        for claim in &plan.claims {
+            assert!(
+                !claim.content.trim().is_empty(),
+                "PlannedClaim at level {} has empty content (would violate \
+                 claims_content_not_empty); id={:?}",
+                claim.level,
+                claim.id,
+            );
+        }
+
+        // The phase claim (level=1) must have fallen back to the title.
+        let phase_claim = plan
+            .claims
+            .iter()
+            .find(|c| c.level == 1)
+            .expect("expected a level-1 phase claim");
+        assert_eq!(
+            phase_claim.content, "Capability Review",
+            "phase claim content should be the phase title when summary is empty"
+        );
+    }
+
+    /// A Phase with a non-empty summary must continue to use the summary as
+    /// content (no regression).
+    #[test]
+    fn phase_with_nonempty_summary_uses_summary() {
+        let mut extraction = extraction_with_empty_phase_summary();
+        extraction.phases[0].summary = "Non-empty summary text".to_string();
+        let plan = build_ingest_plan(&extraction);
+
+        let phase_claim = plan
+            .claims
+            .iter()
+            .find(|c| c.level == 1)
+            .expect("expected a level-1 phase claim");
+        assert_eq!(phase_claim.content, "Non-empty summary text");
     }
 }

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -476,4 +476,82 @@ mod tests {
         );
         assert!(db_count > 0, "must have at least one executes edge");
     }
+
+    /// Regression test for k1-trace-bug: `improve_workflow_hierarchy` must not
+    /// produce a `claims_content_not_empty` constraint violation when a Phase
+    /// has an empty (or omitted) `summary`.
+    ///
+    /// `Phase.summary` is `#[serde(default)]` so it defaults to `""` when
+    /// absent from JSON. Before the fix, `build_ingest_plan` used
+    /// `phase.summary.clone()` as the level-1 claim content without guarding
+    /// against an empty value, causing PostgreSQL to reject the INSERT with
+    /// `ERROR: new row violates check constraint "claims_content_not_empty"`.
+    ///
+    /// The fix falls back to `phase.title` in `builder.rs` when summary is blank.
+    /// This test validates the full end-to-end path through
+    /// `improve_workflow_hierarchy_via_pool`.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn improve_workflow_hierarchy_empty_phase_summary_succeeds(pool: sqlx::PgPool) {
+        // 1. Seed the base workflow (generation 0).
+        let mut base = minimal_extraction();
+        base.source.canonical_name = "weekly-capability-audit".to_string();
+        do_ingest_workflow_via_pool(&pool, &base)
+            .await
+            .expect("base workflow ingest must succeed");
+
+        // 2. Build an improved extraction where summary is explicitly empty —
+        //    this is the triggering condition from the bug report.
+        let improved = WorkflowExtraction {
+            source: epigraph_ingest::workflow::schema::WorkflowSource {
+                canonical_name: "will-be-overwritten".to_string(),
+                goal: "Improved audit capabilities".to_string(),
+                generation: 99, // overwritten by improve_workflow_hierarchy_via_pool
+                parent_canonical_name: None, // overwritten
+                authors: vec![],
+                expected_outcome: None,
+                tags: vec![],
+                metadata: serde_json::json!({}),
+            },
+            thesis: Some("Improved thesis".to_string()),
+            thesis_derivation: epigraph_ingest::common::schema::ThesisDerivation::TopDown,
+            phases: vec![Phase {
+                title: "Capability Review Phase".to_string(),
+                summary: "".to_string(), // empty — the serde default; was the bug trigger
+                steps: vec![Step {
+                    compound: "Review all system capabilities".to_string(),
+                    rationale: "Ensure completeness".to_string(),
+                    operations: vec!["audit step".to_string()],
+                    generality: vec![1],
+                    confidence: 0.85,
+                }],
+            }],
+            relationships: vec![],
+        };
+
+        // 3. Must succeed without a constraint violation.
+        let result = improve_workflow_hierarchy_via_pool(&pool, "weekly-capability-audit", improved)
+            .await
+            .expect("improve must not violate claims_content_not_empty constraint");
+
+        assert!(!result.already_ingested, "should be a fresh generation");
+        assert!(result.claims_ingested > 0, "expected at least one new claim");
+        assert_eq!(result.parent_generation, 0);
+        assert_eq!(result.new_generation, 1);
+
+        // 4. Verify the phase claim actually has the title as content (not empty).
+        let phase_content: String = sqlx::query_scalar(
+            "SELECT content FROM claims \
+             WHERE properties->>'kind' = 'workflow_step' \
+               AND properties->>'level' = '1' \
+             ORDER BY created_at DESC LIMIT 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("phase claim must exist");
+
+        assert_eq!(
+            phase_content, "Capability Review Phase",
+            "phase claim content must fall back to title when summary is empty"
+        );
+    }
 }

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -529,12 +529,16 @@ mod tests {
         };
 
         // 3. Must succeed without a constraint violation.
-        let result = improve_workflow_hierarchy_via_pool(&pool, "weekly-capability-audit", improved)
-            .await
-            .expect("improve must not violate claims_content_not_empty constraint");
+        let result =
+            improve_workflow_hierarchy_via_pool(&pool, "weekly-capability-audit", improved)
+                .await
+                .expect("improve must not violate claims_content_not_empty constraint");
 
         assert!(!result.already_ingested, "should be a fresh generation");
-        assert!(result.claims_ingested > 0, "expected at least one new claim");
+        assert!(
+            result.claims_ingested > 0,
+            "expected at least one new claim"
+        );
         assert_eq!(result.parent_generation, 0);
         assert_eq!(result.new_generation, 1);
 


### PR DESCRIPTION
## Summary

- *Root cause*: `Phase.summary` has `#[serde(default)]` in `schema.rs:54`, so it silently defaults to `""` when omitted from JSON. `build_ingest_plan` (`builder.rs:65` pre-fix) used `phase.summary.clone()` directly as `PlannedClaim.content` for level-1 phase claims with no guard. `ClaimRepository::create_with_id_if_absent` passes the content raw to SQL, so the empty string reaches PostgreSQL and the `claims_content_not_empty` CHECK (`length(TRIM(BOTH FROM content)) > 0`, migration line 629) rejects the INSERT.

- *Scope*: the bug is NOT specific to `weekly-capability-audit` or `improve_workflow_hierarchy`. It affects every code path that calls `build_ingest_plan` (i.e. `ingest_workflow`, `improve_workflow_hierarchy`, the HTTP route) whenever a `Phase` is submitted without a `summary` field. `improve_workflow_hierarchy` with `parent_canonical_name = "weekly-capability-audit"` was the first observed trigger.

- *What `improve_workflow_hierarchy_with_inserted` does NOT overwrite*: it overwrites `canonical_name`, `generation`, and `parent_canonical_name`, but leaves `goal`, `thesis`, and all `phases` (including `phase.summary`) unchanged. `goal` does not flow into any claim `content` column. The empty `phase.summary` is what flows into `content` — that is the root-cause field.

- *Fix*: in `builder.rs`, when `phase.summary.trim().is_empty()`, use `phase.title` as the claim content instead. The content hash is computed from whichever string is used so the deterministic claim ID is consistent with what is persisted. `phase.title` is always required (no `serde(default)`) and must be non-empty.

- *Executor / constraint path*: `execute_workflow_ingest_plan` creates no claims beyond the plan; the `ON CONFLICT DO NOTHING` idempotency path does not trigger the constraint (it only fires on a fresh INSERT). `create_with_id_if_absent` does no pre-validation — the constraint is enforced only by PostgreSQL.

## Test plan

- `builder::tests::phase_with_empty_summary_falls_back_to_title` — unit; verifies `build_ingest_plan` produces no empty-content `PlannedClaim` and that the level-1 claim content is the phase title when summary is blank
- `builder::tests::phase_with_nonempty_summary_uses_summary` — unit; no-regression for normal case
- `workflow_ingest::tests::improve_workflow_hierarchy_empty_phase_summary_succeeds` — integration (`sqlx::test`); seeds a `weekly-capability-audit` base workflow then calls `improve_workflow_hierarchy_via_pool` with an empty `summary`, verifies no constraint violation and that the persisted claim content equals `phase.title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)