### PR TITLE
fix(engine): recall over claims.embedding, not the dead evidence.embedding

### DIFF
--- a/crates/epigraph-engine/src/recall.rs
+++ b/crates/epigraph-engine/src/recall.rs
@@ -14,7 +14,7 @@
 //! MCP behaviour.
 
 use epigraph_core::ClaimId;
-use epigraph_db::{ClaimRepository, EvidenceRepository, PgPool};
+use epigraph_db::{ClaimRepository, PgPool};
 use epigraph_embeddings::EmbeddingService;
 use thiserror::Error;
 
@@ -79,7 +79,11 @@ pub async fn recall(
     // Try semantic search first.
     let results = if let Ok(embedding) = embedder.generate_query(query).await {
         let pgvec = format_pgvector(&embedding);
-        match EvidenceRepository::search_by_embedding(pool, &pgvec, limit_i64).await {
+        // ANN over `claims.embedding` (is_current, all levels) — NOT
+        // `evidence.embedding`, which is a permanently-empty column: searching
+        // it made this semantic leg always return nothing and silently starved
+        // downstream callers (episcience synthesis stage-1 seeding).
+        match ClaimRepository::search_by_embedding_current(pool, &pgvec, limit_i64).await {
             Ok(hits) => {
                 let mut results = Vec::new();
                 for hit in hits {

--- a/crates/epigraph-engine/tests/recall_claims_embedding_test.rs
+++ b/crates/epigraph-engine/tests/recall_claims_embedding_test.rs
@@ -1,0 +1,95 @@
+//! Regression: `epigraph_engine::recall::recall`'s semantic path must query
+//! `claims.embedding`, not the permanently-empty `evidence.embedding` column.
+//!
+//! Before the fix, `recall` ran ANN over `EvidenceRepository::search_by_embedding`
+//! (i.e. `evidence.embedding`, which is 0-populated in prod), so its semantic leg
+//! always returned nothing and episcience synthesis stage-1 seeding failed with
+//! "seed recall returned no claims for query" — even with a real embedder.
+//!
+//! This test seeds a claim whose vector lives ONLY on `claims.embedding` (evidence
+//! is never populated) and asserts `recall` surfaces it via the semantic path with
+//! a real cosine similarity — impossible under the old evidence-column query.
+
+use epigraph_embeddings::{config::EmbeddingConfig, providers::MockProvider, EmbeddingService};
+use epigraph_engine::recall::recall;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn distinct_hash(tag: u8) -> Vec<u8> {
+    let mut h = vec![0u8; 32];
+    h[0] = tag;
+    h
+}
+
+async fn seed_agent(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO agents (id, public_key) VALUES ($1, decode($2, 'hex'))")
+        .bind(id)
+        .bind("bb".repeat(32))
+        .execute(pool)
+        .await
+        .expect("seed agent");
+    id
+}
+
+/// `recall` must find an `is_current`, above-`min_truth` claim by the similarity
+/// of its `claims.embedding` vector to the query embedding.
+#[sqlx::test(migrations = "../../migrations")]
+async fn recall_semantic_path_reads_claims_embedding(pool: PgPool) {
+    // Deterministic mock: embedding a fixed query text always yields the same
+    // 1536-d vector, so seeding a claim with that exact vector guarantees an
+    // exact-match (cosine ~1.0) semantic hit.
+    let mock = MockProvider::new(EmbeddingConfig::openai(1536));
+    let query = "mechanosynthesis tooltip chemistry";
+    let qvec = mock.generate_query(query).await.expect("mock embed");
+    let pgvec = format!(
+        "[{}]",
+        qvec.iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+
+    let agent = seed_agent(&pool).await;
+    let claim_id = Uuid::new_v4();
+    // Vector on claims.embedding only; evidence.embedding is never populated, so
+    // the pre-fix evidence-column search cannot return this claim. truth_value 0.9
+    // clears the recall min_truth gate (0.5 below).
+    sqlx::query(
+        "INSERT INTO claims (id, content, content_hash, agent_id, truth_value, embedding, is_current) \
+         VALUES ($1, $2, $3, $4, 0.9, $5::vector, true)",
+    )
+    .bind(claim_id)
+    .bind("mechanosynthesis tooltip chemistry and molecular manufacturing")
+    .bind(distinct_hash(1))
+    .bind(agent)
+    .bind(&pgvec)
+    .execute(&pool)
+    .await
+    .expect("seed claim with claims.embedding vector");
+
+    let results = recall(&pool, &mock, query, 10, 0.5)
+        .await
+        .expect("recall must not error");
+
+    let hit = results
+        .iter()
+        .find(|r| r.claim_id == claim_id.to_string())
+        .unwrap_or_else(|| {
+            panic!(
+                "recall must surface the seeded claim via claims.embedding; got {} \
+                 result(s) — a pre-fix evidence.embedding search returns 0",
+                results.len()
+            )
+        });
+
+    // Guard against a lexical-fallback false positive: the semantic path yields a
+    // real cosine (~1.0 for the exact-match vector); the ILIKE fallback hard-codes
+    // similarity 0.0.
+    assert!(
+        hit.similarity > 0.5,
+        "hit must come from the semantic (claims.embedding) path, not the lexical \
+         fallback; similarity was {}",
+        hit.similarity
+    );
+}


### PR DESCRIPTION
## Problem

episcience synthesis (`POST /api/v1/eln/syntheses`) fails at **stage-1 seeding** with `"seed recall returned no claims for query"` — even with real OpenAI embeddings live and the graph holding hundreds of thousands of embedded claims.

Root cause: `epigraph_engine::recall::recall` ran its semantic ANN via `EvidenceRepository::search_by_embedding`, i.e. over **`evidence.embedding`** — a permanently-empty column (**0 of 98,549** rows populated in prod). Claim vectors live on **`claims.embedding`** (318,435 of 450,249 populated). Because `generate_query` *succeeds* (returns Ok), the empty semantic result never falls through to the lexical fallback → recall returns hard-empty.

This is the same `evidence.embedding` misrouting class that bit the MCP `recall`/`find_workflow` paths earlier; this low-level `recall::recall` (used by episcience synthesis) was simply never migrated.

## Fix

Point the semantic search at `ClaimRepository::search_by_embedding_current` (is_current, all levels, 1536-d `claims.embedding`) — the same search backing the MCP `recall` tool, whose docstring already documents this exact dead-column bug. `ClaimEmbeddingHit` has the same `{ claim_id: Uuid, similarity: f64 }` shape, so the result loop is unchanged; the now-unused `EvidenceRepository` import is dropped.

**Isolated:** the only caller of this library `recall::recall` is episcience synthesis seeding. The MCP `recall` handler uses its own `recall_with_context` pipeline and is unaffected.

## Verification

- New regression `recall_semantic_path_reads_claims_embedding` (`#[sqlx::test]`): seeds a claim whose vector lives **only** on `claims.embedding`, asserts `recall` surfaces it via the semantic path with real cosine (`> 0.5`). **RED** against unmodified main (0 results) → **GREEN** after the swap. The `similarity > 0.5` assert also guards against a lexical-fallback false positive (fallback hard-codes 0.0).
- `cargo fmt --check`, `cargo clippy -p epigraph-engine -- -D warnings`, and the recall unit tests all pass.
- **Sufficiency** against prod: top-50 nearest on `claims.embedding` for real queries yield ~36–40 claims that also pass `is_current AND truth_value >= 0.5` (`would_seed` = 40/40, 36/36, 40/41) — so recall now returns seeds rather than empty, unblocking synthesis stage-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)