### PR TITLE
fix(matching): resolve claim paper provenance relationally in derive_source_key

### DIFF
--- a/crates/epigraph-engine/src/matching/source_key.rs
+++ b/crates/epigraph-engine/src/matching/source_key.rs
@@ -55,10 +55,20 @@ pub async fn derive_source_key(pool: &PgPool, claim_id: Uuid) -> Result<SourceKe
             .fetch_one(pool)
             .await?;
 
-    let paper_doi = props
-        .get("paper_doi")
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
+    // Canonical paper provenance is relational: paper -asserts-> claim, with
+    // the DOI on the papers row. The properties->>'paper_doi' JSON field is
+    // never written anywhere in the repo, so reading it always yielded None,
+    // making the same-source filter a silent no-op on real data. Resolve the
+    // asserting paper's DOI via the edge instead.
+    let paper_doi = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT p.doi FROM edges e JOIN papers p ON p.id = e.source_id \
+         WHERE e.target_id = $1 AND e.source_type = 'paper' \
+         AND e.relationship = 'asserts' LIMIT 1",
+    )
+    .bind(claim_id)
+    .fetch_optional(pool)
+    .await?
+    .flatten();
 
     let ingestion_run_id = props
         .get("ingestion_run_id")

--- a/crates/epigraph-engine/tests/blocker_union.rs
+++ b/crates/epigraph-engine/tests/blocker_union.rs
@@ -6,31 +6,8 @@ use epigraph_engine::matching::blocker::{
 };
 use epigraph_engine::matching::calibration::EligibilityConfig;
 use epigraph_engine::matching::source_key::SourceFilterConfig;
-use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn try_test_pool() -> Option<PgPool> {
-    let url = std::env::var("DATABASE_URL").ok()?;
-    let pool = PgPoolOptions::new()
-        .max_connections(3)
-        .connect(&url)
-        .await
-        .ok()?;
-    sqlx::migrate!("../../migrations").run(&pool).await.expect("test DB migrations failed — likely a description/version mismatch with existing _sqlx_migrations; use a fresh DB");
-    Some(pool)
-}
-macro_rules! test_pool_or_skip {
-    () => {
-        match try_test_pool().await {
-            Some(p) => p,
-            None => {
-                eprintln!("Skipping DB test");
-                return;
-            }
-        }
-    };
-}
 
 async fn insert_agent(pool: &PgPool) -> Uuid {
     let id = Uuid::new_v4();
@@ -68,14 +45,55 @@ async fn insert_claim_with_props_and_hash(
     id
 }
 
+async fn insert_paper(pool: &PgPool, doi: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO papers (id, doi, title) VALUES ($1, $2, $3)")
+        .bind(id)
+        .bind(doi)
+        .bind(format!("paper {}", id))
+        .execute(pool)
+        .await
+        .expect("insert paper");
+    id
+}
+
+async fn insert_asserts_edge(pool: &PgPool, paper_id: Uuid, claim_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship)
+         VALUES ($1, 'paper', $2, 'claim', 'asserts')",
+    )
+    .bind(paper_id)
+    .bind(claim_id)
+    .execute(pool)
+    .await
+    .expect("insert asserts edge");
+}
+
+/// Regression for the silent-no-op cross-source filter (promoted CORROBORATES
+/// pair 530d00be): two claims asserted by the SAME paper via the relational
+/// `paper -asserts-> claim` edge must be filtered out as same-source. On the
+/// pre-fix code, `derive_source_key` read `properties->>'paper_doi'` (never
+/// written), so both keys had `paper_doi = None`, `both_eq(None,None)=false`,
+/// and the pair slipped through as cross-source — this test would fail.
+///
+/// Load-bearing design: the two claims share an IDENTICAL `content_hash` so
+/// `ContentHashBlocker` EMITS the candidate (defeating the empty-candidate
+/// tautology), but use DISTINCT agents so agent-blocking is not the cause and
+/// the `(content_hash, agent_id)` UNIQUE constraint holds. The shared paper,
+/// reachable only via the asserts edge, is the ONLY same-source signal present.
 #[sqlx::test(migrations = "../../migrations")]
-async fn same_paper_pairs_are_filtered_out(pool: PgPool) {
+async fn same_paper_via_asserts_edge_is_filtered_out(pool: PgPool) {
     let a1 = insert_agent(&pool).await;
     let a2 = insert_agent(&pool).await;
-    let hash = [9u8; 32];
-    let props = serde_json::json!({"paper_doi": "10.1/sameforboth"});
-    let _seed = insert_claim_with_props_and_hash(&pool, a1, props.clone(), &hash).await;
-    let _peer = insert_claim_with_props_and_hash(&pool, a2, props.clone(), &hash).await;
+    let hash = [42u8; 32];
+    // No paper_doi in properties, no derived_from edges: the ONLY provenance
+    // link is the relational asserts edge to a shared paper.
+    let seed = insert_claim_with_props_and_hash(&pool, a1, serde_json::json!({}), &hash).await;
+    let peer = insert_claim_with_props_and_hash(&pool, a2, serde_json::json!({}), &hash).await;
+
+    let paper_id = insert_paper(&pool, "10.1/regression").await;
+    insert_asserts_edge(&pool, paper_id, seed).await;
+    insert_asserts_edge(&pool, paper_id, peer).await;
 
     let blockers: Vec<Box<dyn Blocker>> = vec![
         Box::new(ContentHashBlocker),
@@ -84,7 +102,7 @@ async fn same_paper_pairs_are_filtered_out(pool: PgPool) {
     let pairs = union_block(
         &pool,
         &blockers,
-        &[_seed],
+        &[seed],
         SourceFilterConfig::default(),
         &EligibilityConfig::default(),
     )
@@ -93,7 +111,50 @@ async fn same_paper_pairs_are_filtered_out(pool: PgPool) {
 
     assert!(
         pairs.is_empty(),
-        "same-paper pair should be filtered out, got {:?}",
+        "same-paper pair resolved via asserts edge must be filtered out, got {:?}",
+        pairs
+    );
+}
+
+/// Positive control for the relational paper resolution: two claims asserted
+/// by DIFFERENT papers (distinct DOIs), each via its own `asserts` edge, must
+/// SURVIVE `union_block` as a genuine cross-source pair. This closes the loop
+/// on `same_paper_via_asserts_edge_is_filtered_out` — that test proves the
+/// filter FIRES on a shared paper, this one proves it DISCRIMINATES by DOI and
+/// doesn't over-match (e.g. collapse any two paper-asserted claims to
+/// same-source, or drop the `p.doi` predicate). Shares a `content_hash` so
+/// `ContentHashBlocker` emits the candidate; distinct agents so agent-blocking
+/// is not involved. The shared-vs-distinct paper is the ONLY difference from
+/// the filtered-out case.
+#[sqlx::test(migrations = "../../migrations")]
+async fn different_papers_via_asserts_edges_survive_as_cross_source(pool: PgPool) {
+    let a1 = insert_agent(&pool).await;
+    let a2 = insert_agent(&pool).await;
+    let hash = [43u8; 32];
+    let seed = insert_claim_with_props_and_hash(&pool, a1, serde_json::json!({}), &hash).await;
+    let peer = insert_claim_with_props_and_hash(&pool, a2, serde_json::json!({}), &hash).await;
+
+    // Two DISTINCT papers with different DOIs — a genuine cross-source pair.
+    let paper_a = insert_paper(&pool, "10.1/cross-A").await;
+    let paper_b = insert_paper(&pool, "10.1/cross-B").await;
+    insert_asserts_edge(&pool, paper_a, seed).await;
+    insert_asserts_edge(&pool, paper_b, peer).await;
+
+    let blockers: Vec<Box<dyn Blocker>> = vec![Box::new(ContentHashBlocker)];
+    let pairs = union_block(
+        &pool,
+        &blockers,
+        &[seed],
+        SourceFilterConfig::default(),
+        &EligibilityConfig::default(),
+    )
+    .await
+    .expect("union_block");
+
+    assert_eq!(
+        pairs.len(),
+        1,
+        "claims from DIFFERENT papers must survive as a cross-source pair, got {:?}",
         pairs
     );
 }
@@ -132,8 +193,10 @@ async fn insert_claim_labeled(
 async fn workflow_step_claims_are_excluded_by_hygiene(pool: PgPool) {
     let a1 = insert_agent(&pool).await;
     let a2 = insert_agent(&pool).await;
-    // Different paper_doi → the source-key filter does NOT drop these, so the
-    // hygiene filter is the only thing that can.
+    // No asserts edges are inserted, so post-fix both claims resolve
+    // paper_doi = None and the source-key filter does NOT drop them (None does
+    // not match None); the hygiene filter is the only thing that can. (The
+    // props below are inert — properties->>'paper_doi' is no longer read.)
     let props_a = serde_json::json!({"paper_doi": "10.1/HYGI-A"});
     let props_b = serde_json::json!({"paper_doi": "10.1/HYGI-B"});
     let blockers: Vec<Box<dyn Blocker>> = vec![Box::new(ContentHashBlocker)];

--- a/crates/epigraph-engine/tests/source_key_derivation.rs
+++ b/crates/epigraph-engine/tests/source_key_derivation.rs
@@ -4,34 +4,8 @@
 //! Tests skip automatically when the database is unavailable.
 
 use epigraph_engine::matching::source_key::derive_source_key;
-use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-// --- pool helpers (project pattern) ---
-
-async fn try_test_pool() -> Option<PgPool> {
-    let url = std::env::var("DATABASE_URL").ok()?;
-    let pool = PgPoolOptions::new()
-        .max_connections(3)
-        .connect(&url)
-        .await
-        .ok()?;
-    sqlx::migrate!("../../migrations").run(&pool).await.expect("test DB migrations failed — likely a description/version mismatch with existing _sqlx_migrations; use a fresh DB");
-    Some(pool)
-}
-
-macro_rules! test_pool_or_skip {
-    () => {{
-        match try_test_pool().await {
-            Some(p) => p,
-            None => {
-                eprintln!("Skipping DB test: DATABASE_URL not set or unreachable");
-                return;
-            }
-        }
-    }};
-}
 
 // --- seed helpers ---
 
@@ -73,6 +47,30 @@ async fn insert_claim(pool: &PgPool, agent_id: Uuid) -> Uuid {
     insert_claim_with_properties(pool, agent_id, serde_json::json!({})).await
 }
 
+async fn insert_paper(pool: &PgPool, doi: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO papers (id, doi, title) VALUES ($1, $2, $3)")
+        .bind(id)
+        .bind(doi)
+        .bind(format!("paper {}", id))
+        .execute(pool)
+        .await
+        .expect("insert paper");
+    id
+}
+
+async fn insert_asserts_edge(pool: &PgPool, paper_id: Uuid, claim_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO edges (source_id, source_type, target_id, target_type, relationship)
+         VALUES ($1, 'paper', $2, 'claim', 'asserts')",
+    )
+    .bind(paper_id)
+    .bind(claim_id)
+    .execute(pool)
+    .await
+    .expect("insert asserts edge");
+}
+
 async fn insert_derived_from(pool: &PgPool, child: Uuid, parent: Uuid) {
     // source_type and target_type are NOT NULL; both are 'claim' here.
     sqlx::query(
@@ -89,16 +87,17 @@ async fn insert_derived_from(pool: &PgPool, child: Uuid, parent: Uuid) {
 // --- tests ---
 
 #[sqlx::test(migrations = "../../migrations")]
-async fn derive_extracts_paper_doi_from_properties(pool: PgPool) {
+async fn derive_extracts_paper_doi_from_asserts_edge(pool: PgPool) {
+    // Canonical paper provenance is relational: the DOI lives on the papers
+    // row and is reached via a paper -asserts-> claim edge, NOT in
+    // properties->>'paper_doi' (which no write path ever populates).
     let agent_id = insert_agent(&pool).await;
-    let claim_id = insert_claim_with_properties(
-        &pool,
-        agent_id,
-        serde_json::json!({"paper_doi": "10.1/abc"}),
-    )
-    .await;
+    let claim_id = insert_claim(&pool, agent_id).await;
+    let paper_id = insert_paper(&pool, "10.1/regression").await;
+    insert_asserts_edge(&pool, paper_id, claim_id).await;
+
     let key = derive_source_key(&pool, claim_id).await.expect("derive");
-    assert_eq!(key.paper_doi.as_deref(), Some("10.1/abc"));
+    assert_eq!(key.paper_doi.as_deref(), Some("10.1/regression"));
     assert_eq!(key.agent_id, agent_id);
     assert_eq!(key.ingestion_run_id, None);
     assert_eq!(key.derivation_root, None);


### PR DESCRIPTION
## Claim
The cross-source matcher's same-source exclusion was a **silent no-op on real data**. `derive_source_key` read `claim.properties->>'paper_doi'` — a JSON field no write path in the repo ever populates. Canonical paper provenance is relational (`paper -asserts-> claim` edge, DOI on `papers.doi`), so every claim resolved `paper_doi = None`, `both_eq(None,None)=false`, and same-paper pairs slipped through as cross-source.

## Evidence
- Empirical: promoted CORROBORATES candidate `530d00be` ("ERMAR 20-shot supports 4-shot", verdict `same`) joined two claims (`8c5c810c`, `ff77bae4`) **both asserted by the same paper** `da533e27`.
- Prod audit (2026-07-21) of 324 promoted candidates: **71 are same-paper leaks** (51 `same` / 13 `paraphrase` / 7 `contradicts`).

## Reasoning
Replace the dead property read with the same relational lookup the rest of the system uses (cf. `claim.rs` `paper_doi_filter`):
```sql
SELECT p.doi FROM edges e JOIN papers p ON p.id = e.source_id
WHERE e.target_id = $1 AND e.source_type = 'paper' AND e.relationship = 'asserts' LIMIT 1
```
Runtime `query_scalar` (not the `query!` macro) so no `.sqlx/` regen is needed and `SQLX_OFFLINE` CI stays green; `Option<String> + .flatten()` guards a NULL `papers.doi` decode panic. `SourceKey`, `is_same_source`, `SourceFilterConfig`, the `derivation_root` walk, and the fn signature are **untouched**, so the in-memory unit tests and the sole caller (`blocker/mod.rs`) need no change.

## Verification
- **Red-green anti-tautology**: reverting only the paper_doi line makes the new tests fail (pair leaks; `None != Some("10.1/regression")`); restoring passes them.
- New regression test `same_paper_via_asserts_edge_is_filtered_out`: same-paper pair (provenance via asserts edge, shared `content_hash` so `ContentHashBlocker` emits the candidate, distinct agents) is filtered out.
- New positive control `different_papers_via_asserts_edges_survive_as_cross_source`: two claims from **different** papers survive as cross-source (proves it discriminates by DOI, doesn't over-match).
- Against a throwaway pgvector container (never prod): 5/5 affected tests pass. `cargo fmt --check` clean; `cargo clippy --workspace --locked -- -D warnings` (real CI form) clean.

## Follow-ups (filed as backlog)
- `c618e4fc` — non-paper provenance (memory/journal/RFP): 242/324 promoted pairs have no asserting paper; needs a distinct same-source signal.
- `50b19b4e` — residual `derive_source_key` limits: multi-paper `LIMIT 1`, dead `ingestion_run_id` branch, weak `derivation_root` semantics.
- `07fb018c` — retirement/belief-retraction gap: no sanctioned path to retire a promoted candidate; edge deletion doesn't retract the auto-created `factors`/`bp_messages` (belief persists). Needed to clean up the 71 existing leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)