### PR TITLE
test(db,mcp): lock chk_deprecated_no_embedding invariant on supersede path

### DIFF
--- a/crates/epigraph-db/tests/supersede_nulls_embedding.rs
+++ b/crates/epigraph-db/tests/supersede_nulls_embedding.rs
@@ -1,0 +1,132 @@
+//! `ClaimRepository::supersede` must null the superseded claim's embedding so
+//! it drops out of semantic search.  Mirrors mark_duplicate_nulls_embedding.rs.
+//!
+//! Regression for the backlog item router-c1cabe28: the invariant
+//! `chk_deprecated_no_embedding` (migration 052) requires that any row with
+//! `is_current = false` also has `embedding = NULL`. The supersede path must
+//! satisfy this in the same UPDATE statement — splitting the two assignments
+//! would violate the per-statement CHECK between statements.
+//!
+//! This test is the lock: if someone removes `embedding = NULL` from the
+//! supersede UPDATE in `ClaimRepository::supersede`, the test will fail with a
+//! `chk_deprecated_no_embedding` constraint violation before any assertion is
+//! reached, making the regression immediately visible.
+
+use epigraph_core::{ClaimId, TruthValue};
+use epigraph_db::ClaimRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn supersede_nulls_embedding_on_old_claim(pool: PgPool) {
+    // Seed one agent row.
+    let agent_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, $2)")
+        .bind(agent_id)
+        .bind([0u8; 32].as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Seed a CURRENT, embedded claim directly via SQL.  The stub vector is
+    // sized to the column's declared dim (1536; the column has a fixed-dim
+    // constraint).  This is the claim that will be superseded.
+    let old_id = Uuid::new_v4();
+    let stub_vec = {
+        let mut v = vec!["0.0"; 1536];
+        v[0] = "0.1";
+        format!("[{}]", v.join(","))
+    };
+    let stub_vec = stub_vec.as_str();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, is_current, embedding) \
+         VALUES ($1, $2, $3, $4, 0.7, true, $5::vector)",
+    )
+    .bind(old_id)
+    .bind("supersede-embedding-test-old")
+    .bind(blake3::hash("supersede-embedding-test-old".as_bytes()).as_bytes().as_slice())
+    .bind(agent_id)
+    .bind(stub_vec)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Confirm the pre-condition: the old claim has a non-NULL embedding.
+    let has_embedding_before: bool =
+        sqlx::query_scalar("SELECT embedding IS NOT NULL FROM claims WHERE id = $1")
+            .bind(old_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        has_embedding_before,
+        "pre-condition: old claim {old_id} must have an embedding before supersede"
+    );
+
+    // Supersede the old claim.
+    let (new_id, returned_old) = ClaimRepository::supersede(
+        &pool,
+        ClaimId::from_uuid(old_id),
+        "supersede-embedding-test-new",
+        TruthValue::clamped(0.85),
+        "regression test for chk_deprecated_no_embedding",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        returned_old, old_id,
+        "supersede must return the old claim id"
+    );
+
+    // Post-condition 1: old claim's embedding is NULL (the invariant).
+    let old_embedding_null: bool =
+        sqlx::query_scalar("SELECT embedding IS NULL FROM claims WHERE id = $1")
+            .bind(old_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        old_embedding_null,
+        "superseded claim {old_id} embedding must be NULL after supersede \
+         (chk_deprecated_no_embedding invariant)"
+    );
+
+    // Post-condition 2: old claim is not current.
+    let old_is_current: bool =
+        sqlx::query_scalar("SELECT COALESCE(is_current, true) FROM claims WHERE id = $1")
+            .bind(old_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        !old_is_current,
+        "superseded claim {old_id} must have is_current = false"
+    );
+
+    // Post-condition 3: new claim exists and is current (with no embedding yet —
+    // callers embed post-commit; the INSERT leaves it NULL intentionally).
+    let new_is_current: bool =
+        sqlx::query_scalar("SELECT COALESCE(is_current, true) FROM claims WHERE id = $1")
+            .bind(new_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        new_is_current,
+        "replacement claim {new_id} must be is_current = true"
+    );
+
+    // Post-condition 4: new claim's supersedes pointer links back to the old claim.
+    let new_supersedes: Option<Uuid> =
+        sqlx::query_scalar("SELECT supersedes FROM claims WHERE id = $1")
+            .bind(new_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        new_supersedes,
+        Some(old_id),
+        "replacement claim {new_id} must have supersedes = {old_id}"
+    );
+}

--- a/crates/epigraph-mcp/tests/supersede_claim_test.rs
+++ b/crates/epigraph-mcp/tests/supersede_claim_test.rs
@@ -38,3 +38,107 @@ async fn supersede_claim_marks_old_and_links_new(pool: PgPool) {
             .unwrap();
     assert_eq!(sup, Some(old));
 }
+
+/// Regression for backlog item router-c1cabe28: supersede_claim must null the
+/// old claim's embedding in the same statement as the is_current=false flip.
+/// The CHECK constraint `chk_deprecated_no_embedding` (migration 052) fires
+/// per-statement; splitting the two assignments would violate it between them.
+///
+/// This test seeds an embedded claim, supersedes it via the MCP handler, then
+/// asserts:
+/// 1. The old claim's embedding is NULL.
+/// 2. The new claim was created and is current.
+///
+/// If `embedding = NULL` is ever removed from the supersede UPDATE the test
+/// will fail with a constraint violation before reaching the assertions.
+#[sqlx::test(migrations = "../../migrations")]
+async fn supersede_claim_nulls_embedding_on_superseded_claim(pool: PgPool) {
+    // Seed an agent row so we can insert a claim with a real embedding.
+    let agent_id = uuid::Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, $2)")
+        .bind(agent_id)
+        .bind([0u8; 32].as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Insert the claim WITH a stub 1536-dim embedding so the constraint path
+    // is exercised (is_current=true with embedding != NULL is valid; flipping
+    // is_current=false without nulling is what breaks the constraint).
+    let old_id = uuid::Uuid::new_v4();
+    let stub_vec = {
+        let mut v = vec!["0.0"; 1536];
+        v[0] = "0.1";
+        format!("[{}]", v.join(","))
+    };
+    sqlx::query(
+        "INSERT INTO claims \
+             (id, content, content_hash, agent_id, truth_value, is_current, embedding) \
+         VALUES ($1, $2, $3, $4, 0.6, true, $5::vector)",
+    )
+    .bind(old_id)
+    .bind("mcp-supersede-embedding-test")
+    .bind(
+        blake3::hash("mcp-supersede-embedding-test".as_bytes())
+            .as_bytes()
+            .as_slice(),
+    )
+    .bind(agent_id)
+    .bind(stub_vec.as_str())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let server = build_test_server(pool.clone());
+    let auth = admin_auth();
+
+    // Call the MCP supersede handler. If the handler fails to null the
+    // embedding before flipping is_current=false this will surface as a
+    // chk_deprecated_no_embedding constraint violation, not an assertion error.
+    let result = epigraph_mcp::tools::supersede::supersede_claim(
+        &server,
+        epigraph_mcp::types::SupersedeClaimParams {
+            claim_id: old_id.to_string(),
+            content: "mcp-supersede-embedding-test-v2".into(),
+            truth_value: 0.8,
+            reason: "regression test for chk_deprecated_no_embedding".into(),
+        },
+        Some(&auth),
+    )
+    .await
+    .expect("supersede_claim must succeed on an embedded claim");
+
+    let json = first_text(&result);
+    let new_id = parse_uuid_field(&json, "new_claim_id");
+
+    // Old claim: is_current=false AND embedding=NULL.
+    let (old_is_current, old_has_embedding): (bool, bool) = sqlx::query_as(
+        "SELECT COALESCE(is_current, true), embedding IS NOT NULL FROM claims WHERE id = $1",
+    )
+    .bind(old_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert!(
+        !old_is_current,
+        "superseded claim {old_id} must have is_current = false"
+    );
+    assert!(
+        !old_has_embedding,
+        "superseded claim {old_id} embedding must be NULL \
+         (chk_deprecated_no_embedding invariant)"
+    );
+
+    // New claim exists and is current.
+    let new_is_current: bool =
+        sqlx::query_scalar("SELECT COALESCE(is_current, true) FROM claims WHERE id = $1")
+            .bind(new_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        new_is_current,
+        "replacement claim {new_id} must be is_current = true"
+    );
+}


### PR DESCRIPTION
## Context

Backlog item router-c1cabe28 reported that `mcp__epigraph__supersede_claim` raises `chk_deprecated_no_embedding` on embedded claims because the MCP handler was diverging from `ClaimRepository::supersede` (missing `embedding = NULL`).

**Key finding:** The production fix was already in place. Commit `b5a80ac` (2026-06-15, `fix(db,mcp): null embeddings atomically on all is_current=false paths`) added `embedding = NULL` to the supersede UPDATE in `ClaimRepository::supersede` (claim.rs:1875). The MCP handler already routes through that repo method (supersede.rs:26). No production code change was needed.

## What this PR adds

Two regression test files that lock the `chk_deprecated_no_embedding` invariant on the supersede path:

1. **`crates/epigraph-db/tests/supersede_nulls_embedding.rs`** — repo-layer test: seeds an embedded claim, calls `ClaimRepository::supersede` directly, asserts `embedding IS NULL` on the old claim and `is_current = false`.

2. **`crates/epigraph-mcp/tests/supersede_claim_test.rs`** — adds `supersede_claim_nulls_embedding_on_superseded_claim`: seeds an embedded claim, calls the full MCP handler, asserts both `is_current = false` and `embedding IS NULL` on the superseded claim.

Both tests will fail with a **constraint violation** (not just an assertion error) if `embedding = NULL` is ever removed from the supersede UPDATE — making any future regression immediately visible in CI.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `DATABASE_URL=.../epigraph_db_repo_test cargo test -p epigraph-db --test supersede_nulls_embedding` — 1 passed
- [x] `DATABASE_URL=.../epigraph_db_repo_test cargo test -p epigraph-mcp --test supersede_claim_test` — 2 passed (existing + new regression test)
- [ ] Resolve backlog item router-c1cabe28 via `resolve_backlog_item` after merge

Note: pre-existing clippy failures in `epigraph-tools` and some `epigraph-db` test files (`match_candidate_repo`, `last_match_scan_column`) are present on `main` and not introduced by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)