### PR TITLE
fix(entities): enforce claims:write scope on entity and triple write endpoints

### DIFF
--- a/crates/epigraph-api/src/routes/entities.rs
+++ b/crates/epigraph-api/src/routes/entities.rs
@@ -109,8 +109,11 @@ pub struct BatchIdsResponse {
 #[cfg(feature = "db")]
 pub async fn create_entity(
     State(state): State<AppState>,
+    _scope: crate::middleware::bearer::RequireScopeWrite,
     Json(req): Json<CreateEntityRequest>,
 ) -> Result<Json<EntityResponse>, ApiError> {
+    // Scope gate ran in the extractor; if we reach the body, the caller has
+    // `claims:write`. See `RequireScopeWrite` in `middleware::bearer`.
     let properties = req
         .properties
         .unwrap_or(serde_json::Value::Object(Default::default()));
@@ -146,8 +149,11 @@ pub async fn create_entity(
 #[cfg(feature = "db")]
 pub async fn batch_create_mentions(
     State(state): State<AppState>,
+    _scope: crate::middleware::bearer::RequireScopeWrite,
     Json(req): Json<BatchMentionsRequest>,
 ) -> Result<Json<BatchIdsResponse>, ApiError> {
+    // Scope gate ran in the extractor; if we reach the body, the caller has
+    // `claims:write`. See `RequireScopeWrite` in `middleware::bearer`.
     let data = req
         .mentions
         .into_iter()
@@ -182,8 +188,11 @@ pub async fn batch_create_mentions(
 #[cfg(feature = "db")]
 pub async fn batch_create_triples(
     State(state): State<AppState>,
+    _scope: crate::middleware::bearer::RequireScopeWrite,
     Json(req): Json<BatchTriplesRequest>,
 ) -> Result<Json<BatchIdsResponse>, ApiError> {
+    // Scope gate ran in the extractor; if we reach the body, the caller has
+    // `claims:write`. See `RequireScopeWrite` in `middleware::bearer`.
     let data = req
         .triples
         .into_iter()

--- a/crates/epigraph-api/tests/entities_scope_test.rs
+++ b/crates/epigraph-api/tests/entities_scope_test.rs
@@ -1,0 +1,169 @@
+//! Integration tests verifying that entity and triple write endpoints enforce
+//! `claims:write` scope.
+//!
+//! All three POST write handlers were previously missing a `RequireScopeWrite`
+//! extractor, allowing any valid JWT — regardless of granted scopes — to create
+//! entities and triples. These tests guard against regression.
+//!
+//! # Why no positive (200) case for batch endpoints
+//! `POST /api/v1/entity-mentions/batch` and `POST /api/v1/triples/batch` require
+//! seeded FK rows (entity_id, claim_id) in the database. Building that fixture
+//! is non-trivial and out of scope here. The scope guard (403-before-body-parse)
+//! fires from the extractor, so the 401/403 path is fully exercised without DB
+//! write fixtures.
+
+#![cfg(feature = "db")]
+mod common;
+
+// ─── POST /api/v1/entities ──────────────────────────────────────────────────
+
+/// No token → 401
+#[tokio::test(flavor = "multi_thread")]
+async fn create_entity_no_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/entities"))
+        .json(&serde_json::json!({
+            "canonical_name": "Test Entity",
+            "type_top": "organization"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// Token with `claims:read` only (missing `claims:write`) → 403
+#[tokio::test(flavor = "multi_thread")]
+async fn create_entity_missing_scope_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:read"]);
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/entities"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "canonical_name": "Test Entity",
+            "type_top": "organization"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ─── POST /api/v1/entity-mentions/batch ─────────────────────────────────────
+
+/// No token → 401
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_create_mentions_no_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/entity-mentions/batch"))
+        .json(&serde_json::json!({ "mentions": [] }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// Token with `claims:read` only (missing `claims:write`) → 403
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_create_mentions_missing_scope_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:read"]);
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/entity-mentions/batch"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "mentions": [] }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+// ─── POST /api/v1/triples/batch ─────────────────────────────────────────────
+
+/// No token → 401
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_create_triples_no_token_returns_401() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/triples/batch"))
+        .json(&serde_json::json!({ "triples": [] }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "expected 401, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}
+
+/// Token with `claims:read` only (missing `claims:write`) → 403
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_create_triples_missing_scope_returns_403() {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let (addr, _shutdown) = common::spawn_app(&url).await;
+
+    let token = common::test_bearer_token_with_scopes(&["claims:read"]);
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/triples/batch"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "triples": [] }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected 403, got {} — {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+}


### PR DESCRIPTION
## Summary

- Backlog ca4bfb62: `POST /api/v1/entities`, `POST /api/v1/entity-mentions/batch`, and `POST /api/v1/triples/batch` accepted any valid JWT regardless of granted scopes
- Fix: added `RequireScopeWrite` extractor to all three handlers — enforces `claims:write`, consistent with ingestion tools in `scope_map.rs` which already map entity/triple-creating MCP tools to `claims:write`
- `RequireScopeWrite` was already defined in `middleware::bearer.rs` but had zero production uses; this is its first application

## Why `claims:write` not a new scope

`entities:write` / `triples:write` appear nowhere in the codebase — introducing them would lock out all current writers with no grant path. All MCP ingestion tools that create entities/triples are already scoped to `claims:write` in `scope_map.rs`, so `claims:write` is the correct and consistent gate.

## Changes

- `crates/epigraph-api/src/routes/entities.rs` — `_scope: RequireScopeWrite` added to `create_entity`, `batch_create_mentions`, `batch_create_triples`
- `crates/epigraph-api/tests/entities_scope_test.rs` — 6 new tests: 401 (no token) and 403 (read-only token) for all three endpoints

## Test plan

- [ ] `cargo test --test entities_scope_test` — 6/6 (401 + 403 per endpoint)
- [ ] `cargo clippy -p epigraph-api --features db -- -D warnings`
- [ ] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)