### PR TITLE
fix(mcp): update_with_evidence now adds caller labels on its dedup-match write

### DIFF
--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -498,6 +498,19 @@ pub async fn update_with_evidence(
         .await
         .map_err(internal_error)?;
 
+    // Additive label merge on the dedup-match write, mirroring submit_claim's
+    // and memorize's dedup-hit behavior: labels union into the claim's
+    // existing array (ClaimRepository::update_labels dedupes via
+    // array_agg(DISTINCT ...)), never overwriting labels from the claim's
+    // original creation cycle. Fixes backlog f14592cb: run-tag labels (e.g.
+    // norcal-rfp-2026-07-05) were previously dropped on every call because
+    // UpdateWithEvidenceParams had no labels field at all.
+    if !params.labels.is_empty() {
+        ClaimRepository::update_labels(&server.pool, claim_id, &params.labels, &[])
+            .await
+            .map_err(internal_error)?;
+    }
+
     success_json(&UpdateResponse {
         claim_id: claim_id.to_string(),
         truth_before: before,

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -259,6 +259,15 @@ pub struct UpdateWithEvidenceParams {
 
     #[schemars(description = "Source URL or DOI for this evidence (optional)")]
     pub source_url: Option<String>,
+
+    #[schemars(
+        description = "Optional labels to add to the claim (e.g. current-cycle run tags like \
+                        'norcal-rfp-2026-07-05'). Additive: merged into the claim's existing \
+                        label array via ClaimRepository::update_labels, never overwrites \
+                        pre-existing labels — matches submit_claim/memorize's dedup-hit behavior."
+    )]
+    #[serde(default)]
+    pub labels: Vec<String>,
 }
 
 // ── Provenance ──

--- a/crates/epigraph-mcp/tests/cdst_cross_frame_betp_monotonic.rs
+++ b/crates/epigraph-mcp/tests/cdst_cross_frame_betp_monotonic.rs
@@ -145,6 +145,7 @@ async fn cross_frame_supporting_evidence_does_not_drop_betp() {
             source_url: None,
             supports: true,
             strength: 0.9,
+            labels: vec![],
         },
     )
     .await;

--- a/crates/epigraph-mcp/tests/cdst_initial_cache_monotonic.rs
+++ b/crates/epigraph-mcp/tests/cdst_initial_cache_monotonic.rs
@@ -66,6 +66,7 @@ async fn adding_supporting_evidence_does_not_drop_cached_betp(pool: sqlx::PgPool
             source_url: None,
             supports: true,
             strength: 0.8,
+            labels: vec![],
         },
     )
     .await;

--- a/crates/epigraph-mcp/tests/cdst_multi_evidence_monotonic.rs
+++ b/crates/epigraph-mcp/tests/cdst_multi_evidence_monotonic.rs
@@ -49,6 +49,7 @@ async fn add_evidence(
             source_url: None,
             supports,
             strength,
+            labels: vec![],
         },
     )
     .await;

--- a/crates/epigraph-mcp/tests/perspectival_canonical_ingest_proto.rs
+++ b/crates/epigraph-mcp/tests/perspectival_canonical_ingest_proto.rs
@@ -56,6 +56,7 @@ async fn add_evidence(
             source_url: None,
             supports,
             strength,
+            labels: vec![],
         },
     )
     .await

--- a/crates/epigraph-mcp/tests/update_with_evidence_labels_test.rs
+++ b/crates/epigraph-mcp/tests/update_with_evidence_labels_test.rs
@@ -1,0 +1,67 @@
+//! Regression for backlog claim f14592cb-17a7-4e33-a41d-fa1ddd57d3a1
+//! ("`update_with_evidence` dedup-match never updates labels").
+//!
+//! `update_with_evidence` is the write path an upstream pipeline (e.g. the
+//! norcal-rfp weekly reviewer) calls when it resolves a dedup match — the
+//! claim already exists from a prior cycle, so instead of `submit_claim`
+//! creating a duplicate, the caller re-asserts evidence against the
+//! existing `claim_id`. That re-assertion should also be able to carry the
+//! current cycle's label (e.g. a run-tag like `norcal-rfp-2026-07-05`) and
+//! have it added to the claim's label array — additive, alongside whatever
+//! labels the claim already carries from its original creation cycle.
+//!
+//! Before this fix, `UpdateWithEvidenceParams` had no `labels` field at
+//! all, so any run-tag the caller intended to attach was silently dropped:
+//! the claim retained only its original creation-time labels forever. That
+//! breaks the reviewer's `query_claims_by_label([RUN_TAG])` discovery step
+//! for claims that predate the current week but are still relevant.
+//!
+//! `submit_claim` and `memorize` already handle this correctly on their
+//! dedup-hit branch (see `claims.rs::submit_claim`, `memory.rs::memorize`):
+//! both call `ClaimRepository::update_labels(pool, claim_id, &labels, &[])`
+//! unconditionally when labels are non-empty, which is additive because
+//! `update_labels` unions the new labels into the existing array via
+//! `array_agg(DISTINCT ...)`. `update_with_evidence` was the odd one out.
+
+use sqlx::PgPool;
+mod common;
+use common::*;
+
+use epigraph_mcp::types::UpdateWithEvidenceParams;
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn update_with_evidence_adds_labels_without_dropping_existing(pool: PgPool) {
+    let claim_id =
+        seed_claim_with_labels(&pool, "norcal-rfp weekly claim", &["norcal-rfp-2026-06-29"]).await;
+    let server = build_test_server(pool.clone());
+
+    let result = epigraph_mcp::tools::claims::update_with_evidence(
+        &server,
+        UpdateWithEvidenceParams {
+            claim_id: claim_id.to_string(),
+            evidence_type: "empirical".into(),
+            evidence_data: "Re-confirmed in this week's norcal-rfp cycle.".into(),
+            source_url: None,
+            supports: true,
+            strength: 0.7,
+            labels: vec!["norcal-rfp-2026-07-05".into()],
+        },
+    )
+    .await;
+    assert!(result.is_ok(), "update_with_evidence failed: {result:?}");
+
+    let (labels,): (Vec<String>,) = sqlx::query_as("SELECT labels FROM claims WHERE id = $1")
+        .bind(claim_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert!(
+        labels.contains(&"norcal-rfp-2026-06-29".to_string()),
+        "original creation-cycle label must survive the dedup-match write; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"norcal-rfp-2026-07-05".to_string()),
+        "current-cycle run-tag label must be added on the dedup-match write; got {labels:?}"
+    );
+}

--- a/crates/epigraph-mcp/tests/update_with_evidence_plausibility_one.rs
+++ b/crates/epigraph-mcp/tests/update_with_evidence_plausibility_one.rs
@@ -37,6 +37,7 @@ async fn update_with_evidence_does_not_violate_plausibility_bounds_at_one(pool: 
             source_url: None,
             supports: true,
             strength: 0.8,
+            labels: vec![],
         },
     )
     .await;

--- a/crates/epigraph-mcp/tests/update_with_evidence_supporting_warning.rs
+++ b/crates/epigraph-mcp/tests/update_with_evidence_supporting_warning.rs
@@ -32,6 +32,7 @@ async fn run_update(
             source_url: None,
             supports,
             strength,
+            labels: Vec::new(),
         },
     )
     .await

--- a/docs/superpowers/plans/2026-07-09-backlog-resolution.md
+++ b/docs/superpowers/plans/2026-07-09-backlog-resolution.md
@@ -468,21 +468,51 @@ mcp__epigraph__resolve_backlog_item(
 
 **Files:** `crates/epigraph-db/src/repos/claim.rs` (`update_with_evidence` dedup-match path).
 
-- [ ] **Step 1: Locate**
+> **Stale pointer, confirmed during implementation:** there is no `update_with_evidence`
+> function in `epigraph-db`. The real (and only) implementation is
+> `crates/epigraph-mcp/src/tools/claims.rs::update_with_evidence`, backed by
+> `UpdateWithEvidenceParams` in `crates/epigraph-mcp/src/types.rs`. `update_with_evidence`
+> takes an already-resolved `claim_id` (there is no in-repo similarity/hash lookup inside
+> the function itself) — it *is* the dedup-match write: the caller (the norcal-rfp
+> orchestrator, external to this repo) resolves the dedup match upstream and calls this
+> tool instead of `submit_claim` to re-assert evidence against the existing claim. The gap
+> was structural: `UpdateWithEvidenceParams` had no `labels` field at all, so no label could
+> ever reach this path. `submit_claim` and `memorize` already handle the analogous
+> dedup-hit case correctly (both call `ClaimRepository::update_labels` unconditionally when
+> labels are non-empty); `update_with_evidence` was the odd one out. Fixed at the MCP tool
+> layer; `ClaimRepository::update_labels` (db layer) needed no changes — its
+> `array_agg(DISTINCT ...)` union is already the additive primitive the fix reuses.
+
+- [x] **Step 1: Locate**
 
 ```bash
 rg -n "fn update_with_evidence" crates/epigraph-db/src/repos/claim.rs
 ```
 
-- [ ] **Step 2: Write the failing test** — call `update_with_evidence` against an existing claim
+(Returned nothing — see stale-pointer note above. Located instead via
+`rg -n "fn update_with_evidence" crates/ --type rust`, which resolved to
+`crates/epigraph-mcp/src/tools/claims.rs`.)
+
+- [x] **Step 2: Write the failing test** — call `update_with_evidence` against an existing claim
 that already carries label `norcal-rfp-2026-06-29`; pass a new `run_tag` label
 `norcal-rfp-2026-07-05`. Assert the claim's labels afterward include **both** the original and the
 new run tag (additive, not replacing).
 
-- [ ] **Step 3: Fix** — add the caller-supplied current-cycle label(s) to the claim's label array on
+(`crates/epigraph-mcp/tests/update_with_evidence_labels_test.rs`. RED before the fix:
+`current-cycle run-tag label must be added on the dedup-match write; got
+["norcal-rfp-2026-06-29"]` — the original label alone, proving the seed worked and the new
+label was silently dropped.)
+
+- [x] **Step 3: Fix** — add the caller-supplied current-cycle label(s) to the claim's label array on
 every dedup-match write, alongside the existing evidence/truth update. Use array-append
 (`labels = array_cat(labels, $new_labels)` with dedup via `array(select distinct unnest(...))` or
 equivalent) — do not overwrite the array.
+
+(Added `labels: Vec<String>` with `#[serde(default)]` to `UpdateWithEvidenceParams`, then in
+`update_with_evidence` call `ClaimRepository::update_labels(&server.pool, claim_id,
+&params.labels, &[])` when non-empty — reusing the existing `array_agg(DISTINCT ...)`
+union primitive, no new SQL needed. Mirrors `submit_claim`'s and `memorize`'s dedup-hit
+label handling in the same file.)
 
 - [ ] **Step 4: Also standardize the `bucket-k12`/`bucket-a` naming mismatch** flagged in the same
 claim — grep the norcal-rfp orchestrator prompt/workflow definition for the literal string
@@ -490,7 +520,13 @@ claim — grep the norcal-rfp orchestrator prompt/workflow definition for the li
 `bucket-k12`); this is a workflow-definition edit via `evolve_step`, not a code change — do it as
 part of Part 10, Task 10.7 (norcal-rfp source refresh), not here.
 
+(Out of scope for this task per the plan's own instruction — left for Part 10 Task 10.7.)
+
 - [ ] **Step 5: Verify, commit, resolve**
+
+(Verify + commit done on branch `fix/update-with-evidence-dedup-labels`. The
+`resolve_backlog_item` graph write is intentionally NOT executed from this branch — it's a
+live EpiGraph mutation meant to run post-merge, once the fix is actually on `main`.)
 
 ```python
 mcp__epigraph__resolve_backlog_item(


### PR DESCRIPTION
## Summary

- `update_with_evidence` — the tool an upstream pipeline (e.g. the norcal-rfp weekly reviewer) calls when it resolves a dedup match and re-asserts evidence against an already-existing claim instead of `submit_claim`-ing a duplicate — had no `labels` field at all on `UpdateWithEvidenceParams`. Any current-cycle run-tag the caller intended to attach (e.g. `norcal-rfp-2026-07-05`) was silently dropped; the claim retained only its original creation-time labels forever, breaking the reviewer's label-based discovery protocol every week.
- Fixes backlog claim `f14592cb-17a7-4e33-a41d-fa1ddd57d3a1` (Task 3.4 of `docs/superpowers/plans/2026-07-09-backlog-resolution.md`).
- **Note on the plan's file pointer:** the plan says the fix lives in `crates/epigraph-db/src/repos/claim.rs`. That's stale — there is no `update_with_evidence` function anywhere in `epigraph-db`. The only implementation is the MCP tool layer, `crates/epigraph-mcp/src/tools/claims.rs::update_with_evidence`. I read every call site (all in-repo callers are the 5 sibling test files) and confirmed none of them perform their own dedup/similarity lookup — `update_with_evidence` itself, which takes an already-resolved `claim_id`, *is* the dedup-match write the claim is describing. `submit_claim` and `memorize` in the same file already handle the analogous case correctly (both call `ClaimRepository::update_labels` unconditionally when labels are non-empty); `update_with_evidence` was the one claim-mutating tool missing it.

## Changes

- `crates/epigraph-mcp/src/types.rs`: add `labels: Vec<String>` to `UpdateWithEvidenceParams`, `#[serde(default)]` so existing callers omitting it keep deserializing.
- `crates/epigraph-mcp/src/tools/claims.rs`: `update_with_evidence` now calls `ClaimRepository::update_labels(pool, claim_id, &params.labels, &[])` when non-empty — reuses the existing `array_agg(DISTINCT ...)` additive-union primitive (no new SQL), mirroring `submit_claim`/`memorize`.
- 5 pre-existing test files updated with `labels: vec![]` on their `UpdateWithEvidenceParams` literals (compile-only change, no behavior change): `update_with_evidence_plausibility_one.rs`, `cdst_cross_frame_betp_monotonic.rs`, `cdst_initial_cache_monotonic.rs`, `cdst_multi_evidence_monotonic.rs`, `perspectival_canonical_ingest_proto.rs`.
- New test: `crates/epigraph-mcp/tests/update_with_evidence_labels_test.rs`.
- `docs/superpowers/plans/2026-07-09-backlog-resolution.md`: Task 3.4 checkboxes updated (Steps 1-3 and 5 done, with inline notes correcting the stale file pointer; Step 4's bucket-k12/bucket-a naming fix explicitly left for Part 10 Task 10.7 per the plan's own scoping; the live `resolve_backlog_item` graph write deferred to post-merge).

## RED → GREEN

RED (before the fix):
```
test update_with_evidence_adds_labels_without_dropping_existing ... FAILED
thread ... panicked: current-cycle run-tag label must be added on the dedup-match write; got ["norcal-rfp-2026-06-29"]
```
(original label survived, proving the seed worked; the new label was silently dropped — the exact bug)

GREEN (after the fix):
```
test update_with_evidence_adds_labels_without_dropping_existing ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --locked -- -D warnings` — clean (matches CI's exact invocation; a pre-existing `-D dead-code` clippy failure exists in `epigraph-tools/examples/table_graph` only when `--tests` is added, which CI does not do — confirmed unrelated to this change and pre-existing on an untouched tree)
- [x] `SQLX_OFFLINE=true cargo check --workspace --all-targets` — clean, no `.sqlx/` diff (no new `query!`/`query_as!` macros)
- [x] `cargo test -p epigraph-db` — full suite green, 0 failed
- [x] `cargo test -p epigraph-mcp` — every test binary green except `theme_cluster_test.rs::theme_cluster_caps_oversized_limit`, which hangs past a 60s timeout **both with and without this change** (confirmed via `git stash` against unmodified `origin/main`); it uses a shared, non-ephemeral `DATABASE_URL` pool (`test_pool_or_skip!`) instead of `#[sqlx::test]`'s isolated per-test DB and is environmentally slow on this machine's accumulated `epigraph_db_repo_test` state — unrelated to this change. Every label/`update_with_evidence`-relevant binary was explicitly re-run and passed: `update_with_evidence_labels_test`, `update_with_evidence_plausibility_one`, `update_labels_test`, `submit_claim_labels_test`, `memorize_persists_labels`, the 3 `cdst_*_monotonic` tests, `perspectival_canonical_ingest_proto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)