### PR TITLE
feat(mcp): add doi_to_slug helper for DOI-to-slug conversion

### DIFF
--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -656,6 +656,13 @@ pub async fn do_ingest_document(
     })
 }
 
+/// Convert a DOI into a slug form safe for use as a URL path segment or
+/// canonical name: every `/` becomes `-`. Casing is left untouched.
+#[allow(dead_code)] // not yet wired into a caller; covered by unit tests below
+fn doi_to_slug(doi: &str) -> String {
+    doi.replace('/', "-")
+}
+
 fn resolve_doi(extraction: &DocumentExtraction) -> String {
     if let Some(d) = &extraction.source.doi {
         return d.clone();
@@ -1131,5 +1138,18 @@ mod tests {
             .await
             .expect("gate query");
         assert_eq!(hit, Some(paper_id));
+    }
+
+    #[test]
+    fn doi_to_slug_replaces_slash() {
+        assert_eq!(
+            doi_to_slug("10.48550/arXiv.2606.04990"),
+            "10.48550-arXiv.2606.04990"
+        );
+    }
+
+    #[test]
+    fn doi_to_slug_replaces_all_slashes() {
+        assert_eq!(doi_to_slug("10.1000/xyz/123/abc"), "10.1000-xyz-123-abc");
     }
 }


### PR DESCRIPTION
## Summary
- Add a pure `doi_to_slug()` helper in `crates/epigraph-mcp/src/tools/ingestion.rs`, next to the other DOI-handling helpers (`source_url` construction and `resolve_doi()`), converting a DOI like `10.48550/arXiv.2606.04990` into the slug form `10.48550-arXiv.2606.04990` (all `/` replaced with `-`, casing untouched).
- Not yet wired into a caller (no existing duplicated slug logic was found in `do_ingest_document` / `do_ingest_document_spine` to consolidate), so it's marked `#[allow(dead_code)]` with a note that it's exercised by the unit tests, per the task's "do not change any other ingestion behavior" constraint.

## Test plan
- [x] Unit test: `doi_to_slug("10.48550/arXiv.2606.04990") == "10.48550-arXiv.2606.04990"`
- [x] Unit test: multi-slash DOI (`"10.1000/xyz/123/abc"`) confirms all slashes are replaced, not just the first
- [ ] CI: `cargo test -p epigraph-mcp` and `cargo clippy --workspace -- -D warnings` (no local Rust toolchain available in this sandbox to run directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)