### PR TITLE
chore(ci): run epigraph-migrate before non-DB tests to seed workflows table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,15 @@ jobs:
       # than silently resolving newer versions.
       - name: Build
         run: cargo build --workspace --locked
+      - name: Run migrations
+        # epigraph-ingest-executor's e2e_empty_content_guard test connects to
+        # DATABASE_URL directly (no #[sqlx::test] template DB) and queries the
+        # `workflows` table. The postgres service starts empty; without this step
+        # the non-DB parallel tests fail with "relation workflows does not exist".
+        # The epigraph-migrate binary embeds all migrations at compile time
+        # (sqlx::migrate!("../../migrations") in epigraph-api/src/lib.rs) so no
+        # external sqlx-cli is needed — just run the already-built binary.
+        run: ./target/debug/epigraph-migrate
       - name: Test (non-DB packages, parallel)
         # Packages without DB tests can run fully in parallel.
         # Crates with #[sqlx::test] integration tests (or live DB usage) are

--- a/crates/epigraph-ds/tests/perspectival_seed_validation.rs
+++ b/crates/epigraph-ds/tests/perspectival_seed_validation.rs
@@ -29,37 +29,54 @@ fn betp(frame: &FrameOfDiscernment, bbas: &[(Value, f64)], target: usize) -> f64
 #[test]
 fn perspectival_seed_matches_python_model() {
     // Binary frames; index 0 is the target ("positive") hypothesis. theta key = "0,1".
-    let eff = FrameOfDiscernment::new("treatment_efficacy", vec!["efficacious".into(), "no_effect".into()]).unwrap();
-    let saf = FrameOfDiscernment::new("treatment_safety", vec!["safe".into(), "harmful".into()]).unwrap();
+    let eff = FrameOfDiscernment::new(
+        "treatment_efficacy",
+        vec!["efficacious".into(), "no_effect".into()],
+    )
+    .unwrap();
+    let saf =
+        FrameOfDiscernment::new("treatment_safety", vec!["safe".into(), "harmful".into()]).unwrap();
 
     // --- treatment-c SAFETY {safe(0), harmful(1)} : clinical harmful vs tradition safe (K>0) ---
     let tc_saf = |a_clin: f64, a_trad: f64, a_prac: f64| {
-        betp(&saf, &[
-            (json!({"1": 0.70, "0,1": 0.30}), a_clin), // source_clinical: harmful
-            (json!({"0": 0.50, "0,1": 0.50}), a_trad), // source_tradition: safe
-            (json!({"0": 0.45, "0,1": 0.55}), a_prac), // source_practitioner: safe
-        ], 0)
+        betp(
+            &saf,
+            &[
+                (json!({"1": 0.70, "0,1": 0.30}), a_clin), // source_clinical: harmful
+                (json!({"0": 0.50, "0,1": 0.50}), a_trad), // source_tradition: safe
+                (json!({"0": 0.45, "0,1": 0.55}), a_prac), // source_practitioner: safe
+            ],
+            0,
+        )
     };
     let saf_clin = tc_saf(0.95, 0.15, 0.10);
     let saf_trad = tc_saf(0.60, 0.90, 0.85);
 
     // --- treatment-e EFFICACY {efficacious(0), no_effect(1)} : tradition efficacious vs clinical no_effect (K>0) ---
     let te_eff = |a_trad: f64, a_prac: f64, a_clin: f64| {
-        betp(&eff, &[
-            (json!({"0": 0.55, "0,1": 0.45}), a_trad), // source_tradition: efficacious
-            (json!({"0": 0.45, "0,1": 0.55}), a_prac), // source_practitioner: efficacious
-            (json!({"1": 0.60, "0,1": 0.40}), a_clin), // source_clinical: no_effect
-        ], 0)
+        betp(
+            &eff,
+            &[
+                (json!({"0": 0.55, "0,1": 0.45}), a_trad), // source_tradition: efficacious
+                (json!({"0": 0.45, "0,1": 0.55}), a_prac), // source_practitioner: efficacious
+                (json!({"1": 0.60, "0,1": 0.40}), a_clin), // source_clinical: no_effect
+            ],
+            0,
+        )
     };
     let te_clin = te_eff(0.15, 0.10, 0.95);
     let te_trad = te_eff(0.90, 0.85, 0.60);
 
     // --- treatment-a EFFICACY (consensus control, K=0), clinical lens ---
-    let ta_clin = betp(&eff, &[
-        (json!({"0": 0.75, "0,1": 0.25}), 0.95), // source_clinical
-        (json!({"0": 0.55, "0,1": 0.45}), 0.15), // source_tradition
-        (json!({"0": 0.40, "0,1": 0.60}), 0.10), // source_practitioner
-    ], 0);
+    let ta_clin = betp(
+        &eff,
+        &[
+            (json!({"0": 0.75, "0,1": 0.25}), 0.95), // source_clinical
+            (json!({"0": 0.55, "0,1": 0.45}), 0.15), // source_tradition
+            (json!({"0": 0.40, "0,1": 0.60}), 0.10), // source_practitioner
+        ],
+        0,
+    );
 
     eprintln!("REAL ENGINE vs Python model (verify_beliefs.py):");
     eprintln!("  treatment-c safety  clinical = {saf_clin:.3}  (python 0.203)");
@@ -69,9 +86,24 @@ fn perspectival_seed_matches_python_model() {
     eprintln!("  treatment-a eff     clinical = {ta_clin:.3}  (python 0.873)");
 
     let approx = |a: f64, b: f64| (a - b).abs() < 0.005;
-    assert!(approx(saf_clin, 0.203), "treatment-c safety clinical = {saf_clin}, expected 0.203");
-    assert!(approx(saf_trad, 0.666), "treatment-c safety tradition = {saf_trad}, expected 0.666");
-    assert!(approx(te_clin, 0.260), "treatment-e eff clinical = {te_clin}, expected 0.260");
-    assert!(approx(te_trad, 0.718), "treatment-e eff tradition = {te_trad}, expected 0.718");
-    assert!(approx(ta_clin, 0.873), "treatment-a eff clinical = {ta_clin}, expected 0.873");
+    assert!(
+        approx(saf_clin, 0.203),
+        "treatment-c safety clinical = {saf_clin}, expected 0.203"
+    );
+    assert!(
+        approx(saf_trad, 0.666),
+        "treatment-c safety tradition = {saf_trad}, expected 0.666"
+    );
+    assert!(
+        approx(te_clin, 0.260),
+        "treatment-e eff clinical = {te_clin}, expected 0.260"
+    );
+    assert!(
+        approx(te_trad, 0.718),
+        "treatment-e eff tradition = {te_trad}, expected 0.718"
+    );
+    assert!(
+        approx(ta_clin, 0.873),
+        "treatment-a eff clinical = {ta_clin}, expected 0.873"
+    );
 }

--- a/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
+++ b/crates/epigraph-mcp/tests/improve_workflow_hierarchy_test.rs
@@ -185,6 +185,7 @@ async fn improve_workflow_hierarchy_empty_phase_summary_uses_title(pool: sqlx::P
                 operations: vec![],
                 generality: vec![],
                 confidence: 0.8,
+                evidence_type: None,
             }],
         }],
         relationships: vec![],


### PR DESCRIPTION
## Summary

- CI has been red on `main` since PR #304 (merged 2026-06-24) introduced `e2e_empty_content_guard.rs` in `epigraph-ingest-executor`
- The test queries `SELECT COUNT(*) FROM workflows WHERE canonical_name = $1` on `DATABASE_URL` directly (no `#[sqlx::test]` template DB) — but the CI postgres service starts empty, so the table doesn't exist
- Fix: add a **Run migrations** step between Build and the non-DB parallel tests; `epigraph-migrate` embeds all 52 migrations at compile time, no external sqlx-cli needed

## Root cause

`cargo test --workspace … --exclude epigraph-db …` includes `epigraph-ingest-executor`. The test `e2e_empty_thesis_rejected_before_db_write` connects to `DATABASE_URL` and verifies no zombie row was written to `workflows` after a guard rejection. CI's `epigraph` database has no schema until `#[sqlx::test]` serialized steps run — but those run **after** the parallel step.

## Test plan

- [ ] CI on this PR passes "Test (non-DB packages, parallel)" (the step that was failing)
- [ ] All serialized DB test steps still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)