### PR TITLE
fix(mcp,api): populate workflows.goal_embedding in store_workflow and HTTP ingest routes

### DIFF
--- a/crates/epigraph-api/src/routes/workflows.rs
+++ b/crates/epigraph-api/src/routes/workflows.rs
@@ -239,6 +239,7 @@ pub async fn store_workflow(
     // Embed inline, best-effort. Satisfies the is_current=true → has-embedding
     // invariant (CLAUDE.md "Embedding policy"). Failures warn and continue.
     if let Some(embedder) = state.embedding_service() {
+        let wf_id = result.workflow_id;
         for (claim_id, content) in &result.inserted {
             match embedder.generate(content).await {
                 Ok(embedding) => {
@@ -256,6 +257,23 @@ pub async fn store_workflow(
                 Err(e) => {
                     tracing::warn!(claim_id = %claim_id, error = %e, "Failed to generate embedding for ingested workflow claim");
                 }
+            }
+        }
+        // Also embed into workflows.goal_embedding for find_workflow_hierarchical.
+        match embedder.generate(&request.goal).await {
+            Ok(qvec) => {
+                if let Err(e) = epigraph_db::WorkflowRepository::set_goal_embedding(
+                    &state.db_pool,
+                    wf_id,
+                    &qvec,
+                )
+                .await
+                {
+                    tracing::warn!(workflow_id=%wf_id, error=?e, "set_goal_embedding failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(workflow_id=%wf_id, error=?e, "goal embedding generation failed for workflow goal");
             }
         }
     }
@@ -1276,6 +1294,7 @@ pub async fn ingest_workflow(
     // Embed inline, best-effort. Satisfies the is_current=true → has-embedding
     // invariant (CLAUDE.md "Embedding policy"). Failures warn and continue.
     if let Some(embedder) = state.embedding_service() {
+        let wf_id = result.workflow_id;
         for (claim_id, content) in &result.inserted {
             match embedder.generate(content).await {
                 Ok(embedding) => {
@@ -1293,6 +1312,23 @@ pub async fn ingest_workflow(
                 Err(e) => {
                     tracing::warn!(claim_id = %claim_id, error = %e, "Failed to generate embedding for ingested workflow claim");
                 }
+            }
+        }
+        // Also embed into workflows.goal_embedding for find_workflow_hierarchical.
+        match embedder.generate(&extraction.source.goal).await {
+            Ok(qvec) => {
+                if let Err(e) = epigraph_db::WorkflowRepository::set_goal_embedding(
+                    &state.db_pool,
+                    wf_id,
+                    &qvec,
+                )
+                .await
+                {
+                    tracing::warn!(workflow_id=%wf_id, error=?e, "set_goal_embedding failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(workflow_id=%wf_id, error=?e, "goal embedding generation failed for workflow goal");
             }
         }
     }

--- a/crates/epigraph-mcp/src/tools/workflows.rs
+++ b/crates/epigraph-mcp/src/tools/workflows.rs
@@ -371,6 +371,24 @@ pub async fn store_workflow(
         let _ = server.embedder.embed_and_store(*claim_id, content).await;
     }
 
+    // Also embed the workflow goal into workflows.goal_embedding for
+    // embedding-first find_workflow_hierarchical. Omitted from the original
+    // store_workflow; do_ingest_workflow embeds it correctly.
+    if let Ok(wf_id) = uuid::Uuid::parse_str(&response.workflow_id) {
+        match server.embedder.generate(&params.goal).await {
+            Ok(qvec) => {
+                if let Err(e) =
+                    WorkflowRepository::set_goal_embedding(&server.pool, wf_id, &qvec).await
+                {
+                    tracing::warn!(workflow_id=%wf_id, error=?e, "set_goal_embedding failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(workflow_id=%wf_id, error=?e, "goal embedding generation failed");
+            }
+        }
+    }
+
     success_json(&StoreWorkflowResponse {
         workflow_id: response.workflow_id,
         canonical_name: response.canonical_name,


### PR DESCRIPTION
## Summary

- `a142e8f` added `workflows.goal_embedding` and wired `set_goal_embedding` into `do_ingest_workflow`, but omitted it from three other write paths that also create `workflows` table rows: MCP `store_workflow`, HTTP `POST /api/v1/workflows`, and HTTP `POST /api/v1/workflows/ingest`.
- 31 workflows created since 2026-05-27 are missing `goal_embedding`; `find_workflow_hierarchical` skips them in the embedding-first path, surfacing them only via ILIKE fallback (similarity=0.0). This caused agents to miss newly-ingested workflows in semantic recall.
- `claims.embedding` is unaffected (`live_missing=0`); only `workflows.goal_embedding` was leaking.

## Changes

Three write paths patched to call `WorkflowRepository::set_goal_embedding` post-ingest, best-effort (warn + continue, never blocks the write):

- `crates/epigraph-mcp/src/tools/workflows.rs` — MCP `store_workflow`
- `crates/epigraph-api/src/routes/workflows.rs` — HTTP `store_workflow` and `ingest_workflow`

## Test plan

- [ ] `cargo fmt --all --check` — passes
- [ ] `cargo clippy --workspace --locked -- -D warnings` — passes (no new warnings)
- [ ] Deploy + run `SELECT COUNT(*) FILTER (WHERE goal_embedding IS NULL) FROM workflows WHERE created_at > NOW() - INTERVAL '1 hour'` after ingesting a new workflow via `store_workflow` — should be 0
- [ ] Backfill the 31 existing missing rows via `backfill_embeddings` or direct SQL update

🤖 Generated with [Claude Code](https://claude.com/claude-code)