### PR TITLE
fix(db): pre-delete diamond-conflict dup-edges in mark_duplicate

### DIFF
--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -2702,9 +2702,69 @@ impl ClaimRepository {
         // claim, mirroring supersede()'s edge migration — otherwise edges to/from
         // third claims dangle at a claim that no longer surfaces. Unlike supersede
         // (which targets a freshly-minted claim with no pre-existing edges), the
-        // canonical here already exists, so guard against creating a
-        // canonical->canonical self-loop when an edge already linked dup and
-        // canonical. The 'supersedes' edges (dedup/lineage trail) are preserved.
+        // canonical here already exists, so we must guard against two collision
+        // classes before running the UPDATEs:
+        //
+        //   1. Self-loops: `dup→canonical` or `canonical→dup` edges that would
+        //      become `canonical→canonical` after migration (handled by the
+        //      `AND NOT (... = $1)` filters in the UPDATE clauses below).
+        //
+        //   2. Diamond duplicates: a third claim T that has edges to *both* dup
+        //      and canonical with the same relationship — e.g.
+        //      `T→[CORROBORATES]→dup` AND `T→[CORROBORATES]→canonical`.
+        //      Migrating the dup edge to point at canonical would produce a
+        //      second `T→[CORROBORATES]→canonical` triple, tripping the partial
+        //      unique index `idx_edges_unique_triple_non_authored`
+        //      (migration 017, covers all relationship types except AUTHORED)
+        //      and rolling back the whole transaction before `is_current` is
+        //      flipped.  Pre-delete the redundant dup edges so the UPDATE only
+        //      touches survivors.  AUTHORED edges are excluded because the
+        //      partial index does not cover them, and they are meant to
+        //      accumulate (migration 017 explicitly allows multiple AUTHORED
+        //      edges per triple).
+        //
+        // The 'supersedes' edges (dedup/lineage trail) are preserved throughout.
+
+        // Drop incoming dup-edges whose migrated triple already exists on canonical.
+        sqlx::query(
+            "DELETE FROM edges \
+             WHERE target_id = $2 AND target_type = 'claim' \
+               AND relationship != 'supersedes' AND relationship != 'AUTHORED' \
+               AND source_type = 'claim' AND source_id != $1 \
+               AND EXISTS ( \
+                   SELECT 1 FROM edges e2 \
+                   WHERE e2.source_id = source_id \
+                     AND e2.source_type = source_type \
+                     AND e2.target_id = $1 \
+                     AND e2.target_type = 'claim' \
+                     AND e2.relationship = relationship \
+               )",
+        )
+        .bind(canon_uuid)
+        .bind(dup_uuid)
+        .execute(&mut *tx)
+        .await?;
+
+        // Drop outgoing dup-edges whose migrated triple already exists on canonical.
+        sqlx::query(
+            "DELETE FROM edges \
+             WHERE source_id = $2 AND source_type = 'claim' \
+               AND relationship != 'supersedes' AND relationship != 'AUTHORED' \
+               AND target_type = 'claim' AND target_id != $1 \
+               AND EXISTS ( \
+                   SELECT 1 FROM edges e2 \
+                   WHERE e2.source_id = $1 \
+                     AND e2.source_type = 'claim' \
+                     AND e2.target_id = target_id \
+                     AND e2.target_type = target_type \
+                     AND e2.relationship = relationship \
+               )",
+        )
+        .bind(canon_uuid)
+        .bind(dup_uuid)
+        .execute(&mut *tx)
+        .await?;
+
         sqlx::query(
             "UPDATE edges SET target_id = $1 \
              WHERE target_id = $2 AND target_type = 'claim' AND relationship != 'supersedes' \

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -2726,18 +2726,24 @@ impl ClaimRepository {
         // The 'supersedes' edges (dedup/lineage trail) are preserved throughout.
 
         // Drop incoming dup-edges whose migrated triple already exists on canonical.
+        // Alias the outer table as `e` so the correlated subquery references
+        // `e.source_id`, `e.source_type`, `e.relationship` unambiguously.
+        // Without the alias, unqualified column names inside the EXISTS bind to
+        // `edges e2` (innermost scope in PostgreSQL), making the predicate
+        // tautological and causing false-positive deletions of edges that should
+        // be migrated.
         sqlx::query(
-            "DELETE FROM edges \
-             WHERE target_id = $2 AND target_type = 'claim' \
-               AND relationship != 'supersedes' AND relationship != 'AUTHORED' \
-               AND source_type = 'claim' AND source_id != $1 \
+            "DELETE FROM edges AS e \
+             WHERE e.target_id = $2 AND e.target_type = 'claim' \
+               AND e.relationship != 'supersedes' AND e.relationship != 'AUTHORED' \
+               AND e.source_type = 'claim' AND e.source_id != $1 \
                AND EXISTS ( \
                    SELECT 1 FROM edges e2 \
-                   WHERE e2.source_id = source_id \
-                     AND e2.source_type = source_type \
+                   WHERE e2.source_id = e.source_id \
+                     AND e2.source_type = e.source_type \
                      AND e2.target_id = $1 \
                      AND e2.target_type = 'claim' \
-                     AND e2.relationship = relationship \
+                     AND e2.relationship = e.relationship \
                )",
         )
         .bind(canon_uuid)
@@ -2746,18 +2752,20 @@ impl ClaimRepository {
         .await?;
 
         // Drop outgoing dup-edges whose migrated triple already exists on canonical.
+        // Same aliasing discipline: `e.target_id`, `e.target_type`, `e.relationship`
+        // must refer to the outer (being-deleted) row, not the subquery table.
         sqlx::query(
-            "DELETE FROM edges \
-             WHERE source_id = $2 AND source_type = 'claim' \
-               AND relationship != 'supersedes' AND relationship != 'AUTHORED' \
-               AND target_type = 'claim' AND target_id != $1 \
+            "DELETE FROM edges AS e \
+             WHERE e.source_id = $2 AND e.source_type = 'claim' \
+               AND e.relationship != 'supersedes' AND e.relationship != 'AUTHORED' \
+               AND e.target_type = 'claim' AND e.target_id != $1 \
                AND EXISTS ( \
                    SELECT 1 FROM edges e2 \
                    WHERE e2.source_id = $1 \
                      AND e2.source_type = 'claim' \
-                     AND e2.target_id = target_id \
-                     AND e2.target_type = target_type \
-                     AND e2.relationship = relationship \
+                     AND e2.target_id = e.target_id \
+                     AND e2.target_type = e.target_type \
+                     AND e2.relationship = e.relationship \
                )",
         )
         .bind(canon_uuid)

--- a/crates/epigraph-db/tests/mark_duplicate_repo.rs
+++ b/crates/epigraph-db/tests/mark_duplicate_repo.rs
@@ -175,6 +175,92 @@ async fn mark_duplicate_migrates_edges_to_canonical(pool: PgPool) {
     );
 }
 
+/// Regression test for backlog 2905150e: mark_duplicate returned HTTP 500
+/// "Duplicate entity already exists" when dup and canonical already shared
+/// a graph edge via a third claim (diamond pattern).
+///
+/// Scenario: `third →[CORROBORATES]→ dup` AND `third →[CORROBORATES]→ canonical`
+/// both exist.  Migrating the dup-edge would produce a second
+/// `third →[CORROBORATES]→ canonical`, tripping `idx_edges_unique_triple_non_authored`
+/// and rolling back the transaction before `is_current` was flipped.
+///
+/// The fix pre-deletes dup-edges whose migrated triple already exists on
+/// canonical, so the UPDATE only touches survivors.  Verify both the incoming
+/// (target=dup) and outgoing (source=dup) diamond cases.
+#[sqlx::test(migrations = "../../migrations")]
+async fn mark_duplicate_with_shared_neighbor_edge_succeeds(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let canonical = seed_claim(&pool, agent, "canonical").await;
+    let dup = seed_claim(&pool, agent, "duplicate").await;
+    let third = seed_claim(&pool, agent, "third").await;
+
+    // Diamond — incoming: third already points at both dup and canonical with same relationship.
+    seed_edge(&pool, third, dup, "CORROBORATES").await;
+    seed_edge(&pool, third, canonical, "CORROBORATES").await;
+
+    // Diamond — outgoing: dup and canonical both point at third with same relationship.
+    seed_edge(&pool, dup, third, "supports").await;
+    seed_edge(&pool, canonical, third, "supports").await;
+
+    // Before the fix this would return Err(DuplicateKey) / HTTP 500.
+    ClaimRepository::mark_duplicate(
+        &pool,
+        ClaimId::from_uuid(dup),
+        ClaimId::from_uuid(canonical),
+    )
+    .await
+    .expect("mark_duplicate must succeed even when dup and canonical share a neighbour edge");
+
+    // dup must be retired.
+    let (sup, is_current): (Option<Uuid>, bool) =
+        sqlx::query_as("SELECT supersedes, is_current FROM claims WHERE id = $1")
+            .bind(dup)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        sup,
+        Some(canonical),
+        "dup.supersedes should point at canonical"
+    );
+    assert!(
+        !is_current,
+        "dup must not be is_current after mark_duplicate"
+    );
+
+    // canonical must still be current.
+    let (canon_current,): (bool,) = sqlx::query_as("SELECT is_current FROM claims WHERE id = $1")
+        .bind(canonical)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(canon_current, "canonical must remain is_current");
+
+    // The canonical→third edge should exist (either migrated or pre-existing).
+    assert_eq!(
+        edge_count(&pool, canonical, third).await,
+        1,
+        "canonical should have exactly one outgoing 'supports' edge to third"
+    );
+    // The third→canonical edge should exist exactly once.
+    assert_eq!(
+        edge_count(&pool, third, canonical).await,
+        1,
+        "canonical should have exactly one incoming 'CORROBORATES' edge from third"
+    );
+    // No dangling edges on dup.
+    assert_eq!(
+        edge_count(&pool, dup, third).await,
+        0,
+        "dup should have no remaining outgoing edges to third"
+    );
+    assert_eq!(
+        edge_count(&pool, third, dup).await,
+        0,
+        "dup should have no remaining incoming edges from third"
+    );
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn mark_duplicate_rejects_missing_canonical(pool: PgPool) {
     let agent = seed_agent(&pool).await;


### PR DESCRIPTION
## Summary
- Fixes HTTP 500 in `mark_duplicate` when dup and canonical already share a neighbor edge (diamond pattern) — backlog 2905150e
- Pre-deletes incoming and outgoing dup-edges whose migrated triple already exists on canonical before running the migration UPDATE, preventing `idx_edges_unique_triple_non_authored` conflicts
- AUTHORED and supersedes edges excluded per the partial index scope

## Test plan
- [x] `mark_duplicate_with_shared_neighbor_edge_succeeds` — covers both incoming and outgoing diamond cases, asserts `is_current=false` on dup and `is_current=true` on canonical with correct edge counts

🤖 Generated with Claude Code