### PR TITLE
feat(engine,cli): PROV-O export-time serialization layer for the provenance graph

### DIFF
--- a/crates/epigraph-cli/Cargo.toml
+++ b/crates/epigraph-cli/Cargo.toml
@@ -100,6 +100,11 @@ name = "calibrate_matcher"
 path = "src/bin/calibrate_matcher.rs"
 required-features = ["db"]
 
+[[bin]]
+name = "export_provenance"
+path = "src/bin/export_provenance.rs"
+required-features = ["db"]
+
 [[test]]
 name = "cross_source_sweep_smoke"
 path = "tests/cross_source_sweep_smoke.rs"

--- a/crates/epigraph-cli/src/bin/export_provenance.rs
+++ b/crates/epigraph-cli/src/bin/export_provenance.rs
@@ -1,0 +1,87 @@
+//! Operator CLI: export a claim's provenance graph as PROV-O JSON-LD.
+//!
+//! Wraps `epigraph_engine::export::prov::export_provenance_prov_o`, which
+//! walks claim-to-claim ancestry via `LineageRepository` and maps internal
+//! `edges.relationship` values (`derived_from`, `supersedes`, ...) onto
+//! `http://www.w3.org/ns/prov#` predicates **at serialization time only** —
+//! this binary never writes to the database.
+//!
+//! Usage:
+//!     epigraph-export-provenance --claim-id <uuid> --format prov-o
+//!     epigraph-export-provenance --claim-id <uuid> --max-depth 10 --output /tmp/prov.json
+//!
+//! `--format` currently only accepts `prov-o`. RO-Crate (an
+//! `ro-crate-metadata.json` manifest) was considered and rejected for this
+//! first pass — this schema's provenance shape is claims/edges/agents, not
+//! packaged research-object files, so PROV-O is the more natural fit. See
+//! `crates/epigraph-engine/src/export/prov.rs` module docs for the full
+//! reasoning; RO-Crate support (if a file-artifact use case emerges) is a
+//! documented follow-up, not implemented here.
+
+use clap::Parser;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "export_provenance",
+    about = "Export a claim's provenance graph as PROV-O JSON-LD (read-only)"
+)]
+struct Cli {
+    /// Root claim to export provenance for.
+    #[arg(long)]
+    claim_id: Uuid,
+
+    /// Output vocabulary. Only `prov-o` is implemented today.
+    #[arg(long, default_value = "prov-o")]
+    format: String,
+
+    /// Maximum ancestor traversal depth (defaults to the repository default
+    /// of 100 when omitted).
+    #[arg(long)]
+    max_depth: Option<i32>,
+
+    /// Write the JSON-LD document to this file instead of stdout.
+    #[arg(long)]
+    output: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let cli = Cli::parse();
+    if let Err(e) = run(cli).await {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    if cli.format != "prov-o" {
+        return Err(format!(
+            "unsupported --format '{}': only 'prov-o' is implemented",
+            cli.format
+        )
+        .into());
+    }
+
+    let pool = epigraph_cli::db_connect().await?;
+    let document =
+        epigraph_engine::export::prov::export_provenance_prov_o(&pool, cli.claim_id, cli.max_depth)
+            .await?;
+    let pretty = serde_json::to_string_pretty(&document)?;
+
+    match cli.output {
+        Some(path) => {
+            std::fs::write(&path, &pretty)?;
+            eprintln!("wrote PROV-O export to {}", path.display());
+        }
+        None => println!("{pretty}"),
+    }
+
+    Ok(())
+}

--- a/crates/epigraph-engine/Cargo.toml
+++ b/crates/epigraph-engine/Cargo.toml
@@ -118,5 +118,9 @@ path = "tests/rerank_pipeline.rs"
 name = "alt_set_cdst_integration"
 path = "tests/alt_set_cdst_integration.rs"
 
+[[test]]
+name = "export_prov_o"
+path = "tests/export_prov_o.rs"
+
 [lints]
 workspace = true

--- a/crates/epigraph-engine/src/export/mod.rs
+++ b/crates/epigraph-engine/src/export/mod.rs
@@ -1,0 +1,9 @@
+//! Export-time serialization of the epistemic graph into external
+//! provenance/interchange vocabularies.
+//!
+//! Everything in this module is **read-only against the DB and additive at
+//! serialization time only**: internal edge relationship strings
+//! (`derived_from`, `supersedes`, etc.) are never rewritten in the `edges`
+//! table. See `prov` for the PROV-O mapping.
+
+pub mod prov;

--- a/crates/epigraph-engine/src/export/prov.rs
+++ b/crates/epigraph-engine/src/export/prov.rs
@@ -27,6 +27,17 @@
 //! `CLAUDE.md` reserves `supersedes` specifically for epistemic-replacement
 //! semantics. So the mapping in this module is applied only when building
 //! the exported JSON-LD document; the underlying row is never touched.
+//!
+//! # Scope: no `prov:Activity` nodes (yet)
+//!
+//! `get_provenance` (the existing MCP tool) maps `reasoning_traces` rows to
+//! `prov:Activity`. This module deliberately does not: it emits the
+//! activity-less shorthand form of derivation (`entity1 prov:wasDerivedFrom
+//! entity2`, which PROV-O explicitly permits as short for "some activity
+//! generated entity1 by using entity2") rather than reconstructing full
+//! Entity-Activity-Agent triples. Adding `reasoning_traces` as `prov:Activity`
+//! nodes (as `get_provenance` already does) is a natural follow-up once
+//! there's a concrete consumer that needs the activity-level detail.
 
 /// Map an internal `edges.relationship` value to its PROV-O predicate,
 /// for use in exported JSON-LD only. Returns `None` for relationship types
@@ -51,12 +62,45 @@ pub fn relationship_to_prov_predicate(relationship: &str) -> Option<&'static str
     }
 }
 
+/// `edges.relationship` values are not all written in the same direction.
+/// `derived_from`-family edges (and everything else this module maps) point
+/// **ancestor -> descendant** (`source_id` = the older/ancestor claim,
+/// `target_id` = the newer/descendant claim) — this is the convention
+/// `LineageRepository`'s recursive CTEs assume. `supersedes` is the
+/// opposite: both production write paths
+/// (`ClaimRepository::supersede` and `ClaimRepository::evolve_step`) insert
+/// it as `source_id` = the *new* claim, `target_id` = the claim being
+/// superseded. This helper returns, for a mapped relationship, which edge
+/// endpoint is the PROV-O "generated" (newer) entity and which is the
+/// "used" (older/source) entity — so callers don't have to hardcode the
+/// direction per relationship type at each call site.
+fn prov_relation_endpoints(
+    relationship: &str,
+    source_id: uuid::Uuid,
+    target_id: uuid::Uuid,
+) -> (uuid::Uuid, uuid::Uuid) {
+    if relationship == "supersedes" {
+        // source = new claim (generated), target = old claim (used).
+        (source_id, target_id)
+    } else {
+        // derived_from / derives_from / generated / uses_evidence:
+        // source = ancestor (used), target = descendant (generated).
+        (target_id, source_id)
+    }
+}
+
 /// Build a PROV-O JSON-LD document describing the provenance of
 /// `root_claim_id`: the claim itself, every ancestor claim reachable via
-/// claim-to-claim edges (up to `max_depth`, default 100 — mirrors
-/// [`epigraph_db::LineageRepository::get_lineage`]'s default), the edges
-/// between them mapped to PROV-O predicates, and the authoring agent of
-/// each claim as a `prov:Agent`.
+/// `derived_from`-family claim-to-claim edges (up to `max_depth`, default
+/// 100 — mirrors [`epigraph_db::LineageRepository::get_lineage`]'s
+/// default), one hop of `supersedes` predecessors for each of those claims,
+/// the edges between them mapped to PROV-O predicates, and the authoring
+/// agent of each claim as a `prov:Agent`.
+///
+/// `supersedes` is only expanded one hop per claim (not recursively) in
+/// this first pass — deeper supersession *chains* (claims that themselves
+/// supersede a claim already reached via a supersedes edge) are a follow-up;
+/// see the module's PR description.
 ///
 /// This is **read-only**: it issues only `SELECT`s (via
 /// `LineageRepository`, `EdgeRepository`, `ClaimRepository`,
@@ -79,19 +123,46 @@ pub async fn export_provenance_prov_o(
     use epigraph_core::domain::ids::{AgentId, ClaimId};
     use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, LineageRepository};
 
+    // --- Pass 1: assemble the full claim set ---------------------------
+    //
+    // `get_ancestor_ids` walks the ancestor-first convention
+    // (`derived_from`-family edges); it includes the root itself. It does
+    // NOT reach a claim's supersedes-predecessor, because that edge's
+    // *target* (the old claim) is never itself an edge *source* pointing
+    // at something already in the lineage — the direction is inverted
+    // relative to what the CTE looks for. So we add supersedes targets
+    // explicitly, one hop per claim already in the set.
     let ancestor_ids = LineageRepository::get_ancestor_ids(pool, root_claim_id, max_depth).await?;
-
-    // `get_ancestor_ids` includes the root itself at depth 0; dedupe just in
-    // case callers pass a claim with no ancestors.
     let mut claim_ids = ancestor_ids;
     if !claim_ids.contains(&root_claim_id) {
         claim_ids.push(root_claim_id);
     }
 
+    let mut supersedes_targets = Vec::new();
+    for &claim_id in &claim_ids {
+        let outgoing = EdgeRepository::get_by_source(pool, claim_id, "claim").await?;
+        for edge in outgoing {
+            if edge.target_type == "claim"
+                && edge.relationship == "supersedes"
+                && !claim_ids.contains(&edge.target_id)
+            {
+                supersedes_targets.push(edge.target_id);
+            }
+        }
+    }
+    for id in supersedes_targets {
+        if !claim_ids.contains(&id) {
+            claim_ids.push(id);
+        }
+    }
+
+    // --- Pass 2: emit entities, agents, and relations -------------------
+
     let mut entities = Vec::new();
     let mut agents_seen = std::collections::HashSet::new();
     let mut agent_entities = Vec::new();
     let mut relations = Vec::new();
+    let mut edges_seen = std::collections::HashSet::new();
 
     for &claim_id in &claim_ids {
         let Some(claim) = ClaimRepository::get_by_id(pool, ClaimId::from_uuid(claim_id)).await?
@@ -126,28 +197,37 @@ pub async fn export_provenance_prov_o(
             "predicate": "prov:wasAttributedTo",
         }));
 
-        // Inbound edges (ancestor -> this claim) carry the derivation and
-        // supersession relationships in this schema: `LineageRepository`'s
-        // recursive CTEs treat `edges.source_id` as the ancestor and
-        // `edges.target_id` as the descendant already in the lineage
-        // (`JOIN edges e ON e.source_id = c.id ... e.target_id = l.id`), so
-        // we mirror that direction here rather than inventing a new one.
-        let edges = EdgeRepository::get_by_target(pool, claim_id, "claim").await?;
-        for edge in edges {
-            if edge.source_type != "claim" || !claim_ids.contains(&edge.source_id) {
+        // Collect claim-to-claim edges touching this claim from both
+        // directions — `derived_from` edges have this claim as the
+        // `target_id` (see doc comment on `prov_relation_endpoints`),
+        // `supersedes` edges have this claim as the `source_id`. Dedup by
+        // edge id since a claim can appear on both sides across the loop
+        // (e.g. the root is both a target of its ancestor's edge and a
+        // source of its own supersedes edge).
+        let mut claim_edges = EdgeRepository::get_by_target(pool, claim_id, "claim").await?;
+        claim_edges.extend(EdgeRepository::get_by_source(pool, claim_id, "claim").await?);
+
+        for edge in claim_edges {
+            if !edges_seen.insert(edge.id) {
+                continue;
+            }
+            if edge.source_type != "claim"
+                || edge.target_type != "claim"
+                || !claim_ids.contains(&edge.source_id)
+                || !claim_ids.contains(&edge.target_id)
+            {
                 continue;
             }
             let Some(predicate) = relationship_to_prov_predicate(&edge.relationship) else {
                 continue;
             };
+            let (generated, used) =
+                prov_relation_endpoints(&edge.relationship, edge.source_id, edge.target_id);
             relations.push(serde_json::json!({
                 "@id": format!("edge:{}", edge.id),
                 "@type": "prov:Relation",
-                // PROV-O reads "target wasDerivedFrom source": the claim
-                // this edge points at is the derived/newer entity, and the
-                // edge's source is the ancestor entity it was derived from.
-                "prov:generatedEntity": format!("claim:{}", edge.target_id),
-                "prov:usedEntity": format!("claim:{}", edge.source_id),
+                "prov:generatedEntity": format!("claim:{generated}"),
+                "prov:usedEntity": format!("claim:{used}"),
                 "predicate": predicate,
                 "source_relationship": edge.relationship,
             }));

--- a/crates/epigraph-engine/src/export/prov.rs
+++ b/crates/epigraph-engine/src/export/prov.rs
@@ -1,0 +1,206 @@
+//! PROV-O export mapping: internal edge relationship names to
+//! `http://www.w3.org/ns/prov#` predicates, applied **only** at
+//! serialization time. Nothing here writes to the database.
+//!
+//! # Why PROV-O over RO-Crate
+//!
+//! This graph's provenance shape is claims (PROV Entities), the edges
+//! between them (PROV relations), the agents that authored them (PROV
+//! Agents), and reasoning traces (PROV Activities) — there are no packaged
+//! research-object *files* to describe, which is RO-Crate's core use case
+//! (an `ro-crate-metadata.json` manifest for a directory of research
+//! artifacts). PROV-O also already has a foothold here:
+//! `crates/epigraph-mcp/src/tools/provenance.rs::get_provenance` already
+//! emits a partial `prov:` JSON-LD bundle, and `edges.relationship` already
+//! carries PROV-flavored names (`attributed_to`, `associated_with`) with
+//! comments citing `prov:wasAttributedTo` / `prov:wasAssociatedWith`
+//! directly. Extending that vocabulary end-to-end is the smaller, more
+//! natural change.
+//!
+//! # Export-time-only
+//!
+//! `edges.relationship` stores internal names (`derived_from`,
+//! `supersedes`, ...) and an edges-API allow-list
+//! (`crates/epigraph-api/src/routes/edges.rs::VALID_RELATIONSHIPS`) rejects
+//! unknown relationship types — renaming the column to PROV-O predicates
+//! live is not possible without breaking every write path, and this repo's
+//! `CLAUDE.md` reserves `supersedes` specifically for epistemic-replacement
+//! semantics. So the mapping in this module is applied only when building
+//! the exported JSON-LD document; the underlying row is never touched.
+
+/// Map an internal `edges.relationship` value to its PROV-O predicate,
+/// for use in exported JSON-LD only. Returns `None` for relationship types
+/// that have no natural PROV-O analogue (the caller should fall back to a
+/// generic `prov:wasInfluencedBy` or skip the edge).
+///
+/// Both historical/current spellings are accepted where the schema has
+/// carried more than one (`derived_from` is the canonical value in
+/// `VALID_RELATIONSHIPS`; `derives_from` shows up in older docs/specs).
+#[must_use]
+pub fn relationship_to_prov_predicate(relationship: &str) -> Option<&'static str> {
+    match relationship {
+        "derived_from" | "derives_from" => Some("prov:wasDerivedFrom"),
+        "supersedes" => Some("prov:wasRevisionOf"),
+        "asserts" | "authored_by" | "attributed_to" | "ATTRIBUTED_TO" => {
+            Some("prov:wasAttributedTo")
+        }
+        "associated_with" => Some("prov:wasAssociatedWith"),
+        "generated" => Some("prov:wasGeneratedBy"),
+        "uses_evidence" => Some("prov:used"),
+        _ => None,
+    }
+}
+
+/// Build a PROV-O JSON-LD document describing the provenance of
+/// `root_claim_id`: the claim itself, every ancestor claim reachable via
+/// claim-to-claim edges (up to `max_depth`, default 100 — mirrors
+/// [`epigraph_db::LineageRepository::get_lineage`]'s default), the edges
+/// between them mapped to PROV-O predicates, and the authoring agent of
+/// each claim as a `prov:Agent`.
+///
+/// This is **read-only**: it issues only `SELECT`s (via
+/// `LineageRepository`, `EdgeRepository`, `ClaimRepository`,
+/// `AgentRepository`) and never writes to `edges` or `claims`. Internal
+/// relationship strings in the DB are left exactly as they are; the PROV-O
+/// predicate only ever appears in the returned JSON value.
+///
+/// Works for any claim's provenance — there is no filter on evidence type
+/// or claim label. Computational-model claims (marked by
+/// `evidence.evidence_type = 'computation'`) are simply one shape of input;
+/// the exporter does not special-case them.
+///
+/// # Errors
+/// Returns [`epigraph_db::DbError`] if any underlying repository call fails.
+pub async fn export_provenance_prov_o(
+    pool: &epigraph_db::PgPool,
+    root_claim_id: uuid::Uuid,
+    max_depth: Option<i32>,
+) -> Result<serde_json::Value, epigraph_db::DbError> {
+    use epigraph_core::domain::ids::{AgentId, ClaimId};
+    use epigraph_db::{AgentRepository, ClaimRepository, EdgeRepository, LineageRepository};
+
+    let ancestor_ids = LineageRepository::get_ancestor_ids(pool, root_claim_id, max_depth).await?;
+
+    // `get_ancestor_ids` includes the root itself at depth 0; dedupe just in
+    // case callers pass a claim with no ancestors.
+    let mut claim_ids = ancestor_ids;
+    if !claim_ids.contains(&root_claim_id) {
+        claim_ids.push(root_claim_id);
+    }
+
+    let mut entities = Vec::new();
+    let mut agents_seen = std::collections::HashSet::new();
+    let mut agent_entities = Vec::new();
+    let mut relations = Vec::new();
+
+    for &claim_id in &claim_ids {
+        let Some(claim) = ClaimRepository::get_by_id(pool, ClaimId::from_uuid(claim_id)).await?
+        else {
+            continue;
+        };
+
+        entities.push(serde_json::json!({
+            "@id": format!("claim:{claim_id}"),
+            "@type": "prov:Entity",
+            "content": claim.content,
+            "truth_value": claim.truth_value.value(),
+        }));
+
+        let agent_uuid: uuid::Uuid = claim.agent_id.into();
+        if agents_seen.insert(agent_uuid) {
+            if let Some(agent) =
+                AgentRepository::get_by_id(pool, AgentId::from_uuid(agent_uuid)).await?
+            {
+                agent_entities.push(serde_json::json!({
+                    "@id": format!("agent:{agent_uuid}"),
+                    "@type": "prov:Agent",
+                    "display_name": agent.display_name,
+                }));
+            }
+        }
+        relations.push(serde_json::json!({
+            "@id": format!("relation:attribution:{claim_id}"),
+            "@type": "prov:Attribution",
+            "prov:entity": format!("claim:{claim_id}"),
+            "prov:agent": format!("agent:{agent_uuid}"),
+            "predicate": "prov:wasAttributedTo",
+        }));
+
+        // Inbound edges (ancestor -> this claim) carry the derivation and
+        // supersession relationships in this schema: `LineageRepository`'s
+        // recursive CTEs treat `edges.source_id` as the ancestor and
+        // `edges.target_id` as the descendant already in the lineage
+        // (`JOIN edges e ON e.source_id = c.id ... e.target_id = l.id`), so
+        // we mirror that direction here rather than inventing a new one.
+        let edges = EdgeRepository::get_by_target(pool, claim_id, "claim").await?;
+        for edge in edges {
+            if edge.source_type != "claim" || !claim_ids.contains(&edge.source_id) {
+                continue;
+            }
+            let Some(predicate) = relationship_to_prov_predicate(&edge.relationship) else {
+                continue;
+            };
+            relations.push(serde_json::json!({
+                "@id": format!("edge:{}", edge.id),
+                "@type": "prov:Relation",
+                // PROV-O reads "target wasDerivedFrom source": the claim
+                // this edge points at is the derived/newer entity, and the
+                // edge's source is the ancestor entity it was derived from.
+                "prov:generatedEntity": format!("claim:{}", edge.target_id),
+                "prov:usedEntity": format!("claim:{}", edge.source_id),
+                "predicate": predicate,
+                "source_relationship": edge.relationship,
+            }));
+        }
+    }
+
+    Ok(serde_json::json!({
+        "@context": "https://www.w3.org/ns/prov#",
+        "root_claim": format!("claim:{root_claim_id}"),
+        "entities": entities,
+        "agents": agent_entities,
+        "relations": relations,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_derived_from_to_prov_was_derived_from() {
+        assert_eq!(
+            relationship_to_prov_predicate("derived_from"),
+            Some("prov:wasDerivedFrom")
+        );
+    }
+
+    #[test]
+    fn maps_legacy_derives_from_spelling_to_prov_was_derived_from() {
+        assert_eq!(
+            relationship_to_prov_predicate("derives_from"),
+            Some("prov:wasDerivedFrom")
+        );
+    }
+
+    #[test]
+    fn maps_supersedes_to_prov_was_revision_of() {
+        assert_eq!(
+            relationship_to_prov_predicate("supersedes"),
+            Some("prov:wasRevisionOf")
+        );
+    }
+
+    #[test]
+    fn maps_attributed_to_to_prov_was_attributed_to() {
+        assert_eq!(
+            relationship_to_prov_predicate("attributed_to"),
+            Some("prov:wasAttributedTo")
+        );
+    }
+
+    #[test]
+    fn unknown_relationship_maps_to_none() {
+        assert_eq!(relationship_to_prov_predicate("relates_to"), None);
+    }
+}

--- a/crates/epigraph-engine/src/lib.rs
+++ b/crates/epigraph-engine/src/lib.rs
@@ -39,6 +39,7 @@ pub mod epistemic_interval;
 pub mod error_mass;
 pub mod errors;
 pub mod evidence;
+pub mod export;
 pub mod interval_bp;
 pub mod lifecycle;
 pub mod matching;

--- a/crates/epigraph-engine/tests/export_prov_o.rs
+++ b/crates/epigraph-engine/tests/export_prov_o.rs
@@ -6,15 +6,22 @@
 //! Fixture graph:
 //!
 //!   root_claim  -- derived_from --> child_claim   (child derives from root)
-//!   prior_claim -- supersedes   --> child_claim   (child supersedes prior)
+//!   child_claim -- supersedes   --> prior_claim    (child supersedes prior)
 //!
-//! Both edges are `source_id = <ancestor>`, `target_id = child_claim`:
-//! `LineageRepository`'s recursive CTEs (`get_lineage`, `get_ancestor_ids`)
-//! walk `edges e ON e.source_id = c.id ... JOIN lineage l ON e.target_id =
-//! l.id`, i.e. an ancestor is reached by an edge whose `source_id` is the
-//! ancestor and whose `target_id` is the already-known (descendant) claim.
-//! This fixture matches that existing, production convention rather than
-//! inventing a new one.
+//! `derived_from`: `source_id = <ancestor>`, `target_id = <descendant>` —
+//! matches `LineageRepository`'s recursive CTEs (`get_lineage`,
+//! `get_ancestor_ids`), which walk `edges e ON e.source_id = c.id ... JOIN
+//! lineage l ON e.target_id = l.id`, i.e. an ancestor is reached by an edge
+//! whose `source_id` is the ancestor and whose `target_id` is the
+//! already-known (descendant) claim.
+//!
+//! `supersedes`: the OPPOSITE direction — `source_id = <new/current claim>`,
+//! `target_id = <old/superseded claim>`. This is not a choice made for this
+//! module; it is how the two production write paths
+//! (`ClaimRepository::supersede` and `ClaimRepository::evolve_step`) both
+//! actually insert the edge (`source_id` bound to the newly-inserted claim,
+//! `target_id` bound to the claim being superseded). The fixture mirrors
+//! real data rather than the more "natural"-looking old-to-new direction.
 
 use epigraph_engine::export::prov::export_provenance_prov_o;
 use sqlx::postgres::PgPoolOptions;
@@ -97,22 +104,65 @@ async fn export_maps_predicates_and_leaves_edges_relationship_column_unchanged()
     let child_claim = insert_claim(&pool, agent, "Derived claim under test").await;
 
     let derives_edge_id = insert_edge(&pool, root_claim, child_claim, "derived_from").await;
-    let supersedes_edge_id = insert_edge(&pool, prior_claim, child_claim, "supersedes").await;
+    // Real direction (see module doc comment above): source = new claim,
+    // target = superseded claim.
+    let supersedes_edge_id = insert_edge(&pool, child_claim, prior_claim, "supersedes").await;
 
     let document = export_provenance_prov_o(&pool, child_claim, Some(5))
         .await
         .expect("export should succeed");
 
-    // The exported JSON-LD must carry the PROV-O predicates, not the
-    // internal relationship strings.
-    let serialized = serde_json::to_string(&document).unwrap();
+    // All three claims — root (ancestor), child (root of the export), and
+    // prior (reached only via the one-hop supersedes expansion) — must be
+    // present as entities. `prior_claim` is the case that proves the
+    // one-hop supersedes expansion works: `get_ancestor_ids` alone would
+    // never surface it (see module doc comment).
+    let entities = document["entities"].as_array().expect("entities array");
+    let entity_ids: Vec<&str> = entities
+        .iter()
+        .map(|e| e["@id"].as_str().unwrap())
+        .collect();
+    assert!(entity_ids.contains(&format!("claim:{root_claim}").as_str()));
+    assert!(entity_ids.contains(&format!("claim:{child_claim}").as_str()));
     assert!(
-        serialized.contains("prov:wasDerivedFrom"),
-        "expected prov:wasDerivedFrom in export, got: {serialized}"
+        entity_ids.contains(&format!("claim:{prior_claim}").as_str()),
+        "prior_claim must be reachable via the one-hop supersedes expansion, got entities: {entity_ids:?}"
     );
-    assert!(
-        serialized.contains("prov:wasRevisionOf"),
-        "expected prov:wasRevisionOf in export, got: {serialized}"
+
+    // The exported JSON-LD must carry the PROV-O predicates, not the
+    // internal relationship strings, and — critically — with the correct
+    // subject/object direction per relationship type (derived_from and
+    // supersedes are inverted in the underlying edges table).
+    let relations = document["relations"].as_array().expect("relations array");
+
+    let derived_from_relation = relations
+        .iter()
+        .find(|r| r["predicate"] == "prov:wasDerivedFrom")
+        .unwrap_or_else(|| panic!("expected a prov:wasDerivedFrom relation, got: {relations:?}"));
+    assert_eq!(
+        derived_from_relation["prov:generatedEntity"],
+        format!("claim:{child_claim}"),
+        "child_claim (the newer claim) must be the generated entity for wasDerivedFrom"
+    );
+    assert_eq!(
+        derived_from_relation["prov:usedEntity"],
+        format!("claim:{root_claim}"),
+        "root_claim (the ancestor) must be the used entity for wasDerivedFrom"
+    );
+
+    let supersedes_relation = relations
+        .iter()
+        .find(|r| r["predicate"] == "prov:wasRevisionOf")
+        .unwrap_or_else(|| panic!("expected a prov:wasRevisionOf relation, got: {relations:?}"));
+    assert_eq!(
+        supersedes_relation["prov:generatedEntity"],
+        format!("claim:{child_claim}"),
+        "child_claim (the new claim) must be the generated entity for wasRevisionOf"
+    );
+    assert_eq!(
+        supersedes_relation["prov:usedEntity"],
+        format!("claim:{prior_claim}"),
+        "prior_claim (the superseded claim) must be the used entity for wasRevisionOf"
     );
 
     // Re-query the edges table directly: the raw `relationship` column must

--- a/crates/epigraph-engine/tests/export_prov_o.rs
+++ b/crates/epigraph-engine/tests/export_prov_o.rs
@@ -1,0 +1,135 @@
+//! Regression test: PROV-O export maps internal edge relationship names to
+//! PROV-O predicates and leaves `edges.relationship` in the database
+//! completely unchanged (export-time-only serialization, never a live
+//! rename).
+//!
+//! Fixture graph:
+//!
+//!   root_claim  -- derived_from --> child_claim   (child derives from root)
+//!   prior_claim -- supersedes   --> child_claim   (child supersedes prior)
+//!
+//! Both edges are `source_id = <ancestor>`, `target_id = child_claim`:
+//! `LineageRepository`'s recursive CTEs (`get_lineage`, `get_ancestor_ids`)
+//! walk `edges e ON e.source_id = c.id ... JOIN lineage l ON e.target_id =
+//! l.id`, i.e. an ancestor is reached by an edge whose `source_id` is the
+//! ancestor and whose `target_id` is the already-known (descendant) claim.
+//! This fixture matches that existing, production convention rather than
+//! inventing a new one.
+
+use epigraph_engine::export::prov::export_provenance_prov_o;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn try_test_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&url)
+        .await
+        .ok()?;
+    sqlx::migrate!("../../migrations").run(&pool).await.expect("test DB migrations failed — likely a description/version mismatch with existing _sqlx_migrations; use a fresh DB");
+    Some(pool)
+}
+macro_rules! test_pool_or_skip {
+    () => {
+        match try_test_pool().await {
+            Some(p) => p,
+            None => {
+                eprintln!("Skipping DB test: DATABASE_URL not set");
+                return;
+            }
+        }
+    };
+}
+
+async fn insert_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO agents (id, public_key, display_name, created_at, updated_at)
+         VALUES ($1, sha256($1::text::bytea), 'export-test-agent', NOW(), NOW())",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("insert agent");
+    id
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, truth_value, agent_id)
+         VALUES ($1, $2, sha256($1::text::bytea), 0.7, $3)",
+    )
+    .bind(id)
+    .bind(content)
+    .bind(agent)
+    .execute(pool)
+    .await
+    .expect("insert claim");
+    id
+}
+
+async fn insert_edge(pool: &PgPool, source: Uuid, target: Uuid, relationship: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO edges (id, source_id, source_type, target_id, target_type, relationship)
+         VALUES ($1, $2, 'claim', $3, 'claim', $4)",
+    )
+    .bind(id)
+    .bind(source)
+    .bind(target)
+    .bind(relationship)
+    .execute(pool)
+    .await
+    .expect("insert edge");
+    id
+}
+
+#[tokio::test]
+async fn export_maps_predicates_and_leaves_edges_relationship_column_unchanged() {
+    let pool = test_pool_or_skip!();
+
+    let agent = insert_agent(&pool).await;
+    let root_claim = insert_claim(&pool, agent, "Root: computational model baseline").await;
+    let prior_claim = insert_claim(&pool, agent, "Prior version of the derived claim").await;
+    let child_claim = insert_claim(&pool, agent, "Derived claim under test").await;
+
+    let derives_edge_id = insert_edge(&pool, root_claim, child_claim, "derived_from").await;
+    let supersedes_edge_id = insert_edge(&pool, prior_claim, child_claim, "supersedes").await;
+
+    let document = export_provenance_prov_o(&pool, child_claim, Some(5))
+        .await
+        .expect("export should succeed");
+
+    // The exported JSON-LD must carry the PROV-O predicates, not the
+    // internal relationship strings.
+    let serialized = serde_json::to_string(&document).unwrap();
+    assert!(
+        serialized.contains("prov:wasDerivedFrom"),
+        "expected prov:wasDerivedFrom in export, got: {serialized}"
+    );
+    assert!(
+        serialized.contains("prov:wasRevisionOf"),
+        "expected prov:wasRevisionOf in export, got: {serialized}"
+    );
+
+    // Re-query the edges table directly: the raw `relationship` column must
+    // be untouched by the export call. This is the entire point of the
+    // "export-time-only" claim — a live rename would show PROV-O strings
+    // here instead.
+    let derives_row: (String,) = sqlx::query_as("SELECT relationship FROM edges WHERE id = $1")
+        .bind(derives_edge_id)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch derives edge");
+    assert_eq!(derives_row.0, "derived_from");
+
+    let supersedes_row: (String,) = sqlx::query_as("SELECT relationship FROM edges WHERE id = $1")
+        .bind(supersedes_edge_id)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch supersedes edge");
+    assert_eq!(supersedes_row.0, "supersedes");
+}


### PR DESCRIPTION
## Summary

Adds an **export-time-only** PROV-O JSON-LD serialization layer over the
claim provenance graph, plus a CLI entry point to invoke it.

- `crates/epigraph-engine/src/export/prov.rs`:
  - `relationship_to_prov_predicate(&str) -> Option<&'static str>` — pure
    mapping from internal `edges.relationship` values (`derived_from`,
    `supersedes`, `attributed_to`, `associated_with`, `generated`,
    `uses_evidence`, plus the legacy `derives_from` spelling) to
    `http://www.w3.org/ns/prov#` predicates.
  - `export_provenance_prov_o(pool, claim_id, max_depth) -> serde_json::Value`
    — walks a claim's ancestry via `LineageRepository::get_ancestor_ids`,
    pulls typed edges via `EdgeRepository::get_by_target`, claim content via
    `ClaimRepository::get_by_id`, and authoring agents via
    `AgentRepository::get_by_id`, then assembles a PROV-O JSON-LD document
    (`prov:Entity` = claim, `prov:Agent` = author, `prov:Attribution` /
    `prov:Relation` edges carrying the mapped predicate).
- `crates/epigraph-cli/src/bin/export_provenance.rs`: `--claim-id <uuid>
  --format prov-o [--max-depth N] [--output path]` CLI wrapper.

**This is provably read-only.** `edges.relationship` in the database is
never rewritten — the mapping happens only when building the returned JSON
value. See regression test below.

## Why PROV-O, not RO-Crate

This graph's provenance shape is claims/agents/typed-edges — there are no
packaged research-object *files* to describe, which is RO-Crate's core use
case (an `ro-crate-metadata.json` manifest for a directory of artifacts).
PROV-O also already has a foothold in this codebase:
`crates/epigraph-mcp/src/tools/provenance.rs::get_provenance` already emits
a partial `prov:` JSON-LD bundle, `edges.relationship` values
`attributed_to`/`associated_with` already carry explicit
`prov:wasAttributedTo`/`prov:wasAssociatedWith` comments, and
`epigraph-core`'s `Agent.labels` doc comment already says "LPG labels for
PROV-O typing". Extending that vocabulary end-to-end was the smaller,
more natural change. Full reasoning is in the `prov.rs` module doc comment.

## Why CLI, not MCP

This is an operator/export tool (dump provenance for archival, audit, or
handoff to an external PROV-O consumer) rather than an in-conversation
query pattern — the existing MCP `get_provenance` tool already serves
"agent wants lineage context inline". A new `[[bin]]` follows the same
`dotenvy` + `db_connect()` + `clap::Parser` pattern as
`recompute_claim_belief`/`reembed`.

## Precondition claim (already confirmed, not re-litigated here)

Claim `1582a517-56a5-4b88-9512-f577a4d4c363`: a *live* rename of
`edges.relationship` to PROV-O predicate names is structurally impossible —
`VALID_RELATIONSHIPS` in `routes/edges.rs` rejects unknown relationship
types, and this repo's `CLAUDE.md` reserves `supersedes` specifically for
epistemic-replacement semantics. This PR only ever maps at export time;
internal names are untouched. The regression test asserts this directly.

## Explicitly out of scope

- Full in-toto/SLSA attestation (GitHub Artifact Attestations / Sigstore) —
  optional per the backlog claim, not attempted here; noted as a follow-up.
- Wiring this into the `extend-or-revise-an-existing-computational-model...`
  workflow (claim `4ba388eb-e9a1-4b1b-a399-e31fed8eb8c7`) — that's an
  `evolve_step` MCP call the orchestrator handles separately.
- Unifying `get_provenance` (MCP) onto this same mapping function — flagged
  as a natural follow-up but out of scope for this first landable PR.
- RO-Crate support, if a file-artifact use case emerges later.

## Test plan

- [x] TDD: pure mapping unit tests in `export/prov.rs` written first,
      confirmed RED (`cannot find function relationship_to_prov_predicate`),
      then GREEN.
- [x] TDD: `tests/export_prov_o.rs` fixture regression test written first,
      confirmed RED (unresolved import `export_provenance_prov_o`), then
      GREEN. Asserts the exported JSON-LD contains
      `prov:wasDerivedFrom`/`prov:wasRevisionOf`, **and** re-queries
      `edges.relationship` from Postgres directly afterward to confirm it
      is still exactly `"derived_from"`/`"supersedes"`.
- [x] `cargo test -p epigraph-engine -p epigraph-cli --locked` — all pass.
- [x] `cargo clippy --workspace --locked -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `SQLX_OFFLINE=true cargo check --workspace --all-targets` — clean (no
      new `sqlx::query!` macros were added; all DB access reuses existing
      `epigraph-db` repo methods, so no `.sqlx/` changes needed).
- [x] Manual CLI smoke test against `epigraph_db_repo_test` (inserted
      fixture rows, ran the binary, verified output, cleaned up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)