### PR TITLE
feat(mcp): accept cites relationship in link_epistemic via a structural allow-list

### DIFF
--- a/crates/epigraph-mcp/src/tools/link_epistemic.rs
+++ b/crates/epigraph-mcp/src/tools/link_epistemic.rs
@@ -15,9 +15,14 @@
 //! Tight contract:
 //! - both endpoints are existing claims (`source_type`/`target_type` are always
 //!   `"claim"`, not caller-controllable),
-//! - `relationship` must be one of [`EPISTEMIC_RELATIONSHIPS`] (lowercase
-//!   canonical strings; `supersedes` is intentionally excluded — it has
-//!   dedicated semantics in `supersede_claim`),
+//! - `relationship` must be one of [`EPISTEMIC_RELATIONSHIPS`] or
+//!   [`STRUCTURAL_RELATIONSHIPS`] (lowercase canonical strings; `supersedes`
+//!   is intentionally excluded — it has dedicated semantics in
+//!   `supersede_claim`). The structural set (currently just `cites`) is kept
+//!   separate because its members map to `RestrictionKind::Neutral` by
+//!   design — belief-wiring already no-ops on Neutral, so accepting them
+//!   here just lets citation/provenance edges be created MCP-natively
+//!   without a doomed detour through the raw HTTP edges route.
 //! - idempotent on `(source, target, relationship)`: a re-hit returns the
 //!   existing edge with `was_created=false` and never re-creates the durable
 //!   edge row or re-emits `edge.added`. Belief wiring, however, is NOT gated
@@ -72,6 +77,24 @@ fn is_epistemic_relationship(s: &str) -> bool {
     EPISTEMIC_RELATIONSHIPS.contains(&s)
 }
 
+/// Structural (non-belief-affecting) relations `link_epistemic` also accepts,
+/// kept deliberately SEPARATE from `EPISTEMIC_RELATIONSHIPS`.
+///
+/// Unlike the epistemic set, these are expected to map to
+/// `RestrictionKind::Neutral` — a citation/provenance link is not an
+/// epistemic claim about the relationship between two nodes, so it must not
+/// move belief. Folding `cites` into `EPISTEMIC_RELATIONSHIPS` would break
+/// `every_epistemic_relationship_maps_to_non_neutral`'s all-non-Neutral
+/// invariant (and its hard count=7 assertion) below, so it gets its own
+/// allow-list instead. `auto_wire_edge_if_epistemic` already no-ops safely on
+/// `Neutral` relationships (see `epigraph_engine::edge_factor`'s
+/// short-circuit), so no changes are needed to the belief-wiring path itself.
+pub const STRUCTURAL_RELATIONSHIPS: &[&str] = &["cites"];
+
+fn is_structural_relationship(s: &str) -> bool {
+    STRUCTURAL_RELATIONSHIPS.contains(&s)
+}
+
 fn success_json(value: &impl serde::Serialize) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(
         serde_json::to_string_pretty(value).map_err(internal_error)?,
@@ -95,12 +118,18 @@ pub async fn do_link_epistemic(
     let source_id = parse_uuid(&params.source_claim_id)?;
     let target_id = parse_uuid(&params.target_claim_id)?;
 
-    // Tight allow-list — lowercase canonical epistemic relations only.
-    if !is_epistemic_relationship(&params.relationship) {
+    // Tight allow-list — lowercase canonical epistemic relations, plus the
+    // separate structural set (currently just `cites`; see
+    // STRUCTURAL_RELATIONSHIPS doc comment for why it isn't folded into
+    // EPISTEMIC_RELATIONSHIPS).
+    if !is_epistemic_relationship(&params.relationship)
+        && !is_structural_relationship(&params.relationship)
+    {
         return Err(invalid_params(format!(
-            "invalid relationship '{}'. Valid epistemic types: {}",
+            "invalid relationship '{}'. Valid epistemic types: {}. Valid structural types: {}",
             params.relationship,
             EPISTEMIC_RELATIONSHIPS.join(", "),
+            STRUCTURAL_RELATIONSHIPS.join(", "),
         )));
     }
 
@@ -282,6 +311,37 @@ mod tests {
                  EPISTEMIC_RELATIONSHIPS or fix the engine mapping. Got: {kind:?}"
             );
         }
+    }
+
+    /// `cites` is a citation/provenance link, not an epistemic claim about the
+    /// relationship between two nodes — it is DELIBERATELY `Neutral` (does not
+    /// move belief). This is the mirror image of the coverage guard above:
+    /// `cites` must NOT be added to `EPISTEMIC_RELATIONSHIPS` (that would break
+    /// `every_epistemic_relationship_maps_to_non_neutral`'s all-non-Neutral
+    /// invariant and its hard count=7 assertion), but `link_epistemic` must
+    /// still accept it via the separate `STRUCTURAL_RELATIONSHIPS` allow-list
+    /// so the conflict-resolution workflow's cites-edge pinning step can run
+    /// MCP-natively (backlog 47afad2e).
+    #[test]
+    fn cites_is_structural_and_maps_to_neutral() {
+        let profile = RestrictionProfile::scientific();
+        assert!(
+            is_structural_relationship("cites"),
+            "'cites' must be accepted via STRUCTURAL_RELATIONSHIPS"
+        );
+        assert!(
+            !is_epistemic_relationship("cites"),
+            "'cites' must NOT be in EPISTEMIC_RELATIONSHIPS (it is Neutral by design, which \
+             would break the all-non-Neutral coverage guard)"
+        );
+        assert!(
+            matches!(
+                restriction_kind_with_profile("cites", &profile),
+                RestrictionKind::Neutral
+            ),
+            "'cites' must map to RestrictionKind::Neutral — a citation link is not an \
+             epistemic claim and must not move belief"
+        );
     }
 
     /// Pin the polarity split from the spec §4 table: the five positive

--- a/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
+++ b/crates/epigraph-mcp/tests/link_epistemic_smoke.rs
@@ -500,6 +500,85 @@ async fn structural_relationship_is_rejected(pool: PgPool) {
     );
 }
 
+// ── cites is accepted (structural, non-belief-affecting) — backlog 47afad2e ──
+
+/// `cites` is accepted via the separate `STRUCTURAL_RELATIONSHIPS` allow-list
+/// (kept apart from `EPISTEMIC_RELATIONSHIPS` so the coverage guard's
+/// all-non-Neutral invariant stays intact — see `link_epistemic.rs`'s
+/// `cites_is_structural_and_maps_to_neutral` unit test for that half). This
+/// test proves the END-TO-END behavior through the same MCP path
+/// `supports_raises_target_belief_and_is_idempotent` exercises above: the
+/// edge is created, but — unlike `supports` — the target's belief does NOT
+/// move, because `cites` maps to `RestrictionKind::Neutral` and
+/// `auto_wire_edge_if_epistemic` no-ops on Neutral relationships.
+#[sqlx::test(migrations = "../../migrations")]
+async fn cites_edge_is_created_but_does_not_move_belief(pool: PgPool) {
+    let server = build_test_server(pool.clone());
+    // Same high-commitment source as the `supports` test, so a failure to
+    // no-op couldn't hide behind `SourceFactorless`.
+    let source = seed_claim_with_belief(&pool, 0.9, 0.9, Some(0.9)).await;
+    let target = seed_claim(&pool, "cited claim", 0.5).await;
+
+    assert!(
+        read_betp(&pool, target).await.is_none(),
+        "target must start with NULL pignistic_prob (no BBA yet)"
+    );
+
+    let result = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "cites".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect("cites must be accepted by link_epistemic");
+    let resp = parse_response(&result);
+
+    assert!(resp.was_created, "first cites call must create the edge");
+    assert_eq!(resp.relationship, "cites");
+    assert!(
+        !resp.belief_wired,
+        "cites is structural/Neutral — it must NOT wire belief"
+    );
+    assert_eq!(
+        edge_count(&pool, source, target, "cites").await,
+        1,
+        "exactly one cites edge must exist"
+    );
+    assert!(
+        read_betp(&pool, target).await.is_none(),
+        "target's pignistic_prob must remain NULL — a cites edge must not materialize a BBA"
+    );
+
+    // Idempotent re-hit: same as the epistemic relationships, a second call
+    // with the same (source, target, relationship) must not create a
+    // duplicate edge or attempt to re-wire.
+    let second = do_link_epistemic(
+        &server,
+        LinkEpistemicParams {
+            source_claim_id: source.to_string(),
+            target_claim_id: target.to_string(),
+            relationship: "cites".to_string(),
+            properties: None,
+        },
+    )
+    .await
+    .expect("re-hit must succeed (idempotent)");
+    let second_resp = parse_response(&second);
+    assert!(
+        !second_resp.was_created,
+        "re-hit must report was_created=false"
+    );
+    assert_eq!(
+        edge_count(&pool, source, target, "cites").await,
+        1,
+        "re-hit must not create a duplicate edge"
+    );
+}
+
 // ── validation: supersedes is excluded (belongs to supersede_claim) ─────────
 
 #[sqlx::test(migrations = "../../migrations")]


### PR DESCRIPTION
## Summary
- Adds `relationship="cites"` support to `link_epistemic`, letting the daily conflict-resolution workflow's cites-edge pinning step run MCP-natively instead of hitting a JWT-only `POST /api/v1/edges` dead end from the agent container.
- Introduces a separate `STRUCTURAL_RELATIONSHIPS` allow-list (currently just `cites`) rather than adding it to `EPISTEMIC_RELATIONSHIPS` — verified that the latter would break the existing `every_epistemic_relationship_maps_to_non_neutral` coverage-guard test and the hard `epistemic_set_is_the_documented_seven` count assertion, since `cites` maps to `RestrictionKind::Neutral` (a citation link is not an epistemic claim and must not move belief).
- No changes needed to the belief-wiring path itself: `auto_wire_edge_if_epistemic` already no-ops safely on Neutral relationships.

## Backlog claim addressed
`47afad2e-8bff-434a-b3dd-921c23a6e904` — queue for `resolve_backlog_item` once merged (classifier-blocked this session; see PENDING_RETIREMENTS.md ledger).

## Test plan
- [x] New unit test `cites_is_structural_and_maps_to_neutral` (design invariant: cites is structural, not epistemic, maps to Neutral)
- [x] New integration test `cites_edge_is_created_but_does_not_move_belief` (end-to-end: edge created + idempotent re-hit, target belief stays NULL)
- [x] Pre-existing `structural_relationship_is_rejected` (uses `decomposes_to`) still passes unchanged — no regression
- [x] Full CI gate: build, full `epigraph-mcp` test suite (0 failures), clippy `-D warnings` (clean), fmt (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)