### PR TITLE
fix(mcp): attach doi label to every claim written during document ingestion

### DIFF
--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -309,6 +309,11 @@ pub async fn do_ingest_document(
     let paper_title = extraction.source.title.clone();
     let doi = resolve_doi(extraction);
     let pipeline_version = effective_pipeline_version(extraction);
+    // Attached to every claim this paper asserts so `query_claims_by_label`
+    // and `recompute_beliefs(labels=[...])` can address a paper's full claim
+    // set (backlog c9d12a95: neither could ever find it before this label
+    // existed).
+    let paper_label = format!("doi:{doi}");
 
     // ── 1. Get-or-create paper node ──
     // (Pipeline-version gate removed: node-level content-hash dedup handles
@@ -422,6 +427,11 @@ pub async fn do_ingest_document(
             .map_err(internal_error)?;
         let persisted_id: Uuid = persisted.id.into();
         let already_had_trace = persisted.trace_id.is_some();
+        // Idempotent add: also runs on the dedup branch below, so an atom
+        // shared across papers (convergence) picks up every paper's label.
+        ClaimRepository::update_labels(pool, persisted_id, std::slice::from_ref(&paper_label), &[])
+            .await
+            .map_err(internal_error)?;
         if persisted_id != planned.id || already_had_trace {
             let (_row, _was_created) = EdgeRepository::create_if_not_exists(
                 pool,
@@ -745,6 +755,9 @@ pub async fn do_ingest_document_spine(
     let paper_title = extraction.source.title.clone();
     let doi = resolve_doi(extraction);
     let pipeline_version = effective_pipeline_version(extraction);
+    // See do_ingest_document: attached to every claim so label-based lookup
+    // (recompute_beliefs, query_claims_by_label) can find this paper's set.
+    let paper_label = format!("doi:{doi}");
 
     // Atom planned IDs — skip these claims and any edges referencing them.
     let atom_planned_ids: HashSet<Uuid> = plan
@@ -864,6 +877,9 @@ pub async fn do_ingest_document_spine(
             .map_err(internal_error)?;
         let persisted_id: Uuid = persisted.id.into();
         let already_had_trace = persisted.trace_id.is_some();
+        ClaimRepository::update_labels(pool, persisted_id, std::slice::from_ref(&paper_label), &[])
+            .await
+            .map_err(internal_error)?;
 
         if persisted_id != planned.id || already_had_trace {
             let (_row, _) = EdgeRepository::create_if_not_exists(

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -1878,7 +1878,7 @@ pub struct RecomputeBeliefsParams {
     pub claim_ids: Option<Vec<String>>,
 
     #[schemars(
-        description = "Recompute every current claim carrying ALL of these labels (e.g. a paper's claim set). Used only when `claim_ids` is absent/empty."
+        description = "Recompute every current claim carrying ALL of these labels (e.g. a paper's claim set — ingest_document/ingest_document_inline tag every claim they write with `doi:<doi>`, so pass that to recompute just one paper). Used only when `claim_ids` is absent/empty."
     )]
     #[serde(default)]
     pub labels: Option<Vec<String>>,

--- a/crates/epigraph-mcp/tests/ingest_document_smoke.rs
+++ b/crates/epigraph-mcp/tests/ingest_document_smoke.rs
@@ -7,8 +7,9 @@ use epigraph_crypto::AgentSigner;
 use epigraph_ingest::schema::DocumentExtraction;
 use epigraph_mcp::embed::McpEmbedder;
 use epigraph_mcp::server::EpiGraphMcpFull;
+use epigraph_mcp::tools;
 use epigraph_mcp::tools::ingestion::{do_ingest_document, ingest_document_inline};
-use epigraph_mcp::types::IngestDocumentInlineParams;
+use epigraph_mcp::types::{IngestDocumentInlineParams, RecomputeBeliefsParams};
 use sqlx::PgPool;
 
 const FIXTURE: &str = r#"{
@@ -148,6 +149,53 @@ async fn happy_path_ingests_full_hierarchy(pool: PgPool) {
     .await
     .unwrap();
     assert_eq!(processed.0, 1);
+}
+
+/// Backlog c9d12a95: `recompute_beliefs(labels=[doi_slug])` returned 0 claims for
+/// a paper freshly ingested via `ingest_document_inline`, even though the
+/// claims existed — because ingestion never attached any per-paper label, so
+/// the label-based recompute path (and `query_claims_by_label`) can never find
+/// a paper's claim set. Every claim `do_ingest_document` writes must carry a
+/// `doi:<doi>` label, and `recompute_beliefs` must actually find them by it.
+#[sqlx::test(migrations = "../../migrations")]
+async fn ingested_claims_carry_doi_label_for_recompute(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let extraction: DocumentExtraction = serde_json::from_str(FIXTURE).expect("fixture parses");
+
+    do_ingest_document(&server, &extraction)
+        .await
+        .expect("ingest_document succeeds");
+
+    let doi_label = "doi:10.1234/hierarchy-smoke";
+    let labeled_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM claims WHERE $1 = ANY(labels)")
+            .bind(doi_label)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        labeled_count.0, 5,
+        "all 5 hierarchy-level claims must carry the paper's doi label"
+    );
+
+    let result = tools::cdst_maintenance::recompute_beliefs(
+        &server,
+        RecomputeBeliefsParams {
+            claim_ids: None,
+            labels: Some(vec![doi_label.to_string()]),
+            limit: None,
+            offset: None,
+        },
+    )
+    .await
+    .expect("recompute_beliefs succeeds");
+    let json: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+    assert_eq!(
+        json["claims_considered"],
+        serde_json::json!(5),
+        "recompute_beliefs(labels=[doi_label]) must find the paper's full claim \
+         set, not 0 (the exact symptom reported in backlog c9d12a95)"
+    );
 }
 
 /// Re-ingesting the same extraction returns `already_ingested: true` with no new


### PR DESCRIPTION
## Summary
- Backlog `c9d12a95`: `recompute_beliefs(labels=[doi_slug])` returned 0 claims for a paper freshly ingested via `ingest_document_inline`, even though the write landed. Root cause: `do_ingest_document`/`do_ingest_document_spine` never write anything to `claims.labels` — every claim relies on the DB column default, so no per-paper label-based lookup (`recompute_beliefs(labels=...)`, `query_claims_by_label`) could ever find a paper's claims.
- Fix: attach a `doi:{doi}` label (mirrors the existing `repo:{repo_slug}` convention in `ingest_git.rs`) to every claim written by both ingestion entry points, via the existing `ClaimRepository::update_labels`.

## Test plan
- [x] New test `ingested_claims_carry_doi_label_for_recompute` — verified RED (0 labeled claims) before the fix, GREEN after
- [x] `cargo test -p epigraph-mcp` — full suite green, no regressions
- [x] `cargo fmt --check -p epigraph-mcp` clean
- [x] `cargo clippy -p epigraph-mcp --locked -- -D warnings` clean (matches CI's exact invocation)
- [x] `SQLX_OFFLINE=true cargo check -p epigraph-mcp --tests` clean

Closes backlog claim `c9d12a95` (epigraph knowledge graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)