### PR TITLE
feat(mcp): add graph-expanded epistemic recall to recall_with_context

### DIFF
--- a/.sqlx/query-7c272659bb2656f97ca93c6a85b9b8f60f5973b294d4edcce9b7c1f2ce86897b.json
+++ b/.sqlx/query-7c272659bb2656f97ca93c6a85b9b8f60f5973b294d4edcce9b7c1f2ce86897b.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT target_id, COUNT(*) AS \"degree!\"\n            FROM edges\n            WHERE target_id = ANY($1)\n              AND source_type = 'claim' AND target_type = 'claim'\n              AND relationship = ANY($2)\n            GROUP BY target_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "target_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "degree!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "7c272659bb2656f97ca93c6a85b9b8f60f5973b294d4edcce9b7c1f2ce86897b"
+}

--- a/crates/epigraph-db/src/lib.rs
+++ b/crates/epigraph-db/src/lib.rs
@@ -73,20 +73,20 @@ pub use repos::{
     EvidenceEncryptionRepository, EvidenceEncryptionRow, EvidenceRepository, EvidenceSearchResult,
     EvolveStepResult, ExperimentRepository, ExperimentResultRepository, ExperimentResultRow,
     ExperimentRow, FactorRepository, FrameRepository, GapAnalysisResult, GapChallengeRow,
-    GapRecord, GapRepository, GroupKeyEpochRepository, GroupMembershipRepository, GroupRepository,
-    GroupRow, HierarchicalWorkflowRow, HybridHit, IndexCounts, KeyEpochRow,
-    LearningEventRepository, LearningEventRow, LineageHead, LineageRepository,
-    MassFunctionRepository, MatchCandidateRepo, MatchCandidateRow, MembershipRow, MentionRow,
-    MethodCapability, MethodEvidenceStrength, MethodFailureModes, MethodForCapability,
-    MethodRecord, MethodRepository, MethodSearchResult, MethodSourcePaper, MethodUsageExample,
-    OAuthClientRepository, OAuthClientRow, OwnershipRepository, PaperRepository, PaperRow,
-    PatchClaimDiff, PatchClaimInput, PatternTemplateRepository, PatternTemplateRow,
-    PerspectiveRepository, ProvenanceLogRow, ProvenanceRepository, ReEncryptionKeyRepository,
-    ReEncryptionKeyRow, ReasoningTraceRepository, RefreshTokenRepository, RefreshTokenRow,
-    ResolvedStep, ScopedBeliefRepository, SecurityEventRepository, SecurityEventRow,
-    SheafRepository, TaskRepository, TaskRow, TripleRepository, TripleRow,
-    WorkflowExecutionRepository, WorkflowExecutionRow, WorkflowListRow, WorkflowRecallResult,
-    WorkflowRepository,
+    GapRecord, GapRepository, GraphExpansionHit, GroupKeyEpochRepository,
+    GroupMembershipRepository, GroupRepository, GroupRow, HierarchicalWorkflowRow, HybridHit,
+    IndexCounts, KeyEpochRow, LearningEventRepository, LearningEventRow, LineageHead,
+    LineageRepository, MassFunctionRepository, MatchCandidateRepo, MatchCandidateRow,
+    MembershipRow, MentionRow, MethodCapability, MethodEvidenceStrength, MethodFailureModes,
+    MethodForCapability, MethodRecord, MethodRepository, MethodSearchResult, MethodSourcePaper,
+    MethodUsageExample, OAuthClientRepository, OAuthClientRow, OwnershipRepository,
+    PaperRepository, PaperRow, PatchClaimDiff, PatchClaimInput, PatternTemplateRepository,
+    PatternTemplateRow, PerspectiveRepository, ProvenanceLogRow, ProvenanceRepository,
+    ReEncryptionKeyRepository, ReEncryptionKeyRow, ReasoningTraceRepository,
+    RefreshTokenRepository, RefreshTokenRow, ResolvedStep, ScopedBeliefRepository,
+    SecurityEventRepository, SecurityEventRow, SheafRepository, TaskRepository, TaskRow,
+    TripleRepository, TripleRow, WorkflowExecutionRepository, WorkflowExecutionRow,
+    WorkflowListRow, WorkflowRecallResult, WorkflowRepository, EXPANSION_RELATIONSHIPS,
 };
 
 // Re-export sqlx types that users will need
@@ -97,7 +97,7 @@ pub use repos::activity::ActivityRow;
 pub use repos::community::{CommunityMemberRow, CommunityRow};
 pub use repos::context::ContextRow;
 pub use repos::divergence::DivergenceRow;
-pub use repos::edge::{AttributedClaimRow, EdgeRow};
+pub use repos::edge::{AttributedClaimRow, EdgeRow, EPISTEMIC_RELATIONSHIPS};
 pub use repos::factor::{BpMessageRow, FactorRow};
 pub use repos::frame::{ClaimFrameRow, FrameRow};
 pub use repos::mass_function::MassFunctionRow;

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -2893,6 +2893,131 @@ impl ClaimRepository {
     }
 }
 
+// ── Graph-expanded recall (Task 6.1 / claim 29e789fd) ──
+
+/// Epistemic relationship types followed by [`ClaimRepository::graph_expand_seeds`].
+///
+/// Matches the traversal set named in claim 29e789fd's design sketch
+/// (supports/corroborates/elaborates) — the "argument-chain" subset of
+/// `link_epistemic`'s full `EPISTEMIC_RELATIONSHIPS` allowlist. `contradicts`/
+/// `refutes`/`generalizes`/`specializes` are intentionally excluded: expansion
+/// is meant to pull in claims that reinforce a seed's argument, not claims
+/// that merely relate to it in some other epistemic sense.
+pub const EXPANSION_RELATIONSHIPS: &[&str] = &["supports", "corroborates", "elaborates"];
+
+/// One claim reached by [`ClaimRepository::graph_expand_seeds`], with the hop
+/// count at which it was first discovered (BFS order, so this is the shortest
+/// path length from any seed).
+#[derive(Debug, Clone, Copy, sqlx::FromRow)]
+pub struct GraphExpansionHit {
+    pub claim_id: Uuid,
+    pub hops: i32,
+}
+
+impl ClaimRepository {
+    /// Bounded multi-hop BFS from a set of seed claims, following outgoing
+    /// edges whose relationship is in [`EXPANSION_RELATIONSHIPS`].
+    ///
+    /// Mirrors what the `traverse` MCP tool does internally (BFS over
+    /// `EdgeRepository::get_by_source`, filtering relationship in Rust) rather
+    /// than round-tripping through the MCP tool layer — `traverse` only
+    /// supports a single relationship string and returns a serialized
+    /// `CallToolResult`, neither of which fit a per-seed multi-relationship
+    /// expansion called from inside `recall_with_context`.
+    ///
+    /// Seed IDs themselves are never included in the result (callers already
+    /// have them as ANN hits); a claim reachable from more than one seed, or
+    /// at more than one hop count, is returned once at its shortest hop
+    /// count. `max_depth` is clamped to `[1, 4]` to match `traverse`'s bound
+    /// and keep the fan-out bounded on dense graphs.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if any underlying edge query fails.
+    #[instrument(skip(pool, seed_ids))]
+    pub async fn graph_expand_seeds(
+        pool: &PgPool,
+        seed_ids: &[Uuid],
+        max_depth: u32,
+    ) -> Result<Vec<GraphExpansionHit>, DbError> {
+        let max_depth = max_depth.clamp(1, 4) as i32;
+        let seeds: std::collections::HashSet<Uuid> = seed_ids.iter().copied().collect();
+
+        let mut visited: std::collections::HashSet<Uuid> = seeds.clone();
+        let mut discovered_at: std::collections::HashMap<Uuid, i32> =
+            std::collections::HashMap::new();
+        let mut frontier: Vec<Uuid> = seed_ids.to_vec();
+        let mut depth = 0;
+
+        while depth < max_depth && !frontier.is_empty() {
+            depth += 1;
+            let mut next_frontier = Vec::new();
+            for &node in &frontier {
+                let outgoing =
+                    crate::repos::edge::EdgeRepository::get_by_source(pool, node, "claim").await?;
+                for e in outgoing {
+                    if !EXPANSION_RELATIONSHIPS.contains(&e.relationship.as_str()) {
+                        continue;
+                    }
+                    if visited.insert(e.target_id) {
+                        discovered_at.insert(e.target_id, depth);
+                        next_frontier.push(e.target_id);
+                    }
+                }
+            }
+            frontier = next_frontier;
+        }
+
+        Ok(discovered_at
+            .into_iter()
+            .map(|(claim_id, hops)| GraphExpansionHit { claim_id, hops })
+            .collect())
+    }
+
+    /// In-degree of epistemic-relationship edges (the full `link_epistemic`
+    /// allowlist: supports/corroborates/elaborates/generalizes/specializes/
+    /// contradicts/refutes) targeting each of `claim_ids`, batched in one
+    /// round-trip. Claims with no such incoming edges are simply absent from
+    /// the returned map (degree 0) rather than present with a zero — callers
+    /// should treat a missing key as 0.
+    ///
+    /// One `GROUP BY` query for the whole batch, not one query per claim: the
+    /// N+1 shape would be the naive approach given `recall_with_context`
+    /// calls this once per page over its (already small, ≤200) candidate
+    /// pool, not once per claim.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the query fails.
+    #[instrument(skip(pool, claim_ids))]
+    pub async fn in_epistemic_degree_batch(
+        pool: &PgPool,
+        claim_ids: &[Uuid],
+    ) -> Result<std::collections::HashMap<Uuid, i64>, DbError> {
+        if claim_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let relationships: Vec<String> = crate::repos::edge::EPISTEMIC_RELATIONSHIPS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let rows = sqlx::query!(
+            r#"
+            SELECT target_id, COUNT(*) AS "degree!"
+            FROM edges
+            WHERE target_id = ANY($1)
+              AND source_type = 'claim' AND target_type = 'claim'
+              AND relationship = ANY($2)
+            GROUP BY target_id
+            "#,
+            claim_ids,
+            &relationships[..],
+        )
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows.into_iter().map(|r| (r.target_id, r.degree)).collect())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -2915,6 +2915,17 @@ pub struct GraphExpansionHit {
 }
 
 impl ClaimRepository {
+    /// Hard cap on the number of distinct claims [`Self::graph_expand_seeds`]
+    /// will discover, mirroring the `traverse` MCP tool's `node_limit`
+    /// (`.clamp(1, 100)`, default 50). Depth-clamping alone does NOT bound
+    /// the work: supports/corroborates/elaborates fan-out over up to 4 hops
+    /// on a dense graph can reach thousands of claims, each costing one
+    /// sequential `EdgeRepository::get_by_source` round-trip inside a
+    /// synchronous `recall_with_context` call. The caller's final
+    /// `raw_hits.truncate(want)` bounds the OUTPUT size, not the work done
+    /// to produce it — this cap bounds the work itself.
+    const MAX_EXPANSION_NODES: usize = 200;
+
     /// Bounded multi-hop BFS from a set of seed claims, following outgoing
     /// edges whose relationship is in [`EXPANSION_RELATIONSHIPS`].
     ///
@@ -2928,8 +2939,12 @@ impl ClaimRepository {
     /// Seed IDs themselves are never included in the result (callers already
     /// have them as ANN hits); a claim reachable from more than one seed, or
     /// at more than one hop count, is returned once at its shortest hop
-    /// count. `max_depth` is clamped to `[1, 4]` to match `traverse`'s bound
-    /// and keep the fan-out bounded on dense graphs.
+    /// count. `max_depth` is clamped to `[1, 4]` to match `traverse`'s depth
+    /// bound; the number of DISTINCT claims discovered is separately capped
+    /// at [`Self::MAX_EXPANSION_NODES`] (mirroring `traverse`'s `node_limit`)
+    /// so a dense graph can't turn one `recall_with_context` call into an
+    /// unbounded sequential BFS. When the cap is hit mid-frontier the BFS
+    /// stops immediately — same tradeoff `traverse` makes.
     ///
     /// # Errors
     /// Returns `DbError::QueryFailed` if any underlying edge query fails.
@@ -2948,7 +2963,7 @@ impl ClaimRepository {
         let mut frontier: Vec<Uuid> = seed_ids.to_vec();
         let mut depth = 0;
 
-        while depth < max_depth && !frontier.is_empty() {
+        'bfs: while depth < max_depth && !frontier.is_empty() {
             depth += 1;
             let mut next_frontier = Vec::new();
             for &node in &frontier {
@@ -2961,6 +2976,9 @@ impl ClaimRepository {
                     if visited.insert(e.target_id) {
                         discovered_at.insert(e.target_id, depth);
                         next_frontier.push(e.target_id);
+                        if discovered_at.len() >= Self::MAX_EXPANSION_NODES {
+                            break 'bfs;
+                        }
                     }
                 }
             }

--- a/crates/epigraph-db/src/repos/edge.rs
+++ b/crates/epigraph-db/src/repos/edge.rs
@@ -6,6 +6,26 @@ use sqlx::PgPool;
 use tracing::instrument;
 use uuid::Uuid;
 
+/// Canonical epistemic relationship types — claim-to-claim edges that carry
+/// evidentiary weight and participate in belief propagation / sheaf
+/// consistency. Mirrors `EPISTEMIC_RELATIONSHIPS` in
+/// `epigraph-mcp::tools::link_epistemic` (the edge-writer's allowlist);
+/// `supersedes` is intentionally excluded there and here — it has dedicated
+/// semantics in `supersede_claim`, not `link_epistemic`.
+///
+/// Kept here (the lower `epigraph-db` layer) so DB-layer batch queries like
+/// [`crate::repos::claim::ClaimRepository::in_epistemic_degree_batch`] don't
+/// need to depend upward on `epigraph-mcp` for the list.
+pub const EPISTEMIC_RELATIONSHIPS: &[&str] = &[
+    "supports",
+    "corroborates",
+    "elaborates",
+    "generalizes",
+    "specializes",
+    "contradicts",
+    "refutes",
+];
+
 /// A row from the edges table
 #[derive(Debug, Clone)]
 pub struct EdgeRow {

--- a/crates/epigraph-db/src/repos/mod.rs
+++ b/crates/epigraph-db/src/repos/mod.rs
@@ -66,7 +66,8 @@ pub use analysis::{AnalysisRecord, AnalysisRepository, ClaimSummary};
 pub use challenge::{ChallengeRepository, ChallengeRow, GapChallengeRow};
 pub use claim::{
     ClaimBeliefColumns, ClaimEmbeddingHit, ClaimPairDistance, ClaimRepository, EvolveStepResult,
-    HybridHit, LineageHead, PatchClaimDiff, PatchClaimInput,
+    GraphExpansionHit, HybridHit, LineageHead, PatchClaimDiff, PatchClaimInput,
+    EXPANSION_RELATIONSHIPS,
 };
 pub use claim_theme::{
     centroid_columns_for_dim, BoundaryClaimRow, ClaimThemeRepository, ClaimThemeRow,

--- a/crates/epigraph-mcp/src/tools/recall.rs
+++ b/crates/epigraph-mcp/src/tools/recall.rs
@@ -330,12 +330,17 @@ const GRAPH_EXPANSION_DEGREE_WEIGHT: f64 = 0.1;
 ///    a serialized `CallToolResult`).
 /// 2. Dedup: a claim already in `seeds` is never added a second time as an
 ///    expansion hit, even if graph-reachable from another seed.
-/// 3. Assign each expanded claim a base "similarity" of the CLOSEST seed
-///    that reaches it, decayed by hop count (`seed_similarity * 0.7^hops`)
-///    — expanded claims have no ANN score of their own, and this keeps them
-///    rankable alongside direct hits while ranking closer/stronger-seeded
-///    expansions above farther/weaker-seeded ones. When a claim is reachable
-///    from multiple seeds, the seed yielding the HIGHEST decayed score wins.
+/// 3. Assign each expanded claim a base "similarity" derived from the
+///    HIGHEST-similarity seed in the whole seed set, decayed by the hop
+///    count at which BFS first reached the claim
+///    (`best_seed_similarity * 0.7^hops`) — expanded claims have no ANN
+///    score of their own, and this keeps them rankable alongside direct
+///    hits while ranking closer expansions above farther ones. This is a
+///    conservative approximation, not a true per-path "closest reaching
+///    seed" score: `graph_expand_seeds`' BFS reports hop count from the
+///    frontier as a whole, not which specific seed a given path originated
+///    from, so the single highest seed similarity is used as an upper bound
+///    for every expanded claim rather than tracking per-seed provenance.
 /// 4. Rerank the combined (seed ∪ expansion) set by
 ///    `similarity * (1 + 0.1 * in_epistemic_degree)`, where
 ///    `in_epistemic_degree` is the claim's in-degree over the full

--- a/crates/epigraph-mcp/src/tools/recall.rs
+++ b/crates/epigraph-mcp/src/tools/recall.rs
@@ -120,6 +120,17 @@ pub struct RecallWithContextParams {
     /// with `frame_id`. The perspective's source/locality reliability re-weights
     /// each hit's BBAs on-read.
     pub perspective_id: Option<String>,
+    /// When set, after the normal ANN seed retrieval, follow outgoing
+    /// supports/corroborates/elaborates edges up to this many hops from each
+    /// ANN seed and fold the reached claims into the candidate pool (deduped
+    /// against the seeds), reranked by
+    /// `similarity * (1 + 0.1 * in_epistemic_degree)` before the usual
+    /// `min_truth`/context-enrichment pipeline runs. `None` (the default)
+    /// preserves today's flat-ANN-only behaviour byte-for-byte. Clamped to
+    /// `[1, 4]` to match the `traverse` MCP tool's depth bound. Composes with
+    /// `diverse`/`rerank` — expansion runs on whichever seed pool those
+    /// stages already produced.
+    pub graph_expansion_depth: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -302,6 +313,105 @@ pub async fn recall_with_context(
     .await
 }
 
+/// Weight applied to `in_epistemic_degree` in the graph-expansion rerank
+/// formula: `similarity * (1 + GRAPH_EXPANSION_DEGREE_WEIGHT * in_degree)`.
+/// Matches the coefficient named in claim 29e789fd's design sketch.
+const GRAPH_EXPANSION_DEGREE_WEIGHT: f64 = 0.1;
+
+/// Stage 4 of [`recall_with_context_post_embed`]: fold graph-reachable
+/// claims into the ANN seed pool and rerank the combined set.
+///
+/// 1. BFS up to `depth` hops (clamped `[1,4]`) from every seed in `seeds`,
+///    following outgoing supports/corroborates/elaborates edges
+///    ([`epigraph_db::EXPANSION_RELATIONSHIPS`]) — the same edge-walk
+///    `traverse` does internally, reproduced directly against
+///    `ClaimRepository`/`EdgeRepository` rather than round-tripping the MCP
+///    tool layer (which only takes a single relationship string and returns
+///    a serialized `CallToolResult`).
+/// 2. Dedup: a claim already in `seeds` is never added a second time as an
+///    expansion hit, even if graph-reachable from another seed.
+/// 3. Assign each expanded claim a base "similarity" of the CLOSEST seed
+///    that reaches it, decayed by hop count (`seed_similarity * 0.7^hops`)
+///    — expanded claims have no ANN score of their own, and this keeps them
+///    rankable alongside direct hits while ranking closer/stronger-seeded
+///    expansions above farther/weaker-seeded ones. When a claim is reachable
+///    from multiple seeds, the seed yielding the HIGHEST decayed score wins.
+/// 4. Rerank the combined (seed ∪ expansion) set by
+///    `similarity * (1 + 0.1 * in_epistemic_degree)`, where
+///    `in_epistemic_degree` is the claim's in-degree over the full
+///    `link_epistemic` allowlist ([`epigraph_db::EPISTEMIC_RELATIONSHIPS`] —
+///    all 7 types, not just the 3 traversal types: a claim's authority is a
+///    function of everyone who has weighed in on it, including
+///    `contradicts`/`refutes`, not only the reinforcing subset), computed in
+///    one batched `GROUP BY` query
+///    ([`epigraph_db::ClaimRepository::in_epistemic_degree_batch`]) — not
+///    one query per claim.
+async fn apply_graph_expansion(
+    pool: &sqlx::PgPool,
+    seeds: Vec<epigraph_db::ClaimEmbeddingHit>,
+    depth: u32,
+) -> Result<Vec<epigraph_db::ClaimEmbeddingHit>, McpError> {
+    let seed_ids: Vec<Uuid> = seeds.iter().map(|h| h.claim_id).collect();
+    let seed_similarity: std::collections::HashMap<Uuid, f64> =
+        seeds.iter().map(|h| (h.claim_id, h.similarity)).collect();
+
+    let expansion = epigraph_db::ClaimRepository::graph_expand_seeds(pool, &seed_ids, depth)
+        .await
+        .map_err(|e| internal_error(format!("graph expansion traverse: {e}")))?;
+
+    // Best (highest) decayed score per expanded claim, in case it's
+    // reachable from more than one seed at different hop counts / seed
+    // similarities. graph_expand_seeds already dedupes to each claim's
+    // SHORTEST hop count overall, but that shortest path may not originate
+    // from the highest-similarity seed, so we still need a max-fold here
+    // rather than trusting hop count alone as the tiebreak.
+    const HOP_DECAY: f64 = 0.7;
+    let mut expanded_similarity: std::collections::HashMap<Uuid, f64> =
+        std::collections::HashMap::new();
+    for hit in &expansion {
+        // graph_expand_seeds reports hops from the frontier as a whole, not
+        // per-originating-seed, so approximate the base with the highest
+        // seed similarity available — a conservative upper bound that still
+        // makes expanded claims rank below their strongest supporting seed
+        // once hop decay is applied.
+        let best_seed_similarity = seed_similarity.values().cloned().fold(0.0_f64, f64::max);
+        let score = best_seed_similarity * HOP_DECAY.powi(hit.hops);
+        expanded_similarity
+            .entry(hit.claim_id)
+            .and_modify(|s| *s = s.max(score))
+            .or_insert(score);
+    }
+
+    let mut combined = seeds;
+    for (claim_id, similarity) in expanded_similarity {
+        combined.push(epigraph_db::ClaimEmbeddingHit {
+            claim_id,
+            similarity,
+        });
+    }
+
+    if combined.is_empty() {
+        return Ok(combined);
+    }
+
+    let all_ids: Vec<Uuid> = combined.iter().map(|h| h.claim_id).collect();
+    let degree = epigraph_db::ClaimRepository::in_epistemic_degree_batch(pool, &all_ids)
+        .await
+        .map_err(|e| internal_error(format!("in_epistemic_degree_batch: {e}")))?;
+
+    combined.sort_by(|a, b| {
+        let score = |h: &epigraph_db::ClaimEmbeddingHit| {
+            let d = degree.get(&h.claim_id).copied().unwrap_or(0) as f64;
+            h.similarity * (1.0 + GRAPH_EXPANSION_DEGREE_WEIGHT * d)
+        };
+        score(b)
+            .partial_cmp(&score(a))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(combined)
+}
+
 /// Post-embedding pipeline: shared by `recall_with_context` and the
 /// `__test_only::recall_with_context_with_pgvec` entry point that lets
 /// integration tests skip the OpenAI embedder (no API key available in
@@ -429,6 +539,22 @@ async fn recall_with_context_post_embed(
             corpus_scope,
             centroid_dim_used: centroid_dim,
         });
+    }
+
+    // Stage 4: graph expansion (Task 6.1 / claim 29e789fd). Default-off —
+    // `None` reproduces today's flat-ANN-only `raw_hits` exactly. When set,
+    // follow outgoing supports/corroborates/elaborates edges up to
+    // `graph_expansion_depth` hops from each ANN seed, fold the reached
+    // claims into the pool (deduped against the seeds — a claim that's both
+    // an ANN seed and graph-reachable is not double-counted), and rerank the
+    // combined set by `similarity * (1 + 0.1 * in_epistemic_degree)`.
+    //
+    // Runs BEFORE the optional cross-encoder rerank stage so `rerank=true`
+    // (when both are set) re-ranks the graph-expanded pool, not just the raw
+    // ANN seeds — matching "expand seeds, then rank" rather than "rank seeds,
+    // then expand the winners".
+    if let Some(depth) = params.graph_expansion_depth {
+        raw_hits = apply_graph_expansion(&server.pool, raw_hits, depth).await?;
     }
 
     // Stage 4.5: cross-encoder rerank + optional groundedness gate over the

--- a/crates/epigraph-mcp/tests/perspective_lens_reads.rs
+++ b/crates/epigraph-mcp/tests/perspective_lens_reads.rs
@@ -262,6 +262,7 @@ fn rwc_params(
         groundedness_gate: None,
         frame_id: frame_id.map(|f| f.to_string()),
         perspective_id: perspective_id.map(|p| p.to_string()),
+        graph_expansion_depth: None,
     }
 }
 

--- a/crates/epigraph-mcp/tests/recall_graph_expansion.rs
+++ b/crates/epigraph-mcp/tests/recall_graph_expansion.rs
@@ -1,0 +1,399 @@
+//! Regression test for Task 6.1 (claim `29e789fd-92fb-497f-b9bf-5dff1d96408b`):
+//! `recall_with_context`'s optional `graph_expansion_depth` param.
+//!
+//! Bypasses the MCP wrapper's OpenAI embedder the same way
+//! `recall_with_context.rs` does — via `__test_only::recall_with_context_with_pgvec`,
+//! which lets the test pre-format a known pgvector literal and dispatch
+//! directly into the post-embed pipeline (the same code path
+//! `recall_with_context` runs after `embedder.generate_at_dim`).
+//!
+//! ## Fixture shape
+//!
+//! - Paragraph A: ANN seed. Embedded in the SAME cluster bucket as the query
+//!   (cosine-similar), so flat ANN surfaces it directly.
+//! - Paragraph MID: a level=2 paragraph reachable from A via a `supports`
+//!   edge (1 hop). Embedded ORTHOGONAL to the query (a different bucket) so
+//!   it is not itself an ANN hit — present purely to make the reachability
+//!   to B genuinely 2-hop, not 1-hop-that-happens-to-also-look-2-hop.
+//! - Paragraph B: reachable from MID via a second `supports` edge (2 hops
+//!   from A). Embedded ORTHOGONAL to the query in a DIFFERENT bucket than
+//!   MID, so B is not ANN-close to the query either — the only way B can
+//!   surface in `recall_with_context`'s results is the graph-expansion path.
+//!
+//! `graph_expansion_depth` unset (or `Some(1)`) must NOT surface B (it's 2
+//! hops away). `graph_expansion_depth=2` must surface B. This is the
+//! load-bearing assertion: it proves the expansion path actually reaches and
+//! returns a claim ANN alone would never find, not just that the param is
+//! accepted without crashing.
+
+#[rustfmt::skip]
+use epigraph_mcp::tools::recall::__test_only::recall_with_context_with_pgvec;
+use epigraph_mcp::tools::link_epistemic::do_link_epistemic;
+use epigraph_mcp::tools::recall::RecallWithContextParams;
+use epigraph_mcp::types::LinkEpistemicParams;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod fixture {
+    use super::*;
+
+    const DIM: usize = 1536;
+    const N_BUCKETS: usize = 8;
+    const STRIDE: usize = DIM / N_BUCKETS;
+
+    fn vec_to_pgvec(v: &[f32]) -> String {
+        let inner: Vec<String> = v.iter().map(|x| x.to_string()).collect();
+        format!("[{}]", inner.join(","))
+    }
+
+    /// Pgvector literal concentrated in `bucket * STRIDE .. (bucket+1) * STRIDE`.
+    /// Same-bucket vectors are highly cosine-similar; different-bucket
+    /// vectors are orthogonal (cosine similarity ~0). Mirrors
+    /// `diverse_fixture::cluster_pgvec` in `recall_with_context.rs`.
+    pub fn cluster_pgvec(bucket: usize, value: f32) -> String {
+        let mut v = vec![0.0f32; DIM];
+        let start = bucket * STRIDE;
+        let end = start + STRIDE;
+        for slot in v.iter_mut().take(end).skip(start) {
+            *slot = value;
+        }
+        vec_to_pgvec(&v)
+    }
+
+    /// A "decoy" vector: mostly concentrated in an orthogonal bucket (7) like
+    /// MID/B, but with a small deliberate sliver of overlap in bucket 0 (the
+    /// query's bucket). This gives decoys a small POSITIVE cosine similarity
+    /// to the query, strictly greater than MID/B's exact-zero similarity —
+    /// so flat ANN deterministically ranks decoys above MID/B on ties,
+    /// rather than relying on row-order luck. `search_by_embedding` has no
+    /// similarity cutoff (pure top-K by distance), so this is what makes a
+    /// small `limit` reliably exclude MID/B from the ANN seed set.
+    pub fn decoy_pgvec(sliver: f32) -> String {
+        let mut v = vec![0.0f32; DIM];
+        for slot in v.iter_mut().take(STRIDE) {
+            *slot = sliver;
+        }
+        let start = 7 * STRIDE;
+        let end = start + STRIDE;
+        for slot in v.iter_mut().take(end).skip(start) {
+            *slot = 1.0;
+        }
+        vec_to_pgvec(&v)
+    }
+
+    fn hash_for(id: Uuid) -> Vec<u8> {
+        let mut h = vec![0u8; 32];
+        h[..16].copy_from_slice(id.as_bytes());
+        h
+    }
+
+    pub async fn seed_agent(pool: &PgPool) -> Uuid {
+        let agent_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+            .bind(agent_id)
+            .bind("cc".repeat(32))
+            .execute(pool)
+            .await
+            .expect("seed agent");
+        agent_id
+    }
+
+    pub async fn seed_paper(pool: &PgPool, doi: &str, title: &str) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query("INSERT INTO papers (id, doi, title) VALUES ($1, $2, $3)")
+            .bind(id)
+            .bind(doi)
+            .bind(title)
+            .execute(pool)
+            .await
+            .expect("seed paper");
+        id
+    }
+
+    /// Seed a level=2 paragraph claim with an embedding and a paper
+    /// attribution edge (`recall_with_context` drops any hit missing paper
+    /// attribution, so every fixture paragraph needs one regardless of
+    /// whether it's expected to surface as an ANN seed).
+    pub async fn seed_paragraph(
+        pool: &PgPool,
+        agent_id: Uuid,
+        paper_id: Uuid,
+        content: &str,
+        embedding_pgvec: &str,
+    ) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, properties, embedding) \
+             VALUES ($1, $2, $3, $4, 0.7, jsonb_build_object('level', 2::int), $5::vector)",
+        )
+        .bind(id)
+        .bind(content)
+        .bind(hash_for(id))
+        .bind(agent_id)
+        .bind(embedding_pgvec)
+        .execute(pool)
+        .await
+        .expect("seed paragraph");
+
+        sqlx::query(
+            "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship) \
+             VALUES (gen_random_uuid(), $1, 'paper', $2, 'claim', 'asserts')",
+        )
+        .bind(paper_id)
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("seed paper-attribution edge");
+
+        id
+    }
+}
+
+/// `limit` does double duty in `recall_with_context`: it bounds BOTH the
+/// flat-ANN seed fetch AND the final post-expansion truncation (when
+/// `rerank` is off, both equal `limit` exactly). The fixture seeds A + 2
+/// decoys (similarity ~0.05) + MID/B (similarity 0.0), so:
+///   - `limit=2` admits exactly `{A, decoy}` as ANN seeds — MID/B never
+///     enter the seed pool, which is what the negative
+///     (unset / depth=1) tests need.
+///   - `limit=3` admits `{A, decoy, decoy}` as ANN seeds (still excluding
+///     MID/B), leaving exactly the room graph expansion needs to place B
+///     (and MID) into the final result on its own merit — what the positive
+///     (depth=2) test needs.
+fn base_params(depth: Option<u32>, limit: u32) -> RecallWithContextParams {
+    RecallWithContextParams {
+        query: "ignored — pgvec is passed directly".to_string(),
+        limit: Some(limit),
+        min_truth: Some(0.0),
+        centroid_dim: Some(1536),
+        paper_doi_filter: None,
+        siblings_limit: None,
+        corroborates_limit: None,
+        neighbor_paragraphs_limit: None,
+        diverse: None,
+        max_themes: None,
+        diversity_weight: None,
+        candidate_pool: None,
+        rerank: None,
+        rerank_pool_factor: None,
+        groundedness_gate: None,
+        frame_id: None,
+        perspective_id: None,
+        graph_expansion_depth: depth,
+    }
+}
+
+fn build_test_server(pool: PgPool) -> epigraph_mcp::EpiGraphMcpFull {
+    use epigraph_crypto::AgentSigner;
+    use epigraph_mcp::embed::McpEmbedder;
+    use epigraph_mcp::EpiGraphMcpFull;
+    let signer = AgentSigner::from_bytes(&[0u8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None); // mock — tests use pre-computed pgvec
+    EpiGraphMcpFull::new(pool, signer, embedder, /*read_only=*/ false)
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct RecallResponseStruct {
+    results: Vec<RecallResultStruct>,
+    #[allow(dead_code)]
+    corpus_scope: serde_json::Value,
+    #[allow(dead_code)]
+    centroid_dim_used: u32,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct RecallResultStruct {
+    paragraph_id: Uuid,
+    #[allow(dead_code)]
+    paragraph_content: String,
+    #[allow(dead_code)]
+    similarity: f64,
+}
+
+fn parse_response(result: rmcp::model::CallToolResult) -> RecallResponseStruct {
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text().map(|t| t.text.clone()))
+        .expect("text content");
+    serde_json::from_str(&text).expect("parse RecallWithContextResponse JSON")
+}
+
+/// Build the A --supports--> MID --supports--> B fixture described in the
+/// module doc comment. Returns (server, query_pgvec, A, MID, B).
+async fn build_two_hop_fixture(
+    pool: PgPool,
+) -> (epigraph_mcp::EpiGraphMcpFull, String, Uuid, Uuid, Uuid) {
+    let agent = fixture::seed_agent(&pool).await;
+    let paper = fixture::seed_paper(&pool, "10.1/graph-expansion", "Graph expansion test").await;
+
+    let query_pgvec = fixture::cluster_pgvec(0, 1.0);
+
+    // A: ANN seed, same bucket as the query.
+    let a =
+        fixture::seed_paragraph(&pool, agent, paper, "paragraph A: ANN seed", &query_pgvec).await;
+    // MID: orthogonal bucket 3 — not ANN-close to the query.
+    let mid_pgvec = fixture::cluster_pgvec(3, 1.0);
+    let mid = fixture::seed_paragraph(
+        &pool,
+        agent,
+        paper,
+        "paragraph MID: 1-hop bridge, ANN-invisible",
+        &mid_pgvec,
+    )
+    .await;
+    // B: a DIFFERENT orthogonal bucket (6) — not ANN-close to the query, and
+    // not accidentally similar to MID either.
+    let b_pgvec = fixture::cluster_pgvec(6, 1.0);
+    let b = fixture::seed_paragraph(
+        &pool,
+        agent,
+        paper,
+        "paragraph B: 2-hop target, ANN-invisible",
+        &b_pgvec,
+    )
+    .await;
+
+    // Decoys: `search_by_embedding` (flat ANN) has no similarity cutoff —
+    // it's pure top-K-by-distance — so with `limit` bigger than the corpus
+    // size, EVERY seeded paragraph (however orthogonal) comes back as an ANN
+    // "seed", masking the graph-expansion path entirely. Seed exactly 2
+    // decoys (bucket 7, small deliberate similarity ~0.05 to the query —
+    // well below A's 1.0 but strictly above MID/B's exact 0.0), so at
+    // limit=3 the ANN seed pool is deterministically `{A, decoy, decoy}` —
+    // MID (similarity 0.0, 1-hop score 0.7*1.1=0.77 post-expansion) and B
+    // (similarity 0.0, 2-hop score 0.49*1.1=0.539 post-expansion) can ONLY
+    // enter the result set via graph expansion, never as raw ANN seeds. 2
+    // decoys is load-bearing here: 1 decoy leaves a 3rd ANN slot that MID/B
+    // (tied at similarity 0.0) would nondeterministically win, corrupting
+    // the "not ANN-close" premise the whole test rests on.
+    for i in 0..2 {
+        fixture::seed_paragraph(
+            &pool,
+            agent,
+            paper,
+            &format!("decoy paragraph {i}"),
+            &fixture::decoy_pgvec(0.05),
+        )
+        .await;
+    }
+
+    let server = build_test_server(pool.clone());
+
+    do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: a.to_string(),
+            target_claim_id: mid.to_string(),
+            relationship: "supports".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect("A supports MID");
+
+    do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: mid.to_string(),
+            target_claim_id: b.to_string(),
+            relationship: "supports".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect("MID supports B");
+
+    (server, query_pgvec, a, mid, b)
+}
+
+/// The load-bearing assertion: a claim reachable ONLY via a 2-hop `supports`
+/// chain from an ANN seed, and NOT itself ANN-close to the query, is
+/// returned when `graph_expansion_depth=2` — proving the expansion path
+/// surfaces something flat ANN would miss entirely.
+#[sqlx::test(migrations = "../../migrations")]
+async fn graph_expansion_depth_2_surfaces_two_hop_claim(pool: PgPool) {
+    let (server, query_pgvec, a, _mid, b) = build_two_hop_fixture(pool).await;
+
+    // limit=3: ANN seed pool is deterministically {A, decoy, decoy} (see
+    // base_params doc comment) — MID/B are graph-expansion-only. B's
+    // expansion-assigned score (`seed_similarity * 0.7^hops`, positive)
+    // gives it a real shot at the 3rd result slot on its own merit.
+    let params = base_params(Some(2), 3);
+    let result = recall_with_context_with_pgvec(&server, params, 1536, &query_pgvec)
+        .await
+        .expect("recall with graph_expansion_depth=2 succeeds");
+    let resp = parse_response(result);
+
+    let returned: std::collections::HashSet<Uuid> =
+        resp.results.iter().map(|r| r.paragraph_id).collect();
+
+    assert!(
+        returned.contains(&a),
+        "ANN seed A must still be present with expansion on; got {returned:?}"
+    );
+    assert!(
+        returned.contains(&b),
+        "paragraph B (2-hop supports target, ANN-invisible) must be surfaced \
+         when graph_expansion_depth=2; got {returned:?}"
+    );
+}
+
+/// Default-off / backward-compatible: with `graph_expansion_depth` unset,
+/// the 2-hop claim B must NOT appear — proving expansion is opt-in and the
+/// unset case reproduces today's flat-ANN-only behaviour.
+#[sqlx::test(migrations = "../../migrations")]
+async fn graph_expansion_unset_does_not_surface_two_hop_claim(pool: PgPool) {
+    let (server, query_pgvec, a, mid, b) = build_two_hop_fixture(pool).await;
+
+    let params = base_params(None, 2);
+    let result = recall_with_context_with_pgvec(&server, params, 1536, &query_pgvec)
+        .await
+        .expect("recall with graph_expansion_depth unset succeeds");
+    let resp = parse_response(result);
+
+    let returned: std::collections::HashSet<Uuid> =
+        resp.results.iter().map(|r| r.paragraph_id).collect();
+
+    assert!(
+        returned.contains(&a),
+        "ANN seed A must be present; got {returned:?}"
+    );
+    assert!(
+        !returned.contains(&mid),
+        "MID (orthogonal embedding, no expansion) must NOT be ANN-surfaced; got {returned:?}"
+    );
+    assert!(
+        !returned.contains(&b),
+        "paragraph B must NOT be surfaced when graph_expansion_depth is unset \
+         (default-off, backward-compatible); got {returned:?}"
+    );
+}
+
+/// `graph_expansion_depth=1` must NOT surface B: B is 2 hops from A, and a
+/// 1-hop expansion only reaches MID (which is not asserted here since it is
+/// paper-attributed and would pass the assembly filters, but is not the
+/// point of this test — the point is that depth is a real bound, not just
+/// "on vs off").
+#[sqlx::test(migrations = "../../migrations")]
+async fn graph_expansion_depth_1_does_not_reach_two_hop_claim(pool: PgPool) {
+    let (server, query_pgvec, a, _mid, b) = build_two_hop_fixture(pool).await;
+
+    let params = base_params(Some(1), 2);
+    let result = recall_with_context_with_pgvec(&server, params, 1536, &query_pgvec)
+        .await
+        .expect("recall with graph_expansion_depth=1 succeeds");
+    let resp = parse_response(result);
+
+    let returned: std::collections::HashSet<Uuid> =
+        resp.results.iter().map(|r| r.paragraph_id).collect();
+
+    assert!(
+        returned.contains(&a),
+        "ANN seed A must be present; got {returned:?}"
+    );
+    assert!(
+        !returned.contains(&b),
+        "paragraph B is 2 hops from A; depth=1 must not reach it; got {returned:?}"
+    );
+}

--- a/crates/epigraph-mcp/tests/recall_with_context.rs
+++ b/crates/epigraph-mcp/tests/recall_with_context.rs
@@ -552,6 +552,7 @@ async fn explicit_3072_with_no_population_returns_invalid_params(pool: PgPool) {
         groundedness_gate: None,
         frame_id: None,
         perspective_id: None,
+        graph_expansion_depth: None,
     };
 
     let result = recall_with_context(&server, params).await;
@@ -944,6 +945,7 @@ fn diverse_params_with_pool(
         groundedness_gate: None,
         frame_id: None,
         perspective_id: None,
+        graph_expansion_depth: None,
     }
 }
 

--- a/docs/superpowers/plans/2026-07-09-backlog-resolution.md
+++ b/docs/superpowers/plans/2026-07-09-backlog-resolution.md
@@ -924,14 +924,37 @@ treat the claim content itself as the design spec; the steps below are the build
 
 **Claim:** `29e789fd-92fb-497f-b9bf-5dff1d96408b`
 
-- [ ] **Step 1:** Add `graph_expansion_depth: Option<u32>` param to `recall_with_context` MCP tool.
-- [ ] **Step 2:** In `crates/epigraph-db`, run the standard ANN query for top-k seeds; when
+- [x] **Step 1:** Add `graph_expansion_depth: Option<u32>` param to `recall_with_context` MCP tool.
+DONE — added to `RecallWithContextParams` in `crates/epigraph-mcp/src/tools/recall.rs`, clamped
+`[1,4]`, `None` preserves today's flat-ANN-only behaviour byte-for-byte.
+- [x] **Step 2:** In `crates/epigraph-db`, run the standard ANN query for top-k seeds; when
 `graph_expansion_depth` is set, call `traverse(node_id, depth, relationship=["supports","corroborates","elaborates"], direction="outgoing")` per seed.
-- [ ] **Step 3:** Dedup the expansion set, rerank by `rrf_score * (1 + 0.1 * in_epistemic_degree)`.
-- [ ] **Step 4:** Regression test: a claim reachable only via a 2-hop `supports` edge from an ANN
+DONE, with a scope adjustment: the real `traverse` MCP tool (`crates/epigraph-mcp/src/tools/graph.rs`)
+takes a single `relationship: Option<String>`, not a list, and returns a serialized
+`CallToolResult` — neither fits calling it per-seed with a 3-relationship filter from inside
+`recall_with_context`. Added `ClaimRepository::graph_expand_seeds` in
+`crates/epigraph-db/src/repos/claim.rs` instead: the same BFS-over-`EdgeRepository::get_by_source`
+shape `traverse` uses internally, reproduced directly against the repo layer. New constant
+`EXPANSION_RELATIONSHIPS = ["supports", "corroborates", "elaborates"]`.
+- [x] **Step 3:** Dedup the expansion set, rerank by `rrf_score * (1 + 0.1 * in_epistemic_degree)`.
+DONE, with a scope adjustment: `rrf_score` does not exist on `recall_with_context`'s hit type
+(`ClaimEmbeddingHit`, flat ANN `similarity`) — it belongs to the *other* tool, `recall`'s hybrid
+RRF-fused path (`HybridHit`). The plan conflated the two. Used `similarity` as the rerank base,
+matching what `recall_with_context` actually carries. `in_epistemic_degree` is computed by a new
+batched `GROUP BY` query, `ClaimRepository::in_epistemic_degree_batch` — one round-trip for the
+whole candidate pool, not an N+1 — over the full 7-type `link_epistemic` allowlist (now shared as
+`epigraph_db::EPISTEMIC_RELATIONSHIPS`), not just the 3 expansion-traversal types. Expanded claims
+(no ANN score of their own) are seeded into the rerank with `best_seed_similarity * 0.7^hops`.
+- [x] **Step 4:** Regression test: a claim reachable only via a 2-hop `supports` edge from an ANN
 seed (not itself ANN-close to the query) is returned when `graph_expansion_depth=2`, absent when
 unset (default-off, backward compatible).
-- [ ] **Step 5: Verify, commit, resolve**
+DONE — `crates/epigraph-mcp/tests/recall_graph_expansion.rs`, 3 tests (unset, depth=1, depth=2)
+against an A→MID→B `supports` chain with MID/B embedded orthogonally to the query so they are not
+ANN-close. Confirmed RED (positive test fails, B absent) with the expansion call disabled, GREEN
+with it enabled; negative tests pass either way (they assert absence).
+- [x] **Step 5: Verify, commit, resolve** — verify + commit DONE (this PR); **resolve is
+intentionally NOT run** — `resolve_backlog_item` is a live graph write and this task runs from a
+worktree, per the task's own instruction to leave it for post-merge.
 
 ```python
 mcp__epigraph__resolve_backlog_item(original_id="29e789fd-92fb-497f-b9bf-5dff1d96408b", resolution_content="Resolves 29e789fd: recall_with_context accepts optional graph_expansion_depth, 2-hop-traversing supports/corroborates/elaborates edges from ANN seeds and reranking by rrf_score * (1 + 0.1*in_epistemic_degree). Default-off, backward-compatible.")


### PR DESCRIPTION
## Summary

- Adds an opt-in `graph_expansion_depth: Option<u32>` param to `recall_with_context`. When set, follows outgoing `supports`/`corroborates`/`elaborates` edges up to N hops from each ANN seed, folds reached claims into the candidate pool (deduped against seeds), and reranks the combined set by `similarity * (1 + 0.1 * in_epistemic_degree)`. `None` (default) is byte-for-byte identical to today's flat-ANN-only behavior.
- Implements backlog Task 6.1 / claim `29e789fd-92fb-497f-b9bf-5dff1d96408b`.

## Scope adjustments vs. the plan's design sketch

The plan (`docs/superpowers/plans/2026-07-09-backlog-resolution.md`) had two stale pointers, confirmed against the real code before building on them:

1. **`traverse`'s real signature.** The plan's sketch calls `traverse(node_id, depth, relationship=["supports","corroborates","elaborates"], direction="outgoing")` — but the real `traverse` MCP tool (`crates/epigraph-mcp/src/tools/graph.rs`) takes a single `relationship: Option<String>`, not a list, and returns a serialized `CallToolResult`. Neither fits a per-seed, multi-relationship expansion called from inside `recall_with_context`. Added `ClaimRepository::graph_expand_seeds` in `epigraph-db` instead — the same BFS-over-`EdgeRepository::get_by_source` shape `traverse` uses internally, called directly against the repo layer (per this repo's "all SQL stays in `crates/epigraph-db/src/repos/`" convention) rather than round-tripping the MCP tool layer.
2. **`rrf_score` belongs to a different tool.** The plan specifies reranking by `rrf_score * (1 + 0.1 * in_epistemic_degree)`, but `rrf_score` is a field on `HybridHit` — the *other* recall tool (`recall`'s hybrid RRF-fused path). `recall_with_context`'s hits carry plain ANN `similarity` (`ClaimEmbeddingHit`), so `similarity` is used as the rerank base.

Both are corrected wiring, not scope cuts — the full `similarity * (1 + 0.1 * in_epistemic_degree)` formula is implemented, computed via one batched `GROUP BY` query (`in_epistemic_degree_batch`) over the whole candidate pool, not an N+1.

`in_epistemic_degree` is computed over the full 7-type `link_epistemic` allowlist (`supports`/`corroborates`/`elaborates`/`generalizes`/`specializes`/`contradicts`/`refutes`, now shared as `epigraph_db::EPISTEMIC_RELATIONSHIPS`), not just the 3 traversal-relationship types — a claim's authority is a function of everyone who has weighed in on it, not only the reinforcing subset used for expansion itself.

**Follow-up hardening (3rd commit):** `graph_expand_seeds`'s BFS initially bounded depth (`[1,4]`, matching `traverse`) but not breadth — on a dense graph, 4-hop fan-out could reach thousands of claims, each a sequential DB round-trip inside a synchronous `recall_with_context` call. Added `ClaimRepository::MAX_EXPANSION_NODES = 200`, mirroring `traverse`'s own `node_limit` (`.clamp(1, 100)`, default 50) — this repo already has that precedent for bounding graph-walk work, not just output. The BFS now breaks immediately once the cap is hit.

## Test plan

- [x] New regression test `crates/epigraph-mcp/tests/recall_graph_expansion.rs`: a claim B reachable only via a 2-hop `supports` chain (A → MID → B) from an ANN seed A, with MID/B embedded orthogonally to the query so neither is ANN-close. Confirmed **RED** with the expansion call disabled (positive test fails, B absent from results); **GREEN** with it enabled (3 passed, 0 failed). Negative tests (`graph_expansion_depth` unset / `=1`) assert B's absence and pass in both states — isolating the positive test as the load-bearing proof.
- [x] `cargo fmt --check` — clean, workspace-wide.
- [x] `cargo clippy --workspace --locked -- -D warnings` — clean (CI's exact invocation).
- [x] `cargo test -p epigraph-db` — 93 lib tests + all integration/doc tests, 0 failed.
- [x] `cargo test -p epigraph-mcp` — full suite green; targeted regression + `epigraph-db` suite independently re-verified after the breadth-cap follow-up commit.
- [x] `SQLX_OFFLINE=true cargo check --workspace --all-targets` — clean; `.sqlx/` gained exactly one new query-cache file.
- [ ] `resolve_backlog_item` for claim `29e789fd` — intentionally **not run** from this worktree; queued for post-merge per task instructions (live graph write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)