### PR TITLE
fix(cli): decompose_claims self-configures EPIGRAPH_API_URL fallback and mints token

### DIFF
--- a/crates/epigraph-cli/src/bin/decompose_claims.rs
+++ b/crates/epigraph-cli/src/bin/decompose_claims.rs
@@ -10,8 +10,11 @@
 //! the canonical API claim path so embedding + DS auto-wire + signing happen
 //! on write.
 //!
-//! Required: DATABASE_URL, EPIGRAPH_API (e.g. http://127.0.0.1:8080),
-//! EPIGRAPH_TOKEN (bearer for the API), and CLAUDE_CODE_OAUTH_TOKEN.
+//! Required: DATABASE_URL, and CLAUDE_CODE_OAUTH_TOKEN.
+//! API base: EPIGRAPH_API (primary) or EPIGRAPH_API_URL (container fallback),
+//! default http://127.0.0.1:8080. Auth token: EPIGRAPH_TOKEN if set, otherwise
+//! minted via client_credentials from EPIGRAPH_SERVICE_CLIENT_ID +
+//! EPIGRAPH_SERVICE_SECRET.
 //! Use `--provider mock` for a dry compile/smoke without credentials.
 
 use clap::Parser;
@@ -38,6 +41,32 @@ struct Cli {
     dry_run: bool,
 }
 
+/// Mint a bearer token from service-client credentials via the OAuth
+/// client_credentials flow. Returns `None` if either credential env var is
+/// absent or the request fails — callers fall back to an empty token (which
+/// will produce a 401 on the first API call, surfacing the problem clearly).
+async fn mint_service_token(api_base: &str) -> Option<String> {
+    let client_id = std::env::var("EPIGRAPH_SERVICE_CLIENT_ID").ok()?;
+    let client_secret = std::env::var("EPIGRAPH_SERVICE_SECRET").ok()?;
+    let url = format!("{}/oauth/token", api_base.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .form(&[
+            ("grant_type", "client_credentials"),
+            ("client_id", client_id.as_str()),
+            ("client_secret", client_secret.as_str()),
+            ("scope", "claims:write"),
+        ])
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let json: serde_json::Value = resp.json().await.ok()?;
+    json["access_token"].as_str().map(str::to_owned)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
@@ -58,9 +87,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let embedder = epigraph_cli::embedding_service();
 
     // API submit closure — canonical claim create (embed + DS + sign on write).
-    let api_base =
-        std::env::var("EPIGRAPH_API").unwrap_or_else(|_| "http://127.0.0.1:8080".to_string());
-    let token = std::env::var("EPIGRAPH_TOKEN").unwrap_or_default();
+    // EPIGRAPH_API takes precedence; EPIGRAPH_API_URL is the container-standard
+    // name exposed by epiclaw-host. If neither is set we fall back to localhost.
+    let api_base = std::env::var("EPIGRAPH_API")
+        .or_else(|_| std::env::var("EPIGRAPH_API_URL"))
+        .unwrap_or_else(|_| "http://127.0.0.1:8080".to_string());
+
+    // EPIGRAPH_TOKEN if present; otherwise attempt client_credentials mint so
+    // container deployments work without a token-mint preamble in the schedule.
+    let token = {
+        let t = std::env::var("EPIGRAPH_TOKEN").unwrap_or_default();
+        if t.is_empty() {
+            mint_service_token(&api_base).await.unwrap_or_default()
+        } else {
+            t
+        }
+    };
     let http = reqwest::Client::new();
 
     let mut total_atoms = 0usize;

--- a/crates/epigraph-cli/src/bin/decompose_claims.rs
+++ b/crates/epigraph-cli/src/bin/decompose_claims.rs
@@ -41,13 +41,38 @@ struct Cli {
     dry_run: bool,
 }
 
+/// API base precedence: `EPIGRAPH_API` (explicit override) first,
+/// `EPIGRAPH_API_URL` (the container-standard name epiclaw-host exposes)
+/// second, `http://127.0.0.1:8080` otherwise. Takes already-read env values
+/// (rather than reading `std::env::var` itself) so it's a pure function —
+/// testable without mutating global process env, which races under
+/// parallel test execution.
+fn resolve_api_base(epigraph_api: Option<String>, epigraph_api_url: Option<String>) -> String {
+    epigraph_api
+        .or(epigraph_api_url)
+        .unwrap_or_else(|| "http://127.0.0.1:8080".to_string())
+}
+
+/// `None` unless both service-client credential env values are present.
+/// Split out from `mint_service_token` as a pure guard so the "don't even
+/// attempt a mint without both creds" behavior is unit-testable without an
+/// HTTP mock.
+fn resolve_service_credentials(
+    client_id: Option<String>,
+    client_secret: Option<String>,
+) -> Option<(String, String)> {
+    Some((client_id?, client_secret?))
+}
+
 /// Mint a bearer token from service-client credentials via the OAuth
 /// client_credentials flow. Returns `None` if either credential env var is
 /// absent or the request fails — callers fall back to an empty token (which
 /// will produce a 401 on the first API call, surfacing the problem clearly).
 async fn mint_service_token(api_base: &str) -> Option<String> {
-    let client_id = std::env::var("EPIGRAPH_SERVICE_CLIENT_ID").ok()?;
-    let client_secret = std::env::var("EPIGRAPH_SERVICE_SECRET").ok()?;
+    let (client_id, client_secret) = resolve_service_credentials(
+        std::env::var("EPIGRAPH_SERVICE_CLIENT_ID").ok(),
+        std::env::var("EPIGRAPH_SERVICE_SECRET").ok(),
+    )?;
     let url = format!("{}/oauth/token", api_base.trim_end_matches('/'));
     let resp = reqwest::Client::new()
         .post(&url)
@@ -89,9 +114,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // API submit closure — canonical claim create (embed + DS + sign on write).
     // EPIGRAPH_API takes precedence; EPIGRAPH_API_URL is the container-standard
     // name exposed by epiclaw-host. If neither is set we fall back to localhost.
-    let api_base = std::env::var("EPIGRAPH_API")
-        .or_else(|_| std::env::var("EPIGRAPH_API_URL"))
-        .unwrap_or_else(|_| "http://127.0.0.1:8080".to_string());
+    let api_base = resolve_api_base(
+        std::env::var("EPIGRAPH_API").ok(),
+        std::env::var("EPIGRAPH_API_URL").ok(),
+    );
 
     // EPIGRAPH_TOKEN if present; otherwise attempt client_credentials mint so
     // container deployments work without a token-mint preamble in the schedule.
@@ -186,4 +212,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     eprintln!("decompose complete: {total_atoms} atoms, {total_edges} decomposes_to edges");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_api_base, resolve_service_credentials};
+
+    #[test]
+    fn resolve_api_base_prefers_epigraph_api_when_both_set() {
+        assert_eq!(
+            resolve_api_base(
+                Some("https://explicit.example".to_string()),
+                Some("http://container-standard.example".to_string()),
+            ),
+            "https://explicit.example"
+        );
+    }
+
+    #[test]
+    fn resolve_api_base_falls_back_to_epigraph_api_url() {
+        assert_eq!(
+            resolve_api_base(None, Some("http://container-standard.example".to_string())),
+            "http://container-standard.example"
+        );
+    }
+
+    #[test]
+    fn resolve_api_base_defaults_to_localhost_when_neither_set() {
+        assert_eq!(resolve_api_base(None, None), "http://127.0.0.1:8080");
+    }
+
+    #[test]
+    fn resolve_service_credentials_none_when_client_id_missing() {
+        assert_eq!(
+            resolve_service_credentials(None, Some("secret".to_string())),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_service_credentials_none_when_client_secret_missing() {
+        assert_eq!(
+            resolve_service_credentials(Some("id".to_string()), None),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_service_credentials_some_when_both_present() {
+        assert_eq!(
+            resolve_service_credentials(Some("id".to_string()), Some("secret".to_string())),
+            Some(("id".to_string(), "secret".to_string()))
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Backlog `eccfff31`: `decompose_claims` reads `EPIGRAPH_API`/`EPIGRAPH_TOKEN`, but agent containers expose `EPIGRAPH_API_URL` + service-client creds, so the env reconciliation lived in a fragile token-mint preamble in the `schedules.toml` PROMPT instead of the binary itself.
- `decompose_claims` now falls back to `EPIGRAPH_API_URL` when `EPIGRAPH_API` is unset, and mints a `claims:write` token via `client_credentials` from `EPIGRAPH_SERVICE_CLIENT_ID`/`EPIGRAPH_SERVICE_SECRET` when `EPIGRAPH_TOKEN` is unset — so the decomposition-cycle schedule can just call `decompose_claims` directly.
- Extracted the api_base precedence and the credentials-present guard into pure, unit-tested helper functions (`resolve_api_base`, `resolve_service_credentials`).

## Test plan
- [x] 6 new unit tests covering `resolve_api_base` precedence (EPIGRAPH_API > EPIGRAPH_API_URL > localhost default) and `resolve_service_credentials` (None when either cred missing, Some when both present)
- [x] `cargo test -p epigraph-cli --bin decompose_claims` — 6 passed
- [x] `cargo fmt --check -p epigraph-cli` clean
- [x] `SQLX_OFFLINE=true cargo clippy -p epigraph-cli --locked -- -D warnings` clean
- [x] `SQLX_OFFLINE=true cargo build -p epigraph-cli --bin decompose_claims` succeeds

Part of the fix for backlog `eccfff31`/`fbc043ad`; the other half (making the compiled binary survive a fresh `epiclaw-host` agent-runner image build) is a separate PR in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)