### PR TITLE
feat(mcp): route submit_ds_evidence through calibrated per-source-class reliability

### DIFF
--- a/crates/epigraph-mcp/src/tools/ds.rs
+++ b/crates/epigraph-mcp/src/tools/ds.rs
@@ -125,12 +125,46 @@ pub async fn submit_ds_evidence(
     let frame = FrameOfDiscernment::new(frame_row.name.clone(), frame_row.hypotheses.clone())
         .map_err(internal_error)?;
 
-    // Parse and optionally discount the mass function
+    // Parse the mass function. Reliability handling forks on whether the
+    // caller opted into calibrated per-source-class discounting:
+    //
+    // - `evidence_type` supplied: store the RAW (undiscounted) masses plus
+    //   the resolved `evidence_type`/`locality_tag` metadata, and let the
+    //   existing shared recompute path below
+    //   (`recompute_claim_belief_on_frame` -> `recompute_combined_belief` ->
+    //   `epigraph_engine::edge_factor::effective_source_strength`) derive
+    //   the calibrated discount from that metadata + `calibration.toml`
+    //   ([evidence_type_weights], locality composition) at combine time —
+    //   the same discount authority `auto_wire_ds_update` already uses
+    //   (issue #197 Phase 2/4). We must NOT also pre-discount here: this
+    //   function already reads its returned belief back from the `claims`
+    //   row *after* delegating to that same recompute path (backlog
+    //   2bffdfdc), so a pre-discount would double-apply the calibrated
+    //   weight (e.g. testimonial 0.6 x 0.6 = 0.36) while `params.reliability`
+    //   is simply ignored in favor of the calibrated prior.
+    // - `evidence_type` omitted (default): EXACT pre-change behavior —
+    //   pre-discount the stored masses by the raw `params.reliability`
+    //   float and store `evidence_type = NULL`, `locality_tag = "unknown"`,
+    //   so `effective_source_strength` falls through to its legacy/unknown
+    //   tiers exactly as it did before this change. `locality_tag` alone
+    //   (without `evidence_type`) is a no-op for the same reason: step (1)
+    //   of `effective_source_strength` fires whenever `evidence_type` is
+    //   `None` and never reaches locality composition, so we fold that case
+    //   into the legacy branch too rather than silently accepting a
+    //   parameter that couldn't affect anything.
     let mut mass_fn = parse_masses_json(&frame, &params.masses)?;
-    let reliability = params.reliability.unwrap_or(1.0).clamp(0.0, 1.0);
-    if reliability < 1.0 {
-        mass_fn =
-            epigraph_ds::combination::discount(&mass_fn, reliability).map_err(internal_error)?;
+    let calibrated_evidence_type = params.evidence_type.as_deref().filter(|s| !s.is_empty());
+    let stored_locality_tag = if calibrated_evidence_type.is_some() {
+        params.locality_tag.as_deref().unwrap_or("unknown")
+    } else {
+        "unknown"
+    };
+    if calibrated_evidence_type.is_none() {
+        let reliability = params.reliability.unwrap_or(1.0).clamp(0.0, 1.0);
+        if reliability < 1.0 {
+            mass_fn = epigraph_ds::combination::discount(&mass_fn, reliability)
+                .map_err(internal_error)?;
+        }
     }
 
     // Ensure claim-frame assignment exists
@@ -155,6 +189,11 @@ pub async fn submit_ds_evidence(
     )
     .map_err(internal_error)?;
 
+    // source_strength stays NULL either way: the calibrated path derives
+    // reliability dynamically from evidence_type at recompute time
+    // (effective_source_strength), and the legacy path already baked the
+    // raw `reliability` float into the pre-discounted masses above rather
+    // than caching it here — unchanged from pre-change behavior.
     let mf_id = MassFunctionRepository::store_with_perspective(
         &server.pool,
         claim_id,
@@ -165,9 +204,9 @@ pub async fn submit_ds_evidence(
         None,
         Some(&method_name),
         None,
-        None,
-        "unknown", // MCP ds entrypoint lacks evidence-DOI vs paper context (issue #197)
-        None,      // manual DS submission has no evidence row in scope (issue #197 Phase 3)
+        calibrated_evidence_type, // NULL unless caller opted in (backlog a2b71568)
+        stored_locality_tag,      // "unknown" unless evidence_type was also supplied
+        None, // manual DS submission has no evidence row in scope (issue #197 Phase 3)
     )
     .await
     .map_err(internal_error)?;

--- a/crates/epigraph-mcp/src/types.rs
+++ b/crates/epigraph-mcp/src/types.rs
@@ -758,6 +758,28 @@ pub struct SubmitDsEvidenceParams {
 
     #[schemars(description = "Perspective UUID for scoped combination (optional)")]
     pub perspective_id: Option<String>,
+
+    #[schemars(
+        description = "Evidence classification tag (e.g. 'empirical', 'testimonial', 'statistical') \
+                       used to key the calibrated per-source-class reliability prior \
+                       (epigraph_engine::edge_factor::effective_source_strength / calibration.toml \
+                       [evidence_type_weights]) instead of the caller-supplied `reliability` float. \
+                       When omitted (default), behavior is unchanged: the raw `reliability` float is \
+                       applied and the BBA is stored with evidence_type=NULL, matching every \
+                       pre-existing caller byte-for-byte."
+    )]
+    #[serde(default)]
+    pub evidence_type: Option<String>,
+
+    #[schemars(
+        description = "Locality classification of this evidence vs. the claim's asserting paper: \
+                       'intra' (self-cite / methodological overlap) applies the calibrated intra-locality \
+                       discount on top of the evidence_type weight; 'cross' or 'unknown' apply no locality \
+                       discount. Only consulted when `evidence_type` is also supplied — otherwise ignored \
+                       and the BBA is stored with locality_tag='unknown' as before. Default: 'unknown'."
+    )]
+    #[serde(default)]
+    pub locality_tag: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/epigraph-mcp/tests/ds_evidence_calibrated_reliability.rs
+++ b/crates/epigraph-mcp/tests/ds_evidence_calibrated_reliability.rs
@@ -1,0 +1,210 @@
+//! Backlog a2b71568: `submit_ds_evidence`'s reliability handling was a bare
+//! caller-supplied float with zero connection to per-source-class calibration
+//! (`epigraph_engine::edge_factor::effective_source_strength`,
+//! `calibration.toml [evidence_type_weights]`) — the sophisticated recompute-time
+//! discount chain that `auto_wire_ds_update` (issue #197 Phase 2/4) already uses.
+//!
+//! `submit_ds_evidence` unconditionally stored `evidence_type = NULL` and
+//! `locality_tag = 'unknown'` on every BBA row (see `ds.rs`
+//! `store_with_perspective` call), so a subsequent recompute could never key
+//! off evidence-type calibration for evidence submitted through this entry
+//! point — regardless of what the caller believed `reliability` meant.
+//!
+//! Fix: `SubmitDsEvidenceParams` gains two new OPTIONAL fields,
+//! `evidence_type` and `locality_tag`. When `evidence_type` is supplied, the
+//! BBA is stored with that metadata (raw, undiscounted masses — same as
+//! today) so the *existing* recompute path
+//! (`recompute_claim_belief_on_frame` -> `recompute_combined_belief` ->
+//! `effective_source_strength`), which `submit_ds_evidence` already
+//! delegates to for its returned belief, discounts by the calibrated
+//! per-source-class weight instead of falling through to the 0.5
+//! unknown-evidence-type fallback. When `evidence_type` is omitted (the
+//! default), storage and discounting are byte-for-byte identical to
+//! pre-change behavior: `evidence_type = NULL`, `locality_tag = 'unknown'`,
+//! raw `reliability` float pre-discount as before.
+//!
+//! IMPORTANT: because `submit_ds_evidence` reads its returned belief back
+//! from the `claims` row *after* delegating to the shared recompute path
+//! (backlog 2bffdfdc), the no-`evidence_type` baseline is NOT "undiscounted" —
+//! `effective_source_strength` on a row with `evidence_type = NULL` AND
+//! `source_strength = NULL` falls through its tier chain to the 0.5
+//! unknown-key fallback (see `edge_factor.rs` step 5). So this test compares
+//! the *calibrated* testimonial weight (0.6, `calibration.toml`) against the
+//! *0.5 fallback*, not against a fictitious "no discount" baseline.
+
+use epigraph_crypto::AgentSigner;
+use epigraph_db::MassFunctionRepository;
+use epigraph_mcp::tools::ds_auto::ensure_binary_frame;
+use epigraph_mcp::types::SubmitDsEvidenceParams;
+use epigraph_mcp::{embed::McpEmbedder, tools, EpiGraphMcpFull};
+use rmcp::model::RawContent;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn make_server(pool: PgPool) -> EpiGraphMcpFull {
+    let signer = AgentSigner::from_bytes(&[0x5du8; 32]).expect("signer");
+    let embedder = McpEmbedder::new(pool.clone(), None);
+    EpiGraphMcpFull::new(pool, signer, embedder, false)
+}
+
+fn result_json(out: rmcp::model::CallToolResult) -> serde_json::Value {
+    let first = out.content.first().cloned().expect("first content");
+    let text = match first.raw {
+        RawContent::Text(t) => t.text,
+        other => panic!("expected text content, got {other:?}"),
+    };
+    serde_json::from_str(&text).expect("result is JSON")
+}
+
+async fn insert_agent(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO agents (public_key, display_name, agent_type, labels)
+         VALUES (sha256(gen_random_uuid()::text::bytea), $1, 'system', ARRAY['test'])
+         RETURNING id",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO claims (content, content_hash, truth_value, agent_id, is_current)
+         VALUES ($1, sha256($1::bytea), 0.5, $2, true) RETURNING id",
+    )
+    .bind(content)
+    .bind(agent)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+fn base_params(claim_id: Uuid, frame_id: Uuid) -> SubmitDsEvidenceParams {
+    SubmitDsEvidenceParams {
+        claim_id: claim_id.to_string(),
+        frame_id: frame_id.to_string(),
+        hypothesis_index: 0,
+        masses: serde_json::json!({"0": 0.8, "~": 0.2}),
+        reliability: None,
+        combination_method: None,
+        gamma: None,
+        perspective_id: None,
+        evidence_type: None,
+        locality_tag: None,
+    }
+}
+
+/// A call with `evidence_type = "testimonial"` (calibrated weight 0.6 per
+/// `calibration.toml [evidence_type_weights]`) must produce a DIFFERENT
+/// pignistic_prob than the same masses submitted with no `evidence_type` at
+/// all (which falls to the 0.5 unknown-key fallback in
+/// `effective_source_strength`). Same input masses, same frame, same
+/// hypothesis — the only variable is the calibration key, and it must reach
+/// the belief computation.
+#[sqlx::test(migrations = "../../migrations")]
+async fn evidence_type_testimonial_diverges_from_no_evidence_type(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "ds-calibrated-testimonial").await;
+    let frame_id = ensure_binary_frame(&pool).await.expect("binary frame");
+
+    let claim_a = insert_claim(&pool, agent, &format!("calib-a-{}", Uuid::new_v4())).await;
+    let out_a = tools::ds::submit_ds_evidence(&server, base_params(claim_a, frame_id))
+        .await
+        .expect("submit_ds_evidence (no evidence_type)");
+    let pignistic_a = result_json(out_a)["pignistic_prob"]
+        .as_f64()
+        .expect("pignistic_prob is a number");
+
+    let claim_b = insert_claim(&pool, agent, &format!("calib-b-{}", Uuid::new_v4())).await;
+    let mut params_b = base_params(claim_b, frame_id);
+    params_b.evidence_type = Some("testimonial".to_string());
+    let out_b = tools::ds::submit_ds_evidence(&server, params_b)
+        .await
+        .expect("submit_ds_evidence (evidence_type=testimonial)");
+    let pignistic_b = result_json(out_b)["pignistic_prob"]
+        .as_f64()
+        .expect("pignistic_prob is a number");
+
+    assert!(
+        (pignistic_a - pignistic_b).abs() > 1e-6,
+        "expected evidence_type=testimonial (calibrated weight 0.6) to produce a different \
+         pignistic_prob than no evidence_type (0.5 fallback), got a={pignistic_a} b={pignistic_b}"
+    );
+
+    // Confirm the row actually landed with the resolved evidence_type
+    // (not silently dropped), so future recomputes see consistent metadata.
+    let rows = MassFunctionRepository::get_for_claim_frame(&pool, claim_b, frame_id)
+        .await
+        .expect("get_for_claim_frame");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].evidence_type.as_deref(), Some("testimonial"));
+}
+
+/// Backward-compatibility: a call using ONLY the pre-existing params (no
+/// `evidence_type`/`locality_tag`) must be byte-for-byte identical to
+/// pre-change behavior — both in the returned belief numbers and in the
+/// stored row's metadata columns (`evidence_type = NULL`,
+/// `locality_tag = 'unknown'`, raw-`reliability`-based `source_strength`
+/// semantics unchanged).
+#[sqlx::test(migrations = "../../migrations")]
+async fn omitting_evidence_type_is_byte_identical_to_legacy_behavior(pool: PgPool) {
+    let server = make_server(pool.clone());
+    let agent = insert_agent(&pool, "ds-calibrated-backcompat").await;
+    let frame_id = ensure_binary_frame(&pool).await.expect("binary frame");
+    let claim = insert_claim(&pool, agent, &format!("calib-compat-{}", Uuid::new_v4())).await;
+
+    let mut params = base_params(claim, frame_id);
+    params.reliability = Some(0.8);
+    let out = tools::ds::submit_ds_evidence(&server, params)
+        .await
+        .expect("submit_ds_evidence");
+    let json = result_json(out);
+
+    // Pinned legacy numbers: masses {"0": 0.8, "~": 0.2}, reliability 0.8,
+    // no evidence_type => stored evidence_type=NULL/source_strength=NULL =>
+    // effective_source_strength's step-5 unknown fallback (0.5) is what the
+    // shared recompute path applies — the same value pre-change code path
+    // already produced for this exact input (see
+    // ds_evidence_recompute_belief_match.rs, which established that
+    // submit_ds_evidence's returned value always equals recompute_beliefs's).
+    // We assert the response is well-formed and internally consistent rather
+    // than a hardcoded literal, since the literal is itself an emergent
+    // property of effective_source_strength + combination::discount, not a
+    // constant this test should duplicate by hand.
+    // Pinned literal, captured from this exact input (masses {"0": 0.8,
+    // "~": 0.2}, reliability 0.8, no evidence_type) against BOTH this
+    // change's None-branch (which is textually identical to the
+    // pre-change code — see `ds.rs`'s `if calibrated_evidence_type.is_none()`
+    // gate) and independently verified equal to `origin/main`'s
+    // unconditional pre-discount path for the same input. A future edit
+    // that changes this value for a no-`evidence_type` call is a real
+    // backward-compat regression, not test flake.
+    let pignistic = json["pignistic_prob"].as_f64().expect("pignistic_prob");
+    assert!(
+        (pignistic - 0.673_913_043_478_261_1).abs() < 1e-9,
+        "no-evidence_type call must reproduce the exact pre-change pignistic_prob for this \
+         input; got {pignistic}, expected 0.6739130434782611 (masses {{\"0\":0.8,\"~\":0.2}}, \
+         reliability=0.8, evidence_type=None -> effective_source_strength's step-5 unknown \
+         fallback of 0.5, same as origin/main's unconditional discount path)"
+    );
+
+    let rows = MassFunctionRepository::get_for_claim_frame(&pool, claim, frame_id)
+        .await
+        .expect("get_for_claim_frame");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].evidence_type, None,
+        "legacy no-evidence_type call must still store evidence_type=NULL"
+    );
+    assert_eq!(
+        rows[0].locality_tag, "unknown",
+        "legacy no-evidence_type call must still store locality_tag='unknown'"
+    );
+    assert_eq!(
+        rows[0].source_strength, None,
+        "legacy no-evidence_type call must still store source_strength=NULL \
+         (the raw `reliability` float is applied by pre-discounting the stored \
+         masses, not by caching it as source_strength — matches pre-change behavior)"
+    );
+}

--- a/crates/epigraph-mcp/tests/ds_evidence_recompute_belief_match.rs
+++ b/crates/epigraph-mcp/tests/ds_evidence_recompute_belief_match.rs
@@ -96,6 +96,8 @@ async fn recompute_beliefs_matches_submit_ds_evidence_immediate_result(pool: PgP
             combination_method: None,
             gamma: None,
             perspective_id: None,
+            evidence_type: None,
+            locality_tag: None,
         },
     )
     .await
@@ -206,6 +208,8 @@ async fn recompute_beliefs_matches_submit_ds_evidence_after_two_submissions(pool
                 combination_method: None,
                 gamma: None,
                 perspective_id,
+                evidence_type: None,
+                locality_tag: None,
             },
         )
         .await


### PR DESCRIPTION
## Summary

Backlog claim `a2b71568-a202-419c-8ade-15d951713fcb` (build half; the
companion `bd4b8a22-43d4-4d08-a9be-3c286d3df05c` workflow-wiring "incorporate" half is out of scope here
and handled separately by the orchestrator).

`submit_ds_evidence` — the primary write-time MCP entry point most external
callers use to submit DS evidence — discounted the stored BBA by a bare
caller-supplied `reliability` float and unconditionally stored
`evidence_type = NULL` / `locality_tag = 'unknown'`, with zero connection to
the calibrated per-source-class reliability prior
(`epigraph_engine::edge_factor::effective_source_strength`, issue #197 Phase
2/4) that `auto_wire_ds_update` already uses.

This PR adds two new **optional** `submit_ds_evidence` params —
`evidence_type` and `locality_tag` — so a caller can opt into storing that
metadata on the BBA row instead of pre-discounting by the raw float. Because
`submit_ds_evidence` already delegates its returned belief to the shared
recompute path (`recompute_claim_belief_on_frame` ->
`recompute_combined_belief` -> `effective_source_strength`, per backlog
2bffdfdc), storing the metadata is sufficient — the existing recompute
machinery picks up the calibrated discount by construction. Adding a second,
separate call to `effective_source_strength` at store time would have
double-applied the discount (e.g. testimonial 0.6 × 0.6 = 0.36).

When `evidence_type` is omitted (the default), the executed code path is
textually identical to `origin/main`'s unconditional pre-discount path —
verified — so every existing caller sees **zero behavior change**.

## Design notes / decisions

- `locality_tag` alone (without `evidence_type`) is a no-op by design:
  `effective_source_strength` only composes locality on top of a non-null
  `evidence_type`. Folded into the legacy branch rather than silently
  accepted as meaningful.
- `perspective_id` untouched — uses `effective_source_strength`, not
  `_with_perspective`. The cached global belief recompute never consults
  perspective reliability; that only applies at lensed-read time via
  `get_perspective_belief`, which already works today. Conservative choice,
  and forced by how recompute is wired.
- New optional fields use `#[serde(default)]`, matching the existing
  `novelty_threshold` / `labels` additive-param idiom in `types.rs`.

## Test plan

- [x] RED: `evidence_type_testimonial_diverges_from_no_evidence_type` failed
      before the fix — both the `evidence_type="testimonial"` and
      no-`evidence_type` calls landed on `effective_source_strength`'s 0.5
      unknown-key fallback, producing identical `pignistic_prob`
      (0.7222222222222223 == 0.7222222222222223).
- [x] GREEN: same test passes after wiring — testimonial (calibrated weight
      0.6) now produces a distinct pignistic_prob, and the stored
      `mass_functions` row carries `evidence_type = "testimonial"`.
- [x] Backward-compat: `omitting_evidence_type_is_byte_identical_to_legacy_behavior`
      pins the exact `pignistic_prob` (0.6739130434782611) for a fixed input
      with no `evidence_type`, and asserts the stored row still has
      `evidence_type = NULL`, `locality_tag = 'unknown'`, `source_strength =
      NULL` — a forward regression guard, not just a range check.
- [x] `cargo build --workspace --locked` — clean
- [x] `cargo test -p epigraph-mcp --locked -- --test-threads=1` — 66 test
      groups, 0 failed (includes the pre-existing
      `ds_evidence_recompute_belief_match.rs` suite, unmodified in behavior)
- [x] `cargo clippy --workspace --locked -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — clean
- [x] No `sqlx::query!`/`query_as!` macros touched; `.sqlx/` untouched;
      `SQLX_OFFLINE=true cargo check --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
