### PR TITLE
fix(mcp): populate labels in query_claims results

### DIFF
--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -1288,6 +1288,42 @@ impl ClaimRepository {
         Ok(rows.into_iter().collect())
     }
 
+    /// Fetch `labels` for a batch of claim ids in one round-trip.
+    ///
+    /// Batch companion to [`Self::get_labels`], used by MCP `query_claims` to
+    /// populate `ClaimResponse.labels` without an N+1 fan-out of per-claim
+    /// `get_labels` calls (backlog bug `babd5904`: `query_claims` hardcoded
+    /// `labels: Vec::new()`).
+    ///
+    /// Deliberately does **NOT** filter on `is_current`. `query_claims` runs
+    /// [`Self::list_by_truth_range`], which returns superseded rows, and the
+    /// single-claim label source it mirrors (`get_labels` →
+    /// `SELECT labels FROM claims WHERE id = $1`) has no `is_current` clause
+    /// either. Filtering here would silently re-drop labels for superseded
+    /// claims — the same bug class, narrowed. A missing id is simply absent
+    /// from the map (caller treats absence as "no labels").
+    ///
+    /// Uses the runtime `query_as` form (no compile-time `.sqlx` cache entry)
+    /// to keep `cargo sqlx prepare` out of this change's footprint.
+    ///
+    /// # Errors
+    /// Returns [`DbError::QueryFailed`] on database errors.
+    pub async fn labels_by_ids(
+        pool: &PgPool,
+        ids: &[uuid::Uuid],
+    ) -> Result<std::collections::HashMap<uuid::Uuid, Vec<String>>, DbError> {
+        if ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let rows = sqlx::query_as::<_, (uuid::Uuid, Vec<String>)>(
+            "SELECT id, COALESCE(labels, ARRAY[]::text[]) FROM claims WHERE id = ANY($1)",
+        )
+        .bind(ids)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.into_iter().collect())
+    }
+
     /// List claims that contain ALL of the specified labels.
     ///
     /// Uses the GIN index on `claims.labels` for efficient `@>` containment queries.

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -277,6 +277,16 @@ pub async fn query_claims(
             .into_iter()
             .collect();
 
+    // Populate labels via a single batch round-trip for all returned ids
+    // (backlog babd5904: this handler previously hardcoded `labels: Vec::new()`
+    // while get_claim on the same id returned them). Batch fetch avoids the
+    // N+1 fan-out of per-claim get_labels calls; the helper does NOT filter on
+    // is_current so superseded rows (which list_by_truth_range returns) keep
+    // their labels, matching get_labels' label source. A missing id → no labels.
+    let labels_map = ClaimRepository::labels_by_ids(&server.pool, &ids)
+        .await
+        .map_err(internal_error)?;
+
     let results: Vec<ClaimResponse> = claims
         .into_iter()
         .map(|c| {
@@ -294,7 +304,7 @@ pub async fn query_claims(
                 agent_id: c.agent_id.as_uuid().to_string(),
                 content_hash,
                 created_at: c.created_at.to_rfc3339(),
-                labels: Vec::new(),
+                labels: labels_map.get(&id).cloned().unwrap_or_default(),
                 is_current: true,
                 supersedes: None,
             }

--- a/crates/epigraph-mcp/tests/query_claims_labels_test.rs
+++ b/crates/epigraph-mcp/tests/query_claims_labels_test.rs
@@ -1,0 +1,139 @@
+//! Regression test for backlog `babd5904`: the `query_claims` MCP tool always
+//! returned `labels: []` because its handler hardcoded `labels: Vec::new()` in
+//! the `ClaimResponse` map, while `get_claim` on the same id populated labels
+//! correctly via `ClaimRepository::get_labels`.
+//!
+//! Seeds TWO labelled claims — one current, one superseded — because the fix's
+//! batch label fetch must NOT filter on `is_current` (`query_claims` /
+//! `list_by_truth_range` return superseded claims, and `get_claim`'s label
+//! source has no `is_current` clause). A naive helper that copies the
+//! `COALESCE(is_current, true)` filter from `contents_by_ids` would silently
+//! re-drop labels for the superseded claim — the same bug class, narrowed. This
+//! test locks in the no-filter decision by asserting BOTH claims surface their
+//! labels through the `query_claims` tool entry point.
+
+use epigraph_mcp::tools::claims::query_claims;
+use epigraph_mcp::types::QueryClaimsParams;
+use rmcp::model::CallToolResult;
+use serde_json::Value;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+use common::build_test_server;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn query_claims_populates_labels_for_current_and_superseded(pool: PgPool) {
+    let agent = seed_agent(&pool).await;
+
+    // Two claims with distinct truth values so both land in the [min,max]
+    // window, each carrying known labels. `current` is live; `superseded` has
+    // is_current=false — the discriminating case for the is_current filter.
+    let current = seed_claim(&pool, agent, &["backlog", "task-3-1"], 0.7, true, None).await;
+    let superseded = seed_claim(&pool, agent, &["archived"], 0.3, false, Some(current)).await;
+
+    let server = build_test_server(pool.clone());
+
+    let result = query_claims(
+        &server,
+        QueryClaimsParams {
+            min_truth: Some(0.0),
+            max_truth: Some(1.0),
+            limit: Some(50),
+        },
+        None,
+    )
+    .await
+    .expect("query_claims");
+    let claims = parse_claims(&result);
+
+    let current_claim = find_claim(&claims, current);
+    let current_labels = labels_of(current_claim);
+    assert!(
+        current_labels.contains(&"backlog".to_string())
+            && current_labels.contains(&"task-3-1".to_string()),
+        "current claim must surface its labels through query_claims, got {current_labels:?}"
+    );
+
+    let superseded_claim = find_claim(&claims, superseded);
+    let superseded_labels = labels_of(superseded_claim);
+    assert!(
+        superseded_labels.contains(&"archived".to_string()),
+        "SUPERSEDED claim must ALSO surface its labels — the batch helper must \
+         NOT filter on is_current, matching get_claim's label source. got {superseded_labels:?}"
+    );
+}
+
+fn parse_claims(result: &CallToolResult) -> Vec<Value> {
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text content block");
+    let parsed: Value = serde_json::from_str(&text).expect("response is JSON");
+    parsed.as_array().expect("response is JSON array").clone()
+}
+
+fn find_claim(claims: &[Value], id: Uuid) -> &Value {
+    let id_str = id.to_string();
+    claims
+        .iter()
+        .find(|c| c["id"].as_str() == Some(id_str.as_str()))
+        .unwrap_or_else(|| panic!("claim {id_str} not in response: {claims:?}"))
+}
+
+fn labels_of(claim: &Value) -> Vec<String> {
+    claim["labels"]
+        .as_array()
+        .expect("labels is an array")
+        .iter()
+        .map(|v| v.as_str().expect("label is a string").to_string())
+        .collect()
+}
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("cc".repeat(32))
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    id
+}
+
+async fn seed_claim(
+    pool: &PgPool,
+    agent_id: Uuid,
+    labels: &[&str],
+    truth: f64,
+    is_current: bool,
+    supersedes: Option<Uuid>,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id
+        .as_bytes()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(0, 16))
+        .take(32)
+        .collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, \
+                             labels, is_current, supersedes) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+    )
+    .bind(id)
+    .bind(format!("query_claims labels regression {id}"))
+    .bind(hash)
+    .bind(truth)
+    .bind(agent_id)
+    .bind(labels.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+    .bind(is_current)
+    .bind(supersedes)
+    .execute(pool)
+    .await
+    .expect("seed claim");
+    id
+}


### PR DESCRIPTION
## fix(mcp): populate labels in query_claims results

**Evidence:**
- Backlog `babd5904`: `query_claims` always returned `labels: []` while `get_claim` on the same id returned them correctly — the handler hardcoded `labels: Vec::new()` in the `ClaimResponse` map (`crates/epigraph-mcp/src/tools/claims.rs`).

**Reasoning:**
- Fetch labels via a new batch repo query `ClaimRepository::labels_by_ids` (one round-trip for all returned ids) rather than a per-claim N+1 fan-out of `get_labels`, reusing the id vec already built for `batch_check_content_access`.
- The helper deliberately does **NOT** filter on `is_current`: `query_claims` runs `list_by_truth_range` (which returns superseded rows) and mirrors `get_labels`' label source (`SELECT labels FROM claims WHERE id = $1`, no `is_current` clause). A filtered helper would silently re-drop labels for superseded claims — the same bug class, narrowed. A missing id maps to an empty vec (absence = "no labels").
- All SQL stays in the repo layer per repo convention; `labels_by_ids` uses the runtime `query_as` form (no compile-time `.sqlx` cache entry), matching the adjacent `contents_by_ids` helper, so `cargo sqlx prepare` is a no-op here.

**Verification:**
- New regression test `query_claims_populates_labels_for_current_and_superseded` seeds one current + one superseded labelled claim and asserts **both** surface their labels through the `query_claims` tool entry point. Confirmed **RED** before the fix (`panicked: "current claim must surface its labels ... got []"`), **GREEN** after (`test result: ok. 1 passed; 0 failed`).
- Full local gate green: `cargo fmt --check` = OK; `cargo clippy --workspace --locked -- -D warnings` = clean (no warnings); `cargo test -p epigraph-mcp` against `epigraph_db_repo_test` = all binaries ok, 0 failed.
- `SQLX_OFFLINE=true cargo check --workspace --all-targets` passes; no `.sqlx` changes.

Resolves babd5904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)