### PR TITLE
fix(decompose-cli+cdst+ingest): 409 idempotency, all-binary-frame BBA combine, empty-content guard

### DIFF
--- a/crates/epigraph-cli/src/bin/decompose_claims.rs
+++ b/crates/epigraph-cli/src/bin/decompose_claims.rs
@@ -106,6 +106,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // Canonical create via API: signing + DS + embed-on-write.
                         // methodology/evidence_type belong in `properties` (JSONB);
                         // top-level they were unknown fields and silently dropped.
+                        // if_not_exists=true: when a prior run already decomposed
+                        // the same parent, identical atom text produces the same
+                        // content_hash. Without this flag the API returns 409;
+                        // with it, create_or_get returns the existing claim ID so
+                        // persist_decomposition can re-wire edges idempotently.
                         let resp = http
                             .post(format!("{api_base}/api/v1/claims"))
                             .bearer_auth(&token)
@@ -113,6 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 "content": atom_text,
                                 "agent_id": parent_agent_id,
                                 "initial_truth": 0.5,
+                                "if_not_exists": true,
                                 "properties": {
                                     "methodology": "inductive_generalization",
                                     "evidence_type": "logical"

--- a/crates/epigraph-cli/tests/persist_decomposition_test.rs
+++ b/crates/epigraph-cli/tests/persist_decomposition_test.rs
@@ -96,6 +96,68 @@ async fn persists_atoms_and_wires_parent_to_child_edges(pool: PgPool) {
     }
 }
 
+/// When the same decomposition is run a second time — as happens when
+/// decompose_claims re-processes a claim that was partially decomposed, or
+/// when if_not_exists=true causes the API to return the existing atom ID —
+/// persist_decomposition must not error and must leave edges intact
+/// (create_if_not_exists is idempotent; was_created=false on the second call).
+#[sqlx::test(migrations = "../../migrations")]
+async fn resubmit_with_existing_atom_id_is_idempotent(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+    let parent = insert_min_claim(
+        &pool,
+        agent,
+        "compound: water is H2O and oxygen is diatomic in air",
+    )
+    .await;
+    // Pre-seed both atoms (simulate: a prior run already created them, and the
+    // API returns their IDs via if_not_exists=true on the second call).
+    let atom_a = insert_min_claim(&pool, agent, "Water is H2O").await;
+    let atom_b = insert_min_claim(&pool, agent, "Oxygen is diatomic in air").await;
+
+    let decomp = Decomposition {
+        atoms: vec![
+            "Water is H2O".to_string(),
+            "Oxygen is diatomic in air".to_string(),
+        ],
+        generality: vec![0, 1],
+    };
+    let ids = [atom_a, atom_b];
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let call_count_c = call_count.clone();
+    // submit_via returns pre-existing IDs — mirrors if_not_exists=true returning
+    // existing claim IDs from the API rather than creating new ones.
+    let outcome = persist_decomposition(&pool, parent, &decomp, None, move |_text, _gen| {
+        let idx = call_count_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let id = ids[idx];
+        async move { Ok(id) }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.atom_claim_ids, vec![atom_a, atom_b]);
+    // Edges are NEW because the parent->atom edge didn't exist yet.
+    assert_eq!(outcome.edges_created, 2);
+    assert_eq!(outcome.skipped_singletons, 0);
+
+    // Run again with the same atoms: edges already exist, was_created=false.
+    let call_count2 = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let call_count2_c = call_count2.clone();
+    let ids2 = [atom_a, atom_b];
+    let outcome2 = persist_decomposition(&pool, parent, &decomp, None, move |_text, _gen| {
+        let idx = call_count2_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let id = ids2[idx];
+        async move { Ok(id) }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(outcome2.atom_claim_ids, vec![atom_a, atom_b]);
+    // No new edges created — create_if_not_exists found the existing triple.
+    assert_eq!(outcome2.edges_created, 0);
+    assert_eq!(outcome2.skipped_singletons, 0);
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn single_atom_decomposition_is_skipped(pool: PgPool) {
     let agent = seed_agent(&pool).await;

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -210,6 +210,40 @@ impl MassFunctionRepository {
         Ok(rows)
     }
 
+    /// Get all mass functions for a claim that belong to exactly-2-hypothesis frames.
+    ///
+    /// Joins `mass_functions` with `frames` and restricts to frames whose
+    /// `hypotheses` array has exactly 2 entries. This is the correct query for
+    /// cross-frame combination in `auto_wire_ds_update`: including BBAs from
+    /// frames with 3+ hypotheses would produce semantically wrong focal-element
+    /// interpretation when parsed with the binary frame (index 0 and 1 are
+    /// shared across frames, but `{0,1}` in a ternary frame ≠ Theta on binary).
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn get_for_claim_binary_frames(
+        pool: &PgPool,
+        claim_id: Uuid,
+    ) -> Result<Vec<MassFunctionRow>, DbError> {
+        let rows: Vec<MassFunctionRow> = sqlx::query_as(
+            r#"
+            SELECT mf.id, mf.claim_id, mf.frame_id, mf.source_agent_id, mf.perspective_id,
+                   mf.masses, mf.conflict_k, mf.combination_method, mf.source_strength,
+                   mf.evidence_type, mf.locality_tag, mf.evidence_id, mf.created_at
+            FROM mass_functions mf
+            JOIN frames f ON mf.frame_id = f.id
+            WHERE mf.claim_id = $1 AND array_length(f.hypotheses, 1) = 2
+            ORDER BY mf.frame_id, mf.created_at ASC
+            "#,
+        )
+        .bind(claim_id)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     /// Get mass functions for a (claim, frame) filtered by perspective
     ///
     /// # Errors

--- a/crates/epigraph-engine/tests/herb_belief_dump.rs
+++ b/crates/epigraph-engine/tests/herb_belief_dump.rs
@@ -81,7 +81,10 @@ async fn herb_belief_dump() {
             // line when stdout/stderr interleave.
         }
         for ((herb, persp), (sum, n)) in &acc {
-            println!("ROW\t{mode}\t{aspect}\t{herb}\t{persp}\t{:.3}\t{n}", sum / (*n as f64));
+            println!(
+                "ROW\t{mode}\t{aspect}\t{herb}\t{persp}\t{:.3}\t{n}",
+                sum / (*n as f64)
+            );
         }
     }
 }

--- a/crates/epigraph-engine/tests/perspectival_demo_t2.rs
+++ b/crates/epigraph-engine/tests/perspectival_demo_t2.rs
@@ -89,9 +89,18 @@ async fn store(
 }
 
 async fn make_perspective(pool: &PgPool, name: &str, rel: &[(&str, f64)]) -> Uuid {
-    let p = PerspectiveRepository::create(pool, name, None, None, Some("disciplinary"), &[], None, None)
-        .await
-        .expect("create perspective");
+    let p = PerspectiveRepository::create(
+        pool,
+        name,
+        None,
+        None,
+        Some("disciplinary"),
+        &[],
+        None,
+        None,
+    )
+    .await
+    .expect("create perspective");
     let map: HashMap<String, f64> = rel.iter().map(|(k, v)| ((*k).to_string(), *v)).collect();
     PerspectiveRepository::set_source_reliability(pool, p.id, &map)
         .await
@@ -124,42 +133,152 @@ async fn t2_real_engine_reproduces_python_model() {
     let clinical = make_perspective(
         &pool,
         &format!("clinical_observer_{sfx}"),
-        &[("source_clinical", 0.95), ("source_survey", 0.40), ("source_tradition", 0.15), ("source_practitioner", 0.10)],
+        &[
+            ("source_clinical", 0.95),
+            ("source_survey", 0.40),
+            ("source_tradition", 0.15),
+            ("source_practitioner", 0.10),
+        ],
     )
     .await;
     let tradition = make_perspective(
         &pool,
         &format!("tradition_observer_{sfx}"),
-        &[("source_clinical", 0.60), ("source_survey", 0.70), ("source_tradition", 0.90), ("source_practitioner", 0.85)],
+        &[
+            ("source_clinical", 0.60),
+            ("source_survey", 0.70),
+            ("source_tradition", 0.90),
+            ("source_practitioner", 0.85),
+        ],
     )
     .await;
 
-    let eff_row = FrameRepository::create(&pool, &format!("treatment_efficacy_{sfx}"), None, &["efficacious".to_string(), "no_effect".to_string()])
-        .await
-        .expect("eff frame");
-    let saf_row = FrameRepository::create(&pool, &format!("treatment_safety_{sfx}"), None, &["safe".to_string(), "harmful".to_string()])
-        .await
-        .expect("saf frame");
+    let eff_row = FrameRepository::create(
+        &pool,
+        &format!("treatment_efficacy_{sfx}"),
+        None,
+        &["efficacious".to_string(), "no_effect".to_string()],
+    )
+    .await
+    .expect("eff frame");
+    let saf_row = FrameRepository::create(
+        &pool,
+        &format!("treatment_safety_{sfx}"),
+        None,
+        &["safe".to_string(), "harmful".to_string()],
+    )
+    .await
+    .expect("saf frame");
     let eff = FrameOfDiscernment::new(eff_row.name.clone(), eff_row.hypotheses.clone()).unwrap();
     let saf = FrameOfDiscernment::new(saf_row.name.clone(), saf_row.hypotheses.clone()).unwrap();
 
     // Case A — treatment-c SAFETY {safe(0), harmful(1)}: clinical harmful vs tradition safe (K>0).
     let tc_saf = insert_claim(&pool, author, "treatment-c is safe at therapeutic dose").await;
-    store(&pool, tc_saf, saf_row.id, a_clin, &saf, "source_clinical", 1, 0.70).await;
-    store(&pool, tc_saf, saf_row.id, a_trad, &saf, "source_tradition", 0, 0.50).await;
-    store(&pool, tc_saf, saf_row.id, a_prac, &saf, "source_practitioner", 0, 0.45).await;
+    store(
+        &pool,
+        tc_saf,
+        saf_row.id,
+        a_clin,
+        &saf,
+        "source_clinical",
+        1,
+        0.70,
+    )
+    .await;
+    store(
+        &pool,
+        tc_saf,
+        saf_row.id,
+        a_trad,
+        &saf,
+        "source_tradition",
+        0,
+        0.50,
+    )
+    .await;
+    store(
+        &pool,
+        tc_saf,
+        saf_row.id,
+        a_prac,
+        &saf,
+        "source_practitioner",
+        0,
+        0.45,
+    )
+    .await;
 
     // Case B — treatment-e EFFICACY {efficacious(0), no_effect(1)}: tradition efficacious vs clinical no_effect (K>0).
     let te_eff = insert_claim(&pool, author, "treatment-e is efficacious for symptom-4").await;
-    store(&pool, te_eff, eff_row.id, a_trad, &eff, "source_tradition", 0, 0.55).await;
-    store(&pool, te_eff, eff_row.id, a_prac, &eff, "source_practitioner", 0, 0.45).await;
-    store(&pool, te_eff, eff_row.id, a_clin, &eff, "source_clinical", 1, 0.60).await;
+    store(
+        &pool,
+        te_eff,
+        eff_row.id,
+        a_trad,
+        &eff,
+        "source_tradition",
+        0,
+        0.55,
+    )
+    .await;
+    store(
+        &pool,
+        te_eff,
+        eff_row.id,
+        a_prac,
+        &eff,
+        "source_practitioner",
+        0,
+        0.45,
+    )
+    .await;
+    store(
+        &pool,
+        te_eff,
+        eff_row.id,
+        a_clin,
+        &eff,
+        "source_clinical",
+        1,
+        0.60,
+    )
+    .await;
 
     // Case C — treatment-a EFFICACY (consensus control, K=0).
     let ta_eff = insert_claim(&pool, author, "treatment-a is efficacious for symptom-1").await;
-    store(&pool, ta_eff, eff_row.id, a_clin, &eff, "source_clinical", 0, 0.75).await;
-    store(&pool, ta_eff, eff_row.id, a_trad, &eff, "source_tradition", 0, 0.55).await;
-    store(&pool, ta_eff, eff_row.id, a_prac, &eff, "source_practitioner", 0, 0.40).await;
+    store(
+        &pool,
+        ta_eff,
+        eff_row.id,
+        a_clin,
+        &eff,
+        "source_clinical",
+        0,
+        0.75,
+    )
+    .await;
+    store(
+        &pool,
+        ta_eff,
+        eff_row.id,
+        a_trad,
+        &eff,
+        "source_tradition",
+        0,
+        0.55,
+    )
+    .await;
+    store(
+        &pool,
+        ta_eff,
+        eff_row.id,
+        a_prac,
+        &eff,
+        "source_practitioner",
+        0,
+        0.40,
+    )
+    .await;
 
     let saf_clin = betp(&pool, tc_saf, saf_row.id, clinical).await;
     let saf_trad = betp(&pool, tc_saf, saf_row.id, tradition).await;
@@ -174,10 +293,28 @@ async fn t2_real_engine_reproduces_python_model() {
     eprintln!("  treatment-a eff     clinical={ta_clin:.3} (py 0.873)   tradition={ta_trad:.3} (py 0.908)");
 
     let approx = |a: f64, b: f64| (a - b).abs() < 0.005;
-    assert!(approx(saf_clin, 0.203), "treatment-c safety clinical = {saf_clin}");
-    assert!(approx(saf_trad, 0.666), "treatment-c safety tradition = {saf_trad}");
-    assert!(approx(te_clin, 0.260), "treatment-e eff clinical = {te_clin}");
-    assert!(approx(te_trad, 0.718), "treatment-e eff tradition = {te_trad}");
-    assert!(approx(ta_clin, 0.873), "treatment-a eff clinical = {ta_clin}");
-    assert!(approx(ta_trad, 0.908), "treatment-a eff tradition = {ta_trad}");
+    assert!(
+        approx(saf_clin, 0.203),
+        "treatment-c safety clinical = {saf_clin}"
+    );
+    assert!(
+        approx(saf_trad, 0.666),
+        "treatment-c safety tradition = {saf_trad}"
+    );
+    assert!(
+        approx(te_clin, 0.260),
+        "treatment-e eff clinical = {te_clin}"
+    );
+    assert!(
+        approx(te_trad, 0.718),
+        "treatment-e eff tradition = {te_trad}"
+    );
+    assert!(
+        approx(ta_clin, 0.873),
+        "treatment-a eff clinical = {ta_clin}"
+    );
+    assert!(
+        approx(ta_trad, 0.908),
+        "treatment-a eff tradition = {ta_trad}"
+    );
 }

--- a/crates/epigraph-engine/tests/perspectival_discover_load.rs
+++ b/crates/epigraph-engine/tests/perspectival_discover_load.rs
@@ -11,7 +11,9 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use epigraph_db::{EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool};
+use epigraph_db::{
+    EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool,
+};
 use epigraph_ds::{FocalElement, FrameOfDiscernment, MassFunction};
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
@@ -23,10 +25,16 @@ fn read(path: &str) -> Value {
     serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {path}: {e}"))
 }
 fn arr<'a>(v: &'a Value, key: &str) -> &'a Vec<Value> {
-    v.get(key).and_then(|x| x.as_array()).map(|a| a).unwrap_or_else(|| panic!("missing array {key}"))
+    v.get(key)
+        .and_then(|x| x.as_array())
+        .map(|a| a)
+        .unwrap_or_else(|| panic!("missing array {key}"))
 }
 fn s(v: &Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or_default().to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string()
 }
 
 async fn insert_agent(pool: &PgPool) -> Uuid {
@@ -47,7 +55,9 @@ async fn assign(pool: &PgPool, claim: Uuid, frame: Uuid) {
 }
 async fn betp0(pool: &PgPool, claim: Uuid, frame: Uuid, persp: Uuid) -> f64 {
     epigraph_engine::belief_query::get_perspective_belief(pool, claim, frame, persp)
-        .await.expect("belief").pignistic_prob
+        .await
+        .expect("belief")
+        .pignistic_prob
 }
 
 /// Open-world BBA from an arbitrary masses map (hypothesis names + "theta"); reserves
@@ -61,7 +71,8 @@ fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Map<String,
             theta_mass = val;
         } else if let Some(idx) = hyps.iter().position(|h| h == k) {
             if val > 0.0 {
-                *m.entry(FocalElement::positive(BTreeSet::from([idx]))).or_insert(0.0) += val;
+                *m.entry(FocalElement::positive(BTreeSet::from([idx])))
+                    .or_insert(0.0) += val;
             }
         }
     }
@@ -78,19 +89,32 @@ fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Map<String,
             *v /= sum;
         }
     }
-    MassFunction::new(frame.clone(), m).expect("ow bba").masses_to_json()
+    MassFunction::new(frame.clone(), m)
+        .expect("ow bba")
+        .masses_to_json()
 }
 
 struct ClaimMeta {
-    key: String, kind: String, frame_key: String, target: String, content: String,
-    treatment: Option<String>, symptom: Option<String>, dimension: Option<String>,
-    evidence: Vec<Value>, uuid: Uuid, frame_uuid: Uuid,
+    key: String,
+    kind: String,
+    frame_key: String,
+    target: String,
+    content: String,
+    treatment: Option<String>,
+    symptom: Option<String>,
+    dimension: Option<String>,
+    evidence: Vec<Value>,
+    uuid: Uuid,
+    frame_uuid: Uuid,
 }
 
 #[tokio::test]
 #[ignore = "requires SEED_DIR + dedicated dev DB; run manually with --ignored"]
 async fn discover_to_snapshot() {
-    let Ok(url) = std::env::var("DATABASE_URL") else { eprintln!("SKIP: DATABASE_URL not set"); return; };
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
     let pkg_path = std::env::var("DISCOVERY_IN").expect("set DISCOVERY_IN");
     let dir = std::env::var("SEED_DIR").expect("set SEED_DIR");
     let out = std::env::var("SNAPSHOT_OUT").expect("set SNAPSHOT_OUT");
@@ -106,40 +130,102 @@ async fn discover_to_snapshot() {
     // frames (fixed 4)
     let mut frame_of: HashMap<String, (Uuid, Vec<String>)> = HashMap::new();
     for f in arr(&frames_j, "frames") {
-        let hyps: Vec<String> = arr(f, "hypotheses").iter().map(|h| h.as_str().unwrap().to_string()).collect();
-        let row = FrameRepository::create(&pool, &s(f, "name"), None, &hyps).await.expect("frame");
+        let hyps: Vec<String> = arr(f, "hypotheses")
+            .iter()
+            .map(|h| h.as_str().unwrap().to_string())
+            .collect();
+        let row = FrameRepository::create(&pool, &s(f, "name"), None, &hyps)
+            .await
+            .expect("frame");
         frame_of.insert(s(f, "key"), (row.id, hyps));
     }
     // perspectives (fixed 4)
     let author = insert_agent(&pool).await;
     let mut persp: Vec<(String, String, Uuid, Value)> = Vec::new();
     for p in arr(&obs_j, "perspectives") {
-        let row = PerspectiveRepository::create(&pool, &s(p, "name"), None, None,
-            p.get("perspective_type").and_then(|x| x.as_str()), &[], None, None).await.expect("persp");
-        let map: HashMap<String, f64> = p.get("source_reliability").and_then(|x| x.as_object()).unwrap()
-            .iter().map(|(k, v)| (k.clone(), v.as_f64().unwrap())).collect();
-        PerspectiveRepository::set_source_reliability(&pool, row.id, &map).await.expect("rel");
-        persp.push((s(p, "key"), s(p, "name"), row.id, p.get("source_reliability").cloned().unwrap()));
+        let row = PerspectiveRepository::create(
+            &pool,
+            &s(p, "name"),
+            None,
+            None,
+            p.get("perspective_type").and_then(|x| x.as_str()),
+            &[],
+            None,
+            None,
+        )
+        .await
+        .expect("persp");
+        let map: HashMap<String, f64> = p
+            .get("source_reliability")
+            .and_then(|x| x.as_object())
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_f64().unwrap()))
+            .collect();
+        PerspectiveRepository::set_source_reliability(&pool, row.id, &map)
+            .await
+            .expect("rel");
+        persp.push((
+            s(p, "key"),
+            s(p, "name"),
+            row.id,
+            p.get("source_reliability").cloned().unwrap(),
+        ));
     }
 
     // entities: condition-cluster anchor + treatment organisms
-    let mut entities_out: Vec<Value> = vec![json!({ "key": "disease-state", "name": disease, "type_top": "Condition", "type_sub": "DiseaseState" })];
-    EntityRepository::upsert(&pool, &disease, "Condition", Some("DiseaseState"), None, json!({})).await.expect("condition entity");
-    let symptom_name: HashMap<String, String> =
-        arr(cluster, "symptoms").iter().map(|s_| (s(s_, "key"), s(s_, "name"))).collect();
+    let mut entities_out: Vec<Value> = vec![
+        json!({ "key": "disease-state", "name": disease, "type_top": "Condition", "type_sub": "DiseaseState" }),
+    ];
+    EntityRepository::upsert(
+        &pool,
+        &disease,
+        "Condition",
+        Some("DiseaseState"),
+        None,
+        json!({}),
+    )
+    .await
+    .expect("condition entity");
+    let symptom_name: HashMap<String, String> = arr(cluster, "symptoms")
+        .iter()
+        .map(|s_| (s(s_, "key"), s(s_, "name")))
+        .collect();
     for t in arr(&pkg, "treatments") {
-        let name = if s(t, "latin").is_empty() { s(t, "name") } else { format!("{} ({})", s(t, "name"), s(t, "latin")) };
-        EntityRepository::upsert(&pool, &name, "Organism", Some("Botanical"), None, json!({})).await.expect("treatment entity");
+        let name = if s(t, "latin").is_empty() {
+            s(t, "name")
+        } else {
+            format!("{} ({})", s(t, "name"), s(t, "latin"))
+        };
+        EntityRepository::upsert(&pool, &name, "Organism", Some("Botanical"), None, json!({}))
+            .await
+            .expect("treatment entity");
         entities_out.push(json!({ "key": s(t, "key"), "name": name, "type_top": "Organism", "type_sub": "Botanical" }));
     }
 
     let mut metas: Vec<ClaimMeta> = Vec::new();
-    let mut push_claim = |metas: &mut Vec<ClaimMeta>, key: String, kind: &str, frame_key: &str, content: String,
-                          treatment: Option<String>, symptom: Option<String>, dimension: Option<String>, evidence: Vec<Value>| {
+    let mut push_claim = |metas: &mut Vec<ClaimMeta>,
+                          key: String,
+                          kind: &str,
+                          frame_key: &str,
+                          content: String,
+                          treatment: Option<String>,
+                          symptom: Option<String>,
+                          dimension: Option<String>,
+                          evidence: Vec<Value>| {
         let (fu, hyps) = frame_of.get(frame_key).expect("frame").clone();
         metas.push(ClaimMeta {
-            key, kind: kind.to_string(), frame_key: frame_key.to_string(), target: hyps[0].clone(),
-            content, treatment, symptom, dimension, evidence, uuid: Uuid::nil(), frame_uuid: fu,
+            key,
+            kind: kind.to_string(),
+            frame_key: frame_key.to_string(),
+            target: hyps[0].clone(),
+            content,
+            treatment,
+            symptom,
+            dimension,
+            evidence,
+            uuid: Uuid::nil(),
+            frame_uuid: fu,
         });
     };
 
@@ -150,15 +236,37 @@ async fn discover_to_snapshot() {
                     "masses": { "holds": m.get("holds").and_then(|x| x.as_f64()).unwrap_or(0.4),
                                 "theta": 1.0 - m.get("holds").and_then(|x| x.as_f64()).unwrap_or(0.4) } })
         }).collect()).unwrap_or_default();
-        push_claim(&mut metas, s(sy, "key"), "symptom", "symptom_membership", s(sy, "name"),
-            None, None, sy.get("dimension").and_then(|x| x.as_str()).map(String::from), ev);
+        push_claim(
+            &mut metas,
+            s(sy, "key"),
+            "symptom",
+            "symptom_membership",
+            s(sy, "name"),
+            None,
+            None,
+            sy.get("dimension")
+                .and_then(|x| x.as_str())
+                .map(String::from),
+            ev,
+        );
     }
     // diagnostic-label claims (clinical artifact; perspectives differentiate by α)
     for (i, lbl) in arr(cluster, "western_labels").iter().enumerate() {
         let lbl = lbl.as_str().unwrap_or("clinical diagnosis").to_string();
-        let ev = vec![json!({ "source_type": "source_clinical", "masses": { "holds": 0.85, "theta": 0.15 } })];
-        push_claim(&mut metas, format!("label-{i}"), "label", "diagnostic_label",
-            format!("This state is correctly labeled {lbl}."), None, None, None, ev);
+        let ev = vec![
+            json!({ "source_type": "source_clinical", "masses": { "holds": 0.85, "theta": 0.15 } }),
+        ];
+        push_claim(
+            &mut metas,
+            format!("label-{i}"),
+            "label",
+            "diagnostic_label",
+            format!("This state is correctly labeled {lbl}."),
+            None,
+            None,
+            None,
+            ev,
+        );
     }
     // treatment efficacy + safety claims
     for tev in arr(&pkg, "evidence") {
@@ -167,23 +275,58 @@ async fn discover_to_snapshot() {
         // match it back to the clean treatment key so claim keys + entity links line up.
         let matched = arr(&pkg, "treatments").iter().find(|t| {
             let k = s(t, "key");
-            !k.is_empty() && (raw_tk == k || raw_tk.starts_with(&k) || raw_tk.contains(&k) || k.contains(&raw_tk))
+            !k.is_empty()
+                && (raw_tk == k
+                    || raw_tk.starts_with(&k)
+                    || raw_tk.contains(&k)
+                    || k.contains(&raw_tk))
         });
-        let tk = matched.map(|t| s(t, "key")).unwrap_or_else(|| raw_tk.clone());
-        let tname = matched.map(|t| s(t, "name")).unwrap_or_else(|| raw_tk.clone());
-        for eff in tev.get("efficacy").and_then(|x| x.as_array()).map(|a| a.clone()).unwrap_or_default() {
+        let tk = matched
+            .map(|t| s(t, "key"))
+            .unwrap_or_else(|| raw_tk.clone());
+        let tname = matched
+            .map(|t| s(t, "name"))
+            .unwrap_or_else(|| raw_tk.clone());
+        for eff in tev
+            .get("efficacy")
+            .and_then(|x| x.as_array())
+            .map(|a| a.clone())
+            .unwrap_or_default()
+        {
             let sk = s(&eff, "symptom_key");
             let sname = symptom_name.get(&sk).cloned().unwrap_or(sk.clone());
             let ev: Vec<Value> = eff.get("sources").and_then(|x| x.as_array()).map(|a| a.iter().map(|sc| {
                 json!({ "source_type": s(sc, "source_type"), "masses": sc.get("masses").cloned().unwrap_or(json!({})) })
             }).collect()).unwrap_or_default();
-            push_claim(&mut metas, format!("eff-{tk}-{sk}"), "treatment_effect", "treatment_efficacy",
-                format!("{tname} is efficacious for {sname}."), Some(tk.clone()), Some(sk), None, ev);
+            push_claim(
+                &mut metas,
+                format!("eff-{tk}-{sk}"),
+                "treatment_effect",
+                "treatment_efficacy",
+                format!("{tname} is efficacious for {sname}."),
+                Some(tk.clone()),
+                Some(sk),
+                None,
+                ev,
+            );
         }
-        if let Some(saf) = tev.get("safety").and_then(|x| x.get("sources")).and_then(|x| x.as_array()) {
+        if let Some(saf) = tev
+            .get("safety")
+            .and_then(|x| x.get("sources"))
+            .and_then(|x| x.as_array())
+        {
             let ev: Vec<Value> = saf.iter().map(|sc| json!({ "source_type": s(sc, "source_type"), "masses": sc.get("masses").cloned().unwrap_or(json!({})) })).collect();
-            push_claim(&mut metas, format!("saf-{tk}"), "treatment_safety", "treatment_safety",
-                format!("{tname} is safe at therapeutic dose for chronic use."), Some(tk.clone()), None, None, ev);
+            push_claim(
+                &mut metas,
+                format!("saf-{tk}"),
+                "treatment_safety",
+                "treatment_safety",
+                format!("{tname} is safe at therapeutic dose for chronic use."),
+                Some(tk.clone()),
+                None,
+                None,
+                ev,
+            );
         }
     }
 
@@ -196,14 +339,34 @@ async fn discover_to_snapshot() {
         let frame = FrameOfDiscernment::new(cm.frame_key.clone(), hyps.clone()).unwrap();
         for ev in &cm.evidence {
             let st = s(ev, "source_type");
-            let masses = ev.get("masses").and_then(|x| x.as_object()).cloned().unwrap_or_default();
-            if masses.is_empty() { continue; }
+            let masses = ev
+                .get("masses")
+                .and_then(|x| x.as_object())
+                .cloned()
+                .unwrap_or_default();
+            if masses.is_empty() {
+                continue;
+            }
             let bba = ow_bba_json(&frame, &hyps, &masses);
             // fresh agent per BBA so repeated source_types on one claim don't collide on
             // mass_functions_unique_per_perspective (claim, frame, source_agent, perspective)
             let src = insert_agent(&pool).await;
-            MassFunctionRepository::store_with_perspective(&pool, cu, cm.frame_uuid, Some(src),
-                None, &bba, None, Some("discount"), Some(1.0), Some(&st), "cross", None).await.expect("bba");
+            MassFunctionRepository::store_with_perspective(
+                &pool,
+                cu,
+                cm.frame_uuid,
+                Some(src),
+                None,
+                &bba,
+                None,
+                Some("discount"),
+                Some(1.0),
+                Some(&st),
+                "cross",
+                None,
+            )
+            .await
+            .expect("bba");
         }
     }
 
@@ -212,7 +375,10 @@ async fn discover_to_snapshot() {
     for cm in &metas {
         let mut betp = Map::new();
         for (pk, _pn, pid, _sr) in &persp {
-            betp.insert(pk.clone(), json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await));
+            betp.insert(
+                pk.clone(),
+                json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await),
+            );
         }
         claims_json.push(json!({
             "key": cm.key, "kind": cm.kind, "frame": cm.frame_key, "target": cm.target, "content": cm.content,
@@ -220,7 +386,10 @@ async fn discover_to_snapshot() {
             "betp": Value::Object(betp), "evidence": cm.evidence,
         }));
     }
-    let persp_out: Vec<Value> = persp.iter().map(|(k, n, _, sr)| json!({ "key": k, "name": n, "source_reliability": sr })).collect();
+    let persp_out: Vec<Value> = persp
+        .iter()
+        .map(|(k, n, _, sr)| json!({ "key": k, "name": n, "source_reliability": sr }))
+        .collect();
     let snapshot = json!({
         "generated_from": "agentic discovery → epigraph engine (get_perspective_belief), open-world BBAs",
         "disease": disease,
@@ -229,7 +398,13 @@ async fn discover_to_snapshot() {
         "entities": entities_out,
         "claims": claims_json,
     });
-    if let Some(p) = std::path::Path::new(&out).parent() { std::fs::create_dir_all(p).ok(); }
+    if let Some(p) = std::path::Path::new(&out).parent() {
+        std::fs::create_dir_all(p).ok();
+    }
     std::fs::write(&out, serde_json::to_string_pretty(&snapshot).unwrap()).expect("write");
-    eprintln!("CONDITION-CLUSTER SNAPSHOT → {out}  ({} claims × {} perspectives)", metas.len(), persp.len());
+    eprintln!(
+        "CONDITION-CLUSTER SNAPSHOT → {out}  ({} claims × {} perspectives)",
+        metas.len(),
+        persp.len()
+    );
 }

--- a/crates/epigraph-engine/tests/perspectival_divergence_check.rs
+++ b/crates/epigraph-engine/tests/perspectival_divergence_check.rs
@@ -24,7 +24,10 @@ async fn perspective_divergence_is_real() {
             .fetch_all(&pool)
             .await
             .expect("perspectives");
-    assert!(!perspectives.is_empty(), "no perspectives — run tag_ingest first");
+    assert!(
+        !perspectives.is_empty(),
+        "no perspectives — run tag_ingest first"
+    );
 
     // The native binary frame; BetP(TRUE) = P(the proposition holds).
     let frame_id: Uuid = sqlx::query_scalar("SELECT id FROM frames WHERE name = 'binary_truth'")
@@ -63,7 +66,10 @@ async fn perspective_divergence_is_real() {
             let bi = get_perspective_belief(&pool, *cid, frame_id, *pid)
                 .await
                 .expect("belief");
-            println!("   {:<24} BetP(holds)={:.3}  bel={:.3}  pl={:.3}", pname, bi.pignistic_prob, bi.belief, bi.plausibility);
+            println!(
+                "   {:<24} BetP(holds)={:.3}  bel={:.3}  pl={:.3}",
+                pname, bi.pignistic_prob, bi.belief, bi.plausibility
+            );
             betps.push(bi.pignistic_prob);
         }
         let (min, max) = (

--- a/crates/epigraph-engine/tests/perspectival_interview_merge.rs
+++ b/crates/epigraph-engine/tests/perspectival_interview_merge.rs
@@ -28,7 +28,9 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use epigraph_db::{EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool};
+use epigraph_db::{
+    EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool,
+};
 use epigraph_ds::{FocalElement, FrameOfDiscernment, MassFunction};
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
@@ -41,10 +43,16 @@ fn read(path: &str) -> Value {
     serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {path}: {e}"))
 }
 fn arr<'a>(v: &'a Value, key: &str) -> &'a Vec<Value> {
-    v.get(key).and_then(|x| x.as_array()).map(|a| a).unwrap_or_else(|| panic!("missing array {key}"))
+    v.get(key)
+        .and_then(|x| x.as_array())
+        .map(|a| a)
+        .unwrap_or_else(|| panic!("missing array {key}"))
 }
 fn s(v: &Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or_default().to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string()
 }
 
 async fn insert_agent(pool: &PgPool) -> Uuid {
@@ -65,7 +73,9 @@ async fn assign(pool: &PgPool, claim: Uuid, frame: Uuid) {
 }
 async fn betp0(pool: &PgPool, claim: Uuid, frame: Uuid, persp: Uuid) -> f64 {
     epigraph_engine::belief_query::get_perspective_belief(pool, claim, frame, persp)
-        .await.expect("belief").pignistic_prob
+        .await
+        .expect("belief")
+        .pignistic_prob
 }
 
 /// Open-world BBA from an arbitrary masses map (hypothesis names + "theta");
@@ -84,7 +94,8 @@ fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Map<String,
             theta_mass = val;
         } else if let Some(idx) = hyps.iter().position(|h| h == k) {
             if val > 0.0 {
-                *m.entry(FocalElement::positive(BTreeSet::from([idx]))).or_insert(0.0) += val;
+                *m.entry(FocalElement::positive(BTreeSet::from([idx])))
+                    .or_insert(0.0) += val;
             }
         }
     }
@@ -100,7 +111,9 @@ fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Map<String,
             *v /= sum;
         }
     }
-    MassFunction::new(frame.clone(), m).expect("ow bba").masses_to_json()
+    MassFunction::new(frame.clone(), m)
+        .expect("ow bba")
+        .masses_to_json()
 }
 
 /// Match a (possibly latin-suffixed) evidence treatment_key back onto a clean
@@ -108,10 +121,15 @@ fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Map<String,
 fn match_treatment<'a>(pkg: &'a Value, raw_tk: &str) -> (String, String) {
     let matched = arr(pkg, "treatments").iter().find(|t| {
         let k = s(t, "key");
-        !k.is_empty() && (raw_tk == k || raw_tk.starts_with(&k) || raw_tk.contains(&k) || k.contains(raw_tk))
+        !k.is_empty()
+            && (raw_tk == k || raw_tk.starts_with(&k) || raw_tk.contains(&k) || k.contains(raw_tk))
     });
-    let tk = matched.map(|t| s(t, "key")).unwrap_or_else(|| raw_tk.to_string());
-    let tname = matched.map(|t| s(t, "name")).unwrap_or_else(|| raw_tk.to_string());
+    let tk = matched
+        .map(|t| s(t, "key"))
+        .unwrap_or_else(|| raw_tk.to_string());
+    let tname = matched
+        .map(|t| s(t, "name"))
+        .unwrap_or_else(|| raw_tk.to_string());
     (tk, tname)
 }
 
@@ -142,7 +160,10 @@ struct ClaimMeta {
 #[tokio::test]
 #[ignore = "requires SEED_DIR + dedicated dev DB; run manually with --ignored"]
 async fn merge_interview_and_recompute() {
-    let Ok(url) = std::env::var("DATABASE_URL") else { eprintln!("SKIP: DATABASE_URL not set"); return; };
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
     let pkg_path = std::env::var("DISCOVERY_IN").expect("set DISCOVERY_IN");
     let interview_path = std::env::var("INTERVIEW_IN").expect("set INTERVIEW_IN");
     let dir = std::env::var("SEED_DIR").expect("set SEED_DIR");
@@ -160,48 +181,115 @@ async fn merge_interview_and_recompute() {
     // ---- frames (fixed 4) ----
     let mut frame_of: HashMap<String, (Uuid, Vec<String>)> = HashMap::new();
     for f in arr(&frames_j, "frames") {
-        let hyps: Vec<String> = arr(f, "hypotheses").iter().map(|h| h.as_str().unwrap().to_string()).collect();
-        let row = FrameRepository::create(&pool, &s(f, "name"), None, &hyps).await.expect("frame");
+        let hyps: Vec<String> = arr(f, "hypotheses")
+            .iter()
+            .map(|h| h.as_str().unwrap().to_string())
+            .collect();
+        let row = FrameRepository::create(&pool, &s(f, "name"), None, &hyps)
+            .await
+            .expect("frame");
         frame_of.insert(s(f, "key"), (row.id, hyps));
     }
     // ---- perspectives (fixed 4) ----
     let author = insert_agent(&pool).await;
     let mut persp: Vec<(String, String, Uuid, Value)> = Vec::new();
     for p in arr(&obs_j, "perspectives") {
-        let row = PerspectiveRepository::create(&pool, &s(p, "name"), None, None,
-            p.get("perspective_type").and_then(|x| x.as_str()), &[], None, None).await.expect("persp");
-        let map: HashMap<String, f64> = p.get("source_reliability").and_then(|x| x.as_object()).unwrap()
-            .iter().map(|(k, v)| (k.clone(), v.as_f64().unwrap())).collect();
-        PerspectiveRepository::set_source_reliability(&pool, row.id, &map).await.expect("rel");
-        persp.push((s(p, "key"), s(p, "name"), row.id, p.get("source_reliability").cloned().unwrap()));
+        let row = PerspectiveRepository::create(
+            &pool,
+            &s(p, "name"),
+            None,
+            None,
+            p.get("perspective_type").and_then(|x| x.as_str()),
+            &[],
+            None,
+            None,
+        )
+        .await
+        .expect("persp");
+        let map: HashMap<String, f64> = p
+            .get("source_reliability")
+            .and_then(|x| x.as_object())
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_f64().unwrap()))
+            .collect();
+        PerspectiveRepository::set_source_reliability(&pool, row.id, &map)
+            .await
+            .expect("rel");
+        persp.push((
+            s(p, "key"),
+            s(p, "name"),
+            row.id,
+            p.get("source_reliability").cloned().unwrap(),
+        ));
     }
 
     // ---- entities: condition-cluster anchor + treatment organisms ----
-    let mut entities_out: Vec<Value> = vec![json!({ "key": "disease-state", "name": disease, "type_top": "Condition", "type_sub": "DiseaseState" })];
-    EntityRepository::upsert(&pool, &disease, "Condition", Some("DiseaseState"), None, json!({})).await.expect("disease entity");
-    let symptom_name: HashMap<String, String> =
-        arr(cluster, "symptoms").iter().map(|s_| (s(s_, "key"), s(s_, "name"))).collect();
+    let mut entities_out: Vec<Value> = vec![
+        json!({ "key": "disease-state", "name": disease, "type_top": "Condition", "type_sub": "DiseaseState" }),
+    ];
+    EntityRepository::upsert(
+        &pool,
+        &disease,
+        "Condition",
+        Some("DiseaseState"),
+        None,
+        json!({}),
+    )
+    .await
+    .expect("disease entity");
+    let symptom_name: HashMap<String, String> = arr(cluster, "symptoms")
+        .iter()
+        .map(|s_| (s(s_, "key"), s(s_, "name")))
+        .collect();
     for t in arr(&pkg, "treatments") {
-        let name = if s(t, "latin").is_empty() { s(t, "name") } else { format!("{} ({})", s(t, "name"), s(t, "latin")) };
-        EntityRepository::upsert(&pool, &name, "Organism", Some("Botanical"), None, json!({})).await.expect("treatment entity");
+        let name = if s(t, "latin").is_empty() {
+            s(t, "name")
+        } else {
+            format!("{} ({})", s(t, "name"), s(t, "latin"))
+        };
+        EntityRepository::upsert(&pool, &name, "Organism", Some("Botanical"), None, json!({}))
+            .await
+            .expect("treatment entity");
         entities_out.push(json!({ "key": s(t, "key"), "name": name, "type_top": "Organism", "type_sub": "Botanical" }));
     }
 
     // clean treatment key -> display name (for content of newly-created claims)
-    let treat_name: HashMap<String, String> =
-        arr(&pkg, "treatments").iter().map(|t| (s(t, "key"), s(t, "name"))).collect();
+    let treat_name: HashMap<String, String> = arr(&pkg, "treatments")
+        .iter()
+        .map(|t| (s(t, "key"), s(t, "name")))
+        .collect();
 
     // ============================================================
     // STAGE A: build the discovery cluster exactly as the converter
     // ============================================================
     let mut metas: Vec<ClaimMeta> = Vec::new();
-    let mut push_claim = |metas: &mut Vec<ClaimMeta>, key: String, kind: &str, frame_key: &str, content: String,
-                          treatment: Option<String>, symptom: Option<String>, dimension: Option<String>, evidence: Vec<Value>| {
+    let mut push_claim = |metas: &mut Vec<ClaimMeta>,
+                          key: String,
+                          kind: &str,
+                          frame_key: &str,
+                          content: String,
+                          treatment: Option<String>,
+                          symptom: Option<String>,
+                          dimension: Option<String>,
+                          evidence: Vec<Value>| {
         let (fu, hyps) = frame_of.get(frame_key).expect("frame").clone();
         metas.push(ClaimMeta {
-            key, kind: kind.to_string(), frame_key: frame_key.to_string(), target: hyps[0].clone(),
-            content, treatment, symptom, dimension, evidence, uuid: Uuid::nil(), frame_uuid: fu,
-            before: Map::new(), after: Map::new(), created_for_interview: false, touched: false,
+            key,
+            kind: kind.to_string(),
+            frame_key: frame_key.to_string(),
+            target: hyps[0].clone(),
+            content,
+            treatment,
+            symptom,
+            dimension,
+            evidence,
+            uuid: Uuid::nil(),
+            frame_uuid: fu,
+            before: Map::new(),
+            after: Map::new(),
+            created_for_interview: false,
+            touched: false,
         });
     };
 
@@ -212,33 +300,82 @@ async fn merge_interview_and_recompute() {
                     "masses": { "holds": m.get("holds").and_then(|x| x.as_f64()).unwrap_or(0.4),
                                 "theta": 1.0 - m.get("holds").and_then(|x| x.as_f64()).unwrap_or(0.4) } })
         }).collect()).unwrap_or_default();
-        push_claim(&mut metas, s(sy, "key"), "symptom", "symptom_membership", s(sy, "name"),
-            None, None, sy.get("dimension").and_then(|x| x.as_str()).map(String::from), ev);
+        push_claim(
+            &mut metas,
+            s(sy, "key"),
+            "symptom",
+            "symptom_membership",
+            s(sy, "name"),
+            None,
+            None,
+            sy.get("dimension")
+                .and_then(|x| x.as_str())
+                .map(String::from),
+            ev,
+        );
     }
     // diagnostic-label claims
     for (i, lbl) in arr(cluster, "western_labels").iter().enumerate() {
         let lbl = lbl.as_str().unwrap_or("clinical diagnosis").to_string();
-        let ev = vec![json!({ "source_type": "source_clinical", "masses": { "holds": 0.85, "theta": 0.15 } })];
-        push_claim(&mut metas, format!("label-{i}"), "label", "diagnostic_label",
-            format!("This state is correctly labeled {lbl}."), None, None, None, ev);
+        let ev = vec![
+            json!({ "source_type": "source_clinical", "masses": { "holds": 0.85, "theta": 0.15 } }),
+        ];
+        push_claim(
+            &mut metas,
+            format!("label-{i}"),
+            "label",
+            "diagnostic_label",
+            format!("This state is correctly labeled {lbl}."),
+            None,
+            None,
+            None,
+            ev,
+        );
     }
     // treatment efficacy + safety claims
     for tev in arr(&pkg, "evidence") {
         let raw_tk = s(tev, "treatment_key");
         let (tk, tname) = match_treatment(&pkg, &raw_tk);
-        for eff in tev.get("efficacy").and_then(|x| x.as_array()).map(|a| a.clone()).unwrap_or_default() {
+        for eff in tev
+            .get("efficacy")
+            .and_then(|x| x.as_array())
+            .map(|a| a.clone())
+            .unwrap_or_default()
+        {
             let sk = s(&eff, "symptom_key");
             let sname = symptom_name.get(&sk).cloned().unwrap_or(sk.clone());
             let ev: Vec<Value> = eff.get("sources").and_then(|x| x.as_array()).map(|a| a.iter().map(|sc| {
                 json!({ "source_type": s(sc, "source_type"), "masses": sc.get("masses").cloned().unwrap_or(json!({})) })
             }).collect()).unwrap_or_default();
-            push_claim(&mut metas, format!("eff-{tk}-{sk}"), "treatment_effect", "treatment_efficacy",
-                format!("{tname} is efficacious for {sname}."), Some(tk.clone()), Some(sk), None, ev);
+            push_claim(
+                &mut metas,
+                format!("eff-{tk}-{sk}"),
+                "treatment_effect",
+                "treatment_efficacy",
+                format!("{tname} is efficacious for {sname}."),
+                Some(tk.clone()),
+                Some(sk),
+                None,
+                ev,
+            );
         }
-        if let Some(saf) = tev.get("safety").and_then(|x| x.get("sources")).and_then(|x| x.as_array()) {
+        if let Some(saf) = tev
+            .get("safety")
+            .and_then(|x| x.get("sources"))
+            .and_then(|x| x.as_array())
+        {
             let ev: Vec<Value> = saf.iter().map(|sc| json!({ "source_type": s(sc, "source_type"), "masses": sc.get("masses").cloned().unwrap_or(json!({})) })).collect();
-            push_claim(&mut metas, format!("saf-{tk}"), "treatment_safety", "treatment_safety",
-                format!("{tname} is safe at therapeutic dose for chronic use."), Some(tk.clone()), None, None, ev);
+            push_claim(
+                &mut metas,
+                format!("saf-{tk}"),
+                "treatment_safety",
+                "treatment_safety",
+                format!("{tname} is safe at therapeutic dose for chronic use."),
+                Some(tk.clone()),
+                None,
+                None,
+                ev,
+            );
         }
     }
 
@@ -252,12 +389,32 @@ async fn merge_interview_and_recompute() {
         let frame = FrameOfDiscernment::new(cm.frame_key.clone(), hyps.clone()).unwrap();
         for ev in &cm.evidence {
             let st = s(ev, "source_type");
-            let masses = ev.get("masses").and_then(|x| x.as_object()).cloned().unwrap_or_default();
-            if masses.is_empty() { continue; }
+            let masses = ev
+                .get("masses")
+                .and_then(|x| x.as_object())
+                .cloned()
+                .unwrap_or_default();
+            if masses.is_empty() {
+                continue;
+            }
             let bba = ow_bba_json(&frame, &hyps, &masses);
             let src = insert_agent(&pool).await;
-            MassFunctionRepository::store_with_perspective(&pool, cu, cm.frame_uuid, Some(src),
-                None, &bba, None, Some("discount"), Some(1.0), Some(&st), "cross", None).await.expect("bba");
+            MassFunctionRepository::store_with_perspective(
+                &pool,
+                cu,
+                cm.frame_uuid,
+                Some(src),
+                None,
+                &bba,
+                None,
+                Some("discount"),
+                Some(1.0),
+                Some(&st),
+                "cross",
+                None,
+            )
+            .await
+            .expect("bba");
         }
     }
 
@@ -267,7 +424,10 @@ async fn merge_interview_and_recompute() {
     for cm in metas.iter_mut() {
         let mut betp = Map::new();
         for (pk, _pn, pid, _sr) in &persp {
-            betp.insert(pk.clone(), json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await));
+            betp.insert(
+                pk.clone(),
+                json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await),
+            );
         }
         cm.before = betp;
     }
@@ -282,19 +442,30 @@ async fn merge_interview_and_recompute() {
     let interview = read(&interview_path);
     // (key, id) for each perspective — used to materialize a created claim's
     // baseline "before" BetP inside ensure_meta.
-    let persp_ids: Vec<(String, Uuid)> = persp.iter().map(|(k, _, id, _)| (k.clone(), *id)).collect();
+    let persp_ids: Vec<(String, Uuid)> =
+        persp.iter().map(|(k, _, id, _)| (k.clone(), *id)).collect();
     let practitioner = insert_agent(&pool).await;
-    let practitioner_did = interview.get("agent").and_then(|a| a.get("did"))
-        .and_then(|x| x.as_str()).unwrap_or("did:perspectival:practitioner:unknown").to_string();
+    let practitioner_did = interview
+        .get("agent")
+        .and_then(|a| a.get("did"))
+        .and_then(|x| x.as_str())
+        .unwrap_or("did:perspectival:practitioner:unknown")
+        .to_string();
 
     // index existing metas by key for precise attachment (claims live in the DB
     // by content/hash, so the key->uuid map is the only reliable lookup)
-    let mut key_index: HashMap<String, usize> =
-        metas.iter().enumerate().map(|(i, cm)| (cm.key.clone(), i)).collect();
+    let mut key_index: HashMap<String, usize> = metas
+        .iter()
+        .enumerate()
+        .map(|(i, cm)| (cm.key.clone(), i))
+        .collect();
 
     // collect (meta_index, frame_key, raw_masses_value, source_type) merges to
     // apply after we finish mutating `metas`, to keep the borrow checker happy.
-    struct Merge { idx: usize, masses: Map<String, Value> }
+    struct Merge {
+        idx: usize,
+        masses: Map<String, Value>,
+    }
     let mut merges: Vec<Merge> = Vec::new();
 
     for tev in arr(&interview, "evidence") {
@@ -303,35 +474,77 @@ async fn merge_interview_and_recompute() {
         let tname = treat_name.get(&tk).cloned().unwrap_or_else(|| tk.clone());
 
         // efficacy entries: one practitioner BBA per (treatment, symptom)
-        for eff in tev.get("efficacy").and_then(|x| x.as_array()).map(|a| a.clone()).unwrap_or_default() {
+        for eff in tev
+            .get("efficacy")
+            .and_then(|x| x.as_array())
+            .map(|a| a.clone())
+            .unwrap_or_default()
+        {
             let sk = s(&eff, "symptom_key");
             let sname = symptom_name.get(&sk).cloned().unwrap_or(sk.clone());
             // the interview provides a single practitioner source per symptom;
             // take its masses (raw 3-key)
-            let masses = eff.get("sources").and_then(|x| x.as_array())
+            let masses = eff
+                .get("sources")
+                .and_then(|x| x.as_array())
                 .and_then(|a| a.first())
-                .and_then(|sc| sc.get("masses")).and_then(|x| x.as_object()).cloned()
+                .and_then(|sc| sc.get("masses"))
+                .and_then(|x| x.as_object())
+                .cloned()
                 .unwrap_or_default();
-            if masses.is_empty() { continue; }
+            if masses.is_empty() {
+                continue;
+            }
             let key = format!("eff-{tk}-{sk}");
-            let idx = ensure_meta(&pool, &mut metas, &mut key_index, &frame_of, &persp_ids, author,
-                &key, "treatment_effect", "treatment_efficacy",
+            let idx = ensure_meta(
+                &pool,
+                &mut metas,
+                &mut key_index,
+                &frame_of,
+                &persp_ids,
+                author,
+                &key,
+                "treatment_effect",
+                "treatment_efficacy",
                 format!("{tname} is efficacious for {sname}."),
-                Some(tk.clone()), Some(sk.clone()), None).await;
+                Some(tk.clone()),
+                Some(sk.clone()),
+                None,
+            )
+            .await;
             merges.push(Merge { idx, masses });
         }
 
         // safety entry: one practitioner BBA per treatment
-        if let Some(saf_sources) = tev.get("safety").and_then(|x| x.get("sources")).and_then(|x| x.as_array()) {
-            let masses = saf_sources.first()
-                .and_then(|sc| sc.get("masses")).and_then(|x| x.as_object()).cloned()
+        if let Some(saf_sources) = tev
+            .get("safety")
+            .and_then(|x| x.get("sources"))
+            .and_then(|x| x.as_array())
+        {
+            let masses = saf_sources
+                .first()
+                .and_then(|sc| sc.get("masses"))
+                .and_then(|x| x.as_object())
+                .cloned()
                 .unwrap_or_default();
             if !masses.is_empty() {
                 let key = format!("saf-{tk}");
-                let idx = ensure_meta(&pool, &mut metas, &mut key_index, &frame_of, &persp_ids, author,
-                    &key, "treatment_safety", "treatment_safety",
+                let idx = ensure_meta(
+                    &pool,
+                    &mut metas,
+                    &mut key_index,
+                    &frame_of,
+                    &persp_ids,
+                    author,
+                    &key,
+                    "treatment_safety",
+                    "treatment_safety",
                     format!("{tname} is safe at therapeutic dose for chronic use."),
-                    Some(tk.clone()), None, None).await;
+                    Some(tk.clone()),
+                    None,
+                    None,
+                )
+                .await;
                 merges.push(Merge { idx, masses });
             }
         }
@@ -348,9 +561,22 @@ async fn merge_interview_and_recompute() {
         let hyps = frame_of.get(&cm.frame_key).unwrap().1.clone();
         let frame = FrameOfDiscernment::new(cm.frame_key.clone(), hyps.clone()).unwrap();
         let bba = ow_bba_json(&frame, &hyps, &m.masses);
-        MassFunctionRepository::store_with_perspective(&pool, cm.uuid, cm.frame_uuid, Some(practitioner),
-            None, &bba, None, Some("discount"), Some(1.0), Some(PRACTITIONER_SOURCE_TYPE), "cross", None)
-            .await.expect("practitioner bba");
+        MassFunctionRepository::store_with_perspective(
+            &pool,
+            cm.uuid,
+            cm.frame_uuid,
+            Some(practitioner),
+            None,
+            &bba,
+            None,
+            Some("discount"),
+            Some(1.0),
+            Some(PRACTITIONER_SOURCE_TYPE),
+            "cross",
+            None,
+        )
+        .await
+        .expect("practitioner bba");
         // append raw-masses practitioner entry to the snapshot evidence list
         // (the snapshot stores RAW masses; ow is applied only to the DB BBA)
         cm.evidence.push(json!({
@@ -366,7 +592,10 @@ async fn merge_interview_and_recompute() {
     for cm in metas.iter_mut() {
         let mut betp = Map::new();
         for (pk, _pn, pid, _sr) in &persp {
-            betp.insert(pk.clone(), json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await));
+            betp.insert(
+                pk.clone(),
+                json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await),
+            );
         }
         cm.after = betp;
     }
@@ -382,7 +611,10 @@ async fn merge_interview_and_recompute() {
             "betp": Value::Object(cm.after.clone()), "evidence": cm.evidence,
         }));
     }
-    let persp_out: Vec<Value> = persp.iter().map(|(k, n, _, sr)| json!({ "key": k, "name": n, "source_reliability": sr })).collect();
+    let persp_out: Vec<Value> = persp
+        .iter()
+        .map(|(k, n, _, sr)| json!({ "key": k, "name": n, "source_reliability": sr }))
+        .collect();
     let snapshot = json!({
         "generated_from": "agentic discovery + practitioner interview merge → epigraph engine (get_perspective_belief), open-world BBAs",
         "disease": disease,
@@ -391,7 +623,9 @@ async fn merge_interview_and_recompute() {
         "entities": entities_out,
         "claims": claims_json,
     });
-    if let Some(p) = std::path::Path::new(&out).parent() { std::fs::create_dir_all(p).ok(); }
+    if let Some(p) = std::path::Path::new(&out).parent() {
+        std::fs::create_dir_all(p).ok();
+    }
     std::fs::write(&out, serde_json::to_string_pretty(&snapshot).unwrap()).expect("write snapshot");
 
     // ============================================================
@@ -403,12 +637,25 @@ async fn merge_interview_and_recompute() {
     // ============================================================
     let mut deltas: Vec<Value> = Vec::new();
     for cm in &metas {
-        if !cm.touched { continue; }
+        if !cm.touched {
+            continue;
+        }
         let mut per_persp = Map::new();
         for (pk, _pn, _pid, _sr) in &persp {
-            let b = cm.before.get(pk).and_then(|v| v.as_f64()).unwrap_or(f64::NAN);
-            let a = cm.after.get(pk).and_then(|v| v.as_f64()).unwrap_or(f64::NAN);
-            per_persp.insert(pk.clone(), json!({ "before": b, "after": a, "delta": a - b }));
+            let b = cm
+                .before
+                .get(pk)
+                .and_then(|v| v.as_f64())
+                .unwrap_or(f64::NAN);
+            let a = cm
+                .after
+                .get(pk)
+                .and_then(|v| v.as_f64())
+                .unwrap_or(f64::NAN);
+            per_persp.insert(
+                pk.clone(),
+                json!({ "before": b, "after": a, "delta": a - b }),
+            );
         }
         deltas.push(json!({
             "claim_key": cm.key,
@@ -425,8 +672,12 @@ async fn merge_interview_and_recompute() {
     deltas.sort_by(|x, y| {
         let tx = x.get("treatment").and_then(|v| v.as_str()).unwrap_or("");
         let ty = y.get("treatment").and_then(|v| v.as_str()).unwrap_or("");
-        tx.cmp(ty).then(x.get("kind").and_then(|v| v.as_str()).unwrap_or("")
-            .cmp(y.get("kind").and_then(|v| v.as_str()).unwrap_or("")))
+        tx.cmp(ty).then(
+            x.get("kind")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .cmp(y.get("kind").and_then(|v| v.as_str()).unwrap_or("")),
+        )
     });
     let delta_report = json!({
         "generated_from": "perspectival_interview_merge: before vs after per-perspective BetP for claims touched by the practitioner interview",
@@ -438,8 +689,14 @@ async fn merge_interview_and_recompute() {
         "touched_claim_count": deltas.len(),
         "deltas": deltas,
     });
-    if let Some(p) = std::path::Path::new(&delta_out).parent() { std::fs::create_dir_all(p).ok(); }
-    std::fs::write(&delta_out, serde_json::to_string_pretty(&delta_report).unwrap()).expect("write delta");
+    if let Some(p) = std::path::Path::new(&delta_out).parent() {
+        std::fs::create_dir_all(p).ok();
+    }
+    std::fs::write(
+        &delta_out,
+        serde_json::to_string_pretty(&delta_report).unwrap(),
+    )
+    .expect("write delta");
 
     let touched = metas.iter().filter(|c| c.touched).count();
     let created = metas.iter().filter(|c| c.created_for_interview).count();
@@ -487,10 +744,21 @@ async fn ensure_meta(
     }
     let idx = metas.len();
     metas.push(ClaimMeta {
-        key: key.to_string(), kind: kind.to_string(), frame_key: frame_key.to_string(),
-        target: hyps[0].clone(), content, treatment, symptom, dimension,
-        evidence: Vec::new(), uuid: cu, frame_uuid: fu,
-        before, after: Map::new(), created_for_interview: true, touched: false,
+        key: key.to_string(),
+        kind: kind.to_string(),
+        frame_key: frame_key.to_string(),
+        target: hyps[0].clone(),
+        content,
+        treatment,
+        symptom,
+        dimension,
+        evidence: Vec::new(),
+        uuid: cu,
+        frame_uuid: fu,
+        before,
+        after: Map::new(),
+        created_for_interview: true,
+        touched: false,
     });
     key_index.insert(key.to_string(), idx);
     idx

--- a/crates/epigraph-engine/tests/perspectival_loader.rs
+++ b/crates/epigraph-engine/tests/perspectival_loader.rs
@@ -14,7 +14,9 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use epigraph_db::{EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool};
+use epigraph_db::{
+    EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool,
+};
 use epigraph_ds::{combination, FocalElement, FrameOfDiscernment, MassFunction};
 use serde_json::Value;
 use uuid::Uuid;
@@ -27,10 +29,15 @@ fn read(dir: &str, file: &str) -> Value {
     serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {path}: {e}"))
 }
 fn arr<'a>(v: &'a Value, key: &str) -> &'a Vec<Value> {
-    v.get(key).and_then(|x| x.as_array()).unwrap_or_else(|| panic!("missing array {key}"))
+    v.get(key)
+        .and_then(|x| x.as_array())
+        .unwrap_or_else(|| panic!("missing array {key}"))
 }
 fn s(v: &Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or_else(|| panic!("missing str {key}")).to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or_else(|| panic!("missing str {key}"))
+        .to_string()
 }
 
 async fn insert_agent(pool: &PgPool) -> Uuid {
@@ -53,7 +60,9 @@ async fn assign(pool: &PgPool, claim: Uuid, frame: Uuid) {
 /// BetP for hypothesis index 0 (the target: efficacious / safe / holds) under a perspective.
 async fn betp0(pool: &PgPool, claim: Uuid, frame: Uuid, persp: Uuid) -> f64 {
     epigraph_engine::belief_query::get_perspective_belief(pool, claim, frame, persp)
-        .await.expect("belief").pignistic_prob
+        .await
+        .expect("belief")
+        .pignistic_prob
 }
 
 /// Build an open-world BBA json: mass on the named hypothesis (its frame index),
@@ -69,7 +78,10 @@ fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Value) -> V
         if k == "theta" {
             theta_mass = val;
         } else {
-            let idx = hyps.iter().position(|h| h == k).unwrap_or_else(|| panic!("hyp {k} not in frame"));
+            let idx = hyps
+                .iter()
+                .position(|h| h == k)
+                .unwrap_or_else(|| panic!("hyp {k} not in frame"));
             hyp_idx = Some(idx);
             hyp_mass = val;
         }
@@ -84,13 +96,18 @@ fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Value) -> V
         m.insert(FocalElement::theta(frame), theta_rem);
     }
     m.insert(FocalElement::missing(frame), ow);
-    MassFunction::new(frame.clone(), m).expect("ow bba").masses_to_json()
+    MassFunction::new(frame.clone(), m)
+        .expect("ow bba")
+        .masses_to_json()
 }
 
 #[tokio::test]
 #[ignore = "requires SEED_DIR + dedicated dev DB; run manually with --ignored"]
 async fn load_and_validate_open_world() {
-    let Ok(url) = std::env::var("DATABASE_URL") else { eprintln!("SKIP: DATABASE_URL not set"); return; };
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
     let dir = std::env::var("SEED_DIR").expect("set SEED_DIR");
     let pool = PgPool::connect(&url).await.expect("connect");
     sqlx::migrate!("../../migrations").run(&pool).await.ok();
@@ -112,8 +129,13 @@ async fn load_and_validate_open_world() {
     // ---- frames ----
     for f in arr(&frames_j, "frames") {
         let name = s(f, "name");
-        let hyps: Vec<String> = arr(f, "hypotheses").iter().map(|h| h.as_str().unwrap().to_string()).collect();
-        let row = FrameRepository::create(&pool, &name, None, &hyps).await.expect("frame");
+        let hyps: Vec<String> = arr(f, "hypotheses")
+            .iter()
+            .map(|h| h.as_str().unwrap().to_string())
+            .collect();
+        let row = FrameRepository::create(&pool, &name, None, &hyps)
+            .await
+            .expect("frame");
         frame_of.insert(s(f, "key"), (row.id, hyps));
     }
     // ---- agents (source + observer) ----
@@ -127,19 +149,39 @@ async fn load_and_validate_open_world() {
     // ---- entities ----
     for e in arr(&entities_j, "entities") {
         let type_sub = e.get("type_sub").and_then(|x| x.as_str());
-        let props = e.get("properties").cloned().unwrap_or_else(|| serde_json::json!({}));
-        let row = EntityRepository::upsert(&pool, &s(e, "canonical_name"), &s(e, "type_top"), type_sub, None, props)
-            .await.expect("entity");
+        let props = e
+            .get("properties")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        let row = EntityRepository::upsert(
+            &pool,
+            &s(e, "canonical_name"),
+            &s(e, "type_top"),
+            type_sub,
+            None,
+            props,
+        )
+        .await
+        .expect("entity");
         key_id.insert(s(e, "key"), row.id);
     }
     // ---- perspectives + source_reliability ----
     for p in arr(&obs_j, "perspectives") {
         let ptype = p.get("perspective_type").and_then(|x| x.as_str());
-        let row = PerspectiveRepository::create(&pool, &s(p, "name"), None, None, ptype, &[], None, None)
-            .await.expect("perspective");
-        let map: HashMap<String, f64> = p.get("source_reliability").and_then(|x| x.as_object()).unwrap()
-            .iter().map(|(k, v)| (k.clone(), v.as_f64().unwrap())).collect();
-        PerspectiveRepository::set_source_reliability(&pool, row.id, &map).await.expect("rel");
+        let row =
+            PerspectiveRepository::create(&pool, &s(p, "name"), None, None, ptype, &[], None, None)
+                .await
+                .expect("perspective");
+        let map: HashMap<String, f64> = p
+            .get("source_reliability")
+            .and_then(|x| x.as_object())
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_f64().unwrap()))
+            .collect();
+        PerspectiveRepository::set_source_reliability(&pool, row.id, &map)
+            .await
+            .expect("rel");
         persp_id.insert(s(p, "key"), row.id);
     }
     // ---- claims + BBAs (open-world) ----
@@ -158,9 +200,21 @@ async fn load_and_validate_open_world() {
             let masses = ev.get("masses").expect("masses");
             let bba = ow_bba_json(&frame, &hyps, masses);
             MassFunctionRepository::store_with_perspective(
-                &pool, claim_uuid, frame_uuid, src, None, &bba, None,
-                Some("discount"), Some(1.0), Some(&etype), "cross", None,
-            ).await.expect("store bba");
+                &pool,
+                claim_uuid,
+                frame_uuid,
+                src,
+                None,
+                &bba,
+                None,
+                Some("discount"),
+                Some(1.0),
+                Some(&etype),
+                "cross",
+                None,
+            )
+            .await
+            .expect("store bba");
             n_bba += 1;
         }
     }
@@ -169,7 +223,15 @@ async fn load_and_validate_open_world() {
     for e in arr(&edges_j, "edges") {
         let src = key_id.get(&s(e, "source")).copied().expect("edge source");
         let tgt = key_id.get(&s(e, "target")).copied().expect("edge target");
-        EdgeRepositoryCreate(&pool, src, &s(e, "source_type"), tgt, &s(e, "target_type"), &s(e, "relationship")).await;
+        EdgeRepositoryCreate(
+            &pool,
+            src,
+            &s(e, "source_type"),
+            tgt,
+            &s(e, "target_type"),
+            &s(e, "relationship"),
+        )
+        .await;
         n_edge += 1;
     }
     eprintln!("LOADED: {} frames, {} entities, {} claims, {} BBAs (open-world), {} perspectives, {} edges",
@@ -180,34 +242,104 @@ async fn load_and_validate_open_world() {
     let pid = |k: &str| *persp_id.get(k).expect(k);
     let eff_frame = frame_of.get("treatment_efficacy").unwrap().0;
     let saf_frame = frame_of.get("treatment_safety").unwrap().0;
-    let persps = ["clinical_observer", "tradition_observer", "regulatory_observer", "skeptic_observer"];
+    let persps = [
+        "clinical_observer",
+        "tradition_observer",
+        "regulatory_observer",
+        "skeptic_observer",
+    ];
 
-    eprintln!("\nEFFICACY BetP(efficacious) — open-world, real engine  [clin  trad  regul  skept]:");
-    for claim in ["eff-treatment-a-symptom-1", "eff-treatment-b-symptom-3", "eff-treatment-e-symptom-4", "eff-treatment-c-symptom-2"] {
+    eprintln!(
+        "\nEFFICACY BetP(efficacious) — open-world, real engine  [clin  trad  regul  skept]:"
+    );
+    for claim in [
+        "eff-treatment-a-symptom-1",
+        "eff-treatment-b-symptom-3",
+        "eff-treatment-e-symptom-4",
+        "eff-treatment-c-symptom-2",
+    ] {
         let mut v = vec![];
-        for p in persps { v.push(betp0(&pool, cid(claim), eff_frame, pid(p)).await); }
-        eprintln!("  {claim:<26} {:.3} {:.3} {:.3} {:.3}", v[0], v[1], v[2], v[3]);
+        for p in persps {
+            v.push(betp0(&pool, cid(claim), eff_frame, pid(p)).await);
+        }
+        eprintln!(
+            "  {claim:<26} {:.3} {:.3} {:.3} {:.3}",
+            v[0], v[1], v[2], v[3]
+        );
     }
     eprintln!("SAFETY BetP(safe):");
     for claim in ["saf-treatment-a", "saf-treatment-c"] {
         let mut v = vec![];
-        for p in persps { v.push(betp0(&pool, cid(claim), saf_frame, pid(p)).await); }
-        eprintln!("  {claim:<26} {:.3} {:.3} {:.3} {:.3}", v[0], v[1], v[2], v[3]);
+        for p in persps {
+            v.push(betp0(&pool, cid(claim), saf_frame, pid(p)).await);
+        }
+        eprintln!(
+            "  {claim:<26} {:.3} {:.3} {:.3} {:.3}",
+            v[0], v[1], v[2], v[3]
+        );
     }
 
     // Directional assertions (open-world shifts magnitudes; directions hold).
     for p in persps {
-        assert!(betp0(&pool, cid("eff-treatment-a-symptom-1"), eff_frame, pid(p)).await > 0.5, "consensus eff {p}");
+        assert!(
+            betp0(&pool, cid("eff-treatment-a-symptom-1"), eff_frame, pid(p)).await > 0.5,
+            "consensus eff {p}"
+        );
     }
-    let bv = betp0(&pool, cid("eff-treatment-b-symptom-3"), eff_frame, pid("tradition_observer")).await;
-    let bc = betp0(&pool, cid("eff-treatment-b-symptom-3"), eff_frame, pid("clinical_observer")).await;
-    assert!(bv > bc + 0.15, "tradition-only gap: tradition {bv} vs clinical {bc}");
-    let jv = betp0(&pool, cid("eff-treatment-e-symptom-4"), eff_frame, pid("tradition_observer")).await;
-    let jc = betp0(&pool, cid("eff-treatment-e-symptom-4"), eff_frame, pid("clinical_observer")).await;
-    assert!(jv > jc && jc < 0.5, "conflict: tradition {jv} vs clinical {jc}");
-    let sv = betp0(&pool, cid("saf-treatment-c"), saf_frame, pid("tradition_observer")).await;
-    let sc = betp0(&pool, cid("saf-treatment-c"), saf_frame, pid("clinical_observer")).await;
-    assert!(sv > sc + 0.25 && sc < 0.5, "safety divergence: tradition {sv} vs clinical {sc}");
+    let bv = betp0(
+        &pool,
+        cid("eff-treatment-b-symptom-3"),
+        eff_frame,
+        pid("tradition_observer"),
+    )
+    .await;
+    let bc = betp0(
+        &pool,
+        cid("eff-treatment-b-symptom-3"),
+        eff_frame,
+        pid("clinical_observer"),
+    )
+    .await;
+    assert!(
+        bv > bc + 0.15,
+        "tradition-only gap: tradition {bv} vs clinical {bc}"
+    );
+    let jv = betp0(
+        &pool,
+        cid("eff-treatment-e-symptom-4"),
+        eff_frame,
+        pid("tradition_observer"),
+    )
+    .await;
+    let jc = betp0(
+        &pool,
+        cid("eff-treatment-e-symptom-4"),
+        eff_frame,
+        pid("clinical_observer"),
+    )
+    .await;
+    assert!(
+        jv > jc && jc < 0.5,
+        "conflict: tradition {jv} vs clinical {jc}"
+    );
+    let sv = betp0(
+        &pool,
+        cid("saf-treatment-c"),
+        saf_frame,
+        pid("tradition_observer"),
+    )
+    .await;
+    let sc = betp0(
+        &pool,
+        cid("saf-treatment-c"),
+        saf_frame,
+        pid("clinical_observer"),
+    )
+    .await;
+    assert!(
+        sv > sc + 0.25 && sc < 0.5,
+        "safety divergence: tradition {sv} vs clinical {sc}"
+    );
 
     // ---- OPEN-WORLD PROOF ----
     // The engine implements the YagerOpen rule as inagaki_combine(gamma=1.0) (routes ALL
@@ -220,7 +352,9 @@ async fn load_and_validate_open_world() {
     let mk = |idx: usize, ow: f64| {
         let mut m = BTreeMap::new();
         m.insert(FocalElement::positive(BTreeSet::from([idx])), 0.80); // K = 0.80*0.80 = 0.64 >= 0.5
-        if ow > 0.0 { m.insert(FocalElement::missing(&bf), ow); }
+        if ow > 0.0 {
+            m.insert(FocalElement::missing(&bf), ow);
+        }
         m.insert(FocalElement::theta(&bf), 0.20 - ow);
         MassFunction::new(bf.clone(), m).unwrap()
     };

--- a/crates/epigraph-engine/tests/perspectival_snapshot.rs
+++ b/crates/epigraph-engine/tests/perspectival_snapshot.rs
@@ -11,7 +11,9 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use epigraph_db::{EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool};
+use epigraph_db::{
+    EntityRepository, FrameRepository, MassFunctionRepository, PerspectiveRepository, PgPool,
+};
 use epigraph_ds::{FocalElement, FrameOfDiscernment, MassFunction};
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -24,10 +26,15 @@ fn read(dir: &str, file: &str) -> Value {
     serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {path}: {e}"))
 }
 fn arr<'a>(v: &'a Value, key: &str) -> &'a Vec<Value> {
-    v.get(key).and_then(|x| x.as_array()).unwrap_or_else(|| panic!("missing array {key}"))
+    v.get(key)
+        .and_then(|x| x.as_array())
+        .unwrap_or_else(|| panic!("missing array {key}"))
 }
 fn s(v: &Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or_else(|| panic!("missing str {key}")).to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or_else(|| panic!("missing str {key}"))
+        .to_string()
 }
 fn s_opt(v: &Value, key: &str) -> Option<String> {
     v.get(key).and_then(|x| x.as_str()).map(String::from)
@@ -51,36 +58,62 @@ async fn assign(pool: &PgPool, claim: Uuid, frame: Uuid) {
 }
 async fn betp0(pool: &PgPool, claim: Uuid, frame: Uuid, persp: Uuid) -> f64 {
     epigraph_engine::belief_query::get_perspective_belief(pool, claim, frame, persp)
-        .await.expect("belief").pignistic_prob
+        .await
+        .expect("belief")
+        .pignistic_prob
 }
 fn ow_bba_json(frame: &FrameOfDiscernment, hyps: &[String], masses: &Value) -> Value {
     let obj = masses.as_object().expect("masses obj");
     let (mut hyp_idx, mut hyp_mass, mut theta_mass) = (None, 0.0, 0.0);
     for (k, v) in obj {
         let val = v.as_f64().expect("mass f64");
-        if k == "theta" { theta_mass = val; }
-        else { hyp_idx = Some(hyps.iter().position(|h| h == k).unwrap_or_else(|| panic!("hyp {k}"))); hyp_mass = val; }
+        if k == "theta" {
+            theta_mass = val;
+        } else {
+            hyp_idx = Some(
+                hyps.iter()
+                    .position(|h| h == k)
+                    .unwrap_or_else(|| panic!("hyp {k}")),
+            );
+            hyp_mass = val;
+        }
     }
     let idx = hyp_idx.expect("hyp");
     let ow = OPEN_WORLD_FRACTION.min(theta_mass);
     let theta_rem = (theta_mass - ow).max(0.0);
     let mut m: BTreeMap<FocalElement, f64> = BTreeMap::new();
     m.insert(FocalElement::positive(BTreeSet::from([idx])), hyp_mass);
-    if theta_rem > 1e-9 { m.insert(FocalElement::theta(frame), theta_rem); }
+    if theta_rem > 1e-9 {
+        m.insert(FocalElement::theta(frame), theta_rem);
+    }
     m.insert(FocalElement::missing(frame), ow);
-    MassFunction::new(frame.clone(), m).expect("ow bba").masses_to_json()
+    MassFunction::new(frame.clone(), m)
+        .expect("ow bba")
+        .masses_to_json()
 }
 
 struct ClaimMeta {
-    key: String, kind: String, frame: String, target: String, content: String,
-    treatment: Option<String>, symptom: Option<String>, dimension: Option<String>, archetype: Option<String>,
-    evidence: Vec<Value>, uuid: Uuid, frame_uuid: Uuid,
+    key: String,
+    kind: String,
+    frame: String,
+    target: String,
+    content: String,
+    treatment: Option<String>,
+    symptom: Option<String>,
+    dimension: Option<String>,
+    archetype: Option<String>,
+    evidence: Vec<Value>,
+    uuid: Uuid,
+    frame_uuid: Uuid,
 }
 
 #[tokio::test]
 #[ignore = "requires SEED_DIR + dedicated dev DB; run manually with --ignored"]
 async fn generate_snapshot() {
-    let Ok(url) = std::env::var("DATABASE_URL") else { eprintln!("SKIP: DATABASE_URL not set"); return; };
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
     let dir = std::env::var("SEED_DIR").expect("set SEED_DIR");
     let out = std::env::var("SNAPSHOT_OUT").expect("set SNAPSHOT_OUT");
     let pool = PgPool::connect(&url).await.expect("connect");
@@ -98,27 +131,63 @@ async fn generate_snapshot() {
     let mut frame_of: HashMap<String, (Uuid, Vec<String>)> = HashMap::new();
 
     for f in arr(&frames_j, "frames") {
-        let hyps: Vec<String> = arr(f, "hypotheses").iter().map(|h| h.as_str().unwrap().to_string()).collect();
-        let row = FrameRepository::create(&pool, &s(f, "name"), None, &hyps).await.expect("frame");
+        let hyps: Vec<String> = arr(f, "hypotheses")
+            .iter()
+            .map(|h| h.as_str().unwrap().to_string())
+            .collect();
+        let row = FrameRepository::create(&pool, &s(f, "name"), None, &hyps)
+            .await
+            .expect("frame");
         frame_of.insert(s(f, "key"), (row.id, hyps));
     }
     for grp in ["source_agents", "observer_agents"] {
         if let Some(list) = agents_j.get(grp).and_then(|x| x.as_array()) {
-            for a in list { agent_id.insert(s(a, "key"), insert_agent(&pool).await); }
+            for a in list {
+                agent_id.insert(s(a, "key"), insert_agent(&pool).await);
+            }
         }
     }
     for e in arr(&entities_j, "entities") {
-        EntityRepository::upsert(&pool, &s(e, "canonical_name"), &s(e, "type_top"),
-            e.get("type_sub").and_then(|x| x.as_str()), None,
-            e.get("properties").cloned().unwrap_or_else(|| json!({}))).await.expect("entity");
+        EntityRepository::upsert(
+            &pool,
+            &s(e, "canonical_name"),
+            &s(e, "type_top"),
+            e.get("type_sub").and_then(|x| x.as_str()),
+            None,
+            e.get("properties").cloned().unwrap_or_else(|| json!({})),
+        )
+        .await
+        .expect("entity");
     }
     for p in arr(&obs_j, "perspectives") {
-        let row = PerspectiveRepository::create(&pool, &s(p, "name"), None, None,
-            p.get("perspective_type").and_then(|x| x.as_str()), &[], None, None).await.expect("persp");
-        let map: HashMap<String, f64> = p.get("source_reliability").and_then(|x| x.as_object()).unwrap()
-            .iter().map(|(k, v)| (k.clone(), v.as_f64().unwrap())).collect();
-        PerspectiveRepository::set_source_reliability(&pool, row.id, &map).await.expect("rel");
-        persp.push((s(p, "key"), s(p, "name"), row.id, p.get("source_reliability").cloned().unwrap()));
+        let row = PerspectiveRepository::create(
+            &pool,
+            &s(p, "name"),
+            None,
+            None,
+            p.get("perspective_type").and_then(|x| x.as_str()),
+            &[],
+            None,
+            None,
+        )
+        .await
+        .expect("persp");
+        let map: HashMap<String, f64> = p
+            .get("source_reliability")
+            .and_then(|x| x.as_object())
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_f64().unwrap()))
+            .collect();
+        PerspectiveRepository::set_source_reliability(&pool, row.id, &map)
+            .await
+            .expect("rel");
+        persp.push((
+            s(p, "key"),
+            s(p, "name"),
+            row.id,
+            p.get("source_reliability").cloned().unwrap(),
+        ));
     }
 
     let mut claims: Vec<ClaimMeta> = Vec::new();
@@ -133,15 +202,37 @@ async fn generate_snapshot() {
             let etype = s(ev, "evidence_type");
             let masses = ev.get("masses").expect("masses");
             let bba = ow_bba_json(&frame, &hyps, masses);
-            MassFunctionRepository::store_with_perspective(&pool, cu, frame_uuid,
-                agent_id.get(&s(ev, "source_agent")).copied(), None, &bba, None,
-                Some("discount"), Some(1.0), Some(&etype), "cross", None).await.expect("bba");
+            MassFunctionRepository::store_with_perspective(
+                &pool,
+                cu,
+                frame_uuid,
+                agent_id.get(&s(ev, "source_agent")).copied(),
+                None,
+                &bba,
+                None,
+                Some("discount"),
+                Some(1.0),
+                Some(&etype),
+                "cross",
+                None,
+            )
+            .await
+            .expect("bba");
             ev_out.push(json!({ "source_type": etype, "source_agent": s(ev, "source_agent"), "masses": masses }));
         }
         claims.push(ClaimMeta {
-            key: s(c, "key"), kind: s(c, "claim_kind"), frame: fk, target: hyps[0].clone(), content: s(c, "content"),
-            treatment: s_opt(c, "treatment"), symptom: s_opt(c, "symptom"), dimension: s_opt(c, "dimension"),
-            archetype: s_opt(c, "archetype"), evidence: ev_out, uuid: cu, frame_uuid,
+            key: s(c, "key"),
+            kind: s(c, "claim_kind"),
+            frame: fk,
+            target: hyps[0].clone(),
+            content: s(c, "content"),
+            treatment: s_opt(c, "treatment"),
+            symptom: s_opt(c, "symptom"),
+            dimension: s_opt(c, "dimension"),
+            archetype: s_opt(c, "archetype"),
+            evidence: ev_out,
+            uuid: cu,
+            frame_uuid,
         });
     }
 
@@ -149,7 +240,10 @@ async fn generate_snapshot() {
     for cm in &claims {
         let mut betp = serde_json::Map::new();
         for (pk, _pn, pid, _sr) in &persp {
-            betp.insert(pk.clone(), json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await));
+            betp.insert(
+                pk.clone(),
+                json!(betp0(&pool, cm.uuid, cm.frame_uuid, *pid).await),
+            );
         }
         claims_json.push(json!({
             "key": cm.key, "kind": cm.kind, "frame": cm.frame, "target": cm.target, "content": cm.content,
@@ -158,16 +252,29 @@ async fn generate_snapshot() {
         }));
     }
 
-    let entities_out: Vec<Value> = arr(&entities_j, "entities").iter().map(|e| json!({
-        "key": s(e, "key"), "name": s(e, "canonical_name"), "type_top": s(e, "type_top"),
-        "type_sub": e.get("type_sub").and_then(|x| x.as_str()),
-    })).collect();
-    let disease = entities_out.iter()
+    let entities_out: Vec<Value> = arr(&entities_j, "entities")
+        .iter()
+        .map(|e| {
+            json!({
+                "key": s(e, "key"), "name": s(e, "canonical_name"), "type_top": s(e, "type_top"),
+                "type_sub": e.get("type_sub").and_then(|x| x.as_str()),
+            })
+        })
+        .collect();
+    let disease = entities_out
+        .iter()
         .find(|e| e["type_sub"].as_str() == Some("DiseaseState"))
-        .and_then(|e| e["name"].as_str()).unwrap_or("condition cluster").to_string();
-    let persp_out: Vec<Value> = persp.iter().map(|(k, n, _, sr)| json!({
-        "key": k, "name": n, "source_reliability": sr,
-    })).collect();
+        .and_then(|e| e["name"].as_str())
+        .unwrap_or("condition cluster")
+        .to_string();
+    let persp_out: Vec<Value> = persp
+        .iter()
+        .map(|(k, n, _, sr)| {
+            json!({
+                "key": k, "name": n, "source_reliability": sr,
+            })
+        })
+        .collect();
 
     let snapshot = json!({
         "generated_from": "epigraph_demo_dev — real CDST engine (get_perspective_belief), open-world BBAs",
@@ -178,7 +285,13 @@ async fn generate_snapshot() {
         "claims": claims_json,
     });
 
-    if let Some(parent) = std::path::Path::new(&out).parent() { std::fs::create_dir_all(parent).ok(); }
+    if let Some(parent) = std::path::Path::new(&out).parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
     std::fs::write(&out, serde_json::to_string_pretty(&snapshot).unwrap()).expect("write snapshot");
-    eprintln!("SNAPSHOT → {out}  ({} claims × {} perspectives)", claims.len(), persp.len());
+    eprintln!(
+        "SNAPSHOT → {out}  ({} claims × {} perspectives)",
+        claims.len(),
+        persp.len()
+    );
 }

--- a/crates/epigraph-engine/tests/perspectival_t3.rs
+++ b/crates/epigraph-engine/tests/perspectival_t3.rs
@@ -27,10 +27,16 @@ const OW: f64 = 0.10;
 fn bba(frame: &FrameOfDiscernment, m0: f64, m1: f64, theta: f64) -> MassFunction {
     let ow = OW.min(theta);
     let mut m: BTreeMap<FocalElement, f64> = BTreeMap::new();
-    if m0 > 0.0 { m.insert(FocalElement::positive(BTreeSet::from([0])), m0); }
-    if m1 > 0.0 { m.insert(FocalElement::positive(BTreeSet::from([1])), m1); }
+    if m0 > 0.0 {
+        m.insert(FocalElement::positive(BTreeSet::from([0])), m0);
+    }
+    if m1 > 0.0 {
+        m.insert(FocalElement::positive(BTreeSet::from([1])), m1);
+    }
     let tr = theta - ow;
-    if tr > 1e-9 { m.insert(FocalElement::theta(frame), tr); }
+    if tr > 1e-9 {
+        m.insert(FocalElement::theta(frame), tr);
+    }
     m.insert(FocalElement::missing(frame), ow);
     MassFunction::new(frame.clone(), m).expect("bba")
 }
@@ -51,16 +57,61 @@ async fn insert_claim(pool: &PgPool, author: Uuid, content: &str) -> Uuid {
 #[tokio::test]
 #[ignore = "requires SEED_DIR + dedicated dev DB; run manually with --ignored"]
 async fn t3_engine_adjudicates_agent_bbas() {
-    let eff = FrameOfDiscernment::new("treatment_efficacy", vec!["efficacious".into(), "no_effect".into()]).unwrap();
-    let saf = FrameOfDiscernment::new("treatment_safety", vec!["safe".into(), "harmful".into()]).unwrap();
+    let eff = FrameOfDiscernment::new(
+        "treatment_efficacy",
+        vec!["efficacious".into(), "no_effect".into()],
+    )
+    .unwrap();
+    let saf =
+        FrameOfDiscernment::new("treatment_safety", vec!["safe".into(), "harmful".into()]).unwrap();
 
     // v2 agent-gathered BBAs (label, frame, prove (m0,m1,theta), refute (m0,m1,theta),
     //                         agent_K, agent_consolidated, agent_BetP_target)
-    let cases: Vec<(&str, &FrameOfDiscernment, (f64, f64, f64), (f64, f64, f64), f64, bool, f64)> = vec![
-        ("clinical/efficacy",  &eff, (0.32, 0.13, 0.55), (0.12, 0.13, 0.75), 0.057, true, 0.584),
-        ("clinical/safety",    &saf, (0.27, 0.45, 0.28), (0.20, 0.52, 0.28), 0.230, true, 0.292),
-        ("tradition/efficacy", &eff, (0.55, 0.08, 0.37), (0.22, 0.30, 0.48), 0.183, true, 0.679),
-        ("tradition/safety",   &saf, (0.50, 0.32, 0.18), (0.30, 0.45, 0.25), 0.321, true, 0.518),
+    let cases: Vec<(
+        &str,
+        &FrameOfDiscernment,
+        (f64, f64, f64),
+        (f64, f64, f64),
+        f64,
+        bool,
+        f64,
+    )> = vec![
+        (
+            "clinical/efficacy",
+            &eff,
+            (0.32, 0.13, 0.55),
+            (0.12, 0.13, 0.75),
+            0.057,
+            true,
+            0.584,
+        ),
+        (
+            "clinical/safety",
+            &saf,
+            (0.27, 0.45, 0.28),
+            (0.20, 0.52, 0.28),
+            0.230,
+            true,
+            0.292,
+        ),
+        (
+            "tradition/efficacy",
+            &eff,
+            (0.55, 0.08, 0.37),
+            (0.22, 0.30, 0.48),
+            0.183,
+            true,
+            0.679,
+        ),
+        (
+            "tradition/safety",
+            &saf,
+            (0.50, 0.32, 0.18),
+            (0.30, 0.45, 0.25),
+            0.321,
+            true,
+            0.518,
+        ),
     ];
 
     // Optional DB recording (records the agent-gathered evidence into the dev DB).
@@ -76,15 +127,35 @@ async fn t3_engine_adjudicates_agent_bbas() {
         // frame UUIDs already exist in the loaded DB; look them up by name.
         for (label, frame, p, r, _ak, _ac, _ab) in &cases {
             let frame_name = frame.id.clone(); // FrameOfDiscernment.id == name we constructed
-            let frame_id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM frames WHERE name = $1 ORDER BY created_at LIMIT 1")
-                .bind(&frame_name).fetch_optional(pool).await.expect("frame lookup");
+            let frame_id: Option<Uuid> = sqlx::query_scalar(
+                "SELECT id FROM frames WHERE name = $1 ORDER BY created_at LIMIT 1",
+            )
+            .bind(&frame_name)
+            .fetch_optional(pool)
+            .await
+            .expect("frame lookup");
             let Some(frame_id) = frame_id else { continue };
             let claim = insert_claim(pool, author, &format!("T3 gathered: {label}")).await;
-            for (src, m) in [(prove_src, bba(frame, p.0, p.1, p.2)), (refute_src, bba(frame, r.0, r.1, r.2))] {
+            for (src, m) in [
+                (prove_src, bba(frame, p.0, p.1, p.2)),
+                (refute_src, bba(frame, r.0, r.1, r.2)),
+            ] {
                 MassFunctionRepository::store_with_perspective(
-                    pool, claim, frame_id, Some(src), None, &m.masses_to_json(),
-                    None, Some("discount"), Some(1.0), Some("agent_gathered"), "cross", None,
-                ).await.expect("record bba");
+                    pool,
+                    claim,
+                    frame_id,
+                    Some(src),
+                    None,
+                    &m.masses_to_json(),
+                    None,
+                    Some("discount"),
+                    Some(1.0),
+                    Some("agent_gathered"),
+                    "cross",
+                    None,
+                )
+                .await
+                .expect("record bba");
                 recorded += 1;
             }
         }
@@ -92,12 +163,16 @@ async fn t3_engine_adjudicates_agent_bbas() {
 
     let th = ClassifierThresholds::default();
     println!("\nT3 — ENGINE adjudication of agent-gathered BBAs (calibrated classify, conflict_threshold=0.05):");
-    println!("  {:<20} {:>8} {:>10} {:>11} {:>9}  {:<13} {}", "axis", "engineK", "BetP_tgt", "open-world", "(agentK)", "ENGINE", "(agent said)");
+    println!(
+        "  {:<20} {:>8} {:>10} {:>11} {:>9}  {:<13} {}",
+        "axis", "engineK", "BetP_tgt", "open-world", "(agentK)", "ENGINE", "(agent said)"
+    );
     let mut safety_verdicts = vec![];
     for (label, frame, p, r, ak, ac, ab) in &cases {
         let prove = bba(frame, p.0, p.1, p.2);
         let refute = bba(frame, r.0, r.1, r.2);
-        let (combined, reports) = combination::combine_multiple(&[prove.clone(), refute.clone()], 0.1).unwrap();
+        let (combined, reports) =
+            combination::combine_multiple(&[prove.clone(), refute.clone()], 0.1).unwrap();
         let k = reports[0].conflict_k;
         let theta_m = combined.mass_of(&FocalElement::theta(frame)) + combined.mass_of_missing();
         let miss = combined.mass_of_missing();
@@ -109,9 +184,13 @@ async fn t3_engine_adjudicates_agent_bbas() {
         let verdict = classify(k, theta_m, bsup, bunsup, has_opp, &th);
         println!("  {label:<20} {k:>8.3} {bsup:>10.3} {miss:>11.3} {:>9}  {:<13} consolidated={ac}, BetP~{ab}",
             format!("{ak:.3}"), format!("{verdict}"));
-        if label.contains("safety") { safety_verdicts.push((label.to_string(), verdict)); }
+        if label.contains("safety") {
+            safety_verdicts.push((label.to_string(), verdict));
+        }
     }
-    if recorded > 0 { println!("\nRecorded {recorded} agent-gathered BBAs into the dev DB (perspective evidence, evidence_type='agent_gathered')."); }
+    if recorded > 0 {
+        println!("\nRecorded {recorded} agent-gathered BBAs into the dev DB (perspective evidence, evidence_type='agent_gathered').");
+    }
 
     // The reviewers' core finding, now rendered by the calibrated engine: the agents stamped
     // "consolidated=true" using an ungrounded 0.5 threshold, but the SAFETY axes carry opposing

--- a/crates/epigraph-ingest-executor/src/error.rs
+++ b/crates/epigraph-ingest-executor/src/error.rs
@@ -27,4 +27,10 @@ pub enum IngestExecutorError {
     /// Plan structure violated an executor invariant.
     #[error("plan inconsistency: {0}")]
     PlanInconsistency(String),
+
+    /// A planned claim has blank content, which would violate the DB
+    /// `claims_content_not_empty` constraint. The embedded `path` names the
+    /// extraction field responsible (e.g. `"phases[2].summary"`).
+    #[error("blank claim content at {path}: claim content must not be empty or whitespace-only")]
+    InvalidContent { path: String },
 }

--- a/crates/epigraph-ingest-executor/src/workflow.rs
+++ b/crates/epigraph-ingest-executor/src/workflow.rs
@@ -84,6 +84,27 @@ pub async fn execute_workflow_ingest_plan(
 
     let workflow_id = root_workflow_id(extraction);
 
+    // ── 0. Pre-flight: reject blank claim content before any DB write ────
+    // Catches fields that serde(default) silently turns into "" (e.g.
+    // Phase.summary when omitted from JSON), which would later hit the
+    // claims_content_not_empty DB constraint and leave a zombie workflows row.
+    {
+        let rev_index: std::collections::HashMap<uuid::Uuid, &str> = plan
+            .path_index
+            .iter()
+            .map(|(path, id)| (*id, path.as_str()))
+            .collect();
+        for planned in &plan.claims {
+            if planned.content.trim().is_empty() {
+                let path = rev_index
+                    .get(&planned.id)
+                    .map(|s| (*s).to_string())
+                    .unwrap_or_else(|| planned.id.to_string());
+                return Err(crate::error::IngestExecutorError::InvalidContent { path });
+            }
+        }
+    }
+
     // ── 1. Idempotency gate: skip if workflow row already processed ──────
     if let Some(existing_id) =
         WorkflowRepository::find_root_by_canonical(pool, canonical_name, generation).await?

--- a/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
+++ b/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
@@ -1,0 +1,76 @@
+//! E2E test for the pre-flight empty-content guard in `execute_workflow_ingest_plan`.
+//!
+//! Unlike `#[sqlx::test]` fixtures this test connects to the DATABASE_URL pool
+//! directly, so it works with a restricted user (no CREATE DATABASE needed).
+//! Run with:
+//!   DATABASE_URL=postgres://epigraph_dev:epigraph_dev@127.0.0.1:5432/epigraph \
+//!     cargo test -p epigraph-ingest-executor --test e2e_empty_content_guard
+
+use epigraph_ingest::common::schema::ThesisDerivation;
+use epigraph_ingest::workflow::builder::build_ingest_plan;
+use epigraph_ingest::workflow::schema::{Phase, WorkflowSource};
+use epigraph_ingest::workflow::WorkflowExtraction;
+use epigraph_ingest_executor::error::IngestExecutorError;
+use epigraph_ingest_executor::execute_workflow_ingest_plan;
+
+fn pool_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://epigraph:epigraph@127.0.0.1:5432/epigraph".to_string())
+}
+
+/// Verify the pre-flight guard catches an empty thesis BEFORE any DB write.
+/// Connects directly to the live DB pool; works with the restricted dev user.
+#[tokio::test]
+async fn e2e_empty_thesis_rejected_before_db_write() {
+    let pool = sqlx::PgPool::connect(&pool_url())
+        .await
+        .expect("connect to dev DB");
+
+    let canonical = "e2e-guard-test-empty-thesis-xyzzy-000";
+    let extraction = WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: canonical.to_string(),
+            goal: "E2E guard test".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: Some(String::new()), // empty thesis → pre-flight must catch this
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "Phase A".to_string(),
+            summary: "Non-empty summary".to_string(),
+            steps: vec![],
+        }],
+        relationships: vec![],
+    };
+
+    let plan = build_ingest_plan(&extraction);
+
+    let result = execute_workflow_ingest_plan(&pool, &plan, &extraction).await;
+
+    assert!(result.is_err(), "empty thesis must be rejected");
+    match result.unwrap_err() {
+        IngestExecutorError::InvalidContent { path } => {
+            assert!(
+                path.contains("thesis"),
+                "error path should mention 'thesis'; got: {path}"
+            );
+        }
+        other => panic!("expected InvalidContent, got: {other:?}"),
+    }
+
+    // No zombie row should have been written.
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM workflows WHERE canonical_name = $1",
+    )
+    .bind(canonical)
+    .fetch_one(&pool)
+    .await
+    .expect("count query");
+
+    assert_eq!(count, 0, "no workflows row should exist after a guard rejection");
+}

--- a/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
+++ b/crates/epigraph-ingest-executor/tests/e2e_empty_content_guard.rs
@@ -64,13 +64,14 @@ async fn e2e_empty_thesis_rejected_before_db_write() {
     }
 
     // No zombie row should have been written.
-    let count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM workflows WHERE canonical_name = $1",
-    )
-    .bind(canonical)
-    .fetch_one(&pool)
-    .await
-    .expect("count query");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workflows WHERE canonical_name = $1")
+        .bind(canonical)
+        .fetch_one(&pool)
+        .await
+        .expect("count query");
 
-    assert_eq!(count, 0, "no workflows row should exist after a guard rejection");
+    assert_eq!(
+        count, 0,
+        "no workflows row should exist after a guard rejection"
+    );
 }

--- a/crates/epigraph-mcp/src/tools/ds_auto.rs
+++ b/crates/epigraph-mcp/src/tools/ds_auto.rs
@@ -353,10 +353,19 @@ pub async fn auto_wire_ds_update(
     .await
     .map_err(|e| format!("store BBA: {e}"))?;
 
-    // Retrieve all BBAs and combine WITH reliability discount
-    let all_rows = MassFunctionRepository::get_for_claim_frame(pool, claim_id, frame_id)
+    // Retrieve BBAs from ALL 2-hypothesis frames for this claim. The DB JOIN
+    // on frames ensures we only include frames with exactly 2 hypotheses —
+    // a BBA from a 3+-hypothesis frame whose focal elements happen to use only
+    // indices 0 and 1 would be semantically wrong when parsed as binary_frame()
+    // ({0,1} in a ternary frame ≠ Theta on binary). Cross-frame retrieval
+    // prevents frame-fragmentation loss: BBAs written to legacy binary frames
+    // (e.g. "research_validity") are included so update_with_evidence combines
+    // the full evidence history rather than starting fresh from just the new
+    // BBA — the root cause of the BetP drop in backlog 30bfbb19
+    // (claims c98b6dec, adf396a8: 0.883→0.725, 0.834→0.733).
+    let all_rows = MassFunctionRepository::get_for_claim_binary_frames(pool, claim_id)
         .await
-        .map_err(|e| format!("get_for_claim_frame: {e}"))?;
+        .map_err(|e| format!("get_for_claim_binary_frames: {e}"))?;
 
     // Phase 2 (issue #197): the combine path no longer trusts the
     // stored `source_strength` as the authority. The Phase 2 helper

--- a/crates/epigraph-mcp/tests/cdst_cross_frame_betp_monotonic.rs
+++ b/crates/epigraph-mcp/tests/cdst_cross_frame_betp_monotonic.rs
@@ -1,0 +1,165 @@
+//! Regression for backlog 30bfbb19: `update_with_evidence(supports=true)` drops
+//! BetP on claims whose existing BBAs live on a legacy frame other than
+//! "binary_truth".
+//!
+//! Root cause: `auto_wire_ds_update` called `get_for_claim_frame(binary_truth)`
+//! which only returned BBAs on the new frame, missing all legacy BBAs. The
+//! combination of 1 new BBA produced a lower BetP than the combination of
+//! the many pre-existing legacy BBAs.
+//!
+//! Fix: use `get_for_claim` (all frames) and filter to binary-compatible BBAs.
+//! This test seeds a claim, writes 5 strong supporting BBAs on a separate
+//! legacy binary frame, computes their combined BetP (betp0), then adds one
+//! more supporting BBA via `update_with_evidence` and asserts betp1 >= betp0.
+
+#[macro_use]
+mod common;
+use common::*;
+
+use epigraph_db::{FrameRepository, MassFunctionRepository};
+use epigraph_ds::{combination, measures, FocalElement, FrameOfDiscernment, MassFunction};
+use epigraph_engine::calibration::CalibrationConfig;
+use epigraph_mcp::{tools::ds_auto::effective_source_strength, types::UpdateWithEvidenceParams};
+use std::collections::BTreeSet;
+use uuid::Uuid;
+
+async fn cached_betp(pool: &sqlx::PgPool, claim_id: Uuid) -> f64 {
+    sqlx::query_scalar::<_, Option<f64>>("SELECT pignistic_prob FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(pool)
+        .await
+        .expect("query pignistic_prob")
+        .expect("pignistic_prob populated")
+}
+
+#[tokio::test]
+async fn cross_frame_supporting_evidence_does_not_drop_betp() {
+    let pool = test_pool_or_skip!();
+
+    let claim_id = seed_claim(
+        &pool,
+        "30bfbb19 cross-frame BetP monotonicity regression",
+        0.5,
+    )
+    .await;
+
+    // 1. Create a legacy binary frame with a unique name to avoid collisions
+    //    across runs on the shared test DB.
+    let legacy_frame_name = format!("test_legacy_binary_{}", &Uuid::new_v4().to_string()[..8]);
+    let legacy_frame_id = FrameRepository::create(
+        &pool,
+        &legacy_frame_name,
+        Some("Legacy binary frame for cross-frame BetP regression test"),
+        &["TRUE".to_string(), "FALSE".to_string()],
+    )
+    .await
+    .expect("create legacy frame")
+    .id;
+
+    FrameRepository::assign_claim(&pool, claim_id, legacy_frame_id, Some(0))
+        .await
+        .expect("assign claim to legacy frame");
+
+    // 2. Write 5 strong supporting BBAs on the legacy frame (5 different agents
+    //    to avoid ON CONFLICT overwrite on the unique key).
+    //    BBA: m({TRUE})=0.85, m(Θ)=0.15, source_strength=0.7
+    let bba_masses = serde_json::json!({"0": 0.85, "0,1": 0.15});
+
+    for _ in 0..5 {
+        let agent = seed_agent(&pool).await;
+        MassFunctionRepository::store_with_perspective(
+            &pool,
+            claim_id,
+            legacy_frame_id,
+            Some(agent),
+            None, // perspective_id: each (claim,frame,agent,NULL) is unique
+            &bba_masses,
+            None,
+            Some("auto_wire"),
+            Some(0.7), // source_strength; NULL evidence_type → used verbatim
+            None,      // NULL evidence_type → effective_source_strength takes stored α=0.7
+            "unknown",
+            None,
+        )
+        .await
+        .expect("store legacy BBA");
+    }
+
+    // 3. Compute BetP from those 5 legacy BBAs (betp0).
+    //    This is the ground-truth "before adding new evidence" BetP that the
+    //    combination must not decrease. Uses the same combination path as
+    //    auto_wire_ds_update so the comparison is apples-to-apples.
+    let legacy_frame = FrameOfDiscernment::new(
+        legacy_frame_name.clone(),
+        vec!["TRUE".to_string(), "FALSE".to_string()],
+    )
+    .expect("construct legacy frame");
+
+    let calibration = CalibrationConfig::default_for_phase2_fallback();
+    let legacy_rows = MassFunctionRepository::get_for_claim_frame(&pool, claim_id, legacy_frame_id)
+        .await
+        .expect("get legacy BBAs");
+    assert_eq!(legacy_rows.len(), 5, "should have exactly 5 legacy BBAs");
+
+    let mut mass_fns = Vec::with_capacity(legacy_rows.len());
+    for row in &legacy_rows {
+        let mf = MassFunction::from_json_masses(legacy_frame.clone(), &row.masses)
+            .expect("parse legacy BBA");
+        let alpha = effective_source_strength(row, None, None, &calibration);
+        let discounted = combination::discount(&mf, alpha).expect("discount BBA");
+        mass_fns.push(discounted);
+    }
+    let (legacy_combined, _) =
+        combination::combine_multiple(&mass_fns, 0.9).expect("combine 5 legacy BBAs");
+
+    let true_fe = FocalElement::positive(BTreeSet::from([0_usize]));
+    let betp0 = measures::pignistic_probability(&legacy_combined, 0);
+
+    // Write betp0 to claims so the baseline is visible in the DB.
+    MassFunctionRepository::update_claim_belief(
+        &pool,
+        claim_id,
+        measures::belief(&legacy_combined, &true_fe),
+        measures::plausibility(&legacy_combined, &true_fe),
+        legacy_combined.mass_of_conflict(),
+        Some(betp0),
+        legacy_combined.mass_of_missing(),
+    )
+    .await
+    .expect("write initial belief from legacy BBAs");
+
+    let stored_betp0 = cached_betp(&pool, claim_id).await;
+    assert!(
+        (stored_betp0 - betp0).abs() < 1e-9,
+        "stored betp0={stored_betp0:.6} should equal computed betp0={betp0:.6}"
+    );
+
+    // 4. Add a SUPPORTING evidence via the canonical update path (writes to binary_truth).
+    let server = build_test_server(pool.clone());
+    let res = epigraph_mcp::tools::claims::update_with_evidence(
+        &server,
+        UpdateWithEvidenceParams {
+            claim_id: claim_id.to_string(),
+            evidence_type: "empirical".into(),
+            evidence_data: "Independent empirical observation supporting the claim.".into(),
+            source_url: None,
+            supports: true,
+            strength: 0.9,
+        },
+    )
+    .await;
+    assert!(res.is_ok(), "update_with_evidence failed: {res:?}");
+
+    let betp1 = cached_betp(&pool, claim_id).await;
+
+    // 5. Invariant: adding SUPPORTING evidence must not lower BetP.
+    //    Without the fix, auto_wire_ds_update only sees the 1 new BBA on
+    //    binary_truth (ignoring the 5 legacy BBAs), giving BetP ≈ 0.90 which
+    //    is lower than betp0 ≈ 0.994 from the 5-BBA combination.
+    assert!(
+        betp1 >= betp0 - 1e-9,
+        "update_with_evidence dropped BetP below legacy-frame baseline: \
+         betp0={betp0:.6} (from 5 legacy BBAs on {legacy_frame_name}), \
+         betp1={betp1:.6} (after empirical support on binary_truth)"
+    );
+}

--- a/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
+++ b/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
@@ -147,3 +147,125 @@ async fn improve_workflow_hierarchy_errors_when_parent_missing(pool: sqlx::PgPoo
         "error message should mention missing canonical_name; got: {err_msg}"
     );
 }
+
+/// Regression: improve_workflow_hierarchy must not fail with
+/// `claims_content_not_empty` when a phase omits `summary` (serde default "").
+/// The builder falls back to `phase.title`, so the ingest must SUCCEED and the
+/// persisted phase claim must contain the title text.
+#[sqlx::test(migrations = "../../migrations")]
+async fn improve_workflow_hierarchy_empty_phase_summary_uses_title(pool: sqlx::PgPool) {
+    let canonical = "test-improve-hier-empty-summary";
+
+    epigraph_mcp::tools::workflow_ingest::do_ingest_workflow_via_pool(
+        &pool,
+        &parent_extraction(canonical),
+    )
+    .await
+    .expect("parent ingest");
+
+    let extraction = WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: "ignored".to_string(),
+            goal: "Test empty summary fallback".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: None,
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "Phase With No Summary".to_string(),
+            summary: String::new(), // ← blank: builder falls back to title
+            steps: vec![Step {
+                compound: "some step".to_string(),
+                rationale: "irrelevant".to_string(),
+                operations: vec![],
+                generality: vec![],
+                confidence: 0.8,
+            }],
+        }],
+        relationships: vec![],
+    };
+
+    let result = epigraph_mcp::tools::workflow_ingest::improve_workflow_hierarchy_via_pool(
+        &pool, canonical, extraction,
+    )
+    .await
+    .expect("empty summary should not cause a constraint violation; builder falls back to title");
+
+    assert!(!result.already_ingested);
+    assert!(
+        result.claims_ingested > 0,
+        "expected at least one new claim"
+    );
+
+    // Verify the phase claim content is the title, not an empty string.
+    let phase_content: String = sqlx::query_scalar(
+        "SELECT content FROM claims \
+         WHERE properties->>'kind' = 'workflow_step' \
+           AND (properties->>'level')::int = 1 \
+         ORDER BY created_at DESC LIMIT 1",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("phase claim must exist");
+    assert_eq!(
+        phase_content, "Phase With No Summary",
+        "phase claim content must be the title when summary is blank"
+    );
+}
+
+/// Regression: improve_workflow_hierarchy must reject extractions with a blank
+/// thesis string (Some("")) before writing to the DB.
+#[sqlx::test(migrations = "../../migrations")]
+async fn improve_workflow_hierarchy_rejects_empty_thesis(pool: sqlx::PgPool) {
+    let canonical = "test-improve-hier-empty-thesis";
+
+    epigraph_mcp::tools::workflow_ingest::do_ingest_workflow_via_pool(
+        &pool,
+        &parent_extraction(canonical),
+    )
+    .await
+    .expect("parent ingest");
+
+    let bad_extraction = WorkflowExtraction {
+        source: WorkflowSource {
+            canonical_name: "ignored".to_string(),
+            goal: "Test empty thesis rejection".to_string(),
+            generation: 0,
+            parent_canonical_name: None,
+            authors: vec![],
+            expected_outcome: None,
+            tags: vec![],
+            metadata: serde_json::json!({}),
+        },
+        thesis: Some(String::new()), // ← blank thesis
+        thesis_derivation: ThesisDerivation::TopDown,
+        phases: vec![Phase {
+            title: "A Phase".to_string(),
+            summary: "valid summary".to_string(),
+            steps: vec![],
+        }],
+        relationships: vec![],
+    };
+
+    let result = epigraph_mcp::tools::workflow_ingest::improve_workflow_hierarchy_via_pool(
+        &pool,
+        canonical,
+        bad_extraction,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "empty thesis should be rejected before DB write"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("blank claim content") || err_msg.contains("empty"),
+        "error should describe the blank content problem; got: {err_msg}"
+    );
+}

--- a/crates/epigraph-mcp/tests/perspectival_canonical_ingest_proto.rs
+++ b/crates/epigraph-mcp/tests/perspectival_canonical_ingest_proto.rs
@@ -68,24 +68,57 @@ async fn canonical_ingest_preserves_per_lens_discount(pool: sqlx::PgPool) {
 
     // ── 4 observer lenses, reliability keyed on the CANONICAL vocabulary ──
     let lenses: [(&str, HashMap<String, f64>); 4] = [
-        ("tradition_observer", HashMap::from([
-            ("testimonial".into(), 0.85), ("regulatory".into(), 0.70),
-            ("empirical".into(), 0.30), ("statistical".into(), 0.25)])),
-        ("clinical_observer", HashMap::from([
-            ("empirical".into(), 0.90), ("statistical".into(), 0.85),
-            ("testimonial".into(), 0.10), ("regulatory".into(), 0.20)])),
-        ("regulatory_observer", HashMap::from([
-            ("regulatory".into(), 0.80), ("statistical".into(), 0.60),
-            ("empirical".into(), 0.50), ("testimonial".into(), 0.35)])),
-        ("skeptic_observer", HashMap::from([
-            ("statistical".into(), 0.40), ("empirical".into(), 0.30),
-            ("regulatory".into(), 0.05), ("testimonial".into(), 0.02)])),
+        (
+            "tradition_observer",
+            HashMap::from([
+                ("testimonial".into(), 0.85),
+                ("regulatory".into(), 0.70),
+                ("empirical".into(), 0.30),
+                ("statistical".into(), 0.25),
+            ]),
+        ),
+        (
+            "clinical_observer",
+            HashMap::from([
+                ("empirical".into(), 0.90),
+                ("statistical".into(), 0.85),
+                ("testimonial".into(), 0.10),
+                ("regulatory".into(), 0.20),
+            ]),
+        ),
+        (
+            "regulatory_observer",
+            HashMap::from([
+                ("regulatory".into(), 0.80),
+                ("statistical".into(), 0.60),
+                ("empirical".into(), 0.50),
+                ("testimonial".into(), 0.35),
+            ]),
+        ),
+        (
+            "skeptic_observer",
+            HashMap::from([
+                ("statistical".into(), 0.40),
+                ("empirical".into(), 0.30),
+                ("regulatory".into(), 0.05),
+                ("testimonial".into(), 0.02),
+            ]),
+        ),
     ];
     let mut persp: Vec<(String, Uuid)> = Vec::new();
     for (name, rel) in &lenses {
-        let row = PerspectiveRepository::create(&pool, name, None, None, Some("observer"), &[], None, None)
-            .await
-            .expect("create perspective");
+        let row = PerspectiveRepository::create(
+            &pool,
+            name,
+            None,
+            None,
+            Some("observer"),
+            &[],
+            None,
+            None,
+        )
+        .await
+        .expect("create perspective");
         PerspectiveRepository::set_source_reliability(&pool, row.id, rel)
             .await
             .expect("set reliability");
@@ -100,7 +133,9 @@ async fn canonical_ingest_preserves_per_lens_discount(pool: sqlx::PgPool) {
         async move {
             let mut out: Vec<(String, f64)> = Vec::new();
             for (k, id) in &persp {
-                let b = get_perspective_belief(&pool, claim, frame, *id).await.expect("belief");
+                let b = get_perspective_belief(&pool, claim, frame, *id)
+                    .await
+                    .expect("belief");
                 out.push((k.clone(), b.pignistic_prob));
             }
             out
@@ -109,23 +144,68 @@ async fn canonical_ingest_preserves_per_lens_discount(pool: sqlx::PgPool) {
 
     // ── representative claims ──
     let c_eff = seed_claim(&pool, "treatment-e is efficacious for symptom-5.", 0.5).await;
-    let c_saf = seed_claim(&pool, "treatment-d is safe at therapeutic dose for chronic use.", 0.5).await;
+    let c_saf = seed_claim(
+        &pool,
+        "treatment-d is safe at therapeutic dose for chronic use.",
+        0.5,
+    )
+    .await;
     let c_novel = seed_claim(&pool, "treatment-a is efficacious for symptom-6.", 0.5).await;
 
     // ── prior (discovery) evidence, mapped to canonical types ──
-    add_evidence(&server, c_eff, "empirical", true, 0.55, "source_clinical: modest RCT signal").await; // source_clinical→empirical
-    add_evidence(&server, c_saf, "statistical", true, 0.60, "source_survey: largely safe in practice").await; // source_survey→statistical
-    // c_novel: no prior evidence (practitioner-only signal)
+    add_evidence(
+        &server,
+        c_eff,
+        "empirical",
+        true,
+        0.55,
+        "source_clinical: modest RCT signal",
+    )
+    .await; // source_clinical→empirical
+    add_evidence(
+        &server,
+        c_saf,
+        "statistical",
+        true,
+        0.60,
+        "source_survey: largely safe in practice",
+    )
+    .await; // source_survey→statistical
+            // c_novel: no prior evidence (practitioner-only signal)
 
     let before_eff = read(c_eff).await;
     let before_saf = read(c_saf).await;
     let before_novel = read(c_novel).await;
 
     // ── the INTERVIEW, ingested via the real path as canonical `testimonial` ──
-    add_evidence(&server, c_eff, "testimonial", true, 0.82, "practitioner: foremost treatment, strong in symptom-5").await;
+    add_evidence(
+        &server,
+        c_eff,
+        "testimonial",
+        true,
+        0.82,
+        "practitioner: foremost treatment, strong in symptom-5",
+    )
+    .await;
     // treatment-d: two-sided {safe 0.20, harmful 0.55} → can only be one-sided refutation
-    add_evidence(&server, c_saf, "testimonial", false, 0.55, "practitioner: caution in chronic use of the condition cluster").await;
-    add_evidence(&server, c_novel, "testimonial", true, 0.80, "practitioner: calms symptom-6").await;
+    add_evidence(
+        &server,
+        c_saf,
+        "testimonial",
+        false,
+        0.55,
+        "practitioner: caution in chronic use of the condition cluster",
+    )
+    .await;
+    add_evidence(
+        &server,
+        c_novel,
+        "testimonial",
+        true,
+        0.80,
+        "practitioner: calms symptom-6",
+    )
+    .await;
 
     let after_eff = read(c_eff).await;
     let after_saf = read(c_saf).await;
@@ -138,9 +218,17 @@ async fn canonical_ingest_preserves_per_lens_discount(pool: sqlx::PgPool) {
         }
     };
     eprintln!("\n=== option ii: interview ingested via update_with_evidence (canonical types), per-lens BetP ===");
-    show("treatment-e efficacious (practitioner=testimonial, supports)", &before_eff, &after_eff);
+    show(
+        "treatment-e efficacious (practitioner=testimonial, supports)",
+        &before_eff,
+        &after_eff,
+    );
     show("treatment-d safe (practitioner=testimonial, REFUTES — one-sided collapse of {safe .20, harmful .55})", &before_saf, &after_saf);
-    show("treatment-a efficacious — NOVEL practitioner-only", &before_novel, &after_novel);
+    show(
+        "treatment-a efficacious — NOVEL practitioner-only",
+        &before_novel,
+        &after_novel,
+    );
 
     // ── core (ii) claim: the per-lens discount survives the canonical mapping ──
     let d = |rows_b: &[(String, f64)], rows_a: &[(String, f64)], lens: &str| -> f64 {
@@ -158,5 +246,8 @@ async fn canonical_ingest_preserves_per_lens_discount(pool: sqlx::PgPool) {
     // safety must fall (or at least not rise) for the trusting lens on a refutation
     let tradition_saf = d(&before_saf, &after_saf, "tradition_observer");
     eprintln!("  treatment-d safety — tradition Δ {tradition_saf:+.3} (refutation; one-sided)");
-    assert!(tradition_saf < 0.0, "practitioner caution must lower safety for the trusting lens");
+    assert!(
+        tradition_saf < 0.0,
+        "practitioner caution must lower safety for the trusting lens"
+    );
 }


### PR DESCRIPTION
## Summary
- Add `if_not_exists=true` to decompose_claims atom POST — prevents 409 on re-runs (backlog 5a18708e, 2e13bcb7)
- Combine BBAs from all binary frames in `update_with_evidence` — cdst correctness
- Guard ingest-executor against empty thesis/content with pre-flight check + E2E test
- Guard workflow-ingest against empty Phase.summary violating `claims_content_not_empty`
- Apply rustfmt to 10 perspectival test files from PR #304

## Test plan
- [x] `persist_decomposition_test` — idempotency: re-run on existing atoms returns 0 created, no 409
- [x] `cdst_cross_frame_betp_monotonic` — BetP never decreases across frames on supporting evidence
- [x] `cdst_multi_evidence_monotonic` — monotonicity with mixed-format BBAs
- [x] `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)