### PR TITLE
feat(mcp): unify recall() to optionally search workflows alongside claims (Task 6.3, backlog 88a09fd2)

### DIFF
--- a/crates/epigraph-db/src/lib.rs
+++ b/crates/epigraph-db/src/lib.rs
@@ -85,8 +85,8 @@ pub use repos::{
     ReEncryptionKeyRow, ReasoningTraceRepository, RefreshTokenRepository, RefreshTokenRow,
     ResolvedStep, ScopedBeliefRepository, SecurityEventRepository, SecurityEventRow,
     SheafRepository, TaskRepository, TaskRow, TripleRepository, TripleRow,
-    WorkflowExecutionRepository, WorkflowExecutionRow, WorkflowListRow, WorkflowRecallResult,
-    WorkflowRepository,
+    WorkflowExecutionRepository, WorkflowExecutionRow, WorkflowGoalEmbeddingHit, WorkflowListRow,
+    WorkflowRecallResult, WorkflowRepository,
 };
 
 // Re-export sqlx types that users will need

--- a/crates/epigraph-db/src/repos/mod.rs
+++ b/crates/epigraph-db/src/repos/mod.rs
@@ -108,8 +108,8 @@ pub use sheaf::{ClaimNeighborBetpRow, EpistemicEdgePairRow, SheafRepository};
 pub use trace::ReasoningTraceRepository;
 pub use triple::{IndexCounts, MentionRow, TripleRepository, TripleRow};
 pub use workflow::{
-    HierarchicalWorkflowRow, ResolvedStep, WorkflowListRow, WorkflowRecallResult,
-    WorkflowRepository,
+    HierarchicalWorkflowRow, ResolvedStep, WorkflowGoalEmbeddingHit, WorkflowListRow,
+    WorkflowRecallResult, WorkflowRepository,
 };
 
 // Privacy / encryption repositories

--- a/crates/epigraph-db/src/repos/workflow.rs
+++ b/crates/epigraph-db/src/repos/workflow.rs
@@ -47,6 +47,19 @@ pub struct WorkflowListRow {
     pub properties: serde_json::Value,
 }
 
+/// One hit from [`WorkflowRepository::search_by_goal_embedding`] — the ANN
+/// leg `recall()` RRF-merges with its claims dense+lexical leg.
+///
+/// `similarity` is `1 - cosine_distance` in `[0, 1]`, matching the convention
+/// used by `ClaimEmbeddingHit`/`HybridHit.dense_similarity`.
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct WorkflowGoalEmbeddingHit {
+    pub workflow_id: Uuid,
+    pub content: String,
+    pub truth_value: f64,
+    pub similarity: f64,
+}
+
 /// Row type returned by `WorkflowRepository::search_hierarchical_by_text`.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct HierarchicalWorkflowRow {
@@ -723,6 +736,43 @@ impl WorkflowRepository {
             .bind(limit)
             .fetch_all(pool)
             .await
+    }
+
+    /// ANN search over `workflows.goal_embedding` shaped for `recall()`'s
+    /// workflows leg: takes a pre-formatted pgvector literal (like
+    /// `ClaimRepository::search_hybrid_scoped`/`search_by_embedding_scoped`,
+    /// so callers reuse ONE query embedding across claims + workflows), and
+    /// returns `similarity = 1 - cosine_distance` per row so `recall` can
+    /// populate `RecallResult.similarity` the same way it does for claim
+    /// hits.
+    ///
+    /// Distinct from `find_hierarchical_by_embedding`: that helper takes
+    /// `&[f32]`, drops the distance/similarity column from its outer SELECT
+    /// (only used for existence/ordering, not surfaced), and carries
+    /// `resolve_to_latest`/threshold semantics recall doesn't need. This is
+    /// a lighter sibling: no truth-value floor here (recall applies its own
+    /// `min_truth` uniformly across claims + workflows after the merge, same
+    /// as it already does for claim hits).
+    ///
+    /// # Errors
+    /// Returns `sqlx::Error` if the database query fails.
+    pub async fn search_by_goal_embedding(
+        pool: &PgPool,
+        query_embedding_pgvector: &str,
+        limit: i64,
+    ) -> Result<Vec<WorkflowGoalEmbeddingHit>, sqlx::Error> {
+        sqlx::query_as::<_, WorkflowGoalEmbeddingHit>(
+            "SELECT id AS workflow_id, goal AS content, truth_value, \
+                    (1 - (goal_embedding <=> $1::vector))::float8 AS similarity \
+             FROM workflows \
+             WHERE goal_embedding IS NOT NULL \
+             ORDER BY goal_embedding <=> $1::vector \
+             LIMIT $2",
+        )
+        .bind(query_embedding_pgvector)
+        .bind(limit)
+        .fetch_all(pool)
+        .await
     }
 
     /// Write the embedding vector for a hierarchical workflow's goal text.

--- a/crates/epigraph-mcp/src/tools/memory.rs
+++ b/crates/epigraph-mcp/src/tools/memory.rs
@@ -12,9 +12,11 @@ use epigraph_core::{
     TruthValue,
 };
 use epigraph_crypto::ContentHasher;
-use epigraph_db::{ClaimRepository, EvidenceRepository, HybridHit, ReasoningTraceRepository};
+use epigraph_db::{
+    ClaimRepository, EvidenceRepository, HybridHit, ReasoningTraceRepository, WorkflowRepository,
+};
 
-use crate::embed::HYBRID_RRF_K;
+use crate::embed::{format_pgvector, HYBRID_CANDIDATE_POOL, HYBRID_RRF_K};
 
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
@@ -151,6 +153,39 @@ pub async fn recall(
     server: &EpiGraphMcpFull,
     params: RecallParams,
 ) -> Result<CallToolResult, McpError> {
+    // Generate the query embedding ONCE up front. Reused for both the claims
+    // dense leg and (when requested) the workflows ANN leg — recall must not
+    // re-embed the same query text twice (see `recall_post_embed`/workflows
+    // leg below). `None` on embedder failure degrades both legs: claims fall
+    // back to lexical-only (existing behavior) and the workflows leg is
+    // skipped entirely (there is no lexical fallback for goal_embedding).
+    let pgvec_opt = match server.embedder.generate(&params.query).await {
+        Ok(v) => Some(format_pgvector(&v)),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                query = %params.query,
+                "recall: embedder failed; degrading to lexical-only claims leg, no workflows leg"
+            );
+            None
+        }
+    };
+
+    recall_post_embed(server, params, pgvec_opt).await
+}
+
+/// Post-embedding pipeline: shared by `recall` and the
+/// `__test_only::recall_with_pgvec` entry point that lets integration tests
+/// skip the OpenAI embedder (no API key available in CI / sandbox), mirroring
+/// `workflows.rs`'s `find_workflow`/`find_workflow_post_embed` split.
+///
+/// Recomputes `limit`/`min_truth` from `params` internally so the two
+/// extraction sites cannot drift.
+async fn recall_post_embed(
+    server: &EpiGraphMcpFull,
+    params: RecallParams,
+    pgvec_opt: Option<String>,
+) -> Result<CallToolResult, McpError> {
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
     let min_truth = params.min_truth.unwrap_or(0.3);
     let agent_filter = parse_agent_filter(params.agent_id.as_deref()).map_err(invalid_params)?;
@@ -170,93 +205,197 @@ pub async fn recall(
     }
 
     // Hybrid retrieval: dense (claims.embedding) + lexical (content_tsv), RRF-fused.
-    // On embedder failure, degrade to lexical-only — which, unlike the old ILIKE
-    // fallback, still honors tag/agent scope because it filters in SQL.
-    let hits: Vec<HybridHit> = match server
-        .embedder
-        .search_hybrid_scoped(&params.query, limit, tags_opt, agent_filter)
+    // On embedder failure (pgvec_opt is None), degrade to lexical-only — which,
+    // unlike the old ILIKE fallback, still honors tag/agent scope because it
+    // filters in SQL.
+    let hits: Vec<HybridHit> = match pgvec_opt.as_deref() {
+        Some(pgvec) => ClaimRepository::search_hybrid_scoped(
+            &server.pool,
+            pgvec,
+            &params.query,
+            HYBRID_CANDIDATE_POOL,
+            HYBRID_RRF_K,
+            limit,
+            tags_opt,
+            agent_filter,
+        )
         .await
-    {
-        Ok(hits) => hits,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                query = %params.query,
-                "recall: hybrid embed leg failed; serving scope-honoring lexical-only"
-            );
-            ClaimRepository::search_lexical_scoped(
-                &server.pool,
-                &params.query,
-                HYBRID_RRF_K,
-                limit,
-                tags_opt,
-                agent_filter,
-            )
-            .await
-            .map_err(internal_error)?
-        }
+        .map_err(internal_error)?,
+        None => ClaimRepository::search_lexical_scoped(
+            &server.pool,
+            &params.query,
+            HYBRID_RRF_K,
+            limit,
+            tags_opt,
+            agent_filter,
+        )
+        .await
+        .map_err(internal_error)?,
     };
 
+    // Workflows ANN leg (opt-in, backlog 88a09fd2 / Task 6.3). Only runs when
+    // BOTH include_workflows=true AND the query embedding succeeded — there is
+    // no lexical fallback for workflows.goal_embedding, so on embedder failure
+    // this leg is silently absent rather than serving stale/irrelevant rows.
+    // Ranked by cosine distance (best first), independent of the claims dense+
+    // lexical fusion above; RRF-merged with the claims ranking below using the
+    // SAME k constant/formula `search_hybrid_scoped` already uses in SQL for
+    // its dense+lexical fusion (`crate::embed::HYBRID_RRF_K`), just applied in
+    // Rust across two disjoint (claim vs workflow) ranked lists instead of two
+    // legs of one list.
+    let workflow_hits: Vec<epigraph_db::WorkflowGoalEmbeddingHit> = if params.include_workflows {
+        match pgvec_opt.as_deref() {
+            Some(pgvec) => WorkflowRepository::search_by_goal_embedding(
+                &server.pool,
+                pgvec,
+                HYBRID_CANDIDATE_POOL,
+            )
+            .await
+            .map_err(internal_error)?,
+            None => Vec::new(),
+        }
+    } else {
+        Vec::new()
+    };
+
+    // RRF-merge: claims already carry a fused `rrf_score` from the SQL dense+
+    // lexical fusion — that score is used ONLY to establish the claims'
+    // relative rank order here (rank 1 = best), then discarded. Each item's
+    // merged score is a single `1/(k + rank)` term against its own list;
+    // claims and workflows are disjoint id-spaces so nothing sums across
+    // lists (unlike the dense+lexical fusion, where the SAME claim can appear
+    // in both legs and its two terms sum).
+    #[derive(Clone)]
+    enum MergedHit {
+        Claim(HybridHit),
+        Workflow(epigraph_db::WorkflowGoalEmbeddingHit),
+    }
+    let mut merged: Vec<(f64, MergedHit)> = Vec::with_capacity(hits.len() + workflow_hits.len());
+    for (idx, hit) in hits.iter().enumerate() {
+        let rank = idx as f64 + 1.0;
+        merged.push((
+            1.0 / (HYBRID_RRF_K as f64 + rank),
+            MergedHit::Claim(hit.clone()),
+        ));
+    }
+    for (idx, hit) in workflow_hits.iter().enumerate() {
+        let rank = idx as f64 + 1.0;
+        merged.push((
+            1.0 / (HYBRID_RRF_K as f64 + rank),
+            MergedHit::Workflow(hit.clone()),
+        ));
+    }
+    merged.sort_by(|a, b| b.0.total_cmp(&a.0));
+    merged.truncate(limit as usize);
+
     let mut results = Vec::new();
-    for hit in hits {
-        if let Ok(Some(claim)) =
-            ClaimRepository::get_by_id(&server.pool, ClaimId::from_uuid(hit.claim_id)).await
-        {
-            let tv = claim.truth_value.value();
-            if tv >= min_truth {
-                let mut matched_via = Vec::new();
-                if hit.dense_similarity.is_some() {
-                    matched_via.push("dense".to_string());
-                }
-                if hit.in_lexical {
-                    matched_via.push("lexical".to_string());
-                }
-
-                // Additive lensed belief per returned claim. Degrade-not-fail:
-                // a compute error for ONE claim yields null + a warn, never an
-                // aborted page (spec §8). min_truth/ranking stay on `tv`.
-                let lensed_belief = match lens {
-                    Some((frame_id, perspective_id)) => {
-                        match epigraph_engine::belief_query::get_perspective_belief(
-                            &server.pool,
-                            hit.claim_id,
-                            frame_id,
-                            perspective_id,
-                        )
-                        .await
-                        {
-                            Ok(interval) => Some(LensedBelief::from_interval(
-                                frame_id,
-                                perspective_id,
-                                &interval,
-                            )),
-                            Err(e) => {
-                                tracing::warn!(
-                                    claim_id = %hit.claim_id,
-                                    error = %e,
-                                    "lensed belief compute failed; serving null lens for this claim"
-                                );
-                                None
-                            }
+    for (merged_rrf_score, merged_hit) in merged {
+        match merged_hit {
+            MergedHit::Claim(hit) => {
+                if let Ok(Some(claim)) =
+                    ClaimRepository::get_by_id(&server.pool, ClaimId::from_uuid(hit.claim_id)).await
+                {
+                    let tv = claim.truth_value.value();
+                    if tv >= min_truth {
+                        let mut matched_via = Vec::new();
+                        if hit.dense_similarity.is_some() {
+                            matched_via.push("dense".to_string());
                         }
-                    }
-                    None => None,
-                };
+                        if hit.in_lexical {
+                            matched_via.push("lexical".to_string());
+                        }
 
-                results.push(RecallResult {
-                    claim_id: hit.claim_id.to_string(),
-                    content: claim.content,
-                    truth_value: tv,
-                    similarity: hit.dense_similarity.unwrap_or(0.0),
-                    rrf_score: hit.rrf_score,
-                    matched_via,
-                    lensed_belief,
-                });
+                        // Additive lensed belief per returned claim. Degrade-not-fail:
+                        // a compute error for ONE claim yields null + a warn, never an
+                        // aborted page (spec §8). min_truth/ranking stay on `tv`.
+                        let lensed_belief = match lens {
+                            Some((frame_id, perspective_id)) => {
+                                match epigraph_engine::belief_query::get_perspective_belief(
+                                    &server.pool,
+                                    hit.claim_id,
+                                    frame_id,
+                                    perspective_id,
+                                )
+                                .await
+                                {
+                                    Ok(interval) => Some(LensedBelief::from_interval(
+                                        frame_id,
+                                        perspective_id,
+                                        &interval,
+                                    )),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            claim_id = %hit.claim_id,
+                                            error = %e,
+                                            "lensed belief compute failed; serving null lens for this claim"
+                                        );
+                                        None
+                                    }
+                                }
+                            }
+                            None => None,
+                        };
+
+                        // Without a workflows leg (include_workflows=false, the
+                        // default), `merged_rrf_score` is 1/(k+rank) where rank is
+                        // the claim's position in `hits` — the SAME ordering
+                        // `hit.rrf_score` already produced (hits is sorted by
+                        // rrf_score DESC in SQL). Reporting hit.rrf_score (not
+                        // merged_rrf_score) here keeps the field byte-identical to
+                        // pre-Task-6.3 output for claims-only recall.
+                        let _ = merged_rrf_score;
+                        results.push(RecallResult {
+                            claim_id: hit.claim_id.to_string(),
+                            content: claim.content,
+                            truth_value: tv,
+                            similarity: hit.dense_similarity.unwrap_or(0.0),
+                            rrf_score: hit.rrf_score,
+                            matched_via,
+                            lensed_belief,
+                            result_type: None,
+                        });
+                    }
+                }
+            }
+            MergedHit::Workflow(hit) => {
+                if hit.truth_value >= min_truth {
+                    results.push(RecallResult {
+                        claim_id: hit.workflow_id.to_string(),
+                        content: hit.content,
+                        truth_value: hit.truth_value,
+                        similarity: hit.similarity,
+                        rrf_score: merged_rrf_score,
+                        matched_via: vec!["dense".to_string()],
+                        lensed_belief: None,
+                        result_type: Some("workflow".to_string()),
+                    });
+                }
             }
         }
     }
 
     success_json(&results)
+}
+
+#[doc(hidden)]
+pub mod __test_only {
+    use super::{recall_post_embed, EpiGraphMcpFull, McpError, RecallParams};
+    use rmcp::model::CallToolResult;
+
+    /// Integration-test entry point that skips the OpenAI embedder.
+    ///
+    /// Tests cannot call the real embedder (no API key in CI / sandbox), so
+    /// they pre-format a known pgvector literal and dispatch directly into
+    /// the post-embed pipeline. This is the same code `recall` runs after
+    /// `embedder.generate`. Mirrors `workflows.rs`'s
+    /// `__test_only::find_workflow_with_pgvec`.
+    pub async fn recall_with_pgvec(
+        server: &EpiGraphMcpFull,
+        params: RecallParams,
+        pgvec: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        recall_post_embed(server, params, pgvec).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -324,6 +324,14 @@ pub struct RecallParams {
     )]
     #[serde(default)]
     pub perspective_id: Option<String>,
+
+    #[schemars(
+        description = "When true, also search workflows.goal_embedding and RRF-merge workflow hits \
+                       into the results (tagged result_type=\"workflow\"). Default false: recall \
+                       searches claims only, byte-identical to pre-existing behavior."
+    )]
+    #[serde(default)]
+    pub include_workflows: bool,
 }
 
 // ── Ingestion ──
@@ -885,6 +893,13 @@ pub struct RecallResult {
     /// a lens-free recall is byte-identical to today.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lensed_belief: Option<LensedBelief>,
+
+    /// `Some("workflow")` for a hit sourced from `workflows.goal_embedding`
+    /// (only possible when `include_workflows=true`); omitted (not `null`)
+    /// for ordinary claim hits, so `include_workflows`-unset recall stays
+    /// byte-identical to pre-existing output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_type: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/epigraph-mcp/tests/perspective_lens_reads.rs
+++ b/crates/epigraph-mcp/tests/perspective_lens_reads.rs
@@ -638,6 +638,7 @@ async fn plain_recall_lens_attaches_diverging_belief(pool: PgPool) {
                 agent_id: None,
                 frame_id: frame.map(|f| f.to_string()),
                 perspective_id: perspective.map(|p| p.to_string()),
+                include_workflows: false,
             },
         )
     };
@@ -761,6 +762,7 @@ async fn plain_recall_lens_degrades_one_bad_claim_without_failing_page(pool: PgP
             agent_id: None,
             frame_id: Some(frame_row.id.to_string()),
             perspective_id: Some(persp.id.to_string()),
+            include_workflows: false,
         },
     )
     .await

--- a/crates/epigraph-mcp/tests/recall_hybrid.rs
+++ b/crates/epigraph-mcp/tests/recall_hybrid.rs
@@ -64,6 +64,7 @@ async fn recall_falls_back_to_scope_honoring_lexical_when_embedder_down(pool: Pg
         agent_id: None,
         frame_id: None,
         perspective_id: None,
+        include_workflows: false,
     };
     let out = recall(&server, params).await.expect("recall ok");
     let arr = parse_results(out);

--- a/crates/epigraph-mcp/tests/recall_workflows.rs
+++ b/crates/epigraph-mcp/tests/recall_workflows.rs
@@ -47,6 +47,32 @@ async fn seed_workflow_with_goal_embedding(pool: &PgPool, goal: &str, pgvec: &st
     id
 }
 
+/// Seed a claim with `embedding` set to the given pgvec literal, so it is a
+/// real hit on the claims dense leg of `search_hybrid_scoped`
+/// (`WHERE c.embedding IS NOT NULL AND c.is_current`). `seed_claim` in
+/// `common` does NOT set `embedding`, so a plain `seed_claim` never appears
+/// in a pgvec-driven dense search — using it here would make the
+/// `include_workflows` assertions vacuously true over an empty results
+/// array. Mirrors the seed pattern in `find_workflow_semantic_test.rs`.
+async fn seed_claim_with_embedding(pool: &PgPool, content: &str, pgvec: &str) -> Uuid {
+    let agent_id = seed_agent(pool).await;
+    let id = Uuid::new_v4();
+    let hash: Vec<u8> = id.as_bytes().iter().copied().cycle().take(32).collect();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id, is_current, labels, embedding) \
+         VALUES ($1, $2, $3, 0.8, $4, true, ARRAY[]::text[], $5::vector)",
+    )
+    .bind(id)
+    .bind(content)
+    .bind(&hash)
+    .bind(agent_id)
+    .bind(pgvec)
+    .execute(pool)
+    .await
+    .expect("seed claim with embedding");
+    id
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn recall_include_workflows_true_returns_matching_workflow(pool: PgPool) {
     // A workflow whose goal text does NOT appear in any claim content, so a
@@ -56,10 +82,13 @@ async fn recall_include_workflows_true_returns_matching_workflow(pool: PgPool) {
     let pgvec = unit_pgvec_1536();
     let workflow_id = seed_workflow_with_goal_embedding(&pool, goal, &pgvec).await;
 
-    // A couple of unrelated claims so the claims leg is non-empty (recall's
-    // normal path keeps working alongside the workflows leg).
-    seed_claim(&pool, "completely unrelated claim about lichens", 0.8).await;
-    seed_claim(&pool, "another unrelated claim about tectonic plates", 0.8).await;
+    // A claim seeded with the SAME embedding, so the claims dense leg is
+    // non-empty and the merge actually interleaves two populated ranked
+    // lists (not degenerately merging one populated list against an empty
+    // one). Without this, `hits` would be empty (plain `seed_claim` sets no
+    // `embedding`) and the test would pass even if the RRF-merge/interleave
+    // logic were broken.
+    let claim_id = seed_claim_with_embedding(&pool, "an unrelated matched claim", &pgvec).await;
 
     let server = build_test_server(pool);
     let params = RecallParams {
@@ -79,18 +108,26 @@ async fn recall_include_workflows_true_returns_matching_workflow(pool: PgPool) {
     let json = first_text(&out);
     let arr = json.as_array().expect("array");
 
-    let hit = arr
+    let claim_hit = arr
+        .iter()
+        .find(|r| r["claim_id"] == claim_id.to_string())
+        .unwrap_or_else(|| panic!("claim {claim_id} not found in recall results: {arr:?}"));
+    assert!(
+        claim_hit.get("result_type").is_none(),
+        "claim hit must NOT carry result_type (omitted, not null): {claim_hit:?}"
+    );
+
+    let workflow_hit = arr
         .iter()
         .find(|r| r["claim_id"] == workflow_id.to_string())
         .unwrap_or_else(|| panic!("workflow {workflow_id} not found in recall results: {arr:?}"));
-
     assert_eq!(
-        hit["result_type"],
+        workflow_hit["result_type"],
         serde_json::json!("workflow"),
         "workflow hit must be tagged result_type=\"workflow\""
     );
     assert_eq!(
-        hit["content"],
+        workflow_hit["content"],
         serde_json::json!(goal),
         "workflow hit content must be the workflow's goal text"
     );
@@ -102,7 +139,10 @@ async fn recall_include_workflows_false_excludes_workflow_only_match(pool: PgPoo
     let pgvec = unit_pgvec_1536();
     let workflow_id = seed_workflow_with_goal_embedding(&pool, goal, &pgvec).await;
 
-    seed_claim(&pool, "completely unrelated claim about lichens", 0.8).await;
+    // Same embedded-claim seed as the true-case test: proves the claims leg
+    // is genuinely populated (non-vacuous exclusion check) rather than the
+    // whole results array being empty regardless of `include_workflows`.
+    let claim_id = seed_claim_with_embedding(&pool, "an unrelated matched claim", &pgvec).await;
 
     let server = build_test_server(pool);
     let params = RecallParams {
@@ -124,6 +164,15 @@ async fn recall_include_workflows_false_excludes_workflow_only_match(pool: PgPoo
     let json = first_text(&out);
     let arr = json.as_array().expect("array");
 
+    assert!(
+        !arr.is_empty(),
+        "sanity: the claims leg must still return the seeded embedded claim \
+         (proves this isn't a vacuous empty-array pass): {arr:?}"
+    );
+    assert!(
+        arr.iter().any(|r| r["claim_id"] == claim_id.to_string()),
+        "matching claim must still be present when include_workflows is false: {arr:?}"
+    );
     assert!(
         arr.iter().all(|r| r["claim_id"] != workflow_id.to_string()),
         "workflow must NOT appear when include_workflows is false: {arr:?}"

--- a/crates/epigraph-mcp/tests/recall_workflows.rs
+++ b/crates/epigraph-mcp/tests/recall_workflows.rs
@@ -1,0 +1,131 @@
+//! Regression test for Task 6.3 (backlog claim 88a09fd2): `recall()` must
+//! optionally search `workflows.goal_embedding` alongside `claims`, RRF-merged
+//! with the existing dense+lexical claims leg, and tag workflow hits with
+//! `result_type: "workflow"`.
+//!
+//! Boundary/fallback note: `build_test_server` wires a mock `McpEmbedder`
+//! (no OpenAI API key — see `common::build_test_server`), so the MCP test
+//! process cannot generate a *real* embedding for the query text in-process.
+//! We therefore drive the deterministic `__test_only::recall_with_pgvec` seam
+//! (mirrors the established `find_workflow_with_pgvec` pattern in
+//! `workflows.rs`) with a hand-built pgvector literal, and seed the workflow's
+//! `goal_embedding` with that SAME literal so the ANN leg has an exact (distance
+//! 0) match. This exercises the real RRF-merge/tagging logic end-to-end; only
+//! the OpenAI HTTP call is stubbed out, matching the precedent set by
+//! `find_workflow_semantic_test.rs` for the same embedder constraint.
+
+#[rustfmt::skip]
+use epigraph_mcp::tools::memory::__test_only::recall_with_pgvec;
+use epigraph_mcp::types::RecallParams;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+use common::*;
+
+/// Build a 1536-d unit pgvector literal so the workflow's `goal_embedding`
+/// (seeded with the same literal) is an exact ANN match (cosine distance 0).
+fn unit_pgvec_1536() -> String {
+    let mut v = vec!["0.0"; 1536];
+    v[0] = "1.0";
+    format!("[{}]", v.join(","))
+}
+
+async fn seed_workflow_with_goal_embedding(pool: &PgPool, goal: &str, pgvec: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO workflows (id, canonical_name, generation, goal, metadata, truth_value, goal_embedding) \
+         VALUES ($1, $2, 0, $3, '{}'::jsonb, 1.0, $4::vector)",
+    )
+    .bind(id)
+    .bind(format!("wf-{id}"))
+    .bind(goal)
+    .bind(pgvec)
+    .execute(pool)
+    .await
+    .expect("seed workflow with goal_embedding");
+    id
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn recall_include_workflows_true_returns_matching_workflow(pool: PgPool) {
+    // A workflow whose goal text does NOT appear in any claim content, so a
+    // lexical/claims-only path can never surface it — only the workflows ANN
+    // leg can.
+    let goal = "orchestrate zylophonic beacon calibration";
+    let pgvec = unit_pgvec_1536();
+    let workflow_id = seed_workflow_with_goal_embedding(&pool, goal, &pgvec).await;
+
+    // A couple of unrelated claims so the claims leg is non-empty (recall's
+    // normal path keeps working alongside the workflows leg).
+    seed_claim(&pool, "completely unrelated claim about lichens", 0.8).await;
+    seed_claim(&pool, "another unrelated claim about tectonic plates", 0.8).await;
+
+    let server = build_test_server(pool);
+    let params = RecallParams {
+        query: "zylophonic beacon".to_string(),
+        min_truth: Some(0.0),
+        limit: Some(10),
+        tags: vec![],
+        agent_id: None,
+        frame_id: None,
+        perspective_id: None,
+        include_workflows: true,
+    };
+
+    let out = recall_with_pgvec(&server, params, Some(pgvec))
+        .await
+        .expect("recall_with_pgvec ok");
+    let json = first_text(&out);
+    let arr = json.as_array().expect("array");
+
+    let hit = arr
+        .iter()
+        .find(|r| r["claim_id"] == workflow_id.to_string())
+        .unwrap_or_else(|| panic!("workflow {workflow_id} not found in recall results: {arr:?}"));
+
+    assert_eq!(
+        hit["result_type"],
+        serde_json::json!("workflow"),
+        "workflow hit must be tagged result_type=\"workflow\""
+    );
+    assert_eq!(
+        hit["content"],
+        serde_json::json!(goal),
+        "workflow hit content must be the workflow's goal text"
+    );
+}
+
+#[sqlx::test(migrations = "../../migrations")]
+async fn recall_include_workflows_false_excludes_workflow_only_match(pool: PgPool) {
+    let goal = "orchestrate zylophonic beacon calibration";
+    let pgvec = unit_pgvec_1536();
+    let workflow_id = seed_workflow_with_goal_embedding(&pool, goal, &pgvec).await;
+
+    seed_claim(&pool, "completely unrelated claim about lichens", 0.8).await;
+
+    let server = build_test_server(pool);
+    let params = RecallParams {
+        query: "zylophonic beacon".to_string(),
+        min_truth: Some(0.0),
+        limit: Some(10),
+        tags: vec![],
+        agent_id: None,
+        frame_id: None,
+        perspective_id: None,
+        include_workflows: false,
+    };
+
+    // include_workflows defaults false: the workflows leg must not even be
+    // queried, so the workflow can never appear regardless of pgvec.
+    let out = recall_with_pgvec(&server, params, Some(pgvec))
+        .await
+        .expect("recall_with_pgvec ok");
+    let json = first_text(&out);
+    let arr = json.as_array().expect("array");
+
+    assert!(
+        arr.iter().all(|r| r["claim_id"] != workflow_id.to_string()),
+        "workflow must NOT appear when include_workflows is false: {arr:?}"
+    );
+}


### PR DESCRIPTION
## Task 6.3 — Unified recall() across claims + workflows

Backlog claim `88a09fd2-ea9c-4333-92c1-5c038031a791`, per the 2026-07-09 backlog-resolution plan. Prerequisite (`goal_embedding` populated on workflows, PR #296) already shipped.

### What this does
`recall()` gains `include_workflows: bool` (default `false`, zero behavior change when unset — the workflows leg is never queried, not run-and-discarded). When `true`, a new `WorkflowRepository::search_by_goal_embedding` ANN query over `workflows.goal_embedding` is RRF-merged in Rust with the claims leg, using the exact same fusion formula/constant claims already use SQL-side (`1.0 / (HYBRID_RRF_K + rank)`, `HYBRID_RRF_K = 60`). Workflow hits are tagged `result_type: "workflow"`.

### Design notes
- Added a **sibling** ANN method (`search_by_goal_embedding`) rather than reusing `find_hierarchical_by_embedding`: that helper takes `&[f32]` (can't share the one pre-formatted pgvector string `recall()`'s claims leg already computes), drops the similarity column, and carries params (`similarity_threshold`, `resolve_to_latest`) `recall` doesn't want.
- Split `recall()` into `recall()` (embeds the query once) → `recall_post_embed(...)` (retrieval/merge/response), mirroring the existing `find_workflow`/`find_workflow_post_embed` seam — lets both legs reuse the SAME query embedding (no re-embedding) and adds a `__test_only::recall_with_pgvec` test seam matching the established `find_workflow_with_pgvec` pattern (confirmed by review to call the real `recall_post_embed`, not a parallel test-only path).
- Used cosine distance (`<=>`) not the brief's literal L2 (`<->`), matching every other ANN query on these columns.

### Task review: Approved, spec compliance Met. Three Minor findings (non-blocking, worth your eyes)
1. **`tags`/`agent_id` don't scope the workflows leg** (workflows have no such columns). A `tags`-scoped `recall()` call can now surface an unscoped workflow it wouldn't have before this PR — a real (if narrow) scope-leak, not just a doc nit. `min_truth` does apply post-merge to both. Reviewer recommends documenting this explicitly on `include_workflows`, or skipping the workflows leg when `tags`/`agent_id` are set — your call on which.
2. `rrf_score` on a claim hit is still its original SQL-fused value (can be a sum across dense+lexical), while the merged list's actual sort order uses a different single-term merge-stage score — so displayed `rrf_score` isn't always monotonic with result order once workflows are mixed in. Serve order is correct; only a client re-sorting by the displayed field would be misled.
3. The "byte-identical to old behavior" claim is narrowly overstated for one edge case: the old code's single `Result` meant a dense/lexical SQL failure (not just embedder failure) fell back to lexical-only; the new code only branches on embedder success, so that specific DB-error arm now propagates instead of degrading. Narrow trigger, but not literally byte-identical in that one case.

### Verification
- New `crates/epigraph-mcp/tests/recall_workflows.rs` (2 tests): `include_workflows=true` surfaces a workflow-only match; `false` excludes it even with the identical pgvector, proving the leg isn't queried when unset.
- Zero-behavior-change regression: `recall_hybrid` (1/1), `recall_with_context` (14/14), `perspective_lens_reads` (9/9), `find_workflow_semantic_test` (1/1), `epigraph-db` workflow lib tests (7/7) all pass unchanged.
- `cargo fmt --check` clean; `cargo clippy --workspace --locked -- -D warnings` clean (CI-exact); no `.sqlx/` drift.
- Full `epigraph-mcp` integration sweep green except `verbatim_spine_e2e.rs`, confirmed pre-existing/unrelated `#[sqlx::test]` temp-DB lifecycle flake (reproduces identically on this branch's base commit; diff touches no ingestion/document-spine files).

### Notes for reviewer
- Backlog `resolve_backlog_item` intentionally **not** fired from this branch — live graph write, deferred to post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)