### PR TITLE
chore(oauth): gitignore live providers.toml, ship blank template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ __pycache__/
 # Table-graph generated artifacts (regenerable from source repos)
 docs/superpowers/artifacts/2026-04-30-table-graph/staging/
 docs/superpowers/artifacts/2026-04-30-table-graph/narratives/
+
+# Live OAuth provider config — real allowed_emails, not for public repo (see providers.toml.example)
+providers.toml
+providers.toml.bak-*

--- a/providers.toml.example
+++ b/providers.toml.example
@@ -1,4 +1,6 @@
 # Example providers.toml — copy to providers.toml and edit, or set EPIGRAPH_PROVIDERS_CONFIG to override path.
+# providers.toml itself is gitignored (it holds real allowlisted emails); this
+# checked-in copy is the template new deployments start from.
 
 [[provider]]
 name              = "google"
@@ -17,7 +19,7 @@ auto_provision    = true
 # authorized external users; empty list = allow ALL (insecure). Add emails/domains
 # before relying on this in prod. With auto_provision=true, any identity NOT on this
 # allowlist is refused (HTTP 403) before any client is created.
-allowed_emails    = ["jeremy.barton@gmail.com"]
+allowed_emails    = []
 # allowed_domains = ["baros.associates"]
 default_scopes = [
   "claims:read", "claims:write", "claims:challenge",


### PR DESCRIPTION
## Summary
- `providers.toml` carries real `allowed_emails` and has been tracked as-is in this public repo since #259, despite its own header comment describing a template/real-config split.
- Adds `providers.toml.example` (tracked, `allowed_emails = []`) as the checked-in template.
- Untracks `providers.toml` (kept on disk, gitignored) and its `providers.toml.bak-*` backups.

## Test plan
- [x] `git status` confirms `providers.toml` is untracked/ignored, `providers.toml.example` is tracked with a blank allowlist
- [ ] Deploy hosts keep their real `providers.toml` on disk untouched (local edit only, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)