### PR TITLE
chore: promote dev to main (PR #312 doi_to_slug + PR #327 get_claim atomic fix)

### DIFF
--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -500,6 +500,60 @@ impl ClaimRepository {
         Ok(row.map(|(l,)| l).unwrap_or_default())
     }
 
+    /// Get a claim by ID together with its labels in a single SQL statement.
+    ///
+    /// `get_by_id` followed by `get_labels` is two independent round trips
+    /// against the shared pool: a concurrent `update_labels` between them can
+    /// return labels inconsistent with the already-read claim row (TOCTOU).
+    /// A single-statement, single-row `SELECT` is inherently consistent under
+    /// Postgres MVCC, so this is the atomic alternative for callers (e.g. MCP
+    /// `get_claim`) that need both together.
+    ///
+    /// # Errors
+    /// Returns `DbError::QueryFailed` if the database query fails.
+    #[instrument(skip(pool))]
+    pub async fn get_by_id_with_labels(
+        pool: &PgPool,
+        id: ClaimId,
+    ) -> Result<Option<(Claim, Vec<String>)>, DbError> {
+        let uuid: Uuid = id.into();
+
+        use sqlx::Row;
+        let row = sqlx::query(
+            r#"
+            SELECT id, content, truth_value, agent_id, trace_id,
+                   created_at, updated_at, is_current, supersedes, labels
+            FROM claims
+            WHERE id = $1
+            "#,
+        )
+        .bind(uuid)
+        .fetch_optional(pool)
+        .await?;
+
+        match row {
+            Some(row) => {
+                let truth_value = TruthValue::new(row.get::<f64, _>("truth_value"))?;
+                let mut claim = claim_from_row(
+                    row.get("id"),
+                    row.get("content"),
+                    row.get("agent_id"),
+                    row.get("trace_id"),
+                    truth_value,
+                    row.get("created_at"),
+                    row.get("updated_at"),
+                );
+                // Post-fix retirement state so callers see real DB values
+                // instead of `claim_from_row`'s defaults, mirroring `get_by_id`.
+                claim.is_current = row.get::<bool, _>("is_current");
+                claim.supersedes = row.get::<Option<Uuid>, _>("supersedes").map(ClaimId::from_uuid);
+                let labels: Vec<String> = row.get("labels");
+                Ok(Some((claim, labels)))
+            }
+            None => Ok(None),
+        }
+    }
+
     /// kNN search over `claims.embedding` (1536d) or `claims.embedding_3072`,
     /// restricted to paragraph-level (level=2) claims, optionally filtered by
     /// the paper that asserts the claim. Results are ordered by cosine

--- a/crates/epigraph-db/src/repos/claim.rs
+++ b/crates/epigraph-db/src/repos/claim.rs
@@ -546,7 +546,9 @@ impl ClaimRepository {
                 // Post-fix retirement state so callers see real DB values
                 // instead of `claim_from_row`'s defaults, mirroring `get_by_id`.
                 claim.is_current = row.get::<bool, _>("is_current");
-                claim.supersedes = row.get::<Option<Uuid>, _>("supersedes").map(ClaimId::from_uuid);
+                claim.supersedes = row
+                    .get::<Option<Uuid>, _>("supersedes")
+                    .map(ClaimId::from_uuid);
                 let labels: Vec<String> = row.get("labels");
                 Ok(Some((claim, labels)))
             }

--- a/crates/epigraph-db/tests/claim_get_by_id_with_labels.rs
+++ b/crates/epigraph-db/tests/claim_get_by_id_with_labels.rs
@@ -113,5 +113,8 @@ async fn get_by_id_with_labels_matches_separate_calls() {
     let mut old_sorted = labels_via_old.clone();
     old_sorted.sort();
     assert_eq!(new_sorted, old_sorted);
-    assert_eq!(new_sorted, vec!["atomic".to_string(), "backlog".to_string()]);
+    assert_eq!(
+        new_sorted,
+        vec!["atomic".to_string(), "backlog".to_string()]
+    );
 }

--- a/crates/epigraph-db/tests/claim_get_by_id_with_labels.rs
+++ b/crates/epigraph-db/tests/claim_get_by_id_with_labels.rs
@@ -1,0 +1,117 @@
+//! Integration tests for `ClaimRepository::get_by_id_with_labels`.
+//!
+//! Regression coverage for the `get_claim` TOCTOU race: the old MCP handler
+//! fetched a claim's core fields and its labels via two separate,
+//! unsynchronized queries (`get_by_id` then `get_labels`), so a concurrent
+//! `update_labels` between the two round trips could return labels
+//! inconsistent with the claim row already read. `get_by_id_with_labels`
+//! reads both from a single SQL statement, which is inherently consistent
+//! under Postgres MVCC.
+
+use epigraph_core::{AgentId, Claim, TruthValue};
+use epigraph_db::ClaimRepository;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn try_test_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&url)
+        .await
+        .ok()?;
+    sqlx::migrate!("../../migrations").run(&pool).await.ok()?;
+    Some(pool)
+}
+
+macro_rules! test_pool_or_skip {
+    () => {{
+        match try_test_pool().await {
+            Some(p) => p,
+            None => {
+                eprintln!("Skipping DB test: DATABASE_URL not set or unreachable");
+                return;
+            }
+        }
+    }};
+}
+
+async fn insert_test_agent(pool: &PgPool, agent_id: Uuid) {
+    sqlx::query(
+        r#"INSERT INTO agents (id, public_key, created_at, updated_at)
+           VALUES ($1, sha256($1::text::bytea), NOW(), NOW())
+           ON CONFLICT (id) DO NOTHING"#,
+    )
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .expect("upsert agent");
+}
+
+fn make_claim(content: &str, agent_id: Uuid) -> Claim {
+    Claim::new(
+        content.to_string(),
+        AgentId::from_uuid(agent_id),
+        [0u8; 32],
+        TruthValue::new(0.5).unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn get_by_id_with_labels_returns_none_when_no_row() {
+    let pool = test_pool_or_skip!();
+
+    let found = ClaimRepository::get_by_id_with_labels(&pool, epigraph_core::ClaimId::new())
+        .await
+        .expect("query call");
+
+    assert!(found.is_none(), "expected None, got {:?}", found.is_some());
+}
+
+#[tokio::test]
+async fn get_by_id_with_labels_matches_separate_calls() {
+    let pool = test_pool_or_skip!();
+    let agent_id = Uuid::new_v4();
+    insert_test_agent(&pool, agent_id).await;
+
+    let claim = make_claim(&format!("atomic read {}", Uuid::new_v4()), agent_id);
+    let created = ClaimRepository::create(&pool, &claim)
+        .await
+        .expect("create");
+
+    ClaimRepository::update_labels(
+        &pool,
+        created.id.as_uuid(),
+        &["backlog".to_string(), "atomic".to_string()],
+        &[],
+    )
+    .await
+    .expect("seed labels");
+
+    let (via_new, labels_via_new) = ClaimRepository::get_by_id_with_labels(&pool, created.id)
+        .await
+        .expect("get_by_id_with_labels")
+        .expect("claim exists");
+
+    let via_old = ClaimRepository::get_by_id(&pool, created.id)
+        .await
+        .expect("get_by_id")
+        .expect("claim exists");
+    let labels_via_old = ClaimRepository::get_labels(&pool, created.id)
+        .await
+        .expect("get_labels");
+
+    assert_eq!(via_new.id, via_old.id);
+    assert_eq!(via_new.content, via_old.content);
+    assert_eq!(via_new.agent_id, via_old.agent_id);
+    assert_eq!(via_new.is_current, via_old.is_current);
+    assert_eq!(via_new.supersedes, via_old.supersedes);
+
+    let mut new_sorted = labels_via_new.clone();
+    new_sorted.sort();
+    let mut old_sorted = labels_via_old.clone();
+    old_sorted.sort();
+    assert_eq!(new_sorted, old_sorted);
+    assert_eq!(new_sorted, vec!["atomic".to_string(), "backlog".to_string()]);
+}

--- a/crates/epigraph-mcp/src/tools/claims.rs
+++ b/crates/epigraph-mcp/src/tools/claims.rs
@@ -322,13 +322,10 @@ pub async fn get_claim(
         crate::tools::lens::validate_lens_exists(&server.pool, frame_id, perspective_id).await?;
     }
 
-    let claim = ClaimRepository::get_by_id(&server.pool, claim_id)
+    let (claim, labels) = ClaimRepository::get_by_id_with_labels(&server.pool, claim_id)
         .await
         .map_err(internal_error)?
         .ok_or_else(|| invalid_params(format!("claim {id} not found")))?;
-    let labels = ClaimRepository::get_labels(&server.pool, claim_id)
-        .await
-        .map_err(internal_error)?;
     let access = check_content_access(&server.pool, claim.id.as_uuid(), requester).await;
     let (content, content_hash) =
         crate::tools::redaction::redact_content(access, &claim.content, &claim.content_hash);

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -656,6 +656,13 @@ pub async fn do_ingest_document(
     })
 }
 
+/// Convert a DOI into a slug form safe for use as a URL path segment or
+/// canonical name: every `/` becomes `-`. Casing is left untouched.
+#[allow(dead_code)] // not yet wired into a caller; covered by unit tests below
+fn doi_to_slug(doi: &str) -> String {
+    doi.replace('/', "-")
+}
+
 fn resolve_doi(extraction: &DocumentExtraction) -> String {
     if let Some(d) = &extraction.source.doi {
         return d.clone();
@@ -1131,5 +1138,18 @@ mod tests {
             .await
             .expect("gate query");
         assert_eq!(hit, Some(paper_id));
+    }
+
+    #[test]
+    fn doi_to_slug_replaces_slash() {
+        assert_eq!(
+            doi_to_slug("10.48550/arXiv.2606.04990"),
+            "10.48550-arXiv.2606.04990"
+        );
+    }
+
+    #[test]
+    fn doi_to_slug_replaces_all_slashes() {
+        assert_eq!(doi_to_slug("10.1000/xyz/123/abc"), "10.1000-xyz-123-abc");
     }
 }


### PR DESCRIPTION
## Summary
- Promotes `dev` to `main`. `dev` was 6 commits ahead / 0 behind `main`, containing two previously-merged-to-dev changes that never got promoted:
  - PR #312: `feat(mcp): add doi_to_slug helper for DOI-to-slug conversion`
  - PR #327: `fix(mcp): make get_claim's claim+labels read atomic` (Foreman-authored, base branch was `dev` not `main` — this is why merging #327 didn't move `main`)
- Clean fast-forward, no conflicts.

## Test plan
- [x] `cargo +1.97.0 build --workspace --locked` — clean
- [x] `cargo +1.97.0 fmt --check` — clean
- [x] `cargo +1.97.0 clippy --workspace --locked -- -D warnings` — clean
- [x] `cargo test -p epigraph-mcp --locked -- --test-threads=1` (full suite) — all pass, 0 failures
- [x] PR #327 itself passed real CI (`test` job) against `dev` as its base before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)