### PR TITLE
fix(mcp): detach embed_and_store from ingest_document response path

### DIFF
--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::wildcard_imports)]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use rmcp::model::*;
 use uuid::Uuid;
@@ -351,7 +352,7 @@ pub async fn do_ingest_document(
 
     let mut claim_ids: Vec<String> = Vec::new();
     let mut id_map: HashMap<Uuid, Uuid> = HashMap::new();
-    let mut embedded_count = 0_usize;
+    let mut embed_queue: Vec<(Uuid, String)> = Vec::new();
     let mut dedup_count = 0_usize;
     let mut ds_entries: Vec<BatchDsEntry> = Vec::new();
 
@@ -477,13 +478,7 @@ pub async fn do_ingest_document(
         .await
         .map_err(internal_error)?;
 
-        if server
-            .embedder
-            .embed_and_store(persisted_id, &planned.content)
-            .await
-        {
-            embedded_count += 1;
-        }
+        embed_queue.push((persisted_id, planned.content.clone()));
 
         // Atoms (level 3) are the units we trust to carry CDST evidence.
         if planned.level == 3 {
@@ -604,13 +599,29 @@ pub async fn do_ingest_document(
     .await
     .map_err(internal_error)?;
 
+    // ── 8. Detach embeddings so the MCP response returns immediately after commit ──
+    // All DB writes are done. Embed in the background so the caller is not blocked
+    // by N × ~0.8 s OpenAI calls. The response reports the number queued; the
+    // invariant (every is_current claim has an embedding) is satisfied eventually.
+    let queued = embed_queue.len();
+    if !embed_queue.is_empty() {
+        let embedder = Arc::clone(&server.embedder);
+        tokio::spawn(async move {
+            for (id, content) in embed_queue {
+                if !embedder.embed_and_store(id, &content).await {
+                    tracing::warn!("background embedding failed for claim {id}");
+                }
+            }
+        });
+    }
+
     success_json(&IngestDocumentResponse {
         paper_id: paper_id.to_string(),
         paper_title,
         doi,
         authors: author_responses,
         claims_ingested: claim_ids.len() - dedup_count,
-        claims_embedded: embedded_count,
+        claims_embedded: queued,
         claims_skipped_dedup: dedup_count,
         relationships_created,
         claims_ds_wired,


### PR DESCRIPTION
## Problem

`ingest_document_inline` times out for full paper ingests (20+ atoms × ~0.8 s/OpenAI call ≈ 16+ s). The MCP client drops the connection before the synchronous embedding loop finishes, which cancels the tokio future and rolls back the entire ingest — even though the DB graph is complete and correct.

## Fix

Move `embed_and_store` calls off the synchronous handler path and onto a detached `tokio::spawn` after all DB writes complete.

**How:**
- During the claims loop, collect `(claim_id, content)` pairs into an `embed_queue` vec instead of calling `embed_and_store` inline.
- After step 7 (processed_by edge written), if the queue is non-empty, `Arc::clone(&server.embedder)` (cheap — one atomic inc) and `tokio::spawn` a background task that iterates the queue.
- The MCP handler returns immediately after the DB commit with `claims_embedded` = count queued for background embedding.

**Policy compliance (CLAUDE.md embedding invariant):** embeddings are best-effort ("warn on failure, never block the write"). The invariant — every `is_current` claim has an embedding — is satisfied eventually; the background task warns on per-claim failures and continues.

## Testing

- `cargo check -p epigraph-mcp` (SQLX_OFFLINE=true): clean
- `cargo clippy -p epigraph-mcp -- -D warnings`: 0 warnings in epigraph-mcp
- `cargo fmt -p epigraph-mcp --check`: no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)