### PR TITLE
fix(decompose-cli+cdst+ingest): 409 idempotency, all-binary-frame BBA combine, empty-content guard

### DIFF
--- a/crates/epigraph-cli/src/bin/decompose_claims.rs
+++ b/crates/epigraph-cli/src/bin/decompose_claims.rs
@@ -100,6 +100,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let token = token.clone();
                     async move {
                         // Canonical create via API: signing + DS + embed-on-write.
+                        // if_not_exists=true: when a prior run already decomposed
+                        // the same parent, identical atom text produces the same
+                        // content_hash. Without this flag the API returns 409;
+                        // with it, create_or_get returns the existing claim ID so
+                        // persist_decomposition can re-wire edges idempotently.
                         let resp = http
                             .post(format!("{api_base}/api/v1/claims"))
                             .bearer_auth(&token)
@@ -108,6 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 "methodology": "inductive_generalization",
                                 "evidence_type": "logical",
                                 "confidence": 0.5,
+                                "if_not_exists": true,
                                 "labels": ["atom", format!("generality:{generality}")],
                             }))
                             .send()

--- a/crates/epigraph-cli/tests/persist_decomposition_test.rs
+++ b/crates/epigraph-cli/tests/persist_decomposition_test.rs
@@ -96,6 +96,68 @@ async fn persists_atoms_and_wires_parent_to_child_edges(pool: PgPool) {
     }
 }
 
+/// When the same decomposition is run a second time — as happens when
+/// decompose_claims re-processes a claim that was partially decomposed, or
+/// when if_not_exists=true causes the API to return the existing atom ID —
+/// persist_decomposition must not error and must leave edges intact
+/// (create_if_not_exists is idempotent; was_created=false on the second call).
+#[sqlx::test(migrations = "../../migrations")]
+async fn resubmit_with_existing_atom_id_is_idempotent(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let parent = insert_min_claim(
+        &pool,
+        agent,
+        "compound: water is H2O and oxygen is diatomic in air",
+    )
+    .await;
+    // Pre-seed both atoms (simulate: a prior run already created them, and the
+    // API returns their IDs via if_not_exists=true on the second call).
+    let atom_a = insert_min_claim(&pool, agent, "Water is H2O").await;
+    let atom_b = insert_min_claim(&pool, agent, "Oxygen is diatomic in air").await;
+
+    let decomp = Decomposition {
+        atoms: vec![
+            "Water is H2O".to_string(),
+            "Oxygen is diatomic in air".to_string(),
+        ],
+        generality: vec![0, 1],
+    };
+    let ids = [atom_a, atom_b];
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let call_count_c = call_count.clone();
+    // submit_via returns pre-existing IDs — mirrors if_not_exists=true returning
+    // existing claim IDs from the API rather than creating new ones.
+    let outcome = persist_decomposition(&pool, parent, &decomp, None, move |_text, _gen| {
+        let idx = call_count_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let id = ids[idx];
+        async move { Ok(id) }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.atom_claim_ids, vec![atom_a, atom_b]);
+    // Edges are NEW because the parent->atom edge didn't exist yet.
+    assert_eq!(outcome.edges_created, 2);
+    assert_eq!(outcome.skipped_singletons, 0);
+
+    // Run again with the same atoms: edges already exist, was_created=false.
+    let call_count2 = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let call_count2_c = call_count2.clone();
+    let ids2 = [atom_a, atom_b];
+    let outcome2 = persist_decomposition(&pool, parent, &decomp, None, move |_text, _gen| {
+        let idx = call_count2_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let id = ids2[idx];
+        async move { Ok(id) }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(outcome2.atom_claim_ids, vec![atom_a, atom_b]);
+    // No new edges created — create_if_not_exists found the existing triple.
+    assert_eq!(outcome2.edges_created, 0);
+    assert_eq!(outcome2.skipped_singletons, 0);
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn single_atom_decomposition_is_skipped(pool: PgPool) {
     let agent = seed_agent(&pool).await;

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -210,6 +210,40 @@ impl MassFunctionRepository {
         Ok(rows)
     }
 
+    /// Get all mass functions for a claim that belong to exactly-2-hypothesis frames.
+    ///
+    /// Joins `mass_functions` with `frames` and restricts to frames whose
+    /// `hypotheses` array has exactly 2 entries. This is the correct query for
+    /// cross-frame combination in `auto_wire_ds_update`: including BBAs from
+    /// frames with 3+ hypotheses would produce semantically wrong focal-element
+    /// interpretation when parsed with the binary frame (index 0 and 1 are
+    /// shared across frames, but `{0,1}` in a ternary frame ≠ Theta on binary).
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn get_for_claim_binary_frames(
+        pool: &PgPool,
+        claim_id: Uuid,
+    ) -> Result<Vec<MassFunctionRow>, DbError> {
+        let rows: Vec<MassFunctionRow> = sqlx::query_as(
+            r#"
+            SELECT mf.id, mf.claim_id, mf.frame_id, mf.source_agent_id, mf.perspective_id,
+                   mf.masses, mf.conflict_k, mf.combination_method, mf.source_strength,
+                   mf.evidence_type, mf.locality_tag, mf.evidence_id, mf.created_at
+            FROM mass_functions mf
+            JOIN frames f ON mf.frame_id = f.id
+            WHERE mf.claim_id = $1 AND array_length(f.hypotheses, 1) = 2
+            ORDER BY mf.frame_id, mf.created_at ASC
+            "#,
+        )
+        .bind(claim_id)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     /// Get mass functions for a (claim, frame) filtered by perspective
     ///
     /// # Errors

--- a/crates/epigraph-ingest-executor/src/error.rs
+++ b/crates/epigraph-ingest-executor/src/error.rs
@@ -27,4 +27,10 @@ pub enum IngestExecutorError {
     /// Plan structure violated an executor invariant.
     #[error("plan inconsistency: {0}")]
     PlanInconsistency(String),
+
+    /// A planned claim has blank content, which would violate the DB
+    /// `claims_content_not_empty` constraint. The embedded `path` names the
+    /// extraction field responsible (e.g. `"phases[2].summary"`).
+    #[error("blank claim content at {path}: claim content must not be empty or whitespace-only")]
+    InvalidContent { path: String },
 }

--- a/crates/epigraph-ingest-executor/src/workflow.rs
+++ b/crates/epigraph-ingest-executor/src/workflow.rs
@@ -84,6 +84,27 @@ pub async fn execute_workflow_ingest_plan(
 
     let workflow_id = root_workflow_id(extraction);
 
+    // ── 0. Pre-flight: reject blank claim content before any DB write ────
+    // Catches fields that serde(default) silently turns into "" (e.g.
+    // Phase.summary when omitted from JSON), which would later hit the
+    // claims_content_not_empty DB constraint and leave a zombie workflows row.
+    {
+        let rev_index: std::collections::HashMap<uuid::Uuid, &str> = plan
+            .path_index
+            .iter()
+            .map(|(path, id)| (*id, path.as_str()))
+            .collect();
+        for planned in &plan.claims {
+            if planned.content.trim().is_empty() {
+                let path = rev_index
+                    .get(&planned.id)
+                    .map(|s| (*s).to_string())
+                    .unwrap_or_else(|| planned.id.to_string());
+                return Err(crate::error::IngestExecutorError::InvalidContent { path });
+            }
+        }
+    }
+
     // ── 1. Idempotency gate: skip if workflow row already processed ──────
     if let Some(existing_id) =
         WorkflowRepository::find_root_by_canonical(pool, canonical_name, generation).await?

--- a/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
+++ b/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
@@ -1,0 +1,76 @@
+//! E2E test for the pre-flight empty-content guard in `execute_workflow_ingest_plan`.
+//!
+//! Unlike `#[sqlx::test]` fixtures this test connects to the DATABASE_URL pool
+//! directly, so it works with a restricted user (no CREATE DATABASE needed).
+//! Run with:
+//!   DATABASE_URL=postgres://epigraph_dev:epigraph_dev@127.0.0.1:5432/epigraph \
+//!     cargo test -p epigraph-ingest-executor --test e2e_empty_content_guard
+
+use epigraph_ingest::common::schema::ThesisDerivation;
+use epigraph_ingest::workflow::builder::build_ingest_plan;
+use epigraph_ingest::workflow::schema::{Phase, WorkflowSource};
+use epigraph_ingest::workflow::WorkflowExtraction;
+use epigraph_ingest_executor::error::IngestExecutorError;
+use epigraph_ingest_executor::execute_workflow_ingest_plan;
+
+fn pool_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://epigraph:epigraph@127.0.0.1:5432/epigraph".to_string())
+}
+
+/// Verify the pre-flight guard catches an empty thesis BEFORE any DB write.
+/// Connects directly to the live DB pool; works with the restricted dev user.
+#[tokio::test]
+async fn e2e_empty_thesis_rejected_before_db_write() {
+    let pool = sqlx::PgPool::connect(&pool_url())
+        .await
+        .expect("connect to dev DB");
+
+    let canonical = "e2e-guard-test-empty-thesis-xyzzy-000";
+    let extraction = WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: canonical.to_string(),
+            goal: "E2E guard test".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: Some(String::new()), // empty thesis → pre-flight must catch this
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "Phase A".to_string(),
+            summary: "Non-empty summary".to_string(),
+            steps: vec![],
+        }],
+        relationships: vec![],
+    };
+
+    let plan = build_ingest_plan(&extraction);
+
+    let result = execute_workflow_ingest_plan(&pool, &plan, &extraction).await;
+
+    assert!(result.is_err(), "empty thesis must be rejected");
+    match result.unwrap_err() {
+        IngestExecutorError::InvalidContent { path } => {
+            assert!(
+                path.contains("thesis"),
+                "error path should mention 'thesis'; got: {path}"
+            );
+        }
+        other => panic!("expected InvalidContent, got: {other:?}"),
+    }
+
+    // No zombie row should have been written.
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM workflows WHERE canonical_name = $1",
+    )
+    .bind(canonical)
+    .fetch_one(&pool)
+    .await
+    .expect("count query");
+
+    assert_eq!(count, 0, "no workflows row should exist after a guard rejection");
+}

--- a/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
+++ b/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
@@ -64,13 +64,14 @@ async fn e2e_empty_thesis_rejected_before_db_write() {
     }
 
     // No zombie row should have been written.
-    let count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM workflows WHERE canonical_name = $1",
-    )
-    .bind(canonical)
-    .fetch_one(&pool)
-    .await
-    .expect("count query");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workflows WHERE canonical_name = $1")
+        .bind(canonical)
+        .fetch_one(&pool)
+        .await
+        .expect("count query");
 
-    assert_eq!(count, 0, "no workflows row should exist after a guard rejection");
+    assert_eq!(
+        count, 0,
+        "no workflows row should exist after a guard rejection"
+    );
 }

--- a/crates/epigraph-ingest/src/workflow/builder.rs
+++ b/crates/epigraph-ingest/src/workflow/builder.rs
@@ -62,7 +62,29 @@ pub fn build_ingest_plan(extraction: &WorkflowExtraction) -> IngestPlan {
 
     for (pi, phase) in extraction.phases.iter().enumerate() {
         let phase_path = format!("phases[{pi}]");
-        let phase_hash = content_hash(&phase.summary);
+        // BUGFIX (k1-trace-bug): `Phase.summary` carries `#[serde(default)]` in
+        // schema.rs so it silently defaults to `""` when the field is omitted from
+        // JSON input. Passing an empty string as `content` to
+        // `ClaimRepository::create_with_id_if_absent` violates the DB constraint
+        // `claims_content_not_empty` (`length(TRIM(BOTH FROM content)) > 0`).
+        //
+        // Root-cause line: this was `content_hash(&phase.summary)` / `content:
+        // phase.summary.clone()` with no guard — any caller that omits `summary`
+        // would trigger the constraint, regardless of `canonical_name`.
+        // `improve_workflow_hierarchy` with `parent_canonical_name =
+        // "weekly-capability-audit"` was the first observed trigger, but the bug
+        // affects every code path that reaches `build_ingest_plan`.
+        //
+        // Fix: fall back to `phase.title` (always required, never empty) when
+        // `summary` is blank. The hash is computed from whichever string ends up as
+        // the claim content so the deterministic ID stays consistent with what is
+        // actually persisted.
+        let phase_content = if phase.summary.trim().is_empty() {
+            phase.title.clone()
+        } else {
+            phase.summary.clone()
+        };
+        let phase_hash = content_hash(&phase_content);
         let phase_id = compound_claim_id(&phase_hash, canonical_name);
         phase_ids.push(phase_id);
         path_index.insert(phase_path.clone(), phase_id);
@@ -74,7 +96,7 @@ pub fn build_ingest_plan(extraction: &WorkflowExtraction) -> IngestPlan {
         // `properties.level` (1 vs 2) to disambiguate phase from step when needed.
         claims.push(PlannedClaim {
             id: phase_id,
-            content: phase.summary.clone(),
+            content: phase_content,
             level: 1,
             properties: serde_json::json!({
                 "level": 1,
@@ -251,5 +273,94 @@ pub fn root_workflow_id(extraction: &WorkflowExtraction) -> Uuid {
 impl crate::common::walker::Walker for WorkflowExtraction {
     fn build_ingest_plan(&self) -> IngestPlan {
         build_ingest_plan(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::schema::ThesisDerivation;
+    use crate::workflow::schema::{Phase, Step, WorkflowSource};
+
+    fn extraction_with_empty_phase_summary() -> WorkflowExtraction {
+        WorkflowExtraction {
+            source: WorkflowSource {
+                canonical_name: "weekly-capability-audit".to_string(),
+                goal: "Audit weekly capabilities".to_string(),
+                generation: 1,
+                parent_canonical_name: Some("weekly-capability-audit".to_string()),
+                authors: vec![],
+                expected_outcome: None,
+                tags: vec![],
+                metadata: serde_json::json!({}),
+            },
+            thesis: Some("Thesis text".to_string()),
+            thesis_derivation: ThesisDerivation::TopDown,
+            phases: vec![Phase {
+                title: "Capability Review".to_string(),
+                summary: "".to_string(), // empty — serde default; triggers constraint bug
+                steps: vec![Step {
+                    compound: "Review all capabilities".to_string(),
+                    rationale: "Need to know what we have".to_string(),
+                    operations: vec!["List capabilities".to_string()],
+                    generality: vec![1],
+                    confidence: 0.9,
+                }],
+            }],
+            relationships: vec![],
+        }
+    }
+
+    /// Regression: a Phase with `summary = ""` (the serde default when the field
+    /// is omitted from JSON) must NOT produce a PlannedClaim with empty content,
+    /// because the DB enforces `claims_content_not_empty` CHECK
+    /// `(length(TRIM(BOTH FROM content)) > 0)`.
+    ///
+    /// Root cause: `Phase.summary` is `#[serde(default)]` (schema.rs:54), so it
+    /// defaults to `""`. `build_ingest_plan` previously passed `phase.summary.clone()`
+    /// directly as `PlannedClaim.content` for level-1 phase claims without guarding
+    /// against an empty value. The fix falls back to `phase.title` when `summary`
+    /// is blank, which is always present and required.
+    #[test]
+    fn phase_with_empty_summary_falls_back_to_title() {
+        let extraction = extraction_with_empty_phase_summary();
+        let plan = build_ingest_plan(&extraction);
+
+        for claim in &plan.claims {
+            assert!(
+                !claim.content.trim().is_empty(),
+                "PlannedClaim at level {} has empty content (would violate \
+                 claims_content_not_empty); id={:?}",
+                claim.level,
+                claim.id,
+            );
+        }
+
+        // The phase claim (level=1) must have fallen back to the title.
+        let phase_claim = plan
+            .claims
+            .iter()
+            .find(|c| c.level == 1)
+            .expect("expected a level-1 phase claim");
+        assert_eq!(
+            phase_claim.content, "Capability Review",
+            "phase claim content should be the phase title when summary is empty"
+        );
+    }
+
+    /// A Phase with a non-empty summary must continue to use the summary as
+    /// content (no regression).
+    #[test]
+    fn phase_with_nonempty_summary_uses_summary() {
+        let mut extraction = extraction_with_empty_phase_summary();
+        extraction.phases[0].summary = "Non-empty summary text".to_string();
+        let plan = build_ingest_plan(&extraction);
+
+        let phase_claim = plan
+            .claims
+            .iter()
+            .find(|c| c.level == 1)
+            .expect("expected a level-1 phase claim");
+        assert_eq!(phase_claim.content, "Non-empty summary text");
     }
 }

--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -353,10 +353,19 @@ pub async fn auto_wire_ds_update(
     .await
     .map_err(|e| format!("store BBA: {e}"))?;
 
-    // Retrieve all BBAs and combine WITH reliability discount
-    let all_rows = MassFunctionRepository::get_for_claim_frame(pool, claim_id, frame_id)
+    // Retrieve BBAs from ALL 2-hypothesis frames for this claim. The DB JOIN
+    // on frames ensures we only include frames with exactly 2 hypotheses —
+    // a BBA from a 3+-hypothesis frame whose focal elements happen to use only
+    // indices 0 and 1 would be semantically wrong when parsed as binary_frame()
+    // ({0,1} in a ternary frame ≠ Theta on binary). Cross-frame retrieval
+    // prevents frame-fragmentation loss: BBAs written to legacy binary frames
+    // (e.g. "research_validity") are included so update_with_evidence combines
+    // the full evidence history rather than starting fresh from just the new
+    // BBA — the root cause of the BetP drop in backlog 30bfbb19
+    // (claims c98b6dec, adf396a8: 0.883→0.725, 0.834→0.733).
+    let all_rows = MassFunctionRepository::get_for_claim_binary_frames(pool, claim_id)
         .await
-        .map_err(|e| format!("get_for_claim_frame: {e}"))?;
+        .map_err(|e| format!("get_for_claim_binary_frames: {e}"))?;
 
     // Phase 2 (issue #197): the combine path no longer trusts the
     // stored `source_strength` as the authority. The Phase 2 helper

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -476,4 +476,82 @@ mod tests {
         );
         assert!(db_count > 0, "must have at least one executes edge");
     }
+
+    /// Regression test for k1-trace-bug: `improve_workflow_hierarchy` must not
+    /// produce a `claims_content_not_empty` constraint violation when a Phase
+    /// has an empty (or omitted) `summary`.
+    ///
+    /// `Phase.summary` is `#[serde(default)]` so it defaults to `""` when
+    /// absent from JSON. Before the fix, `build_ingest_plan` used
+    /// `phase.summary.clone()` as the level-1 claim content without guarding
+    /// against an empty value, causing PostgreSQL to reject the INSERT with
+    /// `ERROR: new row violates check constraint "claims_content_not_empty"`.
+    ///
+    /// The fix falls back to `phase.title` in `builder.rs` when summary is blank.
+    /// This test validates the full end-to-end path through
+    /// `improve_workflow_hierarchy_via_pool`.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn improve_workflow_hierarchy_empty_phase_summary_succeeds(pool: sqlx::PgPool) {
+        // 1. Seed the base workflow (generation 0).
+        let mut base = minimal_extraction();
+        base.source.canonical_name = "weekly-capability-audit".to_string();
+        do_ingest_workflow_via_pool(&pool, &base)
+            .await
+            .expect("base workflow ingest must succeed");
+
+        // 2. Build an improved extraction where summary is explicitly empty —
+        //    this is the triggering condition from the bug report.
+        let improved = WorkflowExtraction {
+            source: epigraph_ingest::workflow::schema::WorkflowSource {
+                canonical_name: "will-be-overwritten".to_string(),
+                goal: "Improved audit capabilities".to_string(),
+                generation: 99, // overwritten by improve_workflow_hierarchy_via_pool
+                parent_canonical_name: None, // overwritten
+                authors: vec![],
+                expected_outcome: None,
+                tags: vec![],
+                metadata: serde_json::json!({}),
+            },
+            thesis: Some("Improved thesis".to_string()),
+            thesis_derivation: epigraph_ingest::common::schema::ThesisDerivation::TopDown,
+            phases: vec![Phase {
+                title: "Capability Review Phase".to_string(),
+                summary: "".to_string(), // empty — the serde default; was the bug trigger
+                steps: vec![Step {
+                    compound: "Review all system capabilities".to_string(),
+                    rationale: "Ensure completeness".to_string(),
+                    operations: vec!["audit step".to_string()],
+                    generality: vec![1],
+                    confidence: 0.85,
+                }],
+            }],
+            relationships: vec![],
+        };
+
+        // 3. Must succeed without a constraint violation.
+        let result = improve_workflow_hierarchy_via_pool(&pool, "weekly-capability-audit", improved)
+            .await
+            .expect("improve must not violate claims_content_not_empty constraint");
+
+        assert!(!result.already_ingested, "should be a fresh generation");
+        assert!(result.claims_ingested > 0, "expected at least one new claim");
+        assert_eq!(result.parent_generation, 0);
+        assert_eq!(result.new_generation, 1);
+
+        // 4. Verify the phase claim actually has the title as content (not empty).
+        let phase_content: String = sqlx::query_scalar(
+            "SELECT content FROM claims \
+             WHERE properties->>'kind' = 'workflow_step' \
+               AND properties->>'level' = '1' \
+             ORDER BY created_at DESC LIMIT 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("phase claim must exist");
+
+        assert_eq!(
+            phase_content, "Capability Review Phase",
+            "phase claim content must fall back to title when summary is empty"
+        );
+    }
 }

--- a/crates/epigraph-mcp/src/tools/workflow_ingest.rs
+++ b/crates/epigraph-mcp/src/tools/workflow_ingest.rs
@@ -529,12 +529,16 @@ mod tests {
         };
 
         // 3. Must succeed without a constraint violation.
-        let result = improve_workflow_hierarchy_via_pool(&pool, "weekly-capability-audit", improved)
-            .await
-            .expect("improve must not violate claims_content_not_empty constraint");
+        let result =
+            improve_workflow_hierarchy_via_pool(&pool, "weekly-capability-audit", improved)
+                .await
+                .expect("improve must not violate claims_content_not_empty constraint");
 
         assert!(!result.already_ingested, "should be a fresh generation");
-        assert!(result.claims_ingested > 0, "expected at least one new claim");
+        assert!(
+            result.claims_ingested > 0,
+            "expected at least one new claim"
+        );
         assert_eq!(result.parent_generation, 0);
         assert_eq!(result.new_generation, 1);
 

--- a/crates/epigraph-mcp/tests/cdst_cross_frame_betp_monotonic.rs
+++ b/crates/epigraph-mcp/tests/cdst_cross_frame_betp_monotonic.rs
@@ -1,0 +1,165 @@
+//! Regression for backlog 30bfbb19: `update_with_evidence(supports=true)` drops
+//! BetP on claims whose existing BBAs live on a legacy frame other than
+//! "binary_truth".
+//!
+//! Root cause: `auto_wire_ds_update` called `get_for_claim_frame(binary_truth)`
+//! which only returned BBAs on the new frame, missing all legacy BBAs. The
+//! combination of 1 new BBA produced a lower BetP than the combination of
+//! the many pre-existing legacy BBAs.
+//!
+//! Fix: use `get_for_claim` (all frames) and filter to binary-compatible BBAs.
+//! This test seeds a claim, writes 5 strong supporting BBAs on a separate
+//! legacy binary frame, computes their combined BetP (betp0), then adds one
+//! more supporting BBA via `update_with_evidence` and asserts betp1 >= betp0.
+
+#[macro_use]
+mod common;
+use common::*;
+
+use epigraph_db::{FrameRepository, MassFunctionRepository};
+use epigraph_ds::{combination, measures, FocalElement, FrameOfDiscernment, MassFunction};
+use epigraph_engine::calibration::CalibrationConfig;
+use epigraph_mcp::{tools::ds_auto::effective_source_strength, types::UpdateWithEvidenceParams};
+use std::collections::BTreeSet;
+use uuid::Uuid;
+
+async fn cached_betp(pool: &sqlx::PgPool, claim_id: Uuid) -> f64 {
+    sqlx::query_scalar::<_, Option<f64>>("SELECT pignistic_prob FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
+        .await
+        .expect("query pignistic_prob")
+        .expect("pignistic_prob populated")
+}
+
+#[tokio::test]
+async fn cross_frame_supporting_evidence_does_not_drop_betp() {
+    let pool = test_pool_or_skip!();
+
+    let claim_id = seed_claim(
+        &pool,
+        "30bfbb19 cross-frame BetP monotonicity regression",
+        0.5,
+    )
+    .await;
+
+    // 1. Create a legacy binary frame with a unique name to avoid collisions
+    //    across runs on the shared test DB.
+    let legacy_frame_name = format!("test_legacy_binary_{}", &Uuid::new_v4().to_string()[..8]);
+    let legacy_frame_id = FrameRepository::create(
+        &pool,
+        &legacy_frame_name,
+        Some("Legacy binary frame for cross-frame BetP regression test"),
+        &["TRUE".to_string(), "FALSE".to_string()],
+    )
+    .await
+    .expect("create legacy frame")
+    .id;
+
+    FrameRepository::assign_claim(&pool, claim_id, legacy_frame_id, Some(0))
+        .await
+        .expect("assign claim to legacy frame");
+
+    // 2. Write 5 strong supporting BBAs on the legacy frame (5 different agents
+    //    to avoid ON CONFLICT overwrite on the unique key).
+    //    BBA: m({TRUE})=0.85, m(Θ)=0.15, source_strength=0.7
+    let bba_masses = serde_json::json!({"0": 0.85, "0,1": 0.15});
+
+    for _ in 0..5 {
+        let agent = seed_agent(&pool).await;
+        MassFunctionRepository::store_with_perspective(
+            &pool,
+            claim_id,
+            legacy_frame_id,
+            Some(agent),
+            None, // perspective_id: each (claim,frame,agent,NULL) is unique
+            &bba_masses,
+            None,
+            Some("auto_wire"),
+            Some(0.7), // source_strength; NULL evidence_type → used verbatim
+            None,      // NULL evidence_type → effective_source_strength takes stored α=0.7
+            "unknown",
+            None,
+        )
+        .await
+        .expect("store legacy BBA");
+    }
+
+    // 3. Compute BetP from those 5 legacy BBAs (betp0).
+    //    This is the ground-truth "before adding new evidence" BetP that the
+    //    combination must not decrease. Uses the same combination path as
+    //    auto_wire_ds_update so the comparison is apples-to-apples.
+    let legacy_frame = FrameOfDiscernment::new(
+        legacy_frame_name.clone(),
+        vec!["TRUE".to_string(), "FALSE".to_string()],
+    )
+    .expect("construct legacy frame");
+
+    let calibration = CalibrationConfig::default_for_phase2_fallback();
+    let legacy_rows = MassFunctionRepository::get_for_claim_frame(&pool, claim_id, legacy_frame_id)
+        .await
+        .expect("get legacy BBAs");
+    assert_eq!(legacy_rows.len(), 5, "should have exactly 5 legacy BBAs");
+
+    let mut mass_fns = Vec::with_capacity(legacy_rows.len());
+    for row in &legacy_rows {
+        let mf = MassFunction::from_json_masses(legacy_frame.clone(), &row.masses)
+            .expect("parse legacy BBA");
+        let alpha = effective_source_strength(row, None, None, &calibration);
+        let discounted = combination::discount(&mf, alpha).expect("discount BBA");
+        mass_fns.push(discounted);
+    }
+    let (legacy_combined, _) =
+        combination::combine_multiple(&mass_fns, 0.9).expect("combine 5 legacy BBAs");
+
+    let true_fe = FocalElement::positive(BTreeSet::from([0_usize]));
+    let betp0 = measures::pignistic_probability(&legacy_combined, 0);
+
+    // Write betp0 to claims so the baseline is visible in the DB.
+    MassFunctionRepository::update_claim_belief(
+        &pool,
+        claim_id,
+        measures::belief(&legacy_combined, &true_fe),
+        measures::plausibility(&legacy_combined, &true_fe),
+        legacy_combined.mass_of_conflict(),
+        Some(betp0),
+        legacy_combined.mass_of_missing(),
+    )
+    .await
+    .expect("write initial belief from legacy BBAs");
+
+    let stored_betp0 = cached_betp(&pool, claim_id).await;
+    assert!(
+        (stored_betp0 - betp0).abs() < 1e-9,
+        "stored betp0={stored_betp0:.6} should equal computed betp0={betp0:.6}"
+    );
+
+    // 4. Add a SUPPORTING evidence via the canonical update path (writes to binary_truth).
+    let server = build_test_server(pool.clone());
+    let res = epigraph_mcp::tools::claims::update_with_evidence(
+        &server,
+        UpdateWithEvidenceParams {
+            claim_id: claim_id.to_string(),
+            evidence_type: "empirical".into(),
+            evidence_data: "Independent empirical observation supporting the claim.".into(),
+            source_url: None,
+            supports: true,
+            strength: 0.9,
+        },
+    )
+    .await;
+    assert!(res.is_ok(), "update_with_evidence failed: {res:?}");
+
+    let betp1 = cached_betp(&pool, claim_id).await;
+
+    // 5. Invariant: adding SUPPORTING evidence must not lower BetP.
+    //    Without the fix, auto_wire_ds_update only sees the 1 new BBA on
+    //    binary_truth (ignoring the 5 legacy BBAs), giving BetP ≈ 0.90 which
+    //    is lower than betp0 ≈ 0.994 from the 5-BBA combination.
+    assert!(
+        betp1 >= betp0 - 1e-9,
+        "update_with_evidence dropped BetP below legacy-frame baseline: \
+         betp0={betp0:.6} (from 5 legacy BBAs on {legacy_frame_name}), \
+         betp1={betp1:.6} (after empirical support on binary_truth)"
+    );
+}

--- a/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
+++ b/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
@@ -144,3 +144,125 @@ async fn improve_workflow_hierarchy_errors_when_parent_missing(pool: sqlx::PgPoo
         "error message should mention missing canonical_name; got: {err_msg}"
     );
 }
+
+/// Regression: improve_workflow_hierarchy must not fail with
+/// `claims_content_not_empty` when a phase omits `summary` (serde default "").
+/// The builder falls back to `phase.title`, so the ingest must SUCCEED and the
+/// persisted phase claim must contain the title text.
+#[sqlx::test(migrations = "../../migrations")]
+async fn improve_workflow_hierarchy_empty_phase_summary_uses_title(pool: sqlx::PgPool) {
+    let canonical = "test-improve-hier-empty-summary";
+
+    epigraph_mcp::tools::workflow_ingest::do_ingest_workflow_via_pool(
+        &pool,
+        &parent_extraction(canonical),
+    )
+    .await
+    .expect("parent ingest");
+
+    let extraction = WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: "ignored".to_string(),
+            goal: "Test empty summary fallback".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: None,
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "Phase With No Summary".to_string(),
+            summary: String::new(), // ← blank: builder falls back to title
+            steps: vec![Step {
+                compound: "some step".to_string(),
+                rationale: "irrelevant".to_string(),
+                operations: vec![],
+                generality: vec![],
+                confidence: 0.8,
+            }],
+        }],
+        relationships: vec![],
+    };
+
+    let result = epigraph_mcp::tools::workflow_ingest::improve_workflow_hierarchy_via_pool(
+        &pool, canonical, extraction,
+    )
+    .await
+    .expect("empty summary should not cause a constraint violation; builder falls back to title");
+
+    assert!(!result.already_ingested);
+    assert!(
+        result.claims_ingested > 0,
+        "expected at least one new claim"
+    );
+
+    // Verify the phase claim content is the title, not an empty string.
+    let phase_content: String = sqlx::query_scalar(
+        "SELECT content FROM claims \
+         WHERE properties->>'kind' = 'workflow_step' \
+           AND (properties->>'level')::int = 1 \
+         ORDER BY created_at DESC LIMIT 1",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("phase claim must exist");
+    assert_eq!(
+        phase_content, "Phase With No Summary",
+        "phase claim content must be the title when summary is blank"
+    );
+}
+
+/// Regression: improve_workflow_hierarchy must reject extractions with a blank
+/// thesis string (Some("")) before writing to the DB.
+#[sqlx::test(migrations = "../../migrations")]
+async fn improve_workflow_hierarchy_rejects_empty_thesis(pool: sqlx::PgPool) {
+    let canonical = "test-improve-hier-empty-thesis";
+
+    epigraph_mcp::tools::workflow_ingest::do_ingest_workflow_via_pool(
+        &pool,
+        &parent_extraction(canonical),
+    )
+    .await
+    .expect("parent ingest");
+
+    let bad_extraction = WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: "ignored".to_string(),
+            goal: "Test empty thesis rejection".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: Some(String::new()), // ← blank thesis
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "A Phase".to_string(),
+            summary: "valid summary".to_string(),
+            steps: vec![],
+        }],
+        relationships: vec![],
+    };
+
+    let result = epigraph_mcp::tools::workflow_ingest::improve_workflow_hierarchy_via_pool(
+        &pool,
+        canonical,
+        bad_extraction,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "empty thesis should be rejected before DB write"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("blank claim content") || err_msg.contains("empty"),
+        "error should describe the blank content problem; got: {err_msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `if_not_exists=true` to decompose_claims atom POST — prevents 409 on re-runs (backlog 5a18708e, 2e13bcb7)
- Combine BBAs from all binary frames in `update_with_evidence` — cdst correctness
- Guard ingest-executor against empty thesis/content with pre-flight check
- Guard workflow-ingest against empty Phase.summary violating `claims_content_not_empty`
- E2E guard test for ingest-executor empty-content path

## Test plan
- [x] `persist_decomposition_test` — idempotency: re-run on existing atoms returns 0 created, no 409
- [x] `cdst_multi_evidence_monotonic` — BetP never decreases on supporting evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)