### PR TITLE
Backlog bug: query_paper(doi) returned claim_count=0 for arXiv 2504.18085 pre-ingest,

### DIFF
--- a/.sqlx/query-87791b59d5ea74b708b89b7ed1bb8b7708def152df8332a59811c50b5f72bbc5.json
+++ b/.sqlx/query-87791b59d5ea74b708b89b7ed1bb8b7708def152df8332a59811c50b5f72bbc5.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) AS \"count!\"\n            FROM claims\n            WHERE is_current\n              AND labels @> ARRAY[$1]::text[]\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "87791b59d5ea74b708b89b7ed1bb8b7708def152df8332a59811c50b5f72bbc5"
+}

--- a/crates/epigraph-api/src/middleware/auth.rs
+++ b/crates/epigraph-api/src/middleware/auth.rs
@@ -98,7 +98,7 @@ pub enum SignatureError {
 impl IntoResponse for SignatureError {
     fn into_response(self) -> Response {
         // Capture error variant name before moving
-        let error_name = format!("{:?}", &self);
+        let error_name = format!("{:?}", self);
 
         let (status, message) = match self {
             SignatureError::MissingHeader(h) => {

--- a/crates/epigraph-db/src/repos/paper.rs
+++ b/crates/epigraph-db/src/repos/paper.rs
@@ -114,8 +114,18 @@ impl PaperRepository {
 
     /// Count the claims this paper asserts (`paper -asserts-> claim` edges).
     ///
-    /// Used by MCP `query_paper` as the canonical "did this paper land in the
-    /// graph?" probe — replaces the old broken `ILIKE '%doi%'` content search.
+    /// This alone under-counts a partially-ingested paper: `do_ingest_document`
+    /// / `do_ingest_document_spine` label every claim `doi:<doi>` *before*
+    /// writing that claim's `asserts` edge (evidence + reasoning-trace writes
+    /// sit in between), so a crash or error mid-loop can leave claims with the
+    /// doi label but no edge yet. Callers that need an accurate "has this DOI
+    /// landed in the graph at all?" probe must combine this with
+    /// [`Self::count_claims_by_doi_label`] (see `query_paper`) — trusting this
+    /// alone as a duplicate-ingestion gate is the write-order race behind
+    /// backlog 7c6ce1b3-b372-4727-a510-43e63001bf18 (the specific claims that
+    /// prompted that report predate the `doi:<doi>` label entirely and were
+    /// resolved separately by a full re-ingestion; this closes the gap for
+    /// future partial ingestions under the current write order).
     ///
     /// # Errors
     /// Returns `DbError::QueryFailed` if the database query fails.
@@ -131,6 +141,36 @@ impl PaperRepository {
               AND relationship = 'asserts'
             "#,
             paper_id,
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(row.count)
+    }
+
+    /// Count current claims labelled `doi:<doi>`, independent of whether a
+    /// `paper -asserts-> claim` edge exists yet for them.
+    ///
+    /// Every claim written by `do_ingest_document` / `do_ingest_document_spine`
+    /// picks up this label as soon as the claim row itself is created — ahead
+    /// of the `asserts` edge, which lands only after evidence + reasoning-trace
+    /// writes succeed. This makes the label a more direct "does this DOI have
+    /// node presence in the graph?" signal than the edge-based count, and is
+    /// what `query_paper` uses to avoid mis-reporting `claim_count=0` for a
+    /// paper that was partially ingested.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn count_claims_by_doi_label(pool: &PgPool, doi: &str) -> Result<i64, DbError> {
+        let label = format!("doi:{doi}");
+        let row = sqlx::query!(
+            r#"
+            SELECT COUNT(*) AS "count!"
+            FROM claims
+            WHERE is_current
+              AND labels @> ARRAY[$1]::text[]
+            "#,
+            label,
         )
         .fetch_one(pool)
         .await?;

--- a/crates/epigraph-db/tests/paper_repo_tests.rs
+++ b/crates/epigraph-db/tests/paper_repo_tests.rs
@@ -87,3 +87,41 @@ async fn has_processed_by_edge_reflects_pipeline_property(pool: PgPool) {
             .expect("query has_processed_by_edge")
     );
 }
+
+/// `count_claims_by_doi_label` counts claims labelled `doi:<doi>` regardless
+/// of whether a `paper -asserts-> claim` edge exists for them — this is the
+/// signal `query_paper` unions with `count_asserted_claims` so a partial
+/// ingestion (claim labelled, edge not yet written) still reads as non-zero.
+#[sqlx::test(migrations = "../../migrations")]
+async fn count_claims_by_doi_label_ignores_asserts_edges(pool: PgPool) {
+    let doi = "10.1234/label-count-test";
+
+    assert_eq!(
+        PaperRepository::count_claims_by_doi_label(&pool, doi)
+            .await
+            .expect("count with no claims"),
+        0
+    );
+
+    let agent = make_agent(Some("label-count-agent"));
+    let agent_row = AgentRepository::create(&pool, &agent)
+        .await
+        .expect("create agent");
+    let claim = make_claim(agent_row.id, "orphan-labeled claim", 0.5);
+    let claim_row = ClaimRepository::create(&pool, &claim)
+        .await
+        .expect("create claim");
+
+    // Label the claim but deliberately create no `asserts` edge.
+    ClaimRepository::update_labels(&pool, claim_row.id.into(), &[format!("doi:{doi}")], &[])
+        .await
+        .expect("label claim");
+
+    assert_eq!(
+        PaperRepository::count_claims_by_doi_label(&pool, doi)
+            .await
+            .expect("count after labeling"),
+        1,
+        "labeled claim must count even without an asserts edge"
+    );
+}

--- a/crates/epigraph-mcp/src/tools/paper_queries.rs
+++ b/crates/epigraph-mcp/src/tools/paper_queries.rs
@@ -32,6 +32,23 @@ fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpErro
 /// Returns a zero-shaped response (claim_count=0, empty title/authors) when
 /// the DOI isn't in the graph. Callers (the monitor) use this as a dedup
 /// probe and expect a structured response, not a 404.
+///
+/// `claim_count` is `max(asserted_count, labeled_count)`: the `asserts`-edge
+/// count alone under-reports a partially-ingested paper, because ingestion
+/// labels a claim `doi:<doi>` before it links the `asserts` edge (see
+/// `PaperRepository::count_claims_by_doi_label`). Without the label-based
+/// floor, a crash between those two writes leaves a claim in the graph that
+/// this probe would report as `claim_count=0`, letting the nightly monitor
+/// re-extract an already (partially) ingested paper.
+///
+/// This closes the write-order race going forward; it does not retroactively
+/// recover claims ingested before the `doi:<doi>` label existed (they carry
+/// neither the label nor, in the failure case, the edge — no DOI-keyed query
+/// can find them). Investigating backlog 7c6ce1b3-b372-4727-a510-43e63001bf18
+/// (arXiv 2504.18085) found exactly that: its orphaned claims predate the
+/// label and are unlabeled in the live DB, so this fix prevents the same
+/// class of gap from recurring rather than repairing that specific paper
+/// (which was already made whole by a subsequent full re-ingestion).
 pub async fn query_paper(
     server: &EpiGraphMcpFull,
     params: QueryPaperParams,
@@ -51,9 +68,16 @@ pub async fn query_paper(
         });
     };
 
-    let claim_count = PaperRepository::count_asserted_claims(&server.pool, paper.id)
+    let asserted_count = PaperRepository::count_asserted_claims(&server.pool, paper.id)
         .await
         .map_err(internal_error)?;
+    // Node-existence probe, independent of the `asserts` edge: catches claims
+    // a partial/crashed ingestion already labelled `doi:<doi>` but never got
+    // to link, which `asserted_count` alone would silently report as zero.
+    let labeled_count = PaperRepository::count_claims_by_doi_label(&server.pool, &paper.doi)
+        .await
+        .map_err(internal_error)?;
+    let claim_count = asserted_count.max(labeled_count);
 
     let authors = PaperRepository::list_authors(&server.pool, paper.id)
         .await

--- a/crates/epigraph-mcp/tests/query_paper_duplicate_gate.rs
+++ b/crates/epigraph-mcp/tests/query_paper_duplicate_gate.rs
@@ -1,0 +1,112 @@
+//! Regression test for backlog 7c6ce1b3-b372-4727-a510-43e63001bf18:
+//! `query_paper(doi)` used the `paper -asserts-> claim` edge count alone as
+//! its "has this DOI landed in the graph?" probe. Ingestion labels a claim
+//! `doi:<doi>` *before* it links that edge (evidence + reasoning-trace writes
+//! sit in between), so a crash mid-ingestion can leave claim nodes that carry
+//! the label but no edge yet. The edge-only count reported `claim_count=0`
+//! for such a paper, which is exactly the shape EpiClaw's nightly monitor
+//! reads as "not yet ingested" — causing it to re-run extraction on an
+//! already (partially) ingested paper.
+
+use epigraph_core::{Agent, AgentId, Claim, TruthValue};
+use epigraph_crypto::{AgentSigner, ContentHasher};
+use epigraph_db::{AgentRepository, ClaimRepository, PaperRepository};
+use epigraph_mcp::embed::McpEmbedder;
+use epigraph_mcp::server::EpiGraphMcpFull;
+use epigraph_mcp::tools::paper_queries::query_paper;
+use epigraph_mcp::types::QueryPaperParams;
+use sqlx::PgPool;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::generate();
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+fn result_json(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .expect("query_paper result has text content")
+        .text
+        .clone();
+    serde_json::from_str(&text).expect("query_paper result is valid JSON")
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn query_paper_surfaces_labeled_claims_missing_asserts_edge(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let doi = "10.48550/arXiv.2504.18085";
+
+    // Simulate a crashed partial ingestion: the paper row and one claim exist,
+    // the claim already carries the `doi:<doi>` label that
+    // `do_ingest_document_spine` attaches immediately after creating the claim
+    // row, but the `paper -asserts-> claim` edge — written later in the same
+    // loop iteration — was never created.
+    PaperRepository::get_or_create(&pool, doi, Some("Random-Set Large Language Models"), None)
+        .await
+        .expect("create paper");
+
+    let agent = Agent::new([9u8; 32], Some("test-extractor".to_string()));
+    let agent_row = AgentRepository::create(&pool, &agent)
+        .await
+        .expect("create agent");
+
+    let content = "Random-Set Large Language Models introduces an epistemic decoding layer";
+    let mut claim = Claim::new(
+        content.to_string(),
+        AgentId::from_uuid(agent_row.id.into()),
+        [0u8; 32],
+        TruthValue::new(0.7).unwrap(),
+    );
+    claim.content_hash = ContentHasher::hash(content.as_bytes());
+    let persisted = ClaimRepository::create(&pool, &claim)
+        .await
+        .expect("create claim");
+    let persisted_id: uuid::Uuid = persisted.id.into();
+    ClaimRepository::update_labels(&pool, persisted_id, &[format!("doi:{doi}")], &[])
+        .await
+        .expect("label claim");
+
+    // No `paper -asserts-> claim` edge is created for this claim — that is
+    // the partial-ingestion state under test.
+
+    let result = query_paper(
+        &server,
+        QueryPaperParams {
+            doi: doi.to_string(),
+        },
+        None,
+    )
+    .await
+    .expect("query_paper succeeds");
+
+    let json = result_json(&result);
+    assert_eq!(
+        json["claim_count"].as_i64(),
+        Some(1),
+        "an orphaned doi-labeled claim must surface in claim_count even \
+         without an asserts edge, or a duplicate-ingestion gate reading \
+         claim_count reports this DOI as unstarted: {json}"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn query_paper_reports_zero_for_unknown_doi(pool: PgPool) {
+    let server = make_server(pool.clone());
+
+    let result = query_paper(
+        &server,
+        QueryPaperParams {
+            doi: "10.9999/never-ingested".to_string(),
+        },
+        None,
+    )
+    .await
+    .expect("query_paper succeeds");
+
+    let json = result_json(&result);
+    assert_eq!(json["claim_count"].as_i64(), Some(0));
+    assert_eq!(json["claims"].as_array().map(Vec::len), Some(0));
+}


### PR DESCRIPTION
## Summary
Fixed the write-order race in query_paper(doi)'s duplicate-gate check. do_ingest_document / do_ingest_document_spine label a claim doi:<doi> immediately after creating the claim row, but the paper-asserts-claim edge lands later in the same loop iteration (after evidence + reasoning-trace writes) -- a crash between those two writes leaves a labeled-but-unlinked claim that the old edge-only claim_count silently reported as zero. Added PaperRepository::count_claims_by_doi_label, a direct node-existence probe on the doi:<doi> label (GIN-indexed containment query) independent of edge state, and query_paper now reports claim_count = max(asserted_count, labeled_count) so a future partial ingestion still registers as 'already ingested' for callers (e.g. the nightly paper-monitor) using claim_count as a dedup gate. IMPORTANT SCOPE NOTE verified against the live dev DB: this is forward-preventive, not a retroactive repair. arXiv 2504.18085 (the paper named in the backlog item) now has 71 asserts-linked claims but zero doi:<doi>-labeled claims -- its claims predate the label contract entirely, so no DOI-keyed query (this fix included) can recover them; that paper was already made whole by a subsequent full re-ingestion, independent of this change. The fix closes the gap for any future occurrence of this exact race under current ingestion code, which is what the regression test exercises.

## Origin
Bridge dev request: `70bdb2a0-a6c5-4c94-a9e8-dbdc552906ef`

Auto-developed by the bridge-dev pipeline. Review and merge when satisfied.