### PR TITLE
security(deps): bump crossbeam-epoch 0.9.18 -> 0.9.20 to clear RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- Clears RUSTSEC-2026-0204 (crossbeam-epoch invalid pointer dereference in `fmt::Pointer`), which has been showing up as a "Security audit (advisory)" CI failure on PRs #317-#320, unrelated to any of their diffs.
- Transitive-only dependency (`crossbeam-deque -> rayon-core -> rayon -> ascent -> epigraph-engine`). Plain `cargo update -p crossbeam-epoch` (0.9.18 -> 0.9.20) resolves it — no other package version changed, no code changes needed.

## Verification
- `cargo audit` exits 0 (previously 1 vulnerability). Remaining advisory warning (anyhow RUSTSEC-2026-0190) is separate, already tracked, out of scope.
- `cargo tree -p crossbeam-epoch` confirms v0.9.20.
- `cargo fmt --check`, `cargo clippy --workspace --locked -- -D warnings`, `SQLX_OFFLINE=true cargo check --workspace --locked` all clean.
- `cargo test --workspace --locked`: 23 pre-existing failures in epigraph-api (edges/policies/submit/workflows route tests) reproduce identically with this change stashed out (confirmed via `git stash` + rerun) — pre-existing local test-environment flakiness (shared dev DB contention from concurrent agent sessions this week), not a regression. 363 other tests pass.

Not merged — leaving for review per the standing pattern on this batch of PRs.