### PR TITLE
feat(mcp): warn when supporting evidence lowers belief in update_with_evidence (Task 3.6, backlog 3b60a785)

### DIFF
--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -473,6 +473,21 @@ pub async fn update_with_evidence(
     let before = claim.truth_value.value();
     let strength = params.strength.clamp(0.0, 1.0);
 
+    // Capture pre-combination pignistic to detect the counterintuitive-but-correct
+    // case where SUPPORTING evidence lowers belief (Task 3.6, backlog 3b60a785).
+    // Compare pignistic-vs-pignistic. `get_belief_columns` reads the persisted
+    // `pignistic_prob` column (distinct from `truth_value`; see claim.rs docs).
+    // It is NULL for a claim with no prior DS state — in that case fall back to
+    // `truth_value` (`before`), which is the belief the fresh BBA is combined
+    // against. The monotonicity clamp in `auto_wire_ds_update` bounds BetP below
+    // by the prior column value for supports=true, so the warning is only ever
+    // reachable on the NULL-column (no-prior-DS-state) path.
+    let pre_pignistic =
+        ClaimRepository::get_belief_columns(&server.pool, ClaimId::from_uuid(claim_id))
+            .await
+            .map_err(internal_error)?
+            .and_then(|c| c.pignistic_prob);
+
     // Load type_weight from calibration (replaces deleted evidence_weight())
     // I-3: use helper that checks CALIBRATION_PATH env var before relative path
     let weight = load_evidence_type_weight(&params.evidence_type);
@@ -498,6 +513,17 @@ pub async fn update_with_evidence(
         .await
         .map_err(internal_error)?;
 
+    // Warn when SUPPORTING evidence lowered the pignistic probability. Compare
+    // pignistic-to-pignistic; when the claim had no prior DS state the column is
+    // NULL, so fall back to the truth_value the fresh BBA combined against.
+    let pre_belief = pre_pignistic.unwrap_or(before);
+    let warning = (params.supports && ds.pignistic_prob < pre_belief).then(|| {
+        "Supporting evidence decreased belief — the new evidence has high \
+         ignorance mass relative to the prior; this is mathematically correct \
+         DS combination, not a bug."
+            .to_string()
+    });
+
     success_json(&UpdateResponse {
         claim_id: claim_id.to_string(),
         truth_before: before,
@@ -506,6 +532,7 @@ pub async fn update_with_evidence(
         belief: Some(ds.belief),
         plausibility: Some(ds.plausibility),
         pignistic_prob: Some(ds.pignistic_prob),
+        warning,
     })
 }
 

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -853,6 +853,12 @@ pub struct UpdateResponse {
     pub plausibility: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pignistic_prob: Option<f64>,
+    /// Populated ONLY when supporting evidence *lowered* the pignistic
+    /// probability (weak/high-ignorance-mass BBA on a claim with no prior DS
+    /// state). This is mathematically correct Dempster-Shafer combination —
+    /// the warning exists so callers don't mistake it for a bug.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/epigraph-mcp/tests/update_with_evidence_supporting_warning.rs
+++ b/crates/epigraph-mcp/tests/update_with_evidence_supporting_warning.rs
@@ -1,0 +1,91 @@
+//! Task 3.6 (backlog 3b60a785) regression: `update_with_evidence` must WARN
+//! when SUPPORTING evidence *lowers* the pignistic probability.
+//!
+//! Weak supporting evidence carries high ignorance mass, widens the belief
+//! interval, and pulls the pignistic toward 0.5 — correct Dempster-Shafer
+//! combination, but counterintuitive. The handler surfaces a `warning` field
+//! so callers don't mistake it for a bug.
+//!
+//! The pre-existing monotonicity clamp in `auto_wire_ds_update` bounds BetP
+//! below by the prior `pignistic_prob` *column* for supports=true, so the drop
+//! (and hence the warning) is only reachable on a claim with NO prior DS state
+//! (NULL `pignistic_prob` column). `seed_claim` leaves that column NULL, so the
+//! fresh BBA is combined against the claim's `truth_value`.
+
+mod common;
+use common::*;
+
+use epigraph_mcp::types::UpdateWithEvidenceParams;
+
+async fn run_update(
+    server: &epigraph_mcp::EpiGraphMcpFull,
+    claim_id: uuid::Uuid,
+    strength: f64,
+    supports: bool,
+) -> serde_json::Value {
+    let result = epigraph_mcp::tools::claims::update_with_evidence(
+        server,
+        UpdateWithEvidenceParams {
+            claim_id: claim_id.to_string(),
+            evidence_type: "empirical".into(),
+            evidence_data: format!("evidence strength={strength} supports={supports}"),
+            source_url: None,
+            supports,
+            strength,
+        },
+    )
+    .await
+    .expect("update_with_evidence ok");
+    first_text(&result)
+}
+
+/// SOME case: moderate (~0.6) supporting evidence against an already-high-belief
+/// claim pulls the pignistic below the prior belief → `warning` is present.
+#[sqlx::test(migrations = "../../migrations")]
+async fn supporting_evidence_lowers_belief_emits_warning(pool: sqlx::PgPool) {
+    // High prior belief, NULL pignistic column (seed_claim leaves it NULL).
+    let claim_id = seed_claim(&pool, "high-belief claim for warning test", 0.85).await;
+    let server = build_test_server(pool.clone());
+
+    let json = run_update(&server, claim_id, 0.6, true).await;
+
+    let after = json["pignistic_prob"].as_f64().expect("pignistic_prob");
+    let before = json["truth_before"].as_f64().expect("truth_before");
+    assert!(
+        after < before,
+        "precondition: post pignistic {after} must be below prior belief {before}"
+    );
+    assert!(
+        json.get("warning").and_then(|w| w.as_str()).is_some(),
+        "warning must be present when supporting evidence lowers belief; got {json}"
+    );
+    assert!(
+        json["warning"]
+            .as_str()
+            .unwrap()
+            .contains("mathematically correct"),
+        "warning text must explain this is correct DS combination"
+    );
+}
+
+/// NONE case: strong (~0.95) supporting evidence against a lower-belief claim
+/// raises the pignistic → belief does NOT drop → `warning` absent.
+#[sqlx::test(migrations = "../../migrations")]
+async fn supporting_evidence_raising_belief_emits_no_warning(pool: sqlx::PgPool) {
+    let claim_id = seed_claim(&pool, "lower-belief claim for no-warning test", 0.4).await;
+    let server = build_test_server(pool.clone());
+
+    let json = run_update(&server, claim_id, 0.95, true).await;
+
+    let after = json["pignistic_prob"].as_f64().expect("pignistic_prob");
+    let before = json["truth_before"].as_f64().expect("truth_before");
+    assert!(
+        after >= before,
+        "precondition: strong supporting evidence must not lower belief; \
+         before={before} after={after}"
+    );
+    assert!(
+        json.get("warning").is_none() || json["warning"].is_null(),
+        "warning must be absent when belief does not drop; got {json}"
+    );
+}


### PR DESCRIPTION
## Task 3.6 — `update_with_evidence` UX trap: supporting evidence can lower belief

Backlog claim `3b60a785-2927-4dab-93e0-431d9ac160d2`, per the 2026-07-09 backlog-resolution plan.

### Problem
Callers report `supports=true` evidence *decreasing* the pignistic probability and mistake it for a bug. It is not: a weak supporting BBA carries high ignorance mass, widens the belief interval, and pulls BetP toward 0.5 — correct Dempster-Shafer combination. The fix is a **warning, not a math change**.

### Change
- Added optional `warning: Option<String>` to `UpdateResponse` (`skip_serializing_if = "Option::is_none"`, so no schema change for existing callers unless the drop occurs).
- Capture pre-combination pignistic via `ClaimRepository::get_belief_columns` (the persisted `pignistic_prob` column). NULL (no prior DS state) → fall back to `truth_value`, the belief the fresh BBA is combined against. The `auto_wire_ds_update` monotonicity clamp bounds BetP below by the prior column for `supports=true`, so the drop is only reachable on the NULL-column path — the fallback is exact.
- Populate the warning only when `supports && ds.pignistic_prob < pre_belief`.

### Verification
- New `crates/epigraph-mcp/tests/update_with_evidence_supporting_warning.rs`, 2 cases (warning present on drop; absent on rise). Both pass.
- `cargo fmt --check` clean; `cargo clippy --workspace --locked -- -D warnings` clean; targeted test green.

### Notes for reviewer
- This branch is based on commit `c41d1f3`, which **predates** open PR #319 (Task 3.4, adds a `labels` field to `UpdateWithEvidenceParams`). Both touch `crates/epigraph-mcp/src/types.rs` and `.../tools/claims.rs` in adjacent-but-distinct regions; expect a trivial merge reconciliation if #319 lands first. No logic overlap.
- Backlog `resolve_backlog_item` intentionally **not** fired from this branch — it is a live graph write meant to run post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)