### PR TITLE
feat(mcp): federation gateway — mount downstream MCP extensions over loopback TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3569,6 +3569,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.4.0",
  "http-body",
@@ -3593,12 +3594,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.8",
 ]
@@ -3644,6 +3647,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rand 0.9.2",
+ "reqwest",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -5190,6 +5194,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ utoipa = { version = "5", features = ["chrono", "uuid"] }
 # CLI & Utilities
 clap = "4"
 reqwest = { version = "0.12", features = ["json"] }
-rmcp = { version = "0.15", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "0.15", features = ["server", "macros", "transport-io", "transport-streamable-http-server", "client", "transport-streamable-http-client-reqwest"] }
 schemars = "1"
 csv = "1.3"
 futures = "0.3"

--- a/crates/epigraph-mcp/src/auth.rs
+++ b/crates/epigraph-mcp/src/auth.rs
@@ -27,6 +27,22 @@ use epigraph_auth::{AuthContext, JwtConfig};
 /// Single source so both 401 arms emit the same value.
 const INVALID_TOKEN: &str = "invalid_token";
 
+/// The raw (still-encoded) Bearer token string, captured by
+/// [`bearer_auth_middleware`] after successful validation and stashed in the
+/// request extensions alongside [`AuthContext`].
+///
+/// The federation gateway needs the *verbatim* caller token to forward it to a
+/// downstream extension MCP: rmcp's `StreamableHttpClientTransportConfig`
+/// `auth_header` is set once at transport construction and there is no per-call
+/// token slot, so the gateway builds a fresh transport per federated call using
+/// this token. `AuthContext` alone is insufficient because it is the *decoded*
+/// claims, not the signed string the downstream server will re-validate.
+///
+/// Present only on the HTTP path (stdio has no Bearer header); federated calls
+/// over stdio therefore have no token to forward.
+#[derive(Clone)]
+pub struct RawBearerToken(pub String);
+
 #[derive(Clone)]
 pub struct McpAuthState {
     pub jwt_config: Arc<JwtConfig>,
@@ -52,6 +68,10 @@ pub async fn bearer_auth_middleware(
                 Ok(claims) => {
                     let auth: AuthContext = claims.into();
                     req.extensions_mut().insert(auth);
+                    // Stash the raw, still-signed token so the federation gateway
+                    // can forward it verbatim to a downstream extension MCP.
+                    req.extensions_mut()
+                        .insert(RawBearerToken(token.to_string()));
                     next.run(req).await
                 }
                 Err(_) => unauthorized(state.resource_metadata_url.as_deref(), INVALID_TOKEN),

--- a/crates/epigraph-mcp/src/federation/client.rs
+++ b/crates/epigraph-mcp/src/federation/client.rs
@@ -1,0 +1,173 @@
+//! rmcp streamable-HTTP client wrappers for the federation gateway.
+//!
+//! Two distinct session shapes, driven by rmcp 0.15's transport model where
+//! `auth_header` is **per-transport** (cloned into every request) — there is no
+//! per-call token slot:
+//!
+//! - **Discovery** ([`discovery_session`]): one long-lived client session per
+//!   extension, authenticated with a gateway *service* token. It drives
+//!   `list_all_tools` for the routing cache and is periodically health-checked /
+//!   reconnected. Persisting it avoids a fresh TCP + `initialize` handshake on
+//!   every list.
+//! - **Invocation** ([`invoke_once`]): a fresh, ephemeral session per federated
+//!   `tools/call`, authenticated with the *caller's* raw bearer so the
+//!   downstream sees the real principal (not the gateway). The session is
+//!   dropped immediately after the call; rmcp's transport worker issues
+//!   `delete_session` on drop, so downstream sessions do not leak.
+//!
+//! ## Timeouts
+//!
+//! The `initialize` handshake ([`serve_client`]) is wrapped in a bounded
+//! [`tokio::time::timeout`]. A downstream that accepts the TCP connection but
+//! never completes `initialize` would otherwise hang the gateway's `build()`
+//! (discovery) or a caller's `tools/call` (invocation) indefinitely. On timeout
+//! we surface a [`FederationError::Timeout`] so the registry can log-and-skip a
+//! wedged extension rather than wedge the whole gateway.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rmcp::model::{CallToolRequestParams, CallToolResult, Tool};
+use rmcp::serve_client;
+use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::{
+    StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
+};
+use rmcp::RoleClient;
+
+/// How long to wait for the `initialize` handshake before giving up on a
+/// downstream extension. Deliberately short: a healthy loopback extension
+/// completes `initialize` in milliseconds; anything slower is either a wedged
+/// process or a mis-routed port, and we would rather log-and-skip than block
+/// gateway startup or a caller's request.
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A live rmcp client session to one downstream extension. The `()` service
+/// handler is the no-op client handler (`impl ClientHandler for ()`), which is
+/// all we need: the gateway is a pure client of the downstream — it issues
+/// requests and never serves the downstream's server-initiated calls.
+pub type ExtensionClient = RunningService<RoleClient, ()>;
+
+/// Errors talking to a downstream extension over the federation transport.
+#[derive(Debug, thiserror::Error)]
+pub enum FederationError {
+    /// The `initialize` handshake did not complete within [`HANDSHAKE_TIMEOUT`].
+    /// Distinguished from [`Connect`](FederationError::Connect) so the registry
+    /// can report a wedged (vs unreachable) downstream.
+    #[error("timed out after {0:?} connecting to extension at {1}")]
+    Timeout(Duration, String),
+
+    /// The `serve_client` handshake failed (connection refused, TCP reset,
+    /// protocol error at `initialize`, …). Carries the target URI and the
+    /// underlying error string.
+    #[error("failed to connect to extension at {uri}: {cause}")]
+    Connect {
+        /// The `http://host:port/mcp` URI we dialed.
+        uri: String,
+        /// Stringified underlying rmcp / transport error. (Named `cause`, not
+        /// `source`, so thiserror does not treat it as a `#[source]` field —
+        /// it is a `String`, which is not `std::error::Error`.)
+        cause: String,
+    },
+
+    /// A request on an established session failed (`list_tools`,
+    /// `call_tool`, …).
+    #[error("request to extension failed: {0}")]
+    Request(String),
+}
+
+/// Build the `http://{addr}/mcp` URI the gateway dials for an extension whose
+/// parsed `addr` is a bare `host:port` (v1 loopback TCP only; see
+/// [`super::config`]).
+#[must_use]
+pub fn extension_uri(addr: &str) -> String {
+    format!("http://{addr}/mcp")
+}
+
+/// Open a persistent **discovery** session to the extension at `addr`,
+/// authenticated with `discovery_token` (the gateway service token, sent as a
+/// bearer). The returned session is meant to be kept alive and reused for
+/// `list_all_tools` and health checks.
+///
+/// # Errors
+/// [`FederationError::Timeout`] if `initialize` does not complete within
+/// [`HANDSHAKE_TIMEOUT`]; [`FederationError::Connect`] on any other handshake
+/// failure.
+pub async fn discovery_session(
+    addr: &str,
+    discovery_token: &str,
+) -> Result<ExtensionClient, FederationError> {
+    connect(addr, Some(discovery_token)).await
+}
+
+/// List every tool the extension advertises over its discovery session,
+/// following pagination to completion.
+///
+/// # Errors
+/// [`FederationError::Request`] if the downstream `tools/list` fails.
+pub async fn list_all_tools(client: &ExtensionClient) -> Result<Vec<Tool>, FederationError> {
+    client
+        .peer()
+        .list_all_tools()
+        .await
+        .map_err(|e| FederationError::Request(e.to_string()))
+}
+
+/// Proxy a single `tools/call` to the extension at `addr` on a **fresh**
+/// ephemeral session authenticated with `caller_token` (the caller's raw
+/// bearer, forwarded verbatim so the downstream sees the real principal).
+///
+/// The session is dropped when this function returns; rmcp's transport worker
+/// issues `delete_session` on drop, so the downstream session is released and
+/// does not leak.
+///
+/// # Errors
+/// [`FederationError::Timeout`] / [`FederationError::Connect`] on handshake
+/// failure; [`FederationError::Request`] if the downstream `tools/call` fails.
+pub async fn invoke_once(
+    addr: &str,
+    caller_token: &str,
+    name: &str,
+    arguments: Option<rmcp::model::JsonObject>,
+) -> Result<CallToolResult, FederationError> {
+    let client = connect(addr, Some(caller_token)).await?;
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams {
+            meta: None,
+            name: std::borrow::Cow::Owned(name.to_string()),
+            arguments,
+            task: None,
+        })
+        .await
+        .map_err(|e| FederationError::Request(e.to_string()));
+    // Explicit drop: releasing the session (and its downstream `delete_session`)
+    // is the whole point of the ephemeral-per-call model. Dropping after we have
+    // the result keeps the RAII contract obvious to future readers.
+    drop(client);
+    result
+}
+
+/// Core connect path shared by discovery and invocation: build a reqwest
+/// streamable-HTTP transport with the given bearer (if any) and run the
+/// `serve_client` `initialize` handshake under [`HANDSHAKE_TIMEOUT`].
+async fn connect(addr: &str, token: Option<&str>) -> Result<ExtensionClient, FederationError> {
+    let uri = extension_uri(addr);
+    let mut config = StreamableHttpClientTransportConfig::with_uri(Arc::<str>::from(uri.as_str()));
+    if let Some(token) = token {
+        // `auth_header` is the raw bearer WITHOUT the `Bearer ` prefix; rmcp's
+        // reqwest client calls `.bearer_auth(token)` which prepends it, so the
+        // downstream receives `Authorization: Bearer <token>`.
+        config.auth_header = Some(token.to_string());
+    }
+    let transport = StreamableHttpClientTransport::<reqwest::Client>::from_config(config);
+
+    match tokio::time::timeout(HANDSHAKE_TIMEOUT, serve_client((), transport)).await {
+        Ok(Ok(client)) => Ok(client),
+        Ok(Err(e)) => Err(FederationError::Connect {
+            uri,
+            cause: e.to_string(),
+        }),
+        Err(_elapsed) => Err(FederationError::Timeout(HANDSHAKE_TIMEOUT, uri)),
+    }
+}

--- a/crates/epigraph-mcp/src/federation/config.rs
+++ b/crates/epigraph-mcp/src/federation/config.rs
@@ -1,0 +1,347 @@
+//! Parser for the `EPIGRAPH_MCP_EXTENSIONS` environment variable.
+//!
+//! The gateway mounts zero or more downstream extension MCP servers. Each is
+//! described by one comma-separated entry; fields within an entry are
+//! semicolon-separated:
+//!
+//! ```text
+//! EPIGRAPH_MCP_EXTENSIONS="episcience=tcp:127.0.0.1:8093;scope=episcience:tools;prefix=episcience__"
+//! ```
+//!
+//! Entry grammar (fields after the first are order-independent `key=value`):
+//!
+//! - **`name=tcp:host:port`** — REQUIRED, MUST be the first field. `name` is the
+//!   extension's logical identifier; the value is a transport spec. v1 supports
+//!   only the `tcp:` scheme (loopback TCP); the parsed `addr` is the bare
+//!   `host:port` with the scheme stripped.
+//! - **`scope=<oauth-scope>`** — REQUIRED. The OAuth scope a caller must hold for
+//!   the gateway to forward any tool owned by this extension. Federated tools are
+//!   deliberately NOT in the static `SCOPE_MAP` (whose coverage is compile-time),
+//!   so this is the sole scope gate for them.
+//! - **`prefix=<str>`** — OPTIONAL. Prepended to each federated tool name to
+//!   avoid collisions with kernel tools or other extensions.
+//!
+//! Absent or empty env → [`Vec::new`] → empty registry → the gateway behaves
+//! exactly as it does today (backward compatible). A malformed entry is a hard
+//! error at parse time (fail fast at boot rather than silently drop an
+//! extension).
+
+use std::fmt;
+
+/// The transport scheme prefix for the v1 loopback-TCP transport. UDS is a
+/// documented fast-follow and is intentionally rejected here.
+const TCP_SCHEME: &str = "tcp:";
+
+/// Parsed configuration for one mounted downstream extension MCP.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionConfig {
+    /// Logical name of the extension (e.g. `"episcience"`). Used in logs and,
+    /// with the default prefix, to disambiguate tools.
+    pub name: String,
+    /// Bare `host:port` the extension serves streamable-HTTP on (scheme
+    /// stripped). v1 is always loopback TCP; the gateway dials
+    /// `http://{addr}/mcp`.
+    pub addr: String,
+    /// OAuth scope a caller must hold for the gateway to forward this
+    /// extension's tools.
+    pub scope: String,
+    /// Optional tool-name prefix to avoid collisions.
+    pub prefix: Option<String>,
+}
+
+/// Failure while parsing `EPIGRAPH_MCP_EXTENSIONS`. Carries the offending entry
+/// so the boot log points the operator straight at the typo.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigError {
+    /// The raw entry (or field) that failed to parse.
+    pub entry: String,
+    /// Human-readable reason.
+    pub reason: String,
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid EPIGRAPH_MCP_EXTENSIONS entry `{}`: {}",
+            self.entry, self.reason
+        )
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// Parse the value of `EPIGRAPH_MCP_EXTENSIONS`.
+///
+/// `None` (env unset) and `Some("")` / whitespace-only both yield an empty
+/// vector. Otherwise every comma-separated entry is parsed; the first malformed
+/// entry aborts with a [`ConfigError`].
+///
+/// # Errors
+/// Returns [`ConfigError`] on the first malformed entry (unknown scheme,
+/// missing required field, duplicate field, empty value, unknown key).
+pub fn parse_extensions(raw: Option<&str>) -> Result<Vec<ExtensionConfig>, ConfigError> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    if raw.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    raw.split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(parse_entry)
+        .collect()
+}
+
+/// Parse a single comma-delimited entry into an [`ExtensionConfig`].
+fn parse_entry(entry: &str) -> Result<ExtensionConfig, ConfigError> {
+    let err = |reason: &str| ConfigError {
+        entry: entry.to_string(),
+        reason: reason.to_string(),
+    };
+
+    let mut fields = entry.split(';').map(str::trim).filter(|f| !f.is_empty());
+
+    // First field MUST be `name=tcp:host:port`.
+    let first = fields
+        .next()
+        .ok_or_else(|| err("entry is empty (expected `name=tcp:host:port`)"))?;
+    let (name, transport) = first
+        .split_once('=')
+        .ok_or_else(|| err("first field must be `name=tcp:host:port`"))?;
+    let name = name.trim();
+    let transport = transport.trim();
+    if name.is_empty() {
+        return Err(err("extension name is empty"));
+    }
+    let addr = transport.strip_prefix(TCP_SCHEME).ok_or_else(|| {
+        err("transport must use the `tcp:` scheme (v1 supports loopback TCP only)")
+    })?;
+    let addr = addr.trim();
+    if addr.is_empty() {
+        return Err(err("transport address (host:port) is empty"));
+    }
+    // Require an explicit `:port`. rmcp dials `http://{addr}/mcp`; without a
+    // port the request would silently target port 80 (or fail), so reject at
+    // boot rather than let a portless address slip through to the dial. The
+    // check is deliberately syntactic (last segment after ':' is all digits) —
+    // full socket-addr validation belongs to the Stage-2 dialer.
+    match addr.rsplit_once(':') {
+        Some((host, port))
+            if !host.is_empty() && !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => {
+        }
+        _ => {
+            return Err(err(
+                "transport address must be `host:port` with a numeric port (e.g. 127.0.0.1:8093)",
+            ))
+        }
+    }
+
+    // Remaining fields are order-independent `key=value` pairs.
+    let mut scope: Option<String> = None;
+    let mut prefix: Option<String> = None;
+    for field in fields {
+        let (key, value) = field
+            .split_once('=')
+            .ok_or_else(|| err(&format!("field `{field}` must be `key=value`")))?;
+        let key = key.trim();
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(err(&format!("field `{key}` has an empty value")));
+        }
+        match key {
+            "scope" => {
+                if scope.is_some() {
+                    return Err(err("duplicate `scope` field"));
+                }
+                scope = Some(value.to_string());
+            }
+            "prefix" => {
+                if prefix.is_some() {
+                    return Err(err("duplicate `prefix` field"));
+                }
+                prefix = Some(value.to_string());
+            }
+            other => {
+                return Err(err(&format!(
+                    "unknown field `{other}` (expected `scope` or `prefix`)"
+                )));
+            }
+        }
+    }
+
+    let scope = scope.ok_or_else(|| err("missing required `scope` field"))?;
+
+    Ok(ExtensionConfig {
+        name: name.to_string(),
+        addr: addr.to_string(),
+        scope,
+        prefix,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_env_yields_empty() {
+        assert_eq!(parse_extensions(None).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn empty_and_whitespace_env_yields_empty() {
+        assert_eq!(parse_extensions(Some("")).unwrap(), Vec::new());
+        assert_eq!(parse_extensions(Some("   ")).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn parses_single_extension_without_prefix() {
+        let cfgs =
+            parse_extensions(Some("episcience=tcp:127.0.0.1:8093;scope=episcience:tools")).unwrap();
+        assert_eq!(
+            cfgs,
+            vec![ExtensionConfig {
+                name: "episcience".into(),
+                addr: "127.0.0.1:8093".into(),
+                scope: "episcience:tools".into(),
+                prefix: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_single_extension_with_prefix() {
+        let cfgs = parse_extensions(Some(
+            "episcience=tcp:127.0.0.1:8093;scope=episcience:tools;prefix=episcience__",
+        ))
+        .unwrap();
+        assert_eq!(
+            cfgs,
+            vec![ExtensionConfig {
+                name: "episcience".into(),
+                addr: "127.0.0.1:8093".into(),
+                scope: "episcience:tools".into(),
+                prefix: Some("episcience__".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_two_extensions_comma_separated() {
+        let cfgs = parse_extensions(Some(
+            "episcience=tcp:127.0.0.1:8093;scope=episcience:tools;prefix=episcience__,\
+             foundry=tcp:127.0.0.1:8094;scope=foundry:tools",
+        ))
+        .unwrap();
+        assert_eq!(cfgs.len(), 2);
+        assert_eq!(cfgs[0].name, "episcience");
+        assert_eq!(cfgs[0].prefix.as_deref(), Some("episcience__"));
+        assert_eq!(cfgs[1].name, "foundry");
+        assert_eq!(cfgs[1].addr, "127.0.0.1:8094");
+        assert_eq!(cfgs[1].scope, "foundry:tools");
+        assert_eq!(cfgs[1].prefix, None);
+    }
+
+    #[test]
+    fn field_order_is_independent() {
+        let cfgs = parse_extensions(Some(
+            "episcience=tcp:127.0.0.1:8093;prefix=e__;scope=episcience:tools",
+        ))
+        .unwrap();
+        assert_eq!(cfgs[0].scope, "episcience:tools");
+        assert_eq!(cfgs[0].prefix.as_deref(), Some("e__"));
+    }
+
+    #[test]
+    fn trailing_comma_and_extra_whitespace_tolerated() {
+        let cfgs = parse_extensions(Some(
+            "  episcience=tcp:127.0.0.1:8093 ; scope=episcience:tools ,",
+        ))
+        .unwrap();
+        assert_eq!(cfgs.len(), 1);
+        assert_eq!(cfgs[0].addr, "127.0.0.1:8093");
+        assert_eq!(cfgs[0].scope, "episcience:tools");
+    }
+
+    #[test]
+    fn missing_scope_is_error() {
+        let err = parse_extensions(Some("episcience=tcp:127.0.0.1:8093")).unwrap_err();
+        assert!(err.reason.contains("scope"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn non_tcp_scheme_is_error() {
+        let err = parse_extensions(Some("episcience=unix:/run/e.sock;scope=episcience:tools"))
+            .unwrap_err();
+        assert!(err.reason.contains("tcp:"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn missing_transport_scheme_is_error() {
+        let err =
+            parse_extensions(Some("episcience=127.0.0.1:8093;scope=episcience:tools")).unwrap_err();
+        assert!(err.reason.contains("tcp:"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn empty_name_is_error() {
+        let err = parse_extensions(Some("=tcp:127.0.0.1:8093;scope=x")).unwrap_err();
+        assert!(err.reason.contains("name"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn empty_addr_is_error() {
+        let err = parse_extensions(Some("episcience=tcp:;scope=x")).unwrap_err();
+        assert!(err.reason.contains("address"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn addr_without_port_is_error() {
+        let err = parse_extensions(Some("episcience=tcp:127.0.0.1;scope=x")).unwrap_err();
+        assert!(err.reason.contains("numeric port"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn addr_with_non_numeric_port_is_error() {
+        let err = parse_extensions(Some("episcience=tcp:127.0.0.1:http;scope=x")).unwrap_err();
+        assert!(err.reason.contains("numeric port"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn unknown_field_is_error() {
+        let err =
+            parse_extensions(Some("episcience=tcp:127.0.0.1:8093;scope=x;bogus=1")).unwrap_err();
+        assert!(err.reason.contains("bogus"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn duplicate_scope_is_error() {
+        let err =
+            parse_extensions(Some("episcience=tcp:127.0.0.1:8093;scope=a;scope=b")).unwrap_err();
+        assert!(err.reason.contains("duplicate"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn empty_field_value_is_error() {
+        let err = parse_extensions(Some("episcience=tcp:127.0.0.1:8093;scope=")).unwrap_err();
+        assert!(err.reason.contains("empty"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn field_without_equals_is_error() {
+        let err =
+            parse_extensions(Some("episcience=tcp:127.0.0.1:8093;scope=x;justakey")).unwrap_err();
+        assert!(err.reason.contains("key=value"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn display_includes_entry_and_reason() {
+        let err = parse_extensions(Some("episcience=tcp:127.0.0.1:8093")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("EPIGRAPH_MCP_EXTENSIONS"), "got: {msg}");
+        assert!(msg.contains("episcience=tcp:127.0.0.1:8093"), "got: {msg}");
+    }
+}

--- a/crates/epigraph-mcp/src/federation/mod.rs
+++ b/crates/epigraph-mcp/src/federation/mod.rs
@@ -109,6 +109,21 @@ pub struct FederationRegistry {
 }
 
 impl FederationRegistry {
+    /// An empty registry with no mounted extensions. Used as the default
+    /// federation for the plain `EpiGraphMcpFull::new`/`new_shared` constructors
+    /// (which keep their pre-federation signatures) and whenever
+    /// `EPIGRAPH_MCP_EXTENSIONS` is absent — the gateway then behaves exactly as
+    /// it did before federation. Unlike [`build`](Self::build) this is sync and
+    /// infallible: no network I/O, no collisions possible.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            extensions: Vec::new(),
+            routes: HashMap::new(),
+            discovery_token: String::new(),
+        }
+    }
+
     /// Build a registry from parsed extension configs, connecting a discovery
     /// session to each and caching its (prefixed) tool list.
     ///

--- a/crates/epigraph-mcp/src/federation/mod.rs
+++ b/crates/epigraph-mcp/src/federation/mod.rs
@@ -1,0 +1,31 @@
+//! MCP federation gateway.
+//!
+//! The gateway mounts zero or more downstream "extension" MCP servers
+//! (e.g. episcience) and exposes their tools alongside the kernel's own,
+//! behind the single EpiGraph MCP endpoint. Callers see one flat tool list;
+//! the gateway routes each federated `tools/call` to the owning extension.
+//!
+//! ## Modules
+//!
+//! - [`config`] — parse `EPIGRAPH_MCP_EXTENSIONS` into [`config::ExtensionConfig`]s.
+//!   (Stage 1; no networking.)
+//!
+//! Stage 2 (networking) adds:
+//! - `client` — thin wrapper over rmcp `serve_client` + streamable-HTTP client
+//!   transport, with a persistent discovery session (service token) and an
+//!   ephemeral per-call invocation session (caller token).
+//! - `registry` — [`config::ExtensionConfig`] → mounted extensions with cached
+//!   tool lists, a `tool_name -> extension` routing map, collision detection,
+//!   health, and a reconnect timer.
+//!
+//! ## Transport (v1)
+//!
+//! Loopback TCP only: rmcp's reqwest streamable-HTTP client cannot dial Unix
+//! sockets. Extensions serve on `127.0.0.1:PORT` (never Caddy-exposed). UDS via
+//! a custom hyper connector is a documented fast-follow.
+
+pub mod config;
+
+// Stage 2 (networking) — filled in the next stage:
+// pub mod client;
+// pub mod registry;

--- a/crates/epigraph-mcp/src/federation/mod.rs
+++ b/crates/epigraph-mcp/src/federation/mod.rs
@@ -24,8 +24,327 @@
 //! sockets. Extensions serve on `127.0.0.1:PORT` (never Caddy-exposed). UDS via
 //! a custom hyper connector is a documented fast-follow.
 
+pub mod client;
 pub mod config;
 
-// Stage 2 (networking) — filled in the next stage:
-// pub mod client;
-// pub mod registry;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rmcp::model::{CallToolResult, Tool};
+use tokio::sync::RwLock;
+
+use crate::federation::client::{ExtensionClient, FederationError};
+use crate::federation::config::ExtensionConfig;
+
+/// Failure building a [`FederationRegistry`]. The only fatal condition is a tool
+/// name COLLISION (two reachable extensions exporting the same effective tool
+/// name) — that is an operator misconfiguration the gateway must not paper over,
+/// because silent last-writer-wins routing would send calls to the wrong
+/// backend. An *unreachable* extension at startup is NOT fatal: it is logged and
+/// skipped (see [`FederationRegistry::build`]).
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    /// Two extensions resolve to the same effective (post-prefix) tool name.
+    #[error(
+        "federated tool-name collision on `{tool}`: exported by both extension \
+         `{first}` and extension `{second}`; set a distinct `prefix=` on one"
+    )]
+    Collision {
+        /// The effective tool name exported by two extensions.
+        tool: String,
+        /// Name of the first extension to claim the tool.
+        first: String,
+        /// Name of the second extension that collided.
+        second: String,
+    },
+}
+
+/// One downstream extension mounted into the gateway: its config, a live
+/// discovery session (service-token authenticated), the cached tool list, and a
+/// health flag. `client` is `None` when the extension was unreachable at build
+/// time (or its discovery session later dropped) — it holds no cached tools and
+/// routes nothing until a [`reconnect_tick`](FederationRegistry::reconnect_tick)
+/// re-establishes it.
+pub struct MountedExtension {
+    /// Parsed config for this extension (name, addr, scope, optional prefix).
+    pub config: ExtensionConfig,
+    /// Persistent discovery session, or `None` if currently unreachable.
+    pub client: Option<ExtensionClient>,
+    /// Cached tools with their **effective** (post-prefix) names, exactly as the
+    /// gateway advertises them to callers.
+    pub tools: Vec<Tool>,
+    /// Whether the discovery session is currently believed healthy.
+    pub healthy: bool,
+}
+
+impl MountedExtension {
+    /// Apply the extension's optional prefix to a downstream tool's name,
+    /// yielding the effective name the gateway advertises and routes on.
+    fn effective_name(prefix: Option<&str>, downstream: &str) -> String {
+        match prefix {
+            Some(p) => format!("{p}{downstream}"),
+            None => downstream.to_string(),
+        }
+    }
+}
+
+/// The federation gateway's routing table over zero or more mounted extensions.
+///
+/// Holds each [`MountedExtension`] and a `effective_tool_name -> extension_index`
+/// map. Lookups ([`route`](Self::route), [`required_scope`](Self::required_scope))
+/// are O(1). The registry is wrapped in the server behind an `Arc`; interior
+/// mutability (for [`reconnect_tick`](Self::reconnect_tick)) is confined to the
+/// per-extension session via the registry being reconstructed or refreshed —
+/// v1 exposes reconnect as a method that mutates in place under `&mut`.
+pub struct FederationRegistry {
+    /// Mounted extensions, indexed by position. The routing map's values are
+    /// indices into this vector.
+    extensions: Vec<MountedExtension>,
+    /// `effective_tool_name -> index into `extensions``.
+    routes: HashMap<String, usize>,
+    /// Discovery token used to (re)establish discovery sessions. Kept so
+    /// [`reconnect_tick`](Self::reconnect_tick) can re-dial dropped extensions
+    /// without the caller threading the token back through.
+    discovery_token: String,
+}
+
+impl FederationRegistry {
+    /// Build a registry from parsed extension configs, connecting a discovery
+    /// session to each and caching its (prefixed) tool list.
+    ///
+    /// Reachability is best-effort: an extension that fails to connect or list
+    /// its tools is logged and mounted **unhealthy** (no client, no tools, no
+    /// routes) rather than aborting the whole gateway — a down backend must not
+    /// take the kernel's own tools offline. A later
+    /// [`reconnect_tick`](Self::reconnect_tick) can bring it up.
+    ///
+    /// # Errors
+    /// [`RegistryError::Collision`] if two *reachable* extensions export the
+    /// same effective tool name. This is the sole fatal condition: it is an
+    /// operator misconfiguration (ambiguous routing) that must fail loudly.
+    pub async fn build(
+        configs: Vec<ExtensionConfig>,
+        discovery_token: &str,
+    ) -> Result<Self, RegistryError> {
+        let mut extensions: Vec<MountedExtension> = Vec::with_capacity(configs.len());
+        let mut routes: HashMap<String, usize> = HashMap::new();
+
+        for config in configs {
+            let index = extensions.len();
+            let mounted = match client::discovery_session(&config.addr, discovery_token).await {
+                Ok(session) => match client::list_all_tools(&session).await {
+                    Ok(raw_tools) => {
+                        let tools = Self::prefix_tools(&config, raw_tools);
+                        // Register routes; a collision on the effective name is
+                        // fatal. Detect BEFORE moving `tools` into the mount.
+                        for tool in &tools {
+                            let name = tool.name.to_string();
+                            if let Some(&prior) = routes.get(&name) {
+                                return Err(RegistryError::Collision {
+                                    tool: name,
+                                    first: extensions[prior].config.name.clone(),
+                                    second: config.name.clone(),
+                                });
+                            }
+                            routes.insert(name, index);
+                        }
+                        tracing::info!(
+                            extension = %config.name,
+                            addr = %config.addr,
+                            tool_count = tools.len(),
+                            "federation: mounted extension"
+                        );
+                        MountedExtension {
+                            config,
+                            client: Some(session),
+                            tools,
+                            healthy: true,
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            extension = %config.name,
+                            addr = %config.addr,
+                            error = %e,
+                            "federation: extension connected but tools/list failed; \
+                             mounting unhealthy (no tools routed)"
+                        );
+                        MountedExtension {
+                            config,
+                            client: None,
+                            tools: Vec::new(),
+                            healthy: false,
+                        }
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        extension = %config.name,
+                        addr = %config.addr,
+                        error = %e,
+                        "federation: extension unreachable at startup; \
+                         mounting unhealthy (no tools routed)"
+                    );
+                    MountedExtension {
+                        config,
+                        client: None,
+                        tools: Vec::new(),
+                        healthy: false,
+                    }
+                }
+            };
+            extensions.push(mounted);
+        }
+
+        Ok(Self {
+            extensions,
+            routes,
+            discovery_token: discovery_token.to_string(),
+        })
+    }
+
+    /// Rewrite each downstream tool's `name` to its effective (prefixed) name.
+    /// Everything else (schema, description, annotations) is preserved so
+    /// callers see the downstream tool faithfully under the gateway namespace.
+    fn prefix_tools(config: &ExtensionConfig, tools: Vec<Tool>) -> Vec<Tool> {
+        let prefix = config.prefix.as_deref();
+        tools
+            .into_iter()
+            .map(|mut tool| {
+                let effective = MountedExtension::effective_name(prefix, tool.name.as_ref());
+                tool.name = std::borrow::Cow::Owned(effective);
+                tool
+            })
+            .collect()
+    }
+
+    /// Every federated tool the gateway currently advertises, across all healthy
+    /// extensions, with effective (prefixed) names. Order follows extension
+    /// mount order then the downstream's own tool order.
+    #[must_use]
+    pub fn list_federated_tools(&self) -> Vec<Tool> {
+        self.extensions
+            .iter()
+            .flat_map(|ext| ext.tools.iter().cloned())
+            .collect()
+    }
+
+    /// `true` when no extensions are mounted (env absent/empty), so the caller
+    /// can cheaply skip the whole federation branch.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.extensions.is_empty()
+    }
+
+    /// Look up the extension config that owns `effective_name`, or `None` if the
+    /// name is not a federated tool (caller should fall through to kernel tools).
+    #[must_use]
+    pub fn route(&self, effective_name: &str) -> Option<&ExtensionConfig> {
+        self.routes
+            .get(effective_name)
+            .map(|&i| &self.extensions[i].config)
+    }
+
+    /// The OAuth scope a caller must hold to invoke `effective_name`, or `None`
+    /// if it is not a federated tool. This is the SOLE scope gate for federated
+    /// tools (they are deliberately absent from the static `SCOPE_MAP`).
+    #[must_use]
+    pub fn required_scope(&self, effective_name: &str) -> Option<&str> {
+        self.route(effective_name).map(|c| c.scope.as_str())
+    }
+
+    /// Proxy a federated `tools/call` to the owning extension on a fresh
+    /// ephemeral session authenticated with `caller_token`.
+    ///
+    /// # Errors
+    /// [`FederationError::Request`] if `effective_name` is not a federated tool
+    /// (the caller should have routed it to the kernel), or any transport /
+    /// downstream error from [`client::invoke_once`].
+    pub async fn invoke(
+        &self,
+        effective_name: &str,
+        caller_token: &str,
+        arguments: Option<rmcp::model::JsonObject>,
+    ) -> Result<CallToolResult, FederationError> {
+        let Some(config) = self.route(effective_name) else {
+            return Err(FederationError::Request(format!(
+                "no federated route for tool `{effective_name}`"
+            )));
+        };
+        // Strip the gateway prefix back off before forwarding: the downstream
+        // knows the tool by its *bare* name, not the gateway's namespaced one.
+        let downstream_name = match config.prefix.as_deref() {
+            Some(p) => effective_name.strip_prefix(p).unwrap_or(effective_name),
+            None => effective_name,
+        };
+        client::invoke_once(&config.addr, caller_token, downstream_name, arguments).await
+    }
+
+    /// Re-establish discovery sessions for any extension currently mounted
+    /// unhealthy, refreshing its cached tool list and routing entries. Healthy
+    /// extensions are left untouched.
+    ///
+    /// Called on a timer by the gateway. A reconnect that would introduce a
+    /// tool-name collision with an already-mounted extension is skipped (logged)
+    /// rather than errored — reconnect must never take down the running gateway;
+    /// the collision is surfaced at the next `build`.
+    pub async fn reconnect_tick(&mut self) {
+        // Snapshot the currently-routed names owned by *other* healthy
+        // extensions so a reviving extension can't silently steal a route.
+        for index in 0..self.extensions.len() {
+            if self.extensions[index].healthy {
+                continue;
+            }
+            let addr = self.extensions[index].config.addr.clone();
+            let name = self.extensions[index].config.name.clone();
+            let session = match client::discovery_session(&addr, &self.discovery_token).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::debug!(extension = %name, error = %e, "federation: reconnect still failing");
+                    continue;
+                }
+            };
+            let raw = match client::list_all_tools(&session).await {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::debug!(extension = %name, error = %e, "federation: reconnect tools/list failed");
+                    continue;
+                }
+            };
+            let tools = Self::prefix_tools(&self.extensions[index].config, raw);
+            // Guard against collisions with routes owned by other extensions.
+            let mut collides = false;
+            for tool in &tools {
+                let n = tool.name.as_ref();
+                if let Some(&owner) = self.routes.get(n) {
+                    if owner != index {
+                        tracing::warn!(
+                            extension = %name,
+                            tool = %n,
+                            "federation: reconnect skipped — tool collides with a mounted extension"
+                        );
+                        collides = true;
+                        break;
+                    }
+                }
+            }
+            if collides {
+                continue;
+            }
+            for tool in &tools {
+                self.routes.insert(tool.name.to_string(), index);
+            }
+            tracing::info!(extension = %name, tool_count = tools.len(), "federation: reconnected extension");
+            let ext = &mut self.extensions[index];
+            ext.client = Some(session);
+            ext.tools = tools;
+            ext.healthy = true;
+        }
+    }
+}
+
+/// A shareable handle to the registry. The gateway constructs one
+/// [`FederationRegistry`] at boot and clones this `Arc` into every per-session
+/// server. The `RwLock` allows the reconnect timer to mutate mounts while
+/// readers (list/route/invoke) proceed concurrently.
+pub type SharedRegistry = Arc<RwLock<FederationRegistry>>;

--- a/crates/epigraph-mcp/src/lib.rs
+++ b/crates/epigraph-mcp/src/lib.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod claim_helper;
 pub mod embed;
 pub mod errors;
+pub mod federation;
 pub mod scope_map;
 pub mod server;
 pub mod tools;

--- a/crates/epigraph-mcp/src/main.rs
+++ b/crates/epigraph-mcp/src/main.rs
@@ -177,11 +177,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create embedder
     let embedder = McpEmbedder::new(pool.clone(), cli.openai_api_key);
 
+    // ── Federation gateway ──────────────────────────────────────────────
+    // Parse EPIGRAPH_MCP_EXTENSIONS and mount each downstream extension MCP.
+    // Built ONCE here and cloned (via the Arc) into every per-session server on
+    // both transport paths, so the discovery-cached tool list is shared. Absent
+    // env -> empty registry -> the gateway behaves exactly as pre-federation.
+    // A malformed EPIGRAPH_MCP_EXTENSIONS is a hard boot error (fail fast rather
+    // than silently drop an extension); a tool-name COLLISION between two
+    // extensions is likewise fatal (ambiguous routing). An individual extension
+    // being unreachable at startup is NOT fatal — it is logged and mounted
+    // unhealthy inside `build`.
+    let ext_env = std::env::var("EPIGRAPH_MCP_EXTENSIONS").ok();
+    let ext_configs = epigraph_mcp::federation::config::parse_extensions(ext_env.as_deref())
+        .map_err(|e| format!("EPIGRAPH_MCP_EXTENSIONS: {e}"))?;
+    // Discovery uses a gateway SERVICE token (never a caller token): the
+    // persistent discovery session is authenticated with it to drive
+    // list_all_tools. Per-call INVOCATION uses the caller's raw bearer instead.
+    let discovery_token = std::env::var("EPIGRAPH_MCP_DISCOVERY_TOKEN")
+        .or_else(|_| std::env::var("EPIGRAPH_SERVICE_TOKEN"))
+        .unwrap_or_default();
+    if !ext_configs.is_empty() && discovery_token.is_empty() {
+        tracing::warn!(
+            "EPIGRAPH_MCP_EXTENSIONS is set but no EPIGRAPH_MCP_DISCOVERY_TOKEN / \
+             EPIGRAPH_SERVICE_TOKEN — federated discovery will send an empty bearer \
+             and likely fail; extensions will mount unhealthy"
+        );
+    }
+    let federation = Arc::new(
+        epigraph_mcp::federation::FederationRegistry::build(ext_configs, &discovery_token)
+            .await
+            .map_err(|e| format!("federation gateway build failed: {e}"))?,
+    );
+    let federated_tool_count = federation.list_federated_tools().len();
+    if federation.is_empty() {
+        tracing::info!(
+            "Federation gateway: no extensions configured (EPIGRAPH_MCP_EXTENSIONS unset)"
+        );
+    } else {
+        tracing::info!(
+            federated_tools = federated_tool_count,
+            "Federation gateway: mounted {} federated tool(s) across configured extension(s)",
+            federated_tool_count
+        );
+    }
+
     let tool_count = EpiGraphMcpFull::all_tools_json()
         .as_array()
         .map_or(0, Vec::len);
     let mode = if cli.read_only { "read-only" } else { "full" };
-    tracing::info!("EpiGraph MCP server running in {mode} ({tool_count} tools) mode");
+    tracing::info!(
+        "EpiGraph MCP server running in {mode} ({tool_count} kernel + {federated_tool_count} federated tools) mode"
+    );
 
     if let Some(addr) = &cli.listen {
         // ── HTTP transport (TCP or Unix socket) ────────────────────────
@@ -194,14 +240,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let signer = Arc::new(signer);
         let embedder = Arc::new(embedder);
         let read_only = cli.read_only;
+        let federation = federation.clone();
 
         let service = StreamableHttpService::new(
             move || {
-                Ok(EpiGraphMcpFull::new_shared(
+                Ok(EpiGraphMcpFull::new_shared_with_federation(
                     pool.clone(),
                     signer.clone(),
                     embedder.clone(),
                     read_only,
+                    federation.clone(),
                 ))
             },
             Arc::new(LocalSessionManager::default()),
@@ -238,7 +286,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         epigraph_mcp::serve_with_listener(addr, router).await?;
     } else {
         // ── Stdio transport (default) ───────────────────────────────────
-        let server = EpiGraphMcpFull::new(pool, signer, embedder, cli.read_only);
+        // Inject the same federation registry so stdio's `list_tools` surfaces
+        // federated tools too (discovery ran at build time with the service
+        // token, independent of transport). Note: over stdio there is no caller
+        // Bearer, so a federated `tools/call` will fail closed in
+        // `enforce_federated_scope` (no AuthContext) — listing works, invoking
+        // does not, which is the intended v1 behavior.
+        let server =
+            EpiGraphMcpFull::new_with_federation(pool, signer, embedder, cli.read_only, federation);
         let service = server.serve(rmcp::transport::stdio()).await.map_err(|e| {
             tracing::error!("MCP serve error: {e}");
             e

--- a/crates/epigraph-mcp/src/server.rs
+++ b/crates/epigraph-mcp/src/server.rs
@@ -26,6 +26,15 @@ pub struct EpiGraphMcpFull {
     pub(crate) agent_db_id: Arc<Mutex<Option<uuid::Uuid>>>,
     pub(crate) embedder: Arc<McpEmbedder>,
     pub(crate) read_only: bool,
+    /// The federation gateway's routing table over downstream extension MCPs.
+    /// Built once in `main` (from `EPIGRAPH_MCP_EXTENSIONS`) and injected into
+    /// both transport paths. When no extensions are configured this is an empty
+    /// registry ([`crate::federation::FederationRegistry::empty`]) and the server
+    /// behaves exactly as it did pre-federation. The plain `new`/`new_shared`
+    /// constructors default to empty (mirroring the `claim_from_row` house rule
+    /// of not widening a ~30-caller signature); `main` and any caller that has a
+    /// registry use `new_with_federation`/`new_shared_with_federation`.
+    pub(crate) federation: Arc<crate::federation::FederationRegistry>,
 }
 
 impl EpiGraphMcpFull {
@@ -136,6 +145,43 @@ impl EpiGraphMcpFull {
         Ok(())
     }
 
+    /// Scope gate for FEDERATED tools, kept deliberately separate from
+    /// [`enforce_tool_scope`](Self::enforce_tool_scope).
+    ///
+    /// Federated tools are NOT in the static `SCOPE_MAP` (its coverage is a
+    /// compile-time invariant over kernel tools only), so the static gate would
+    /// fail them closed with "no scope mapping". Instead the required scope comes
+    /// from the extension's `EPIGRAPH_MCP_EXTENSIONS` config (`scope=…`), passed
+    /// here as `required`. Same fail-closed shape as the static gate: no
+    /// `AuthContext` (stdio, or middleware bypassed) is a hard reject, and a
+    /// caller lacking the extension's scope is forbidden.
+    pub fn enforce_federated_scope(
+        auth: Option<&epigraph_auth::AuthContext>,
+        tool_name: &str,
+        required: &str,
+    ) -> Result<(), McpError> {
+        let Some(auth) = auth else {
+            return Err(McpError {
+                code: rmcp::model::ErrorCode::INVALID_REQUEST,
+                message: std::borrow::Cow::Borrowed(
+                    "Unauthorized: federated tools require a Bearer token (no auth context; \
+                     not available over stdio)",
+                ),
+                data: None,
+            });
+        };
+        if !auth.has_scope(required) {
+            return Err(McpError {
+                code: rmcp::model::ErrorCode::INVALID_REQUEST,
+                message: std::borrow::Cow::Owned(format!(
+                    "Forbidden: federated tool '{tool_name}' requires scope '{required}'"
+                )),
+                data: None,
+            });
+        }
+        Ok(())
+    }
+
     /// Return an error if the server is in read-only mode.
     pub(crate) fn reject_if_read_only(&self) -> Result<(), McpError> {
         if self.read_only {
@@ -156,6 +202,27 @@ impl EpiGraphMcpFull {
 impl EpiGraphMcpFull {
     #[must_use]
     pub fn new(pool: PgPool, signer: AgentSigner, embedder: McpEmbedder, read_only: bool) -> Self {
+        Self::new_with_federation(
+            pool,
+            signer,
+            embedder,
+            read_only,
+            Arc::new(crate::federation::FederationRegistry::empty()),
+        )
+    }
+
+    /// Like [`new`](Self::new) but with a caller-supplied federation registry.
+    /// `main` uses this for the stdio path so stdio's `list_tools` surfaces the
+    /// same federated tools as the HTTP path (the registry is populated at build
+    /// time with the discovery service token, independent of transport).
+    #[must_use]
+    pub fn new_with_federation(
+        pool: PgPool,
+        signer: AgentSigner,
+        embedder: McpEmbedder,
+        read_only: bool,
+        federation: Arc<crate::federation::FederationRegistry>,
+    ) -> Self {
         Self {
             tool_router: Self::tool_router(),
             pool,
@@ -163,16 +230,41 @@ impl EpiGraphMcpFull {
             agent_db_id: Arc::new(Mutex::new(None)),
             embedder: Arc::new(embedder),
             read_only,
+            federation,
         }
     }
 
     /// Create from pre-wrapped `Arc` values (for HTTP transport factory closure).
+    /// Federation defaults to empty; the HTTP factory in `main` uses
+    /// [`new_shared_with_federation`](Self::new_shared_with_federation) to inject
+    /// the live registry per session.
     #[must_use]
     pub fn new_shared(
         pool: PgPool,
         signer: Arc<AgentSigner>,
         embedder: Arc<McpEmbedder>,
         read_only: bool,
+    ) -> Self {
+        Self::new_shared_with_federation(
+            pool,
+            signer,
+            embedder,
+            read_only,
+            Arc::new(crate::federation::FederationRegistry::empty()),
+        )
+    }
+
+    /// Like [`new_shared`](Self::new_shared) but with a caller-supplied
+    /// federation registry. The HTTP transport factory closure in `main` clones
+    /// the one `Arc<FederationRegistry>` built at boot into every per-session
+    /// server via this constructor.
+    #[must_use]
+    pub fn new_shared_with_federation(
+        pool: PgPool,
+        signer: Arc<AgentSigner>,
+        embedder: Arc<McpEmbedder>,
+        read_only: bool,
+        federation: Arc<crate::federation::FederationRegistry>,
     ) -> Self {
         Self {
             tool_router: Self::tool_router(),
@@ -181,6 +273,7 @@ impl EpiGraphMcpFull {
             agent_db_id: Arc::new(Mutex::new(None)),
             embedder,
             read_only,
+            federation,
         }
     }
 
@@ -1067,7 +1160,13 @@ impl EpiGraphMcpFull {
         description = "List all MCP tools available on this server. Returns the name, description, and full JSON Schema for every registered tool — including tools your client may have DEFERRED (name visible but schema not loaded). Use this for runtime tool discovery and to load the schema of any tool your client could not call directly. The list reflects the live server state, including newly deployed tools not yet stored in the knowledge graph."
     )]
     async fn list_mcp_tools(&self) -> Result<CallToolResult, McpError> {
-        let tools = self.tool_router.list_all();
+        // Kernel tools + every federated tool the gateway advertises, matching
+        // `ServerHandler::list_tools`. `server_instructions` directs clients here
+        // to enumerate every tool with its schema, so the federated tools must be
+        // present or a deferred-schema client following that guidance would never
+        // discover them.
+        let mut tools = self.tool_router.list_all();
+        tools.extend(self.federation.list_federated_tools());
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string_pretty(&tools).map_err(crate::errors::internal_error)?,
         )]))
@@ -1139,6 +1238,10 @@ impl ServerHandler for EpiGraphMcpFull {
         // the stdio process boundary is the trust gate and no auth check applies.
         let is_http_call;
         let auth_owned: Option<epigraph_auth::AuthContext>;
+        // The verbatim caller bearer, present only on the HTTP path (stashed by
+        // `auth::bearer_auth_middleware`). Needed to forward to a downstream
+        // extension MCP on a federated call.
+        let raw_token: Option<String>;
         {
             let http_parts = context.extensions.get::<Parts>();
             is_http_call = http_parts.is_some();
@@ -1148,6 +1251,55 @@ impl ServerHandler for EpiGraphMcpFull {
             auth_owned = http_parts
                 .and_then(|p| p.extensions.get::<epigraph_auth::AuthContext>())
                 .cloned();
+            raw_token = http_parts
+                .and_then(|p| p.extensions.get::<crate::auth::RawBearerToken>())
+                .map(|t| t.0.clone());
+        }
+
+        // FEDERATION BRANCH — only for names the static tool router does NOT own.
+        // Must intercept BEFORE the static scope gate below: that gate fails
+        // closed for any name absent from `SCOPE_MAP`, and federated tools are
+        // deliberately not in `SCOPE_MAP`. Kept outside the `is_http_call` guard
+        // so a stdio federated call reaches `enforce_federated_scope` and fails
+        // closed there (no `AuthContext`) rather than falling through to a bare
+        // "unknown tool" from the router. A genuinely-unknown name (neither
+        // static nor federated) still falls through to the static path and its
+        // fail-closed gate, exactly as before.
+        if self.tool_router.get(&request.name).is_none() {
+            if let Some(ext) = self.federation.route(&request.name) {
+                let ext_name = ext.name.clone();
+                let ext_scope = ext.scope.clone();
+                // (a) enforce the extension's configured scope against the caller.
+                if let Err(err) =
+                    Self::enforce_federated_scope(auth_owned.as_ref(), &request.name, &ext_scope)
+                {
+                    self.emit_tool_invoked(&format!("denied:{}:{}", ext_name, request.name))
+                        .await;
+                    return Err(err);
+                }
+                // (b) require the caller's raw bearer to forward downstream.
+                let Some(token) = raw_token else {
+                    return Err(McpError {
+                        code: rmcp::model::ErrorCode::INVALID_REQUEST,
+                        message: std::borrow::Cow::Borrowed(
+                            "Unauthorized: no Bearer token to forward to the downstream \
+                             extension (federated tools are unavailable over stdio)",
+                        ),
+                        data: None,
+                    });
+                };
+                // (c) durable audit event, namespaced by the owning extension.
+                self.emit_tool_invoked(&format!("{}:{}", ext_name, request.name))
+                    .await;
+                // (d) proxy to the downstream on a fresh caller-token session.
+                // `McpError` IS `rmcp::ErrorData`, so `internal_error` yields the
+                // handler's error type directly (no further conversion).
+                return self
+                    .federation
+                    .invoke(&request.name, &token, request.arguments)
+                    .await
+                    .map_err(crate::errors::internal_error);
+            }
         }
 
         if is_http_call {
@@ -1191,15 +1343,28 @@ impl ServerHandler for EpiGraphMcpFull {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::ListToolsResult, rmcp::ErrorData> {
+        // Kernel tools first, then every federated tool the gateway currently
+        // advertises. Static-first mirrors `call_tool`'s resolution order: a
+        // kernel tool always wins a name clash (the operator resolves clashes
+        // between an extension and the kernel with a `prefix=`).
+        let mut tools = self.tool_router.list_all();
+        tools.extend(self.federation.list_federated_tools());
         Ok(rmcp::model::ListToolsResult {
-            tools: self.tool_router.list_all(),
+            tools,
             meta: None,
             next_cursor: None,
         })
     }
 
     fn get_tool(&self, name: &str) -> Option<rmcp::model::Tool> {
-        self.tool_router.get(name).cloned()
+        // Static router first (kernel tools win name clashes, as in call_tool),
+        // then fall back to a federated tool from the routing map.
+        self.tool_router.get(name).cloned().or_else(|| {
+            self.federation
+                .list_federated_tools()
+                .into_iter()
+                .find(|t| t.name.as_ref() == name)
+        })
     }
 }
 

--- a/crates/epigraph-mcp/tests/evaluate_workflow_promotion.rs
+++ b/crates/epigraph-mcp/tests/evaluate_workflow_promotion.rs
@@ -52,11 +52,12 @@ async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
 
 async fn seed_runs(pool: &PgPool, wf: Uuid, successes: usize, failures: usize) {
     let base = chrono::Utc::now();
-    let mut i = 0i64;
-    for succ in std::iter::repeat(true)
+    for (i, succ) in std::iter::repeat(true)
         .take(successes)
         .chain(std::iter::repeat(false).take(failures))
+        .enumerate()
     {
+        let i = i as i64;
         BehavioralExecutionRepository::create(
             pool,
             BehavioralExecutionRow {
@@ -76,7 +77,6 @@ async fn seed_runs(pool: &PgPool, wf: Uuid, successes: usize, failures: usize) {
         )
         .await
         .unwrap();
-        i += 1;
     }
 }
 

--- a/crates/epigraph-mcp/tests/federation_gateway_test.rs
+++ b/crates/epigraph-mcp/tests/federation_gateway_test.rs
@@ -1,0 +1,306 @@
+//! Integration tests for the MCP federation gateway's client + registry
+//! (`epigraph_mcp::federation`), exercised against a **stub** downstream
+//! streamable-HTTP MCP server stood up on `127.0.0.1:0`.
+//!
+//! No database is touched: the gateway's federation layer is a pure MCP client
+//! over rmcp's streamable-HTTP transport, so it can be tested end-to-end against
+//! a tiny hand-rolled `ServerHandler` — we never construct an
+//! `EpiGraphMcpFull` (which needs a pool).
+//!
+//! What is asserted:
+//! - `list_federated_tools()` surfaces the stub's tool (with optional prefix);
+//! - `invoke()` proxies a `tools/call` and returns the stub's result;
+//! - the **caller's bearer** reaches the stub (`Authorization: Bearer <token>`),
+//!   captured by a test-side middleware that mirrors production's
+//!   `bearer_auth_middleware`;
+//! - two extensions exporting the SAME effective tool name make `build()` fail
+//!   with a collision, while a distinct `prefix=` on one is the escape hatch;
+//! - an unreachable address degrades gracefully (empty tools, healthy=false, no
+//!   panic) instead of taking the gateway down.
+
+use std::sync::{Arc, Mutex};
+
+use axum::Router;
+use epigraph_mcp::federation::config::ExtensionConfig;
+use epigraph_mcp::federation::FederationRegistry;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ListToolsResult, ServerCapabilities,
+    ServerInfo, Tool,
+};
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::tower::{
+    StreamableHttpServerConfig, StreamableHttpService,
+};
+use rmcp::{ErrorData, RoleServer, ServerHandler};
+
+/// Shared slot the capture middleware writes the last-seen `Authorization`
+/// header into. Cloned into both the middleware and the assertion.
+type AuthSlot = Arc<Mutex<Option<String>>>;
+
+/// A minimal downstream MCP server exposing exactly one tool named `tool_name`.
+/// `call_tool` echoes a fixed payload so the gateway-side test can assert the
+/// proxied result round-tripped. `get_info` advertises the tools capability,
+/// without which `initialize` / `list_tools` would not behave.
+#[derive(Clone)]
+struct StubServer {
+    tool_name: String,
+}
+
+impl ServerHandler for StubServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let schema = serde_json::json!({ "type": "object", "properties": {} });
+        let obj = schema.as_object().cloned().unwrap_or_default();
+        Ok(ListToolsResult {
+            tools: vec![Tool::new(
+                self.tool_name.clone(),
+                "stub downstream tool",
+                Arc::new(obj),
+            )],
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: rmcp::service::RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Echo the tool name so the gateway test can confirm the DOWNSTREAM
+        // (un-prefixed) name arrived, proving prefix stripping on the proxy path.
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "stub handled `{}`",
+            request.name
+        ))]))
+    }
+}
+
+/// Capture middleware: records the incoming `Authorization` header into `slot`,
+/// then forwards. This is the test-side analogue of production's
+/// `bearer_auth_middleware` — it asserts the token arrived *over HTTP*, without
+/// coupling to rmcp's internal request-context plumbing.
+async fn capture_auth(
+    slot: AuthSlot,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    if let Some(value) = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+    {
+        *slot.lock().unwrap() = Some(value.to_string());
+    }
+    next.run(req).await
+}
+
+/// Stand up a stub MCP server exposing one tool, on an ephemeral loopback port.
+/// Returns the bound `host:port` (as the registry's `addr` form) and the auth
+/// slot the capture middleware writes into.
+async fn spawn_stub(tool_name: &str) -> (String, AuthSlot) {
+    let slot: AuthSlot = Arc::new(Mutex::new(None));
+    let tool_name = tool_name.to_string();
+
+    let service = StreamableHttpService::new(
+        move || {
+            Ok(StubServer {
+                tool_name: tool_name.clone(),
+            })
+        },
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default(),
+    );
+
+    let slot_for_mw = slot.clone();
+    let router: Router =
+        Router::new()
+            .nest_service("/mcp", service)
+            .layer(axum::middleware::from_fn(move |req, next| {
+                let slot = slot_for_mw.clone();
+                capture_auth(slot, req, next)
+            }));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    (format!("127.0.0.1:{}", addr.port()), slot)
+}
+
+fn cfg(name: &str, addr: &str, prefix: Option<&str>) -> ExtensionConfig {
+    ExtensionConfig {
+        name: name.to_string(),
+        addr: addr.to_string(),
+        scope: format!("{name}:tools"),
+        prefix: prefix.map(str::to_string),
+    }
+}
+
+#[tokio::test]
+async fn lists_and_invokes_stub_tool_forwarding_caller_bearer() {
+    let (addr, slot) = spawn_stub("ping").await;
+    let registry = FederationRegistry::build(vec![cfg("episcience", &addr, None)], "discovery-tok")
+        .await
+        .expect("build should succeed against a reachable stub");
+
+    // list_federated_tools surfaces the stub's single tool.
+    let tools = registry.list_federated_tools();
+    assert_eq!(tools.len(), 1, "expected exactly the stub's one tool");
+    assert_eq!(tools[0].name.as_ref(), "ping");
+
+    // route + required_scope resolve to the owning extension.
+    assert!(registry.route("ping").is_some());
+    assert_eq!(registry.required_scope("ping"), Some("episcience:tools"));
+    assert!(registry.route("nonexistent").is_none());
+
+    // invoke() proxies the call and returns the stub's result.
+    let caller_token = "caller-bearer-xyz";
+    let result = registry
+        .invoke("ping", caller_token, None)
+        .await
+        .expect("invoke should proxy to the stub");
+    let text = result.content[0]
+        .as_text()
+        .expect("stub returns text content")
+        .text
+        .clone();
+    assert_eq!(
+        text, "stub handled `ping`",
+        "downstream should receive the un-prefixed tool name"
+    );
+
+    // The CALLER's bearer reached the stub as `Authorization: Bearer <token>`
+    // (rmcp's reqwest client prepends `Bearer ` via `.bearer_auth`).
+    let seen = slot
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("stub saw an Authorization header");
+    assert_eq!(seen, format!("Bearer {caller_token}"));
+}
+
+#[tokio::test]
+async fn prefix_is_applied_to_effective_name_and_stripped_on_invoke() {
+    let (addr, _slot) = spawn_stub("ping").await;
+    let registry = FederationRegistry::build(
+        vec![cfg("episcience", &addr, Some("episcience__"))],
+        "discovery-tok",
+    )
+    .await
+    .unwrap();
+
+    // Advertised (effective) name carries the prefix.
+    let tools = registry.list_federated_tools();
+    assert_eq!(tools[0].name.as_ref(), "episcience__ping");
+    assert!(registry.route("episcience__ping").is_some());
+    // The bare downstream name is NOT a gateway route.
+    assert!(registry.route("ping").is_none());
+
+    // Invoking the prefixed name strips the prefix before forwarding, so the
+    // stub sees the bare `ping`.
+    let result = registry
+        .invoke("episcience__ping", "tok", None)
+        .await
+        .unwrap();
+    let text = result.content[0].as_text().unwrap().text.clone();
+    assert_eq!(text, "stub handled `ping`");
+}
+
+#[tokio::test]
+async fn colliding_tool_names_across_extensions_fail_build() {
+    // Two DISTINCT stubs (distinct ports) both exporting `dup`, neither
+    // prefixed -> same effective name -> build() must error.
+    let (addr_a, _a) = spawn_stub("dup").await;
+    let (addr_b, _b) = spawn_stub("dup").await;
+
+    // `FederationRegistry` is not `Debug` (it holds live rmcp sessions), so
+    // match rather than `expect_err`.
+    let result = FederationRegistry::build(
+        vec![cfg("ext_a", &addr_a, None), cfg("ext_b", &addr_b, None)],
+        "discovery-tok",
+    )
+    .await;
+    let err = match result {
+        Ok(_) => panic!("colliding effective tool names must fail build"),
+        Err(e) => e,
+    };
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("dup"),
+        "collision error should name the tool: {msg}"
+    );
+    assert!(
+        msg.contains("ext_a") && msg.contains("ext_b"),
+        "collision error should name both extensions: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn prefix_resolves_collision_between_extensions() {
+    // Same two stubs both exporting `dup`, but one prefixed -> distinct
+    // effective names -> build() succeeds and both are routable.
+    let (addr_a, _a) = spawn_stub("dup").await;
+    let (addr_b, _b) = spawn_stub("dup").await;
+
+    let registry = FederationRegistry::build(
+        vec![
+            cfg("ext_a", &addr_a, None),
+            cfg("ext_b", &addr_b, Some("b__")),
+        ],
+        "discovery-tok",
+    )
+    .await
+    .expect("distinct prefixes must resolve the collision");
+
+    assert!(registry.route("dup").is_some());
+    assert!(registry.route("b__dup").is_some());
+    assert_eq!(registry.list_federated_tools().len(), 2);
+}
+
+#[tokio::test]
+async fn unreachable_extension_degrades_gracefully() {
+    // Bind :0 to reserve a port, then DROP the listener so the port is closed:
+    // guaranteed connection-refused, deterministic, fast.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let dead_addr = format!("127.0.0.1:{port}");
+
+    let registry = FederationRegistry::build(vec![cfg("ghost", &dead_addr, None)], "discovery-tok")
+        .await
+        .expect("an unreachable extension must NOT fail the whole build");
+
+    // No tools routed; the gateway stands, just without this extension.
+    assert!(
+        registry.list_federated_tools().is_empty(),
+        "unreachable extension contributes no tools"
+    );
+    assert!(registry.route("anything").is_none());
+    assert!(
+        !registry.is_empty(),
+        "the extension is still mounted (unhealthy)"
+    );
+}
+
+#[tokio::test]
+async fn absent_extensions_yield_empty_registry() {
+    let registry = FederationRegistry::build(vec![], "discovery-tok")
+        .await
+        .unwrap();
+    assert!(registry.is_empty());
+    assert!(registry.list_federated_tools().is_empty());
+}

--- a/crates/epigraph-mcp/tests/get_claim.rs
+++ b/crates/epigraph-mcp/tests/get_claim.rs
@@ -190,7 +190,7 @@ async fn seed_claim(
         .as_bytes()
         .iter()
         .copied()
-        .chain(std::iter::repeat_n(0, 16))
+        .chain(std::iter::repeat(0).take(16))
         .take(32)
         .collect();
     sqlx::query(

--- a/crates/epigraph-mcp/tests/query_claims_by_label.rs
+++ b/crates/epigraph-mcp/tests/query_claims_by_label.rs
@@ -263,7 +263,7 @@ async fn seed_claim(
         .as_bytes()
         .iter()
         .copied()
-        .chain(std::iter::repeat_n(0, 16))
+        .chain(std::iter::repeat(0).take(16))
         .take(32)
         .collect();
     sqlx::query(

--- a/crates/epigraph-mcp/tests/query_claims_labels_test.rs
+++ b/crates/epigraph-mcp/tests/query_claims_labels_test.rs
@@ -116,7 +116,7 @@ async fn seed_claim(
         .as_bytes()
         .iter()
         .copied()
-        .chain(std::iter::repeat_n(0, 16))
+        .chain(std::iter::repeat(0).take(16))
         .take(32)
         .collect();
     sqlx::query(

--- a/crates/epigraph-mcp/tests/query_claims_redaction.rs
+++ b/crates/epigraph-mcp/tests/query_claims_redaction.rs
@@ -6,8 +6,10 @@
 //! occur with a single claim, so this test seeds TWO claims with DIFFERENT
 //! access (one public, one private-owned-by-a-stranger), queries as a
 //! non-owner, and asserts each claim gets ITS OWN decision:
-//!   - the public claim → full content + real content_hash
-//!   - the private claim → "[REDACTED]" content + blank content_hash
+//!
+//! - the public claim → full content + real content_hash
+//! - the private claim → "[REDACTED]" content + blank content_hash
+//!
 //! Under a zip/order mispairing the two decisions swap and BOTH assertions
 //! fail; under a deleted/inverted redaction branch the private assertions fail;
 //! under the content_hash oracle leak the blank-hash assertion fails.

--- a/crates/epigraph-mcp/tests/refresh_workflow_promotion.rs
+++ b/crates/epigraph-mcp/tests/refresh_workflow_promotion.rs
@@ -53,11 +53,12 @@ async fn insert_claim(pool: &PgPool, agent: Uuid, content: &str) -> Uuid {
 
 async fn seed_runs(pool: &PgPool, wf: Uuid, successes: usize, failures: usize) {
     let base = chrono::Utc::now();
-    let mut i = 0i64;
-    for succ in std::iter::repeat(true)
+    for (i, succ) in std::iter::repeat(true)
         .take(successes)
         .chain(std::iter::repeat(false).take(failures))
+        .enumerate()
     {
+        let i = i as i64;
         BehavioralExecutionRepository::create(
             pool,
             BehavioralExecutionRow {
@@ -77,7 +78,6 @@ async fn seed_runs(pool: &PgPool, wf: Uuid, successes: usize, failures: usize) {
         )
         .await
         .unwrap();
-        i += 1;
     }
 }
 

--- a/crates/epigraph-mcp/tests/resolve_backlog_item.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item.rs
@@ -174,7 +174,7 @@ async fn seed_claim(
         .as_bytes()
         .iter()
         .copied()
-        .chain(std::iter::repeat_n(0, 16))
+        .chain(std::iter::repeat(0).take(16))
         .take(32)
         .collect();
     sqlx::query(

--- a/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
+++ b/crates/epigraph-mcp/tests/resolve_backlog_item_ownership.rs
@@ -342,7 +342,7 @@ async fn seed_claim_with_agent(pool: &PgPool, agent_id: Uuid, labels: &[&str]) -
         .as_bytes()
         .iter()
         .copied()
-        .chain(std::iter::repeat_n(0, 16))
+        .chain(std::iter::repeat(0).take(16))
         .take(32)
         .collect();
     sqlx::query(

--- a/crates/epigraph-mcp/tests/step_versioning.rs
+++ b/crates/epigraph-mcp/tests/step_versioning.rs
@@ -52,7 +52,7 @@ async fn seed_versioned_step(pool: &PgPool, agent: Uuid, lineage: Uuid, content:
         .as_bytes()
         .iter()
         .copied()
-        .chain(std::iter::repeat_n(0u8, 16))
+        .chain(std::iter::repeat(0u8).take(16))
         .take(32)
         .collect();
     sqlx::query(

--- a/docs/superpowers/specs/2026-07-23-mcp-federation-gateway-design.md
+++ b/docs/superpowers/specs/2026-07-23-mcp-federation-gateway-design.md
@@ -1,8 +1,17 @@
 # EpiGraph MCP Federation Gateway — Design
 
 **Date:** 2026-07-23
-**Status:** Approved (design), pre-implementation
+**Status:** Implemented (gateway kernel, v1 — loopback TCP transport). Episcience socket
+transport + deployment (§B, §C) remain follow-on work.
 **Repos touched:** `epigraph-io/epigraph` (gateway — primary), `epigraph-io/episcience` (socket transport for its existing MCP server)
+
+> **v1 note (post-implementation).** The transport shipped as **loopback TCP only**
+> (`tcp:127.0.0.1:PORT`), not UDS. rmcp 0.15's reqwest streamable-HTTP client cannot
+> dial a Unix socket; a custom `hyper` + `UnixStream` connector is a documented
+> **fast-follow**, not v1. Sections below that still say "unix socket" describe the
+> eventual UDS design; the shipped kernel uses the loopback-TCP form everywhere
+> (config `tcp:host:port`, dial `http://host:port/mcp`). See the **Session model**
+> and **Transport (as built)** subsections for what actually landed.
 
 ## Problem
 
@@ -51,11 +60,27 @@ when the static `tool_router` does not own the requested name.
    servers (or a server and the kernel) export the same tool name, the gateway
    **refuses to start** with a loud error. A per-extension prefix (`episcience__`) is
    available in config to resolve a collision without renaming upstream tools.
-2. **Federation transport:** **unix domain socket primary**, loopback-TCP fallback.
-   Downstream serves streamable-HTTP; the gateway dials it as an rmcp client. UDS is
-   `0o660`, local-only. If the streamable-HTTP-over-UDS client connector proves fiddly
-   in rmcp, fall back to `127.0.0.1:PORT` (never exposed via Caddy). **De-risk the UDS
-   HTTP client on day one.**
+2. **Federation transport:** **loopback TCP for v1; UDS is a fast-follow.** Downstream
+   serves streamable-HTTP on `127.0.0.1:PORT` (never exposed via Caddy); the gateway
+   dials it as an rmcp client at `http://127.0.0.1:PORT/mcp`. The de-risking outcome was
+   decisive: rmcp 0.15's reqwest `StreamableHttpClientTransport` has **no way to dial a
+   Unix socket** — it builds a `reqwest::Client` that only speaks TCP. UDS therefore
+   needs a custom `hyper` + `UnixStream` connector, which is deferred to a follow-on and
+   is **not** in the v1 kernel. Config uses the `tcp:` scheme
+   (`name=tcp:127.0.0.1:8093;scope=…`); a `unix:` scheme is rejected at parse time in v1.
+
+### Transport (as built)
+
+- Config value form (shipped):
+  `EPIGRAPH_MCP_EXTENSIONS="episcience=tcp:127.0.0.1:8093;scope=episcience:tools[;prefix=episcience__]"`
+  — comma-separated extensions, semicolon-separated fields; first field is
+  `name=tcp:host:port`. Absent/empty env → empty registry → gateway behaves exactly as
+  pre-federation (backward compatible). A malformed entry is a hard boot error.
+- `FederationRegistry::empty()` is the sync, infallible default used by the plain
+  `EpiGraphMcpFull::new`/`new_shared` constructors (whose signatures are deliberately
+  **unchanged** — mirroring the `claim_from_row` house rule against widening a
+  ~30-caller signature). `main` injects the live registry via
+  `new_with_federation` / `new_shared_with_federation` on both transport paths.
 
 ## Components
 
@@ -68,12 +93,18 @@ when the static `tool_router` does not own the requested name.
   - `FederationRegistry` — the set of mounted extensions + the aggregate
     `tool_name → extension` routing map. Built at startup from config; collision →
     startup failure.
-  - Persistent client session per extension, established at startup, **lazy reconnect**
-    on a timer.
-- **Config parsing:** `EPIGRAPH_MCP_EXTENSIONS` (env), e.g.
-  `episcience=unix:/run/epigraph/episcience-mcp.sock;scope=episcience:tools[;prefix=episcience__]`,
-  semicolon-separated fields, comma-separated extensions. Absent → gateway behaves
-  exactly as today (pure kernel server), so this is backward-compatible.
+  - Persistent **discovery** client session per extension, established at startup.
+    `reconnect_tick(&mut self)` and the `SharedRegistry = Arc<RwLock<…>>` alias exist for
+    a lazy-reconnect timer, but that timer is **defined-but-unwired in v1** (the field is
+    a plain `Arc<FederationRegistry>`, no reconnect loop is spawned). Intentional: a
+    reviving downstream is a fast-follow; v1 mounts unreachable extensions unhealthy at
+    boot and leaves them so until the next process restart.
+- **Config parsing:** `EPIGRAPH_MCP_EXTENSIONS` (env). **As shipped (v1, loopback TCP):**
+  `episcience=tcp:127.0.0.1:8093;scope=episcience:tools[;prefix=episcience__]`,
+  semicolon-separated fields, comma-separated extensions. (The UDS form
+  `unix:/run/epigraph/episcience-mcp.sock` is the fast-follow shape; `unix:` is rejected
+  in v1.) Absent → gateway behaves exactly as today (pure kernel server), so this is
+  backward-compatible.
 - **`ServerHandler` integration** (extend the existing manual impl):
   - `list_tools` = `tool_router.list_all()` + every mounted extension's cached tools.
   - `get_tool(name)` consults the routing map after the static router.
@@ -107,17 +138,62 @@ when the static `tool_router` does not own the requested name.
 - Rebuild + redeploy `epigraph-mcp-*` and add `episcience-mcp.service`. `nip.io/mcp`
   then serves kernel + episcience tools via one endpoint, one token.
 
+## Session model (as built — the critical correction)
+
+rmcp 0.15's `StreamableHttpClientTransportConfig.auth_header` is **per-transport**: it
+is set once at transport construction and cloned into every request on that transport.
+There is **no per-call token slot**. That forces two distinct session shapes:
+
+- **Discovery** (`federation::client::discovery_session`) — one long-lived client session
+  per extension, built with `auth_header =` a gateway **service token** (env
+  `EPIGRAPH_MCP_DISCOVERY_TOKEN`, falling back to `EPIGRAPH_SERVICE_TOKEN`). It drives
+  `list_all_tools` to populate the routing cache, collision detection, and health. Built
+  once at boot inside `FederationRegistry::build`; independent of caller identity and of
+  transport (so stdio and HTTP share the same populated registry).
+- **Invocation** (`federation::client::invoke_once`) — a **fresh, ephemeral** session per
+  federated `tools/call`, built with `auth_header =` the **caller's raw bearer**, so the
+  downstream sees the real principal (not the gateway). The session is dropped
+  immediately after the call; rmcp's transport worker issues `delete_session` on drop, so
+  downstream sessions do not leak.
+
+### Forwarding the raw caller token (`RawBearerToken`)
+
+`auth::bearer_auth_middleware` validates the incoming bearer and normally discards the
+raw string, inserting only the decoded `AuthContext`. Invocation needs the **verbatim
+signed token** (the downstream re-validates it), so the middleware also inserts
+`RawBearerToken(pub String)` into the request extensions alongside `AuthContext`.
+`call_tool` pulls it from `context.extensions.get::<http::request::Parts>()` →
+`parts.extensions.get::<RawBearerToken>()`. Present only on the HTTP path: **stdio has no
+bearer**, so a federated `tools/call` over stdio has no token to forward and is rejected
+(federated tools list over stdio, but cannot be invoked).
+
+### Scope gate (federated tools only)
+
+The static `enforce_tool_scope` fails **closed** for any name absent from the
+compile-time `SCOPE_MAP`, so federated tools must **not** be added to `SCOPE_MAP` (its
+coverage is a static test invariant). Instead a **separate** `enforce_federated_scope`
+checks the caller holds the extension's configured `scope=…`. `call_tool` branches to
+federation **only after** the static `tool_router` misses the name, so the static gate
+never runs for a federated tool and never runs the federated gate for a kernel tool. A
+kernel tool always wins a name clash (build-time collision detection only guards clashes
+*between extensions*; an extension-vs-kernel clash is the operator's `prefix=`
+responsibility).
+
 ## Data flow (federated call)
 
 1. Client → `POST /mcp` `tools/call {name: "synthesize", …}` + Bearer.
-2. Gateway `auth::bearer_auth_middleware` validates the token → `AuthContext`.
-3. `call_tool`: `synthesize` not in static router → routing map says `episcience`.
-4. Scope gate: caller must hold `episcience:tools` (else 403). Emit `tool.invoked`.
-5. Gateway forwards `tools/call` to the episcience client session **with the same
-   Bearer**.
+2. Gateway `auth::bearer_auth_middleware` validates the token → `AuthContext` **and
+   stashes `RawBearerToken`**.
+3. `call_tool`: `synthesize` not in static `tool_router` → routing map says `episcience`.
+4. `enforce_federated_scope`: caller must hold `episcience:tools` (else 403). Require the
+   `RawBearerToken` (else 401 — e.g. on stdio). Emit `tool.invoked` tagged `episcience:…`.
+5. Gateway opens a **fresh ephemeral session** to the episcience extension with
+   `auth_header =` the caller's raw bearer and forwards `tools/call`; the prefix (if any)
+   is stripped back to the bare downstream name first.
 6. Episcience validates the token, resolves `agent_id`, runs the tool, returns
    `CallToolResult`.
-7. Gateway returns it to the client unchanged.
+7. Gateway returns it to the client unchanged and drops the ephemeral session
+   (`delete_session` downstream).
 
 ## Failure handling
 
@@ -145,9 +221,16 @@ when the static `tool_router` does not own the requested name.
 - No cross-extension transactions or fan-out; one tool → one extension.
 - No change to how the kernel's own tools are defined or dispatched.
 
-## Risks
+## Risks (retired / updated post-implementation)
 
-- **rmcp streamable-HTTP client over UDS** — the one unknown; de-risk first, loopback-TCP
-  fallback ready.
-- **rmcp client API surface** in the pinned version (0.15.x) — confirm a client session
-  supporting `list_tools` + `call_tool` exists before committing to the transport shape.
+- **rmcp streamable-HTTP client over UDS** — *resolved:* confirmed **not supported** in
+  rmcp 0.15's reqwest client. v1 shipped loopback TCP; UDS is a fast-follow needing a
+  custom `hyper`+`UnixStream` connector. No longer a v1 risk.
+- **rmcp client API surface** (0.15.x) — *confirmed:* `serve_client((), transport)` yields
+  a session whose `peer()` exposes `list_all_tools()` and `call_tool(...)`. Both are
+  exercised by `tests/federation_gateway_test.rs` against a stub streamable-HTTP server.
+- **Per-transport `auth_header`** (new, resolved) — there is no per-call token slot, which
+  is why discovery (service token, persistent) and invocation (caller token, ephemeral)
+  are split. See **Session model**.
+- **Reconnect timer unwired in v1** — an extension unreachable at boot stays unhealthy
+  until the next `epigraph-mcp` restart. `reconnect_tick` is implemented but not spawned.

--- a/docs/superpowers/specs/2026-07-23-mcp-federation-gateway-design.md
+++ b/docs/superpowers/specs/2026-07-23-mcp-federation-gateway-design.md
@@ -1,0 +1,153 @@
+# EpiGraph MCP Federation Gateway — Design
+
+**Date:** 2026-07-23
+**Status:** Approved (design), pre-implementation
+**Repos touched:** `epigraph-io/epigraph` (gateway — primary), `epigraph-io/episcience` (socket transport for its existing MCP server)
+
+## Problem
+
+Episcience has a complete, 9-tool MCP server (`EpiscienceServer`: `synthesize`,
+`recall_synthesis`, `get_synthesis`, `list_syntheses`, `propose_protocol`,
+`add_observation`, `countersign`, `list_countersignatures`, `attach_blob`) but it is
+**stdio-only and undeployed** — nothing serves it. We want episcience's tools
+available to MCP clients (claude.ai, `claude` CLI) alongside epigraph's ~78 tools,
+**through the one existing authenticated endpoint** (`https://5-78-124-36.nip.io/mcp`),
+without coupling the kernel to episcience.
+
+Piggybacking episcience tools *into* `epigraph-mcp` is rejected: `epigraph-mcp` does
+not (and must not) depend on `episcience-db`/`episcience-api` — that reverses the
+kernel→downstream dependency. Its tool router and `scope_map` are a closed set with no
+extension point.
+
+## Solution: a federation gateway
+
+`epigraph-mcp` becomes a **gateway**: it serves its own tools locally AND mounts
+downstream MCP servers over a local socket, proxying their `tools/list` and
+`tools/call`. Extensions stay independent processes/deployables. The kernel gains a
+generic MCP **client**; it never links extension code.
+
+```
+        claude.ai / claude CLI
+                │  HTTPS + Bearer
+                ▼
+   Caddy ─▶ epigraph-mcp  ── ~78 local tools
+             (GATEWAY)     ── + federated extensions:
+                │
+                ├─ unix:/run/epigraph/episcience-mcp.sock ─▶ episcience-mcp (9 tools)
+                └─ unix:/run/epigraph/<ext>.sock          ─▶ future extensions
+```
+
+### Why this fits the codebase
+
+`epigraph-mcp/src/server.rs` **already hand-writes** `ServerHandler::call_tool` /
+`list_tools` / `get_tool` (instead of rmcp's `#[tool_handler]` macro) so it can inject
+auth-scope enforcement and `tool.invoked` events. That manual impl is the exact seam:
+`list_tools` appends federated tools; `call_tool` falls through to a mounted extension
+when the static `tool_router` does not own the requested name.
+
+## Confirmed design decisions
+
+1. **Namespacing:** federated tools mount under their **natural names**. If two mounted
+   servers (or a server and the kernel) export the same tool name, the gateway
+   **refuses to start** with a loud error. A per-extension prefix (`episcience__`) is
+   available in config to resolve a collision without renaming upstream tools.
+2. **Federation transport:** **unix domain socket primary**, loopback-TCP fallback.
+   Downstream serves streamable-HTTP; the gateway dials it as an rmcp client. UDS is
+   `0o660`, local-only. If the streamable-HTTP-over-UDS client connector proves fiddly
+   in rmcp, fall back to `127.0.0.1:PORT` (never exposed via Caddy). **De-risk the UDS
+   HTTP client on day one.**
+
+## Components
+
+### A. Kernel: `epigraph-mcp` gateway (primary work)
+
+- **Federation client module** (`epigraph-mcp/src/federation/`):
+  - `MountedExtension` — holds an rmcp client session to one downstream, its cached
+    `Vec<Tool>`, its config (name, socket spec, required scope, optional prefix), and
+    connection state.
+  - `FederationRegistry` — the set of mounted extensions + the aggregate
+    `tool_name → extension` routing map. Built at startup from config; collision →
+    startup failure.
+  - Persistent client session per extension, established at startup, **lazy reconnect**
+    on a timer.
+- **Config parsing:** `EPIGRAPH_MCP_EXTENSIONS` (env), e.g.
+  `episcience=unix:/run/epigraph/episcience-mcp.sock;scope=episcience:tools[;prefix=episcience__]`,
+  semicolon-separated fields, comma-separated extensions. Absent → gateway behaves
+  exactly as today (pure kernel server), so this is backward-compatible.
+- **`ServerHandler` integration** (extend the existing manual impl):
+  - `list_tools` = `tool_router.list_all()` + every mounted extension's cached tools.
+  - `get_tool(name)` consults the routing map after the static router.
+  - `call_tool`: static router owns name → dispatch locally (unchanged); else routing
+    map → **coarse per-extension scope gate**, then **forward the caller's Bearer token
+    verbatim** to the downstream via an rmcp client `call_tool`; else existing
+    unknown-tool error. `tool.invoked` still emits at the chokepoint, tagged with the
+    extension.
+  - `all_tools_json` / `server_instructions` tool-count / `list_mcp_tools` include
+    federated tools (dynamic count stays correct).
+- **Scope handling:** `enforce_tool_scope` currently fails closed for names not in the
+  static `scope_map`. Extend it: a federated tool's required scope comes from its
+  extension's config (`scope=…`). The gateway checks the caller has that scope, then
+  forwards the token; the downstream does fine-grained enforcement.
+
+### B. Episcience: socket transport for its MCP server
+
+- Add a **streamable-HTTP-on-socket** transport to `episcience-mcp-server` (today
+  `serve(stdio())`). Reuse the `unix:`/`host:port` listener pattern from
+  `epigraph-mcp::serve_with_listener`. Keep stdio as an option for local dev.
+- Episcience validates the forwarded Bearer with the shared **`EPIGRAPH_JWT_SECRET`**
+  (its REST server already does) and resolves `agent_id` from claims — no new
+  credential, single token across both hops.
+
+### C. Deployment
+
+- New `episcience-mcp.service` (systemd) serving `unix:/run/epigraph/episcience-mcp.sock`
+  (`0o660`), sharing the episcience env (DB URL, JWT secret, embed/LLM providers,
+  edge-writer client).
+- `epigraph-mcp` env gains `EPIGRAPH_MCP_EXTENSIONS=episcience=unix:/run/epigraph/episcience-mcp.sock;scope=episcience:tools`.
+- Rebuild + redeploy `epigraph-mcp-*` and add `episcience-mcp.service`. `nip.io/mcp`
+  then serves kernel + episcience tools via one endpoint, one token.
+
+## Data flow (federated call)
+
+1. Client → `POST /mcp` `tools/call {name: "synthesize", …}` + Bearer.
+2. Gateway `auth::bearer_auth_middleware` validates the token → `AuthContext`.
+3. `call_tool`: `synthesize` not in static router → routing map says `episcience`.
+4. Scope gate: caller must hold `episcience:tools` (else 403). Emit `tool.invoked`.
+5. Gateway forwards `tools/call` to the episcience client session **with the same
+   Bearer**.
+6. Episcience validates the token, resolves `agent_id`, runs the tool, returns
+   `CallToolResult`.
+7. Gateway returns it to the client unchanged.
+
+## Failure handling
+
+- Downstream socket down at startup → its tools are **absent** from `tools/list`
+  (logged); gateway serves everything else. Reconnect on a timer; tools reappear.
+- Downstream errors mid-call → surfaced as a normal MCP tool error.
+- Collision at startup (two servers, same tool name, no prefix) → **refuse to start**.
+
+## Testing
+
+- **Kernel unit:** config parse; routing-map build; collision refusal; federated-tool
+  scope gate (fail-closed without the configured scope); `list_tools` aggregation;
+  token-forward header present.
+- **Kernel integration:** stub downstream MCP on a socket → mount → assert `tools/list`
+  includes stub tools and a `tools/call` proxies through and returns the stub's result;
+  assert a down socket degrades gracefully (kernel tools still listed).
+- **E2E:** real `episcience-mcp` on a socket, mounted by the gateway; call `synthesize`
+  through the gateway end-to-end (seeds via the recall fix + `claude -p` compose, emits
+  provo edges) — the full stack proven through the single endpoint.
+
+## Non-goals / YAGNI
+
+- No dynamic runtime add/remove of extensions via an API — config at startup only.
+- No resource/prompt federation — **tools only** (episcience exposes only tools).
+- No cross-extension transactions or fan-out; one tool → one extension.
+- No change to how the kernel's own tools are defined or dispatched.
+
+## Risks
+
+- **rmcp streamable-HTTP client over UDS** — the one unknown; de-risk first, loopback-TCP
+  fallback ready.
+- **rmcp client API surface** in the pinned version (0.15.x) — confirm a client session
+  supporting `list_tools` + `call_tool` exists before committing to the transport shape.


### PR DESCRIPTION
Turns `epigraph-mcp` into a **federation gateway**: serves its ~78 tools locally AND mounts downstream MCP servers (e.g. episcience) over loopback TCP, proxying their `tools/list` and `tools/call` through the one authenticated `/mcp` endpoint. The kernel gains a generic rmcp **client**; it never links extension code (dependency direction preserved).

Design spec: `docs/superpowers/specs/2026-07-23-mcp-federation-gateway-design.md`.

## How it works
- **Config:** `EPIGRAPH_MCP_EXTENSIONS="episcience=tcp:127.0.0.1:8093;scope=episcience:tools[;prefix=…]"`. Absent → empty registry → **byte-for-byte backward compatible**.
- **Discovery vs invocation (rmcp 0.15 constraint):** `auth_header` is per-transport, not per-call. A **persistent discovery session** per extension (gateway service token) drives `list_tools`/caching/collision-check; each **federated call builds a fresh ephemeral transport** with the *caller's* bearer, forwards `tools/call`, and drops.
- **Auth:** the caller's raw bearer is captured (`RawBearerToken`) and forwarded verbatim; downstream validates it with the shared `EPIGRAPH_JWT_SECRET`. A **fail-closed** per-extension scope gate (`enforce_federated_scope`) runs before forwarding; federated tools stay out of the static `SCOPE_MAP`.
- **Seams:** `list_tools`/`get_tool`/`list_mcp_tools` aggregate static+federated; `call_tool` branches to federation only after the static router misses.
- **Namespacing:** natural names; **startup collision-refusal**; optional per-extension `prefix=`.
- **Failure:** unreachable extension at boot → mounted unhealthy, skipped (kernel tools stay online). `reconnect_tick` defined-but-unwired in v1 (documented fast-follow).

## v1 scope note
Transport is **loopback TCP only** — rmcp 0.15's reqwest client can't dial a unix socket; a custom hyper+UnixStream connector is a documented **fast-follow** (the security boundary is the shared-JWT validation, not the socket type).

## Verification
- 19 config/registry unit tests + 6 gateway integration tests (stub streamable-HTTP MCP: lists+proxies, **caller bearer forwarded**, prefix apply/strip, **collision refusal**, unreachable-degrades-no-panic). `fmt --check` + `clippy -p epigraph-mcp --lib --tests -- -D warnings` clean.
- Proven against the real downstream: `episcience-mcp-server` on loopback served `initialize`+`tools/list` (9 tools) with shared-JWT auth (401 on no-token/bad-secret).

_One `chore` commit clears pre-existing MSRV/loop clippy lints in unrelated integration-test files (red on base) so the strict `--tests` gate passes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)