### PR TITLE
fix(engine): wake up factorless edges once their source gains belief

### DIFF
--- a/crates/epigraph-api/src/routes/edges.rs
+++ b/crates/epigraph-api/src/routes/edges.rs
@@ -127,7 +127,8 @@ pub fn is_valid_relationship(s: &str) -> bool {
     VALID_RELATIONSHIPS.contains(&s)
 }
 
-/// Trigger DS recomputation on the target claim when an epistemic edge is created.
+/// Trigger DS recomputation on the target claim when an epistemic edge is
+/// created OR re-asserted.
 ///
 /// Delegates to `epigraph_engine::edge_factor::auto_wire_edge_if_epistemic`,
 /// which uses the canonical `binary_truth` frame and the `RestrictionKind`
@@ -135,12 +136,26 @@ pub fn is_valid_relationship(s: &str) -> bool {
 /// 1-hop propagation to dependents (reasoning-trace input chain) — an
 /// HTTP-only concern that doesn't belong in the engine factor module.
 ///
+/// `was_created` is passed straight through to the engine gate rather than
+/// hardcoded — the engine no longer gates wiring on "was this edge just
+/// created" alone. An edge can be written durably while its source is
+/// "factorless" (no belief interval), and a LATER re-assertion of the same
+/// (source, target, relationship) — `was_created=false` since the edge
+/// already exists — must still wake up and wire once the source has since
+/// acquired belief (backlog claim 8ef5cf61-7382-43a4-85cb-565d76ba3f06).
+/// `auto_wire_edge_if_epistemic` self-gates on "does a BBA already exist for
+/// this edge_id", so calling it on every dedup hit is safe/idempotent: an
+/// already-wired edge is a no-op re-check (one `SELECT EXISTS`), not a
+/// re-wire.
+///
 /// BBA attribution: the source claim's `agent_id` is used as the BBA's
 /// `source_agent_id`, mirroring the legacy semantics ("A's author asserts
 /// A SUPPORTS B").
 #[cfg(feature = "db")]
+#[allow(clippy::too_many_arguments)]
 async fn trigger_edge_ds_recomputation(
     pool: &sqlx::PgPool,
+    was_created: bool,
     edge_id: uuid::Uuid,
     source_claim_id: uuid::Uuid,
     target_claim_id: uuid::Uuid,
@@ -164,7 +179,7 @@ async fn trigger_edge_ds_recomputation(
 
     let outcome = auto_wire_edge_if_epistemic(
         pool,
-        true, // caller already gated on was_created
+        was_created,
         edge_id,
         source_claim_id,
         source_type,
@@ -176,8 +191,8 @@ async fn trigger_edge_ds_recomputation(
     .await;
 
     // Only propagate when we actually wired a factor — the other outcomes
-    // (Vacuous / SourceFactorless / NonEpistemic / wrapper-gate skip) leave
-    // target belief unchanged so dependents don't need recomputing.
+    // (Vacuous / SourceFactorless / NonEpistemic / already-wired / wrapper-gate
+    // skip) leave target belief unchanged so dependents don't need recomputing.
     if !matches!(outcome, Some(EdgeFactorOutcome::Wired)) {
         return Ok(());
     }
@@ -541,10 +556,47 @@ pub async fn create_edge(
         valid_to: edge_row.valid_to,
     };
 
-    // ── Side effects: only run when we actually created a new edge ──
-    // A dedup hit (was_created=false) is by design semantically idempotent;
-    // re-running provenance / DS / events would defeat the whole purpose of
-    // if_not_exists for drainer retries.
+    // Edge-triggered DS recomputation. Deliberately OUTSIDE the `if
+    // was_created` block below: an edge can be written durably while its
+    // source is "factorless" (no belief interval yet), and a later
+    // re-assertion of the SAME edge (a dedup hit, `was_created=false`) must
+    // still wake up and wire once the source has since acquired belief
+    // (backlog claim 8ef5cf61-7382-43a4-85cb-565d76ba3f06) — otherwise the
+    // wake-up is a permanent no-op. `trigger_edge_ds_recomputation` /
+    // `auto_wire_edge_if_epistemic` self-gate on "does a BBA already exist
+    // for this edge_id", so calling this on every dedup hit is safe: an
+    // already-wired edge is a cheap no-op re-check, not a re-wire — drainer
+    // retries stay idempotent. The engine self-filters via
+    // `RestrictionKind::Neutral` on non-epistemic relationships, so the
+    // wrapper handles all 13 epistemic types (supports/corroborates/
+    // contradicts/refutes/refines/...) instead of just the 4 evidentials.
+    if let Err(e) = trigger_edge_ds_recomputation(
+        pool,
+        was_created,
+        edge_id,
+        request.source_id,
+        request.target_id,
+        &request.source_type,
+        &request.target_type,
+        &request.relationship,
+    )
+    .await
+    {
+        tracing::warn!(
+            edge_id = %edge_id,
+            source_id = %request.source_id,
+            target_id = %request.target_id,
+            relationship = %request.relationship,
+            error = %e,
+            "Edge-triggered DS recomputation failed; edge created successfully"
+        );
+    }
+
+    // ── Remaining side effects: only run when we actually created a new edge ──
+    // A dedup hit (was_created=false) is by design semantically idempotent for
+    // these; re-running provenance / factor-creation / events would defeat the
+    // whole purpose of if_not_exists for drainer retries. DS recomputation
+    // (above) is the one exception — see its comment for why.
     if was_created {
         // Record provenance when OAuth2-authenticated
         if let Some(axum::Extension(ref auth)) = auth_ctx {
@@ -567,31 +619,6 @@ pub async fn create_edge(
             {
                 tracing::warn!(edge_id = %edge_id, error = %e, "Failed to record edge provenance");
             }
-        }
-
-        // Edge-triggered DS recomputation. The engine self-filters via
-        // `RestrictionKind::Neutral` on non-epistemic relationships, so the
-        // wrapper handles all 13 epistemic types (supports/corroborates/
-        // contradicts/refutes/refines/...) instead of just the 4 evidentials.
-        if let Err(e) = trigger_edge_ds_recomputation(
-            pool,
-            edge_id,
-            request.source_id,
-            request.target_id,
-            &request.source_type,
-            &request.target_type,
-            &request.relationship,
-        )
-        .await
-        {
-            tracing::warn!(
-                edge_id = %edge_id,
-                source_id = %request.source_id,
-                target_id = %request.target_id,
-                relationship = %request.relationship,
-                error = %e,
-                "Edge-triggered DS recomputation failed; edge created successfully"
-            );
         }
 
         // P2a: Auto-create factor for epistemic edges

--- a/crates/epigraph-db/src/repos/mass_function.rs
+++ b/crates/epigraph-db/src/repos/mass_function.rs
@@ -300,6 +300,38 @@ impl MassFunctionRepository {
         Ok(rows)
     }
 
+    /// Whether any mass function row has already been materialized for the
+    /// given `perspective_id`.
+    ///
+    /// Edge-factor BBAs (see `epigraph_engine::edge_factor::auto_wire_ds_for_edge`)
+    /// are persisted with `perspective_id = edge_id`, so this doubles as
+    /// "has this edge ever been wired" — the existence check the
+    /// edge-creation wake-up gate (backlog 8ef5cf61) uses to decide whether
+    /// a re-asserted edge should attempt wiring even when `was_created` is
+    /// `false` (e.g. the source claim was factorless on first write and has
+    /// since acquired a belief interval).
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn exists_for_perspective(
+        pool: &PgPool,
+        perspective_id: Uuid,
+    ) -> Result<bool, DbError> {
+        let exists: bool = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM mass_functions WHERE perspective_id = $1
+            )
+            "#,
+        )
+        .bind(perspective_id)
+        .fetch_one(pool)
+        .await?;
+
+        Ok(exists)
+    }
+
     /// Delete all mass functions for a claim
     ///
     /// Returns the number of rows deleted.

--- a/crates/epigraph-engine/src/edge_factor.rs
+++ b/crates/epigraph-engine/src/edge_factor.rs
@@ -10,7 +10,9 @@
 //! Lives in `epigraph-engine` (not `epigraph-mcp`) so both the MCP edge-creation
 //! path and the HTTP `POST /api/v1/edges` path can share a single algorithm.
 //! The `auto_wire_edge_if_epistemic` wrapper adds the standard gates
-//! (was_created + claim→claim) for use at edge-creation call sites.
+//! (claim→claim, plus "no BBA has ever been materialized for this edge yet" —
+//! NOT simply `was_created`, see that function's doc comment for why) for use
+//! at edge-creation call sites.
 
 use sqlx::PgPool;
 use std::collections::{BTreeSet, HashMap};
@@ -240,11 +242,28 @@ pub async fn auto_wire_ds_for_edge(
 }
 
 /// Fire `auto_wire_ds_for_edge` from an edge-creation call site, gated on
-/// whether the edge was newly created and connects two claim nodes.
+/// whether the edge connects two claim nodes AND (was just created OR has
+/// never been wired).
+///
+/// The `was_created` flag alone is not sufficient: an edge can be written
+/// durably while its source claim is "factorless" (no belief interval yet —
+/// see [`EdgeFactorOutcome::SourceFactorless`]), and later re-asserted via
+/// the same call site once the source acquires belief. That re-assertion
+/// hits `was_created=false` (the edge already exists) but must still attempt
+/// wiring — otherwise the wake-up is a permanent no-op (backlog claim
+/// 8ef5cf61-7382-43a4-85cb-565d76ba3f06). So the real gate is "has a BBA
+/// EVER been materialized for this edge_id" (checked via
+/// `MassFunctionRepository::exists_for_perspective`, since edge-factor BBAs
+/// are persisted keyed by `perspective_id = edge_id`): skip only when one
+/// already exists, regardless of `was_created`. This makes the wake-up
+/// idempotent — once wired, further re-hits on the same edge are no-ops
+/// again, matching the pre-fix behavior for the common (believed-source)
+/// case.
 ///
 /// Best-effort: failures are logged at `warn` and swallowed. Returns `None`
-/// when the edge wasn't newly created, sources/targets aren't claims, or the
-/// auto-wire call failed. Returns `Some(outcome)` when the trigger fired.
+/// when sources/targets aren't claims, a BBA already exists for this edge,
+/// or the auto-wire call failed. Returns `Some(outcome)` when the trigger
+/// fired.
 #[allow(clippy::too_many_arguments)]
 pub async fn auto_wire_edge_if_epistemic(
     pool: &PgPool,
@@ -257,8 +276,21 @@ pub async fn auto_wire_edge_if_epistemic(
     relationship: &str,
     agent_id: Uuid,
 ) -> Option<EdgeFactorOutcome> {
-    if !was_created || source_type != "claim" || target_type != "claim" {
+    if source_type != "claim" || target_type != "claim" {
         return None;
+    }
+    if !was_created {
+        match MassFunctionRepository::exists_for_perspective(pool, edge_id).await {
+            Ok(true) => return None,
+            Ok(false) => {} // never wired — attempt the wake-up below
+            Err(e) => {
+                tracing::warn!(
+                    edge = %edge_id,
+                    "edge auto-wire wake-up check failed: {e}",
+                );
+                return None;
+            }
+        }
     }
     match auto_wire_ds_for_edge(pool, edge_id, agent_id, source_id, target_id, relationship).await {
         Ok(outcome) => Some(outcome),

--- a/crates/epigraph-mcp/src/tools/link_epistemic.rs
+++ b/crates/epigraph-mcp/src/tools/link_epistemic.rs
@@ -19,9 +19,14 @@
 //!   canonical strings; `supersedes` is intentionally excluded — it has
 //!   dedicated semantics in `supersede_claim`),
 //! - idempotent on `(source, target, relationship)`: a re-hit returns the
-//!   existing edge with `was_created=false`, `belief_wired=false`, and performs
-//!   no re-wire (matching the HTTP route, where wiring only fires on first
-//!   creation).
+//!   existing edge with `was_created=false` and never re-creates the durable
+//!   edge row or re-emits `edge.added`. Belief wiring, however, is NOT gated
+//!   on `was_created` alone: a re-hit still attempts the wire, and
+//!   `belief_wired=true` on that re-hit exactly when no BBA has ever been
+//!   materialized for this edge_id AND the source now has a belief interval
+//!   — the "factorless source wakes up later" case (backlog claim
+//!   8ef5cf61-7382-43a4-85cb-565d76ba3f06). Once a BBA exists for the edge,
+//!   further re-hits are stable no-ops again (`belief_wired=false`).
 //!
 //! Deferred vs the HTTP route (tracked as follow-ups): per-edge provenance
 //! recording, 1-hop `propagate_to_dependents` (an HTTP-only concern per the
@@ -143,46 +148,55 @@ pub async fn do_link_epistemic(
     .await
     .map_err(internal_error)?;
 
-    // Belief wiring only fires on first creation (mirrors the HTTP route, where
-    // an idempotent re-hit returns the stored row and never re-wires).
+    // Belief wiring fires whenever no BBA has ever been materialized for this
+    // edge yet — NOT simply on first creation. An edge can be written durably
+    // while its source is "factorless" (no belief interval); if the source
+    // later acquires belief and the SAME edge is re-asserted, `was_created`
+    // is `false` on that call but the wake-up must still fire (backlog claim
+    // 8ef5cf61-7382-43a4-85cb-565d76ba3f06). `auto_wire_edge_if_epistemic`
+    // itself resolves the "already wired?" check (via
+    // `MassFunctionRepository::exists_for_perspective`) and is a no-op once a
+    // BBA exists for this edge_id, so it's safe to attempt on every call.
     //
     // The BBA is attributed to the SOURCE claim's agent_id ("A's author asserts
     // A SUPPORTS B"), NOT the caller — exactly as the HTTP wrapper
     // `trigger_edge_ds_recomputation` does. Resolved here via a runtime query
     // (no `query!` macro → zero .sqlx offline-data churn).
     let mut belief_wired = false;
+    let source_agent_id: Option<uuid::Uuid> =
+        sqlx::query_scalar("SELECT agent_id FROM claims WHERE id = $1")
+            .bind(source_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(internal_error)?;
+
+    if let Some(agent_id) = source_agent_id {
+        // Best-effort: a recompute error must not lose the durable edge.
+        // `belief_wired` is true ONLY when the engine actually materialized
+        // a BBA and recomputed the target (`Wired`). The other outcomes
+        // (SourceFactorless / Vacuous / NonEpistemic / already-wired / None-on-error)
+        // move no belief, so we honestly report `belief_wired=false`.
+        let outcome = auto_wire_edge_if_epistemic(
+            pool,
+            was_created,
+            edge_row.id,
+            source_id,
+            "claim",
+            target_id,
+            "claim",
+            &params.relationship,
+            agent_id,
+        )
+        .await;
+        belief_wired = matches!(outcome, Some(EdgeFactorOutcome::Wired));
+    }
+
     if was_created {
-        let source_agent_id: Option<uuid::Uuid> =
-            sqlx::query_scalar("SELECT agent_id FROM claims WHERE id = $1")
-                .bind(source_id)
-                .fetch_optional(pool)
-                .await
-                .map_err(internal_error)?;
-
-        if let Some(agent_id) = source_agent_id {
-            // Best-effort: a recompute error must not lose the durable edge.
-            // `belief_wired` is true ONLY when the engine actually materialized
-            // a BBA and recomputed the target (`Wired`). The other outcomes
-            // (SourceFactorless / Vacuous / NonEpistemic / None-on-error) move
-            // no belief, so we honestly report `belief_wired=false`.
-            let outcome = auto_wire_edge_if_epistemic(
-                pool,
-                true, // was_created already gated above
-                edge_row.id,
-                source_id,
-                "claim",
-                target_id,
-                "claim",
-                &params.relationship,
-                agent_id,
-            )
-            .await;
-            belief_wired = matches!(outcome, Some(EdgeFactorOutcome::Wired));
-        }
-
         // Emit the durable `edge.added` event (best-effort; never fail the call
         // on a publish error). Actor = the MCP signer agent, mirroring
-        // `emit_tool_invoked`'s actor resolution.
+        // `emit_tool_invoked`'s actor resolution. Scoped to genuine creation
+        // only — a re-assertion of an existing edge (including a wake-up
+        // wire) must not re-emit `edge.added`.
         let actor_id = server.agent_id().await.ok();
         let _ = EventRepository::publish_or_log(
             pool,

--- a/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
+++ b/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
@@ -241,6 +241,13 @@ async fn contradicts_lowers_target_belief(pool: PgPool) {
 /// while the target's belief is left untouched. The other belief tests only
 /// reach `belief_wired=false` via the idempotent re-hit (where `was_created` is
 /// also false), so this pins the distinct created-but-not-wired branch.
+///
+/// This is ONLY the first half of the lifecycle. See
+/// `factorless_source_wakes_up_when_it_later_gains_belief` below for what must
+/// happen when the source subsequently acquires a belief interval and the same
+/// edge is re-asserted (backlog 8ef5cf61): the durable edge already exists
+/// (`was_created=false` on the second call), and the fix under test wires the
+/// edge anyway because no BBA has ever been materialized for it.
 #[sqlx::test(migrations = "../../migrations")]
 async fn factorless_source_writes_durable_edge_without_wiring(pool: PgPool) {
     let server = build_test_server(pool.clone());
@@ -299,6 +306,164 @@ async fn factorless_source_writes_durable_edge_without_wiring(pool: PgPool) {
         props,
         serde_json::json!({"note": "no source belief"}),
         "properties must round-trip even when belief is not wired"
+    );
+}
+
+// ── Backlog 8ef5cf61: factorless edges must wake up once the source gains belief ─
+
+/// Regression for backlog claim 8ef5cf61-7382-43a4-85cb-565d76ba3f06.
+///
+/// Sequence:
+///   1. Write A --supports--> B while A has NO belief interval (factorless).
+///      The durable edge is created but nothing is wired (asserted above,
+///      mirroring `factorless_source_writes_durable_edge_without_wiring`).
+///   2. A subsequently acquires a belief interval (e.g. it gains its own
+///      evidence later in its lifecycle).
+///   3. The SAME (A, supports, B) edge is re-asserted via `link_epistemic`.
+///      The edge already exists, so `was_created=false` on this call — but
+///      because no BBA has EVER been materialized for this edge_id, the fix
+///      must still fire the wake-up wire: B's belief must move and
+///      `belief_wired` must report `true`.
+///
+/// Before the fix, `auto_wire_edge_if_epistemic` (and its caller here) only
+/// fired on `was_created=true`, so this second call was a permanent no-op —
+/// B's belief would NEVER reflect A's later-acquired belief, even though the
+/// edge exists durably. This test must FAIL against that code (RED) and PASS
+/// once the gate is switched from "was this edge just created" to "does an
+/// edge-factor BBA already exist for this edge_id" (GREEN).
+#[sqlx::test(migrations = "../../migrations")]
+async fn factorless_source_wakes_up_when_it_later_gains_belief(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    let source = seed_claim(&pool, "will gain belief later", 0.5).await;
+    let target = seed_claim(&pool, "dependent on source", 0.5).await;
+
+    // ── Step 1: write the edge while A is still factorless ──────────────
+    let first = parse_response(
+        &do_link_epistemic(
+            &server,
+            LinkEpistemicParams {
+                source_claim_id: source.to_string(),
+                target_claim_id: target.to_string(),
+                relationship: "supports".to_string(),
+                properties: None,
+            },
+        )
+        .await
+        .expect("factorless link must still succeed"),
+    );
+    assert!(first.was_created, "first call creates the durable edge");
+    assert!(
+        !first.belief_wired,
+        "factorless source must not wire belief on first write"
+    );
+    assert!(
+        read_betp(&pool, target).await.is_none(),
+        "target belief must remain untouched while the source is factorless"
+    );
+
+    // ── Step 2: the source LATER gains a belief interval ─────────────────
+    sqlx::query(
+        "UPDATE claims SET belief = 0.9, plausibility = 0.9, pignistic_prob = 0.9 WHERE id = $1",
+    )
+    .bind(source)
+    .execute(&pool)
+    .await
+    .expect("give the source a belief interval");
+
+    // ── Step 3: re-assert the SAME edge — must wake up and wire now ──────
+    let second = parse_response(
+        &do_link_epistemic(
+            &server,
+            LinkEpistemicParams {
+                source_claim_id: source.to_string(),
+                target_claim_id: target.to_string(),
+                relationship: "supports".to_string(),
+                properties: None,
+            },
+        )
+        .await
+        .expect("re-assert of the existing edge must succeed"),
+    );
+
+    assert!(
+        !second.was_created,
+        "the edge already exists — this call must not create a duplicate"
+    );
+    assert_eq!(
+        edge_count(&pool, source, target, "supports").await,
+        1,
+        "re-asserting must not create a second edge row"
+    );
+    assert!(
+        second.belief_wired,
+        "backlog 8ef5cf61: a factorless edge must wake up and wire once its \
+         source later gains belief, even though was_created=false on this call"
+    );
+
+    let betp = read_betp(&pool, target)
+        .await
+        .expect("target must now have a computed pignistic_prob");
+    assert!(
+        betp > 0.5,
+        "the wake-up wire must raise the target's pignistic_prob above the \
+         0.5 neutral point, got {betp}"
+    );
+
+    // Exactly one edge-factor BBA row must exist for this edge — the wake-up
+    // must not be re-triggerable into duplicate rows on a further re-hit.
+    let bba_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mass_functions mf \
+         JOIN edges e ON e.id = mf.perspective_id \
+         WHERE e.source_id = $1 AND e.target_id = $2 AND e.relationship = 'supports'",
+    )
+    .bind(source)
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .expect("count edge-factor BBA rows");
+    assert_eq!(
+        bba_count, 1,
+        "exactly one edge-factor BBA must exist after the wake-up wire"
+    );
+
+    // ── Step 4: a THIRD re-hit must be a stable no-op (idempotent wake-up) ─
+    let pre_betp = read_betp(&pool, target).await.expect("betp present");
+    let third = parse_response(
+        &do_link_epistemic(
+            &server,
+            LinkEpistemicParams {
+                source_claim_id: source.to_string(),
+                target_claim_id: target.to_string(),
+                relationship: "supports".to_string(),
+                properties: None,
+            },
+        )
+        .await
+        .expect("third re-assert must succeed"),
+    );
+    assert!(!third.was_created);
+    assert!(
+        !third.belief_wired,
+        "once wired, further re-hits must not re-wire (BBA already exists for this edge)"
+    );
+    let post_betp = read_betp(&pool, target).await.expect("betp present");
+    assert!(
+        (post_betp - pre_betp).abs() < 1e-9,
+        "a third re-hit must not move belief again: before={pre_betp}, after={post_betp}"
+    );
+    let bba_count_after_third: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mass_functions mf \
+         JOIN edges e ON e.id = mf.perspective_id \
+         WHERE e.source_id = $1 AND e.target_id = $2 AND e.relationship = 'supports'",
+    )
+    .bind(source)
+    .bind(target)
+    .fetch_one(&pool)
+    .await
+    .expect("count edge-factor BBA rows after third hit");
+    assert_eq!(
+        bba_count_after_third, 1,
+        "no duplicate BBA row after a third re-hit on an already-wired edge"
     );
 }
 

--- a/docs/superpowers/plans/2026-07-09-backlog-resolution.md
+++ b/docs/superpowers/plans/2026-07-09-backlog-resolution.md
@@ -661,22 +661,27 @@ mcp__epigraph__resolve_backlog_item(
 
 **Files:** `crates/epigraph-engine/src/` (edge-factor wiring, `auto_wire_edge_if_epistemic`), `tests/link_epistemic_smoke.rs::factorless_source_writes_durable_edge_without_wiring` (this test currently **pins the inert state and must be flipped**).
 
-- [ ] **Step 1:** Read `auto_wire_edge_if_epistemic` and confirm it only fires on `was_created=true`.
-- [ ] **Step 2:** Implement option (a) from the claim's own analysis (lowest-risk): make
+- [x] **Step 1:** Read `auto_wire_edge_if_epistemic` and confirm it only fires on `was_created=true`.
+- [x] **Step 2:** Implement option (a) from the claim's own analysis (lowest-risk): make
 `link_epistemic`/`create_edge` re-wire when the edge already exists but has no edge-factor BBA yet
 (not gated on `was_created`) — i.e., check "does a BBA exist for this edge" rather than "was this
-edge just created."
-- [ ] **Step 3:** Flip the pinned regression test:
-
-```rust
-// was: asserts B's belief is unaffected after A later gains belief (pins inert state)
-// now: write A--supports-->B while A has no belief; give A a belief; re-invoke link_epistemic;
-// assert B's pignistic_prob rises.
-#[sqlx::test]
-async fn factorless_source_wakes_up_when_source_gains_belief(pool: PgPool) { /* ... */ }
-```
-
-- [ ] **Step 4:** Verify, commit, resolve.
+edge just created." Implemented via `MassFunctionRepository::exists_for_perspective` (new,
+`crates/epigraph-db/src/repos/mass_function.rs`) keyed on `perspective_id = edge_id`; the gate in
+`auto_wire_edge_if_epistemic` (`crates/epigraph-engine/src/edge_factor.rs`) now skips only when a
+BBA already exists, not on `!was_created`. Both call sites that previously short-circuited the
+whole wiring attempt on `if was_created` — `link_epistemic.rs` (MCP) and
+`trigger_edge_ds_recomputation` in `routes/edges.rs` (HTTP `create_edge`) — now call the engine
+unconditionally (threading the real `was_created` through) so a dedup-hit re-assertion can still
+wake up; provenance/event/factor-table side effects in the HTTP route stay gated on `was_created`
+as before (drainer-retry idempotency for those is unaffected).
+- [x] **Step 3:** Flip the pinned regression test — landed as
+`factorless_source_wakes_up_when_it_later_gains_belief` in
+`crates/epigraph-mcp/tests/link_epistemic_smoke.rs` (the pinning test
+`factorless_source_writes_durable_edge_without_wiring` stays as-is; it still correctly documents
+the first-write factorless no-op half of the lifecycle, cross-referenced in its own doc comment).
+- [ ] **Step 4:** Verify, commit, resolve. Verify/commit done in this PR; `resolve_backlog_item` is
+a live-graph write intentionally deferred to a human/operator action post-merge, not run from this
+branch.
 
 ```python
 mcp__epigraph__resolve_backlog_item(


### PR DESCRIPTION
## Summary

- Backlog claim `8ef5cf61-7382-43a4-85cb-565d76ba3f06` / plan Task 4.3: an epistemic edge (e.g. `A --supports--> B`) written while `A` is "factorless" (no belief interval) correctly stays unwired — but if `A` *later* gains a belief interval and the same edge is re-asserted via `link_epistemic` or `POST /api/v1/edges`, the wiring never fired. `was_created=false` on the re-hit, and the gate (both inside `auto_wire_edge_if_epistemic` and at two call sites) only fired `if was_created`, making the wake-up a permanent no-op.
- Fix: the gate is now "has a BBA ever been materialized for this edge_id" (checked via new `MassFunctionRepository::exists_for_perspective`, since edge-factor BBAs are keyed `perspective_id = edge_id`), not "was this edge just created". `link_epistemic.rs` (MCP) and `trigger_edge_ds_recomputation` in `routes/edges.rs` (HTTP `create_edge`) now call the engine unconditionally instead of short-circuiting on `if was_created`, threading the real flag through. HTTP-route provenance/factor-table/event side effects stay gated on `was_created` (unaffected drainer dedup-hit guarantee); only DS recomputation now also runs on a dedup hit, self-gated so an already-wired edge is a cheap no-op.
- Checked the other 3 `auto_wire_edge_if_epistemic` call sites (workflow_ingest.rs ×2, ds_auto batch path): all pass a hardcoded `true` because their upstream executor only emits just-inserted edges — no behavior change there.

## Test plan

- [x] RED confirmed pre-fix (source stashed, test present): `factorless_source_wakes_up_when_it_later_gains_belief` → 0 passed, 1 failed (`belief_wired` assertion)
- [x] GREEN post-fix: same test → 1 passed, 0 failed
- [x] Full `link_epistemic_smoke.rs` (8 tests, incl. the idempotency test and the factorless-pin test) → 8 passed, 0 failed
- [x] `cargo test -p epigraph-engine` → 353 unit + integration binaries, 0 failed
- [x] `cargo test -p epigraph-mcp` (full suite) → 0 failed
- [x] `cargo test -p epigraph-api --features db --lib` → 386 passed; targeted edge-touching integration suites → 39 passed, 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --locked -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)