### PR TITLE
fix(mcp): make ingest_document/inline fire-and-forget to survive client timeouts

### DIFF
--- a/.claude/skills/extract-claims/SKILL.md
+++ b/.claude/skills/extract-claims/SKILL.md
@@ -128,6 +128,24 @@ embeddings, and CDST mass functions for atoms.
 that must stage JSON on disk first, but `ingest_document_inline` is the primary,
 inline path and the one this flow uses.)
 
+#### Fire-and-forget — response is a queue acknowledgement, not confirmation
+
+`ingest_document_inline` (and `ingest_document`) return **immediately** after
+spawning a detached Tokio task; the response is:
+
+```json
+{ "status": "queued", "doi": "...", "title": "...", "note": "..." }
+```
+
+**The write may still be in flight when you receive this.** Always verify with
+`check_already_ingested` (or `query_paper`) before treating the paper as landed.
+Do not fire a second ingest call based on a timeout — the background task is
+still running. One write at a time per paper is the correct pattern.
+
+`ingest_document_spine`, by contrast, IS synchronous — it must return
+`new_paragraph_paths` before the atomization LLM call can proceed. Spine writes
+are lightweight (no atoms, no CDST) and complete within typical timeout windows.
+
 ## The DocumentExtraction JSON Schema
 
 This is the shape `structure_source` returns and `ingest_document_inline` parses.

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -162,7 +162,26 @@ pub async fn ingest_document(
     let extraction: DocumentExtraction =
         serde_json::from_str(&data).map_err(|e| invalid_params(format!("invalid JSON: {e}")))?;
 
-    do_ingest_document(server, &extraction).await
+    let doi = resolve_doi(&extraction);
+    let title = extraction.source.title.clone();
+    let bg = EpiGraphMcpFull::new_shared(
+        server.pool.clone(),
+        Arc::clone(&server.signer),
+        Arc::clone(&server.embedder),
+        server.read_only,
+    );
+    let doi_log = doi.clone();
+    tokio::spawn(async move {
+        if let Err(e) = do_ingest_document(&bg, &extraction).await {
+            tracing::warn!(doi = doi_log, "background ingest_document failed: {e:?}");
+        }
+    });
+    success_json(&serde_json::json!({
+        "status": "queued",
+        "doi": doi,
+        "title": title,
+        "note": "DB writes are running as a detached background task. Call check_already_ingested to confirm completion before assuming the write landed."
+    }))
 }
 
 /// Inline (typed-param) counterpart to [`ingest_document`]. Takes a
@@ -174,7 +193,30 @@ pub async fn ingest_document_inline(
     server: &EpiGraphMcpFull,
     params: IngestDocumentInlineParams,
 ) -> Result<CallToolResult, McpError> {
-    do_ingest_document(server, &params.extraction).await
+    let extraction = params.extraction;
+    let doi = resolve_doi(&extraction);
+    let title = extraction.source.title.clone();
+    let bg = EpiGraphMcpFull::new_shared(
+        server.pool.clone(),
+        Arc::clone(&server.signer),
+        Arc::clone(&server.embedder),
+        server.read_only,
+    );
+    let doi_log = doi.clone();
+    tokio::spawn(async move {
+        if let Err(e) = do_ingest_document(&bg, &extraction).await {
+            tracing::warn!(
+                doi = doi_log,
+                "background ingest_document_inline failed: {e:?}"
+            );
+        }
+    });
+    success_json(&serde_json::json!({
+        "status": "queued",
+        "doi": doi,
+        "title": title,
+        "note": "DB writes are running as a detached background task. Call check_already_ingested to confirm completion before assuming the write landed."
+    }))
 }
 
 /// Pool-only gate check: returns `Some(paper_id)` iff a paper with `doi`

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -631,12 +631,13 @@ async fn inline_param_ingests_full_hierarchy(pool: PgPool) {
 
     let json: serde_json::Value =
         serde_json::from_str(&result_text(&result)).expect("response JSON");
-    assert_eq!(json["already_ingested"], serde_json::json!(false));
     assert_eq!(
-        json["claims_ingested"].as_u64().unwrap(),
-        5,
-        "typed-inline path lands the same thesis + section + paragraph + 2 atoms as the file path"
+        json["status"], "queued",
+        "fire-and-forget ingest_document_inline returns a queue acknowledgement immediately"
     );
+
+    // Background task writes DB asynchronously; give it time to complete before asserting state.
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
     // Atoms landed as their own claim rows — the atomic resolution.
     let atom_count: (i64,) = sqlx::query_as(

--- a/crates/epigraph-mcp/tests/verbatim_spine_e2e.rs
+++ b/crates/epigraph-mcp/tests/verbatim_spine_e2e.rs
@@ -63,12 +63,22 @@ async fn structure_then_ingest_yields_verbatim_spine(pool: PgPool) {
     extraction.sections[1].paragraphs[0].atoms = vec!["Beta follows alpha".to_string()];
 
     // 3) ingest inline; the writer re-verifies the threaded source_text + spans.
+    //    ingest_document_inline is fire-and-forget: it spawns the write as a
+    //    detached Tokio task and returns {"status":"queued"} immediately.
     let result = ingest_document_inline(&server, IngestDocumentInlineParams { extraction })
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
-    assert_eq!(json["already_ingested"], serde_json::json!(false));
-    let paper_id = uuid::Uuid::parse_str(json["paper_id"].as_str().unwrap()).unwrap();
+    assert_eq!(json["status"], "queued");
+
+    // Give the background task time to finish its DB writes.
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    // Resolve paper_id by DOI now that the background write has landed.
+    let paper_id: uuid::Uuid = sqlx::query_scalar("SELECT id FROM papers WHERE doi = '10.1/e2e'")
+        .fetch_one(&pool)
+        .await
+        .expect("paper row must exist after background task completes");
 
     // 4a) the paragraph node content is BYTE-EQUAL to the source paragraph.
     //


### PR DESCRIPTION
## Summary

- `ingest_document` and `ingest_document_inline` now spawn `do_ingest_document` as a detached Tokio task and return `{ status: \"queued\", doi, title, note }` immediately
- DB writes no longer race against the MCP client's timeout window — the Tokio task outlives the HTTP connection
- `ingest_document_spine` is intentionally kept synchronous: its `new_paragraph_paths` return value is what the agent needs before the atomization LLM call can start; spine writes are lightweight (no atoms, no CDST) and fast
- Skill updated to document the queued-response pattern and the mandatory `check_already_ingested` verification step

## Root cause

PR #293 detached only OpenAI embed calls. DB writes (claims, traces, evidence, edges, CDST mass functions) remained synchronous in the MCP handler. When the MCP HTTP Streamable client times out and closes the SSE connection, Tokio cancels the handler task — the writes stop wherever they are and nothing lands. Agents assumed "timeout = server finishing in background"; it was actually a full rollback.

## Test plan

- [ ] Trigger `ingest_document_inline` with a large paper and verify the response arrives immediately (`status: "queued"`)
- [ ] Poll `check_already_ingested` every few seconds and confirm the paper lands within the DB write window (~1–5s for a typical abstract)
- [ ] Re-ingest the same paper and verify idempotency (content-hash dedup returns the same paper_id, no duplicates)
- [ ] CI: build + test + clippy + fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)