### PR TITLE
feat(ingest): back-fill authors from body byline when source.authors is empty

### DIFF
--- a/crates/epigraph-ingest/src/document/byline.rs
+++ b/crates/epigraph-ingest/src/document/byline.rs
@@ -1,0 +1,269 @@
+//! Conservative author-byline recovery from raw document body text.
+//!
+//! Hierarchical extraction occasionally drops `source.authors` (empty array),
+//! leaving `ingest_document` with no real authors to attribute a paper to.
+//! [`parse_byline_authors`] is a defensive backstop: it scans the *top* of the
+//! source text for the author byline that typically sits between the title and
+//! the abstract, and returns the parsed names.
+//!
+//! The parser is deliberately **conservative** — it must never turn title
+//! words into fake author agents. When it is not confident it returns an empty
+//! `Vec`, which is exactly the existing behavior (the Rust write path inserts
+//! no placeholder author). False negatives are safe; false positives are the
+//! enemy, because each fake name mints a deterministic author agent that then
+//! pollutes co-authorship edges across every paper that shares the phrase.
+
+use crate::common::schema::AuthorEntry;
+
+/// Number of leading lines to consider — the byline of an arXiv/journal paper
+/// sits within the first handful of lines, above the abstract.
+const MAX_SCAN_LINES: usize = 15;
+
+/// Attempt to recover author names from the byline near the top of `source_text`.
+///
+/// Returns the parsed authors, or an empty `Vec` when no confident byline is
+/// found. Conservative by construction: a candidate line only qualifies when
+/// *every* comma / `and`-separated segment is name-shaped (see
+/// [`segment_is_name_shaped`]).
+#[must_use]
+pub fn parse_byline_authors(source_text: &str) -> Vec<AuthorEntry> {
+    // Scan the leading lines, stopping at the abstract (the byline is always
+    // above it). Skip the very first non-empty line: that is the title, and a
+    // title can incidentally be name-shaped ("Firstname Lastname" as a subject).
+    let mut seen_first_content = false;
+    for raw_line in source_text.lines().take(MAX_SCAN_LINES) {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if is_abstract_marker(line) {
+            break;
+        }
+        if !seen_first_content {
+            // This is the title line; never mine it for authors.
+            seen_first_content = true;
+            continue;
+        }
+        if let Some(authors) = parse_byline_line(line) {
+            return authors;
+        }
+    }
+    Vec::new()
+}
+
+/// A line is the abstract boundary if it begins with "abstract" (case-insensitive),
+/// optionally followed by a colon. Once we reach it, the byline is behind us.
+fn is_abstract_marker(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower == "abstract" || lower.starts_with("abstract:") || lower.starts_with("abstract ")
+}
+
+/// Parse a single candidate byline line into authors, or `None` if the line is
+/// not a confident, all-name-shaped byline.
+fn parse_byline_line(line: &str) -> Option<Vec<AuthorEntry>> {
+    let segments = split_author_segments(line);
+    if segments.is_empty() {
+        return None;
+    }
+    let mut authors = Vec::with_capacity(segments.len());
+    for seg in &segments {
+        if !segment_is_name_shaped(seg) {
+            // Any non-name segment disqualifies the whole line: a real byline is
+            // uniformly name-shaped, so a mixed line is almost certainly prose.
+            return None;
+        }
+        authors.push(AuthorEntry {
+            name: (*seg).to_string(),
+            affiliations: Vec::new(),
+            roles: Vec::new(),
+        });
+    }
+    Some(authors)
+}
+
+/// Split a byline line on commas and the conjunction "and" / "&", trimming
+/// whitespace and dropping empty segments. Handles the common
+/// "A, B, and C" / "A and B" / "A, B & C" shapes.
+fn split_author_segments(line: &str) -> Vec<&str> {
+    line.split(',')
+        .flat_map(|piece| {
+            piece
+                .split(" and ")
+                .flat_map(|p| p.split(" & "))
+                .collect::<Vec<_>>()
+        })
+        .map(str::trim)
+        // A trailing "and C" arrives here as the segment "and C" only when there
+        // was no comma before it; the `split(" and ")` above already handles the
+        // spaced form. Guard against a bare leading/trailing "and" token.
+        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("and"))
+        .collect()
+}
+
+/// A segment is name-shaped when it is 2–4 whitespace tokens, each token being
+/// an initial (`J.`) or a Capitalized word, with no digits and no all-caps
+/// acronyms. This rejects title fragments ("Attention Is All You Need" is 5
+/// tokens with no comma → one over-long segment) while accepting real names
+/// ("Jane Q. Smith", "A. Turing").
+fn segment_is_name_shaped(seg: &str) -> bool {
+    let tokens: Vec<&str> = seg.split_whitespace().collect();
+    if tokens.len() < 2 || tokens.len() > 4 {
+        return false;
+    }
+    tokens.iter().all(|t| token_is_name_shaped(t))
+}
+
+/// A token qualifies as a name token when it is either an initial (`J.` / `J`
+/// single uppercase letter, optionally dotted / hyphenated initials) or a
+/// Capitalized word: leading uppercase, at least one following lowercase, no
+/// digits, and not ALL-CAPS.
+fn token_is_name_shaped(token: &str) -> bool {
+    // Strip a trailing name particle punctuation we allow inside names.
+    let t = token.trim_matches(|c: char| c == '.');
+    if t.is_empty() {
+        // token was just dots
+        return false;
+    }
+    let cleaned = t.replace(['-', '\''], "");
+    if cleaned.is_empty() {
+        return false;
+    }
+    // No digits anywhere.
+    if cleaned.chars().any(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    // Every char must be alphabetic (after removing the particle punctuation).
+    if !cleaned.chars().all(char::is_alphabetic) {
+        return false;
+    }
+    let first = cleaned.chars().next().unwrap();
+    if !first.is_uppercase() {
+        return false;
+    }
+    // Single-letter initial (with or without the stripped dot) is fine.
+    if cleaned.chars().count() == 1 {
+        return true;
+    }
+    // Multi-letter word: must not be ALL-CAPS (rejects acronyms like "NASA",
+    // "IEEE"), i.e. it must contain at least one lowercase letter.
+    cleaned.chars().any(char::is_lowercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_only_authors_are_recovered() {
+        // Realistic shape: title, blank, byline, blank, abstract, body.
+        // No structured source.authors exist — the names live ONLY in the body.
+        let text = "\
+Deep Residual Learning for Image Recognition
+
+Kaiming He, Xiangyu Zhang, Shaoqing Ren, and Jian Sun
+
+Abstract
+We present a residual learning framework to ease the training of networks.
+";
+        let authors = parse_byline_authors(text);
+        let names: Vec<&str> = authors.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["Kaiming He", "Xiangyu Zhang", "Shaoqing Ren", "Jian Sun"]
+        );
+    }
+
+    #[test]
+    fn normal_comma_and_byline_yields_three_entries() {
+        let text = "\
+A Study of Something
+
+Ada Lovelace, Grace Hopper, and Barbara Liskov
+
+Abstract
+Body text here.
+";
+        let authors = parse_byline_authors(text);
+        assert_eq!(authors.len(), 3);
+        assert_eq!(authors[0].name, "Ada Lovelace");
+        assert_eq!(authors[1].name, "Grace Hopper");
+        assert_eq!(authors[2].name, "Barbara Liskov");
+    }
+
+    #[test]
+    fn no_recognizable_byline_yields_empty() {
+        // A title-only document with prose — no name-shaped byline line.
+        let text = "\
+Attention Is All You Need
+
+The dominant sequence transduction models are based on complex recurrent or
+convolutional neural networks that include an encoder and a decoder.
+";
+        let authors = parse_byline_authors(text);
+        assert!(authors.is_empty(), "expected no authors, got {authors:?}");
+    }
+
+    #[test]
+    fn all_caps_acronym_line_is_rejected() {
+        // Adversarial: an org line under the title must not be parsed as authors.
+        let text = "\
+Some Technical Report
+
+NASA JPL CALTECH
+
+Abstract
+Contents.
+";
+        assert!(parse_byline_authors(text).is_empty());
+    }
+
+    #[test]
+    fn single_author_with_initial_is_recovered() {
+        let text = "\
+On Computable Numbers
+
+Alan M. Turing
+
+Abstract
+Body.
+";
+        let authors = parse_byline_authors(text);
+        assert_eq!(authors.len(), 1);
+        assert_eq!(authors[0].name, "Alan M. Turing");
+    }
+
+    #[test]
+    fn ampersand_separator_is_supported() {
+        let text = "\
+Structure and Interpretation
+
+Harold Abelson & Gerald Sussman
+
+Abstract
+Body.
+";
+        let authors = parse_byline_authors(text);
+        let names: Vec<&str> = authors.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["Harold Abelson", "Gerald Sussman"]);
+    }
+
+    #[test]
+    fn empty_input_yields_empty() {
+        assert!(parse_byline_authors("").is_empty());
+    }
+
+    #[test]
+    fn prose_sentence_after_title_is_not_mined() {
+        // A short capitalized prose line that is not a byline must be rejected
+        // because its segments are not uniformly name-shaped.
+        let text = "\
+Introduction to Widgets
+
+This Paper Describes a New Approach to widget fabrication.
+
+Abstract
+Body.
+";
+        assert!(parse_byline_authors(text).is_empty());
+    }
+}

--- a/crates/epigraph-ingest/src/document/byline.rs
+++ b/crates/epigraph-ingest/src/document/byline.rs
@@ -100,14 +100,70 @@ fn split_author_segments(line: &str) -> Vec<&str> {
         .collect()
 }
 
+/// Lowercased organizational / publication keywords that betray an institution,
+/// publisher, or document-label line masquerading as a name. A segment
+/// containing any of these is never a personal name, so its presence
+/// disqualifies the whole candidate byline. This closes the false-positive
+/// where a short Title-Case line like "Nuclear Regulatory Commission" or
+/// "Stanford University" (token-shaped like a 2–3 word name) would otherwise
+/// mint a bogus author agent. Conservative by design: over-rejecting is safe.
+const ORG_KEYWORDS: &[&str] = &[
+    "university",
+    "institute",
+    "institution",
+    "college",
+    "commission",
+    "committee",
+    "department",
+    "laboratory",
+    "laboratories",
+    "corporation",
+    "company",
+    "incorporated",
+    "limited",
+    "society",
+    "association",
+    "foundation",
+    "center",
+    "centre",
+    "council",
+    "agency",
+    "administration",
+    "ministry",
+    "bureau",
+    "office",
+    "division",
+    "consortium",
+    "organization",
+    "organisation",
+    "journal",
+    "press",
+    "publishing",
+    "publishers",
+    "review",
+    "proceedings",
+    "report",
+    "hospital",
+    "school",
+    "faculty",
+];
+
 /// A segment is name-shaped when it is 2–4 whitespace tokens, each token being
 /// an initial (`J.`) or a Capitalized word, with no digits and no all-caps
-/// acronyms. This rejects title fragments ("Attention Is All You Need" is 5
-/// tokens with no comma → one over-long segment) while accepting real names
-/// ("Jane Q. Smith", "A. Turing").
+/// acronyms, AND it contains no organizational keyword. This rejects title
+/// fragments ("Attention Is All You Need" is 5 tokens with no comma → one
+/// over-long segment) and institution lines ("Stanford University") while
+/// accepting real names ("Jane Q. Smith", "A. Turing").
 fn segment_is_name_shaped(seg: &str) -> bool {
     let tokens: Vec<&str> = seg.split_whitespace().collect();
     if tokens.len() < 2 || tokens.len() > 4 {
+        return false;
+    }
+    if tokens.iter().any(|t| {
+        let lowered = t.to_ascii_lowercase();
+        let word = lowered.trim_matches('.').trim();
+        ORG_KEYWORDS.contains(&word)
+    }) {
         return false;
     }
     tokens.iter().all(|t| token_is_name_shaped(t))
@@ -250,6 +306,39 @@ Body.
     #[test]
     fn empty_input_yields_empty() {
         assert!(parse_byline_authors("").is_empty());
+    }
+
+    #[test]
+    fn institution_line_is_not_parsed_as_an_author() {
+        // Adversarial false-positive guard: a short Title-Case institution line
+        // on the second content line is name-shaped by token rules but is NOT a
+        // person. It must be rejected — minting it as an author agent would
+        // pollute co-authorship edges.
+        let text = "\
+Annual Safety Report
+
+Nuclear Regulatory Commission
+
+Abstract
+Contents.
+";
+        assert!(
+            parse_byline_authors(text).is_empty(),
+            "institution line must not parse as an author"
+        );
+    }
+
+    #[test]
+    fn university_affiliation_line_is_not_parsed_as_an_author() {
+        let text = "\
+A Preprint
+
+Stanford University
+
+Abstract
+Body.
+";
+        assert!(parse_byline_authors(text).is_empty());
     }
 
     #[test]

--- a/crates/epigraph-ingest/src/document/mod.rs
+++ b/crates/epigraph-ingest/src/document/mod.rs
@@ -1,6 +1,7 @@
 //! Document-specific (paper / textbook / report / …) extraction and ingest.
 
 pub mod builder;
+pub mod byline;
 pub mod schema;
 pub mod structure;
 

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -356,29 +356,33 @@ pub async fn do_ingest_document(
             | epigraph_ingest::document::schema::SourceType::Textbook
     );
     let parsed_fallback;
-    let authors: &[epigraph_ingest::common::schema::AuthorEntry] =
-        if extraction.source.authors.is_empty() && byline_eligible {
-            parsed_fallback = extraction
-                .source_text
-                .as_deref()
-                .map(epigraph_ingest::document::byline::parse_byline_authors)
-                .unwrap_or_default();
-            if parsed_fallback.is_empty() {
-                tracing::warn!(
-                    paper = %paper_title,
-                    "ingest_document: source.authors empty and no byline recovered from body; paper will have no author agents"
-                );
-            } else {
-                tracing::info!(
-                    paper = %paper_title,
-                    count = parsed_fallback.len(),
-                    "ingest_document: source.authors empty; recovered authors from body byline fallback"
-                );
-            }
-            &parsed_fallback
+    let authors: &[epigraph_ingest::common::schema::AuthorEntry] = if extraction
+        .source
+        .authors
+        .is_empty()
+        && byline_eligible
+    {
+        parsed_fallback = extraction
+            .source_text
+            .as_deref()
+            .map(epigraph_ingest::document::byline::parse_byline_authors)
+            .unwrap_or_default();
+        if parsed_fallback.is_empty() {
+            tracing::warn!(
+                paper = %paper_title,
+                "ingest_document: source.authors empty and no byline recovered from body; paper will have no author agents"
+            );
         } else {
-            &extraction.source.authors
-        };
+            tracing::info!(
+                paper = %paper_title,
+                count = parsed_fallback.len(),
+                "ingest_document: source.authors empty; recovered authors from body byline fallback"
+            );
+        }
+        &parsed_fallback
+    } else {
+        &extraction.source.authors
+    };
     for (idx, author) in authors.iter().enumerate() {
         if author.name.is_empty() {
             continue;
@@ -855,29 +859,33 @@ pub async fn do_ingest_document_spine(
             | epigraph_ingest::document::schema::SourceType::Textbook
     );
     let parsed_fallback;
-    let authors: &[epigraph_ingest::common::schema::AuthorEntry] =
-        if extraction.source.authors.is_empty() && byline_eligible {
-            parsed_fallback = extraction
-                .source_text
-                .as_deref()
-                .map(epigraph_ingest::document::byline::parse_byline_authors)
-                .unwrap_or_default();
-            if parsed_fallback.is_empty() {
-                tracing::warn!(
-                    paper = %paper_title,
-                    "ingest_document_spine: source.authors empty and no byline recovered from body; paper will have no author agents"
-                );
-            } else {
-                tracing::info!(
-                    paper = %paper_title,
-                    count = parsed_fallback.len(),
-                    "ingest_document_spine: source.authors empty; recovered authors from body byline fallback"
-                );
-            }
-            &parsed_fallback
+    let authors: &[epigraph_ingest::common::schema::AuthorEntry] = if extraction
+        .source
+        .authors
+        .is_empty()
+        && byline_eligible
+    {
+        parsed_fallback = extraction
+            .source_text
+            .as_deref()
+            .map(epigraph_ingest::document::byline::parse_byline_authors)
+            .unwrap_or_default();
+        if parsed_fallback.is_empty() {
+            tracing::warn!(
+                paper = %paper_title,
+                "ingest_document_spine: source.authors empty and no byline recovered from body; paper will have no author agents"
+            );
         } else {
-            &extraction.source.authors
-        };
+            tracing::info!(
+                paper = %paper_title,
+                count = parsed_fallback.len(),
+                "ingest_document_spine: source.authors empty; recovered authors from body byline fallback"
+            );
+        }
+        &parsed_fallback
+    } else {
+        &extraction.source.authors
+    };
     for (idx, author) in authors.iter().enumerate() {
         if author.name.is_empty() {
             continue;

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -338,7 +338,41 @@ pub async fn do_ingest_document(
     // pending an AgentRepository properties surface.
     let mut author_responses = Vec::new();
     let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
-    for (idx, author) in extraction.source.authors.iter().enumerate() {
+    // Defensive backstop (backlog a55aac45): hierarchical extraction sometimes
+    // drops `source.authors` (empty array), so a paper would be recorded with no
+    // real authors. When the structured list is empty, fall back to parsing the
+    // author byline out of the raw `source_text` body (Tier 1 only; Tier 2 has
+    // no `source_text` and silently no-ops). The parser is conservative and
+    // returns empty when unsure — it never fabricates a placeholder author, so
+    // the empty-fallback case preserves the pre-existing behavior exactly.
+    let parsed_fallback;
+    let authors: &[epigraph_ingest::common::schema::AuthorEntry] = if extraction
+        .source
+        .authors
+        .is_empty()
+    {
+        parsed_fallback = extraction
+            .source_text
+            .as_deref()
+            .map(epigraph_ingest::document::byline::parse_byline_authors)
+            .unwrap_or_default();
+        if parsed_fallback.is_empty() {
+            tracing::warn!(
+                paper = %paper_title,
+                "ingest_document: source.authors empty and no byline recovered from body; paper will have no author agents"
+            );
+        } else {
+            tracing::info!(
+                paper = %paper_title,
+                count = parsed_fallback.len(),
+                "ingest_document: source.authors empty; recovered authors from body byline fallback"
+            );
+        }
+        &parsed_fallback
+    } else {
+        &extraction.source.authors
+    };
+    for (idx, author) in authors.iter().enumerate() {
         if author.name.is_empty() {
             continue;
         }
@@ -802,7 +836,38 @@ pub async fn do_ingest_document_spine(
     // ── 2. Ensure author agents + authored edges ──
     let mut author_responses = Vec::new();
     let mut author_agent_map: HashMap<usize, Uuid> = HashMap::new();
-    for (idx, author) in extraction.source.authors.iter().enumerate() {
+    // Same defensive backstop as `do_ingest_document` (backlog a55aac45): the
+    // spine path is the recommended two-phase entry and shares the empty-authors
+    // failure mode, so recover the byline from `source_text` when the structured
+    // author list is absent. Conservative parser; empty ⇒ pre-existing behavior.
+    let parsed_fallback;
+    let authors: &[epigraph_ingest::common::schema::AuthorEntry] = if extraction
+        .source
+        .authors
+        .is_empty()
+    {
+        parsed_fallback = extraction
+            .source_text
+            .as_deref()
+            .map(epigraph_ingest::document::byline::parse_byline_authors)
+            .unwrap_or_default();
+        if parsed_fallback.is_empty() {
+            tracing::warn!(
+                paper = %paper_title,
+                "ingest_document_spine: source.authors empty and no byline recovered from body; paper will have no author agents"
+            );
+        } else {
+            tracing::info!(
+                paper = %paper_title,
+                count = parsed_fallback.len(),
+                "ingest_document_spine: source.authors empty; recovered authors from body byline fallback"
+            );
+        }
+        &parsed_fallback
+    } else {
+        &extraction.source.authors
+    };
+    for (idx, author) in authors.iter().enumerate() {
         if author.name.is_empty() {
             continue;
         }

--- a/crates/epigraph-mcp/src/tools/ingestion.rs
+++ b/crates/epigraph-mcp/src/tools/ingestion.rs
@@ -345,33 +345,40 @@ pub async fn do_ingest_document(
     // no `source_text` and silently no-ops). The parser is conservative and
     // returns empty when unsure — it never fabricates a placeholder author, so
     // the empty-fallback case preserves the pre-existing behavior exactly.
+    //
+    // Gated on `source_type` Paper/Textbook: only those follow the
+    // title→authors→abstract convention the byline parser assumes. Reports,
+    // legal, transcripts etc. put institution/label lines where a byline would
+    // be, so running the parser there is pure false-positive downside.
+    let byline_eligible = matches!(
+        extraction.source.source_type,
+        epigraph_ingest::document::schema::SourceType::Paper
+            | epigraph_ingest::document::schema::SourceType::Textbook
+    );
     let parsed_fallback;
-    let authors: &[epigraph_ingest::common::schema::AuthorEntry] = if extraction
-        .source
-        .authors
-        .is_empty()
-    {
-        parsed_fallback = extraction
-            .source_text
-            .as_deref()
-            .map(epigraph_ingest::document::byline::parse_byline_authors)
-            .unwrap_or_default();
-        if parsed_fallback.is_empty() {
-            tracing::warn!(
-                paper = %paper_title,
-                "ingest_document: source.authors empty and no byline recovered from body; paper will have no author agents"
-            );
+    let authors: &[epigraph_ingest::common::schema::AuthorEntry] =
+        if extraction.source.authors.is_empty() && byline_eligible {
+            parsed_fallback = extraction
+                .source_text
+                .as_deref()
+                .map(epigraph_ingest::document::byline::parse_byline_authors)
+                .unwrap_or_default();
+            if parsed_fallback.is_empty() {
+                tracing::warn!(
+                    paper = %paper_title,
+                    "ingest_document: source.authors empty and no byline recovered from body; paper will have no author agents"
+                );
+            } else {
+                tracing::info!(
+                    paper = %paper_title,
+                    count = parsed_fallback.len(),
+                    "ingest_document: source.authors empty; recovered authors from body byline fallback"
+                );
+            }
+            &parsed_fallback
         } else {
-            tracing::info!(
-                paper = %paper_title,
-                count = parsed_fallback.len(),
-                "ingest_document: source.authors empty; recovered authors from body byline fallback"
-            );
-        }
-        &parsed_fallback
-    } else {
-        &extraction.source.authors
-    };
+            &extraction.source.authors
+        };
     for (idx, author) in authors.iter().enumerate() {
         if author.name.is_empty() {
             continue;
@@ -839,34 +846,38 @@ pub async fn do_ingest_document_spine(
     // Same defensive backstop as `do_ingest_document` (backlog a55aac45): the
     // spine path is the recommended two-phase entry and shares the empty-authors
     // failure mode, so recover the byline from `source_text` when the structured
-    // author list is absent. Conservative parser; empty ⇒ pre-existing behavior.
+    // author list is absent. Gated on Paper/Textbook source_type (see the
+    // `do_ingest_document` rationale). Conservative parser; empty ⇒ pre-existing
+    // behavior.
+    let byline_eligible = matches!(
+        extraction.source.source_type,
+        epigraph_ingest::document::schema::SourceType::Paper
+            | epigraph_ingest::document::schema::SourceType::Textbook
+    );
     let parsed_fallback;
-    let authors: &[epigraph_ingest::common::schema::AuthorEntry] = if extraction
-        .source
-        .authors
-        .is_empty()
-    {
-        parsed_fallback = extraction
-            .source_text
-            .as_deref()
-            .map(epigraph_ingest::document::byline::parse_byline_authors)
-            .unwrap_or_default();
-        if parsed_fallback.is_empty() {
-            tracing::warn!(
-                paper = %paper_title,
-                "ingest_document_spine: source.authors empty and no byline recovered from body; paper will have no author agents"
-            );
+    let authors: &[epigraph_ingest::common::schema::AuthorEntry] =
+        if extraction.source.authors.is_empty() && byline_eligible {
+            parsed_fallback = extraction
+                .source_text
+                .as_deref()
+                .map(epigraph_ingest::document::byline::parse_byline_authors)
+                .unwrap_or_default();
+            if parsed_fallback.is_empty() {
+                tracing::warn!(
+                    paper = %paper_title,
+                    "ingest_document_spine: source.authors empty and no byline recovered from body; paper will have no author agents"
+                );
+            } else {
+                tracing::info!(
+                    paper = %paper_title,
+                    count = parsed_fallback.len(),
+                    "ingest_document_spine: source.authors empty; recovered authors from body byline fallback"
+                );
+            }
+            &parsed_fallback
         } else {
-            tracing::info!(
-                paper = %paper_title,
-                count = parsed_fallback.len(),
-                "ingest_document_spine: source.authors empty; recovered authors from body byline fallback"
-            );
-        }
-        &parsed_fallback
-    } else {
-        &extraction.source.authors
-    };
+            &extraction.source.authors
+        };
     for (idx, author) in authors.iter().enumerate() {
         if author.name.is_empty() {
             continue;


### PR DESCRIPTION
## What changed

Hierarchical extraction sometimes drops `source.authors` (empty array), so `ingest_document` / `ingest_document_spine` record a paper with **no real author agents** — and the workflow-side extraction subagent then substitutes the placeholder `"Authors Not Specified"` (that string lives in the workflow prompt, **not** in this repo).

This PR adds a **code backstop** (backlog `a55aac45`):

- **New pure helper** `parse_byline_authors` in `crates/epigraph-ingest/src/document/byline.rs`. It scans the top of the raw `source_text` (first ~15 lines, above the abstract, skipping the title line) for the author byline and returns the parsed names. Split on `,` / ` and ` / ` & `.
- **Conservative discriminator**: a line qualifies only when *every* segment is name-shaped — 2–4 whitespace tokens, each an initial (`J.`) or a Capitalized, non-ALL-CAPS, digit-free word. This rejects title fragments (`Attention Is All You Need` → one 5-token segment), acronym lines (`NASA JPL CALTECH`), and prose. **False positives are the enemy** (a bogus name mints a deterministic author agent that pollutes co-authorship edges across every paper sharing the phrase), so the parser returns empty when unsure — which reproduces the pre-existing behavior exactly.
- **No `"Authors Not Specified"` placeholder is reintroduced in Rust** — that stays a workflow-prompt concern. Goal: real authors when parseable, empty otherwise.
- **Wiring**: fallback fires in both `do_ingest_document` and `do_ingest_document_spine` (the recommended two-phase entry shares the identical empty-authors failure mode) whenever `source.authors` is empty. Tier 2 (HTML/CNXML) has no `source_text` and silently no-ops. Emits `tracing::info!` on recovery, `tracing::warn!` when still empty.
- **No new dependencies** (hand-rolled with `std` `str` methods — `--locked` safe), no SQL touched.

## Files changed

- `crates/epigraph-ingest/src/document/byline.rs` (new)
- `crates/epigraph-ingest/src/document/mod.rs` (`pub mod byline;`)
- `crates/epigraph-mcp/src/tools/ingestion.rs` (fallback wired into both ingest paths)

## Test evidence (RED → GREEN)

Followed TDD. Stubbed `parse_byline_authors` to return `Vec::new()` unconditionally first:

**RED** — the 4 positive tests failed on assertion (real parsing behavior), negatives passed trivially:
```
FAILED: body_only_authors_are_recovered            (left: [] right: ["Kaiming He", ...])
FAILED: normal_comma_and_byline_yields_three_entries (left: 0 right: 3)
FAILED: single_author_with_initial_is_recovered      (left: 0 right: 1)
FAILED: ampersand_separator_is_supported             (left: [] right: [...])
test result: FAILED. 4 passed; 4 failed
```

**GREEN** — after implementing:
```
test result: ok. 8 passed; 0 failed
```

### Follow-up commit: false-positive hardening (`fix(ingest)`)

Review caught a false-positive the first cut missed: a short Title-Case line on the second content line (`Nuclear Regulatory Commission`, `Stanford University`) is token-shaped like a 2–4 word name, so it parsed as an author. This is a *confident wrong answer*, not the safe empty. Two defenses added, each via RED→GREEN:

- **Call-site `source_type` gate (primary)** — the fallback only fires for `Paper` / `Textbook` (the types with an arXiv/journal byline convention); Reports, Legal, transcripts etc. are skipped entirely, which is where institution/label lines mostly appear.
- **Helper-level org-keyword reject (secondary, best-effort)** — a segment containing any organizational/publication keyword (university, institute, commission, journal, press, report, …) disqualifies the whole candidate byline. `Stanford University` is caught via `university`, `Nuclear Regulatory Commission` via `commission`.

**Known residual (documented, not chased):** the keyword list is deliberately non-exhaustive. A bare journal-name line whose tokens are not keywords — e.g. `Nature Communications` — still parses as one bogus author on a `Paper`/`Textbook` with empty `source.authors`. Making the list exhaustive is the brittle-dictionary anti-pattern; one stray author agent is the accepted cost, consistent with the conservative "empty when unsure" design. The superscript-affiliation shape (`Kaiming He1, …`) is rejected (digits) — a safe false-negative, intentionally left.

New RED tests `institution_line_is_not_parsed_as_an_author` and `university_affiliation_line_is_not_parsed_as_an_author` both failed first (institution lines parsing as authors), then GREEN.

Final byline unit suite (**10 passed; 0 failed**): `body_only_authors_are_recovered`, `normal_comma_and_byline_yields_three_entries`, `no_recognizable_byline_yields_empty`, `all_caps_acronym_line_is_rejected`, `single_author_with_initial_is_recovered`, `ampersand_separator_is_supported`, `empty_input_yields_empty`, `prose_sentence_after_title_is_not_mined`, `institution_line_is_not_parsed_as_an_author`, `university_affiliation_line_is_not_parsed_as_an_author`. Full CI gate re-green after the follow-up (mcp suite exit 0, all suites 0 failed).

Full CI gate green: `cargo build --workspace --locked`, `cargo test -p epigraph-ingest --locked`, `cargo test -p epigraph-mcp --locked -- --test-threads=1`, `cargo clippy --workspace --locked -- -D warnings`, `cargo fmt --check`.

## Notes for reviewer

- Resolution of backlog claim `a55aac45` is **QUEUED** — `resolve_backlog_item` is classifier-blocked, so this PR does not resolve it; the resolution claim will be filed out-of-band.
- This is the **code-backstop half** only. The prompt/schema-required half — making the extraction subagent emit a schema-required `source.authors` and stop substituting the `"Authors Not Specified"` placeholder — is a **separate graph-side `evolve_step`** handled by the orchestrator, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
