### PR TITLE
fix(mcp): expose min_confidence in query_triples; default 0.0 not 0.5

### DIFF
--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -1000,7 +1000,7 @@ impl EpiGraphMcpFull {
     // ── RDF Triple Layer (3 tools) ──
 
     #[tool(
-        description = "Query RDF-style triples extracted from claims. Filter by subject entity, predicate pattern, and/or object entity. All filters optional (omit to wildcard). Returns triples with source claim references."
+        description = "Query RDF-style triples extracted from claims. Filter by subject entity, predicate pattern, and/or object entity. All filters optional (omit to wildcard). Optional min_confidence threshold (default 0.0, no filtering). Returns triples with source claim references."
     )]
     async fn query_triples(
         &self,

--- a/crates/epigraph-mcp/src/tools/rdf.rs
+++ b/crates/epigraph-mcp/src/tools/rdf.rs
@@ -41,12 +41,13 @@ pub async fn query_triples(
         None
     };
 
+    let min_confidence = params.min_confidence.unwrap_or(0.0);
     let triples = TripleRepository::query(
         &server.pool,
         subject_id,
         params.predicate.as_deref(),
         object_id,
-        0.5,
+        min_confidence,
         limit,
     )
     .await

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -1708,6 +1708,10 @@ pub struct QueryTriplesParams {
     pub object: Option<String>,
     #[schemars(description = "Object entity type (optional)")]
     pub object_type: Option<String>,
+    #[schemars(
+        description = "Minimum triple confidence threshold, 0.0–1.0 (default 0.0 — no filtering)"
+    )]
+    pub min_confidence: Option<f64>,
     #[schemars(description = "Maximum results (default 20)")]
     pub limit: Option<i64>,
 }


### PR DESCRIPTION
## Summary
- Fixes `query_triples` silently returning empty results — min_confidence was hardcoded to `0.5`, filtering the majority of triples in graphs where raw triple confidence is often below 0.5 (foreman triples-fix)
- Exposes `min_confidence` as an optional parameter (default 0.0 = no filtering); callers can pass explicit thresholds
- Updates tool description to document the parameter; `search_triples` and `entity_neighborhood` use different query paths and were unaffected

## Test plan
- [ ] CI passes
- [ ] `query_triples` returns results for graphs with confidence < 0.5

🤖 Generated with Claude Code